### PR TITLE
Return SizedIteratorRanges from ranges::range for RandomAccessIteratorRanges and SizedIterables

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,3 +15,6 @@ add_test(test.range_facade range_facade)
 
 add_executable(range_adaptor range_adaptor.cpp)
 add_test(test.range_adaptor range_adaptor)
+
+add_executable(size size.cpp)
+add_test(test.size size)

--- a/test/algorithm/equal.cpp
+++ b/test/algorithm/equal.cpp
@@ -245,7 +245,7 @@ void test_rng_pred()
                  range(random_access_iterator<const int*>(ia),
                  sentinel<const int*>(ia + s - 1)),
                  counting_equals<int>));
-    CHECK(comparison_count > 0);
+    CHECK(comparison_count == 0);
     CHECK(!equal(range(input_iterator<const int*>(ia),
                   sentinel<const int*>(ia+s)),
                   input_iterator<const int*>(ib),

--- a/test/size.cpp
+++ b/test/size.cpp
@@ -1,0 +1,41 @@
+#include <vector>
+#include <list>
+#include <forward_list>
+#include <range/v3/core.hpp>
+#include <range/v3/range_concepts.hpp>
+#include "./simple_test.hpp"
+#include "./test_utils.hpp"
+
+int main()
+{
+    using namespace ranges;
+
+    auto vec = std::vector<int>{1, 2, 3, 4, 5};
+    auto lst = std::list<int>{1, 2, 3, 4};
+
+    static_assert(
+        concepts::models<concepts::RandomAccessIterator, decltype(vec.begin())>{}, "??");
+
+    CHECK(size(vec) == 5);
+    CHECK(size(lst) == 4); // std::list offers .size() member function
+
+    auto &&vec_rng = range(begin(vec), end(vec));
+    auto &&lst_rng = range(begin(lst), end(lst));
+    auto &&lst_rng2 = range(lst);
+
+    CHECK(size(vec_rng) == 5);
+    CHECK(size(lst_rng2) == 4);
+    static_assert(
+        !concepts::models<concepts::Invokable, decltype(size), decltype(lst_rng)>(),
+        "no O(1) size for bidirectional ranges");
+
+    auto &&lst_sized_rng = range(begin(lst), end(lst), lst.size());
+    CHECK(size(lst_sized_rng) == 4);
+
+    auto f_lst = std::forward_list<int>{1, 2, 3};
+    static_assert(
+        !concepts::models<concepts::Invokable, decltype(size), decltype(f_lst)>(),
+        "no O(1) size member function in std::forward_list");
+
+    return ::test_result();
+}


### PR DESCRIPTION
The interface of `ranges::range` consists of:
- `ranges::range(Iterator, Sentinel, Size) -> sized_iterator_range`
- `ranges::range(Iterator, Sentinel) -> iterator_range`

However, when calling `ranges::range(Iterator, Sentinel)` with `RandomAccessIterator`s, we can 
compute the range size in `O(1)` and return a `sized_iterator_range`.

Furthermore, some containers like `std::list` provide only `BidirectionalIterator`s, but they have
an `O(1)` `size()` member function.

This patch changes `ranges::range` interface to: 
- `ranges::range(Iterator, Sentinel, Size) -> sized_iterator_range`
- `ranges::range(Iterator, Sentinel) -> sized_iterator_range` (if possible) / `iterator_range`
- `ranges::range(Iterable&) -> sized_iterator_range` (if possible) / `iterator_range`

The `ranges::range(Iterable&)` dispatches to a `sized_iterator_range` if the `Iterable` has `RandomAccessIterator`s or `ranges::size(Iterable&)` can compute its size (which is `O(1)`). Otherwise it returns an `iterator_range`.

Note:  the `algorithm/equal.cpp` test used to perform one comparison in the modified `CHECK` clause when comparing two `RandomAccessRange`s even tho they had different sizes. Now it doesn't need to perform any comparison at all. 
