### PR TITLE
Add push_back container algorithm

### DIFF
--- a/include/range/v3/container_algorithm.hpp
+++ b/include/range/v3/container_algorithm.hpp
@@ -1,0 +1,19 @@
+// Boost.Range library
+//
+//  Copyright Eric Niebler 2013
+//  Copyright Gonzalo Brito Gadeschi 2014.
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// For more information, see http://www.boost.org/libs/range/
+//
+
+#ifndef RANGES_V3_CONTAINER_ALGORITHM_HPP
+#define RANGES_V3_CONTAINER_ALGORITHM_HPP
+
+#include <range/v3/container_algorithm/push_back.hpp>
+
+#endif

--- a/include/range/v3/container_algorithm/push_back.hpp
+++ b/include/range/v3/container_algorithm/push_back.hpp
@@ -1,0 +1,69 @@
+//  Copyright Neil Groves 2009.
+//  Copyright Eric Niebler 2013
+//  Copyright Gonzalo Brito Gadeschi 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// For more information, see http://www.boost.org/libs/range/
+//
+#ifndef RANGES_V3_CONTAINER_ALGORITHM_PUSH_BACK_HPP
+#define RANGES_V3_CONTAINER_ALGORITHM_PUSH_BACK_HPP
+
+#include <range/v3/algorithm/copy.hpp>
+
+namespace ranges
+{
+    inline namespace v3
+    {
+        namespace detail
+        {
+            template<typename Container, typename InputIterable>
+            Container& push_back(Container& container, InputIterable&& rng)
+            {
+              ranges::copy(std::forward<InputIterable>(rng),
+                           std::back_inserter(container));
+              return container;
+            }
+        }
+
+        struct push_backer : bindable<push_backer>
+        {
+            /// \brief template function push_backer::operator()
+            ///
+            /// range-based version of the \c push_back Boost.Range algorithm
+            ///
+            /// \pre \c Container is a model of the Container concept
+            /// \pre \c InputIterable is a model of the InputIterable concept
+            template<typename Container, typename InputIterable>
+            static Container& invoke(push_backer, Container& container,
+                                     InputIterable&& rng)
+            {
+              CONCEPT_ASSERT(ranges::Iterable<InputIterable>());
+              // CONCEPT_ASSERT(ranges::Container<Container>()); /// \todo
+              return detail::push_back(container,
+                                       std::forward<InputIterable>(rng));
+            }
+
+            /// \overload
+            /// for container | push_back(rng)
+            template<typename InputIterable>
+            static auto invoke(push_backer push_back, InputIterable&& rng) ->
+                decltype(push_back.move_bind(std::placeholders::_1,
+                                             std::forward<InputIterable>(rng)))
+            {
+                CONCEPT_ASSERT(ranges::Iterable<InputIterable>());
+                return push_back.move_bind(std::placeholders::_1,
+                                           std::forward<InputIterable>(rng));
+            }
+        };
+
+        RANGES_CONSTEXPR push_backer push_back {};
+
+    } // inline namespace v3
+
+} // namespace ranges
+
+#endif // include guard

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 
 add_subdirectory(utility)
 add_subdirectory(algorithm)
+add_subdirectory(container_algorithm)
 

--- a/test/container_algorithm/CMakeLists.txt
+++ b/test/container_algorithm/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(push_back push_back.cpp)
+add_test(test.push_back push_back)

--- a/test/container_algorithm/push_back.cpp
+++ b/test/container_algorithm/push_back.cpp
@@ -1,0 +1,58 @@
+//  Copyright Gonzalo Brito Gadeschi 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// For more information, see http://www.boost.org/libs/range/
+
+#include <cassert>
+#include <vector>
+#include <list>
+#include <deque>
+#include <string>
+#include <range/v3/algorithm/equal.hpp>
+#include <range/v3/container_algorithm/push_back.hpp>
+
+template<class CharContainer> void test() {
+  {
+    CharContainer c1 {'0', '2', '4', '6'};
+    CharContainer c2;
+    assert(!ranges::equal(c1, c2));
+
+    ranges::push_back(c2, c1);
+    assert(ranges::equal(c1, c2));
+
+    CharContainer ext { '7' };
+    ranges::push_back(c2, ext);
+    assert(!ranges::equal(c1, c2));
+
+    ranges::push_back(c1, ext);
+    assert(ranges::equal(c1, c2));
+  }
+
+  {
+    CharContainer c1 {'0', '2', '4', '6'};
+    CharContainer c2;
+    assert(!ranges::equal(c1, c2));
+
+    c2 | ranges::push_back(c1);
+    assert(ranges::equal(c1, c2));
+
+    CharContainer ext { '7' };
+    c2 | ranges::push_back(ext);
+    assert(!ranges::equal(c1, c2));
+
+    c1 | ranges::push_back(ext);
+    assert(ranges::equal(c1, c2));
+  }
+}
+
+int main()
+{
+  test<std::vector<char>>();
+  test<std::list<char>>();
+  test<std::deque<char>>();
+  test<std::string>();
+}


### PR DESCRIPTION
Equivalent to Boost.Range push_back:
push_back operates on STL Containers that
provide a push_back method, and is equivalent to copy(rng,
back_inserter(container)).

Container algorithms are just utilities for operating on containers.
In particular, they do not operate on Iterables.
