### PR TITLE
Add way to swallow spurious warnings

### DIFF
--- a/include/range/v3/algorithm.hpp
+++ b/include/range/v3/algorithm.hpp
@@ -13,6 +13,8 @@
 #ifndef RANGES_V3_ALGORITHM_HPP
 #define RANGES_V3_ALGORITHM_HPP
 
+#include <range/v3/detail/disable_warnings.hpp>
+
 #include <range/v3/algorithm/adjacent_find.hpp>
 #include <range/v3/algorithm/all_of.hpp>
 #include <range/v3/algorithm/binary_search.hpp>
@@ -69,5 +71,7 @@
 #include <range/v3/algorithm/unique.hpp>
 #include <range/v3/algorithm/unique_copy.hpp>
 #include <range/v3/algorithm/upper_bound.hpp>
+
+#include <range/v3/detail/re_enable_warnings.hpp>
 
 #endif

--- a/include/range/v3/detail/disable_warnings.hpp
+++ b/include/range/v3/detail/disable_warnings.hpp
@@ -1,0 +1,14 @@
+/// \file \brief This file disables some warnings produced by the library
+///
+/// \warning This file has no include guards (it is supposed to be included
+/// multiple times) and should always be paired with a:
+///
+/// #include <boost/v3/detail/re_enable_warnings.hpp>
+///
+/// The following warnings are disabled by this file:
+/// -Wshadow
+///
+
+/// \note Works with GCC and Clang
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wshadow"

--- a/include/range/v3/detail/re_enable_warnings.hpp
+++ b/include/range/v3/detail/re_enable_warnings.hpp
@@ -1,0 +1,14 @@
+/// \file \brief This file re-enables the warnings disabled by
+/// range/v3/detail/disable_warnings.hpp
+///
+/// \warning This file has no include guards since it is supposed to be included
+/// multiple times and should always be paired with:
+///
+/// #include <boost/v3/detail/disable_warnings.hpp>
+///
+/// See <boost/v3/detail/disable_warnings.hpp> for a list of the warnings
+/// disabled.
+///
+
+/// \note Works with GCC and Clang
+#pragma GCC diagnostic pop

--- a/include/range/v3/view.hpp
+++ b/include/range/v3/view.hpp
@@ -14,6 +14,8 @@
 #ifndef RANGES_V3_VIEW_HPP
 #define RANGES_V3_VIEW_HPP
 
+#include <range/v3/detail/disable_warnings.hpp>
+
 #include <range/v3/view/adjacent_filter.hpp>
 #include <range/v3/view/all.hpp>
 #include <range/v3/view/as_range.hpp>
@@ -38,5 +40,7 @@
 #include <range/v3/view/unbounded.hpp>
 #include <range/v3/view/unique.hpp>
 #include <range/v3/view/zip.hpp>
+
+#include <range/v3/detail/re_enable_warnings.hpp>
 
 #endif


### PR DESCRIPTION
Two files are provided:
- detail/disable_warnings.hpp,
  which stores the user warnings, and disable some of them, and
- detail/re_enable_warnings.hpp,
  which restores the user warnings.

These files are ment to be included multiple times.

They disable spurious warnings for a code block between
disable_warnings.hpp and re_enable_warnings.hpp

Currently GCC and clang are supported, and Wshadow is the only warning
swallowed in the algorithm.hpp and view.hpp headers.

Support for other compilers/warnings can easily be added.

Rationale: it is better to swallow spurious warnings produced by broken
compilers or insane warning configurations than to waste time modifying
valid and correct code.
