### PR TITLE
Add make cov target: generates code coverage report

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ else()
   message(FATAL_ERROR "Unknown compiler.")
 endif()
 
+include(aux/coverage.cmake)
+
 add_subdirectory(test)
 add_subdirectory(example)
 add_subdirectory(libs/range/v3/scratch)

--- a/aux/coverage.cmake
+++ b/aux/coverage.cmake
@@ -1,0 +1,28 @@
+################################################################################
+# Coverage target: make cov
+################################################################################
+include(CMakeDependentOption)
+option(RANGE_V3_ANALYZE_COVERAGE "Analyzes test coverage" OFF)
+
+if(RANGE_V3_ANALYZE_COVERAGE)
+  message("Coverage analysis enabled.")
+  if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message("[Error] Coverage analysis requires debug information.")
+    exit()
+  endif()
+  if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -Xclang -coverage-cfg-checksum -Xclang -coverage-no-function-names-in-data -Xclang -coverage-version='407*'")
+  elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    message("[Error] Coverage analysis with GCC is untested.")
+    exit()
+    # This should "just work":
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
+  else()
+    message("[Error] Coverage analysis with the ${CMAKE_CXX_COMPILER_ID} compiler is unimplemented yet")
+    exit()
+  endif()
+  # LCov (coverage): make cov
+  add_custom_command(OUTPUT coverage COMMAND
+    ${PROJECT_SOURCE_DIR}/aux/coverage.sh "${PROJECT_SOURCE_DIR}/include/")
+  add_custom_target(cov DEPENDS coverage WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+endif()

--- a/aux/coverage.sh
+++ b/aux/coverage.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+make -j
+ctest
+lcov --capture --base-directory $1 --gcov-tool gcov-4.8 --directory . --output-file coverage.info --no-external
+lcov --remove coverage.info \*\/test\/\* -o coverage.info
+lcov --remove coverage.info \*\/example\/\* -o coverage.info
+genhtml coverage.info --output-directory coverage_results --title "Boost.Range-v3 test coverage" --prefix $1 --legend


### PR DESCRIPTION
Adds the target "make cov" which generates an html report of unit-test coverage. 
The CMake option -DRANGE_V3_ANALYZE_COVERAGE=On enables the target in Debug builds. 
This uses clang --coverage and lcov under the hood to generate the report.

Note that the reported coverage percentages are with respect to the generated code (e.g. template classes and functions that have not been instantiated are neglected!). To get more accurate results one should explicitly instantiate everything on the tests (which is helpful to check that everything compiles anyways).
