### PR TITLE
Updates to concept wording

### DIFF
--- a/doc/D4128.md
+++ b/doc/D4128.md
@@ -663,7 +663,7 @@ The following concepts are proposed to constrain the standard library. The itera
 
 ### Iterator Concepts
 
-The range concepts presented below build on the following iterator concepts. These are largely as found in [N3351] [8], with the addition of WeakIterator, Iterator, WeakOutputIterator and OutputIterator. The entire hierarchy is presented here for completeness. An important new concept is:
+The range concepts presented below build on the following iterator concepts. These are largely as found in [N3351] [8], with the addition of WeakIterator, Iterator, WeakOutputIterator and OutputIterator. The entire hierarchy is presented here for completeness. An important, new concept is:
 
     concept WeakIterator<typename I> =
         WeaklyIncrementable<I> && Copyable<I> &&
@@ -706,20 +706,8 @@ This concept is refined  by the addition of either Readable or Writable, which a
         ForwardIterator<I> &&
         Derived<IteratorCategory<I>, bidirectional_iterator_tag> &&
         requires decrement (I i, I j) {
-            // Pre-decrement:
-            I& == { ––i };
-            axiom { is_valid(––i) => &––i == &i; }
-            // Post-decrement:
-            I == { i–– };
-            axiom {
-                is_valid(––i) <=> is_valid(i––);
-                is_valid(i––) => (i == j => i–– == j);
-                is_valid(i––) => (i == j => (i––, i) == ––j);
-            }
-        } &&
-        axiom increment_decrement (I i, I j) {
-            is_valid(++i) => (is_valid(––(++i)) && (i == j => ––(++i) == j));
-            is_valid(––i) => (is_valid(++(––i)) && (i == j => ++(––i) == j));
+            { ––i } -> I&;
+            { i–– } -> I;
         };
 
     concept RandomAccessIterator<typename I> =
@@ -727,50 +715,26 @@ This concept is refined  by the addition of either Readable or Writable, which a
         TotallyOrdered<I> &&
         Derived<IteratorCategory<I>, random_access_iterator_tag> &&
         SignedIntegral<DistanceType<I>> &&
-        // Difference:
         SizedIteratorRange<I, I> && // see below
         requires advance (I i, I j, DifferenceType<I> n) {
-            // Addition:
-            I& == { i += n };
-            I == { i + n };
-            I == { n + i };
-            axiom {
-                is_valid(advance(i, n) <=> is_valid(i += n);
-                is_valid(i += n) => i += n == (advance(i, n), i);
-                is_valid(i += n) => &(i += n) == &i;
-                is_valid(i += n) => i + n == (i += n);
-                // Commutativity of pointer addition
-                is_valid(i + n) => i + n == n + i;
-                // Associativity of pointer addition
-                is_valid(i + (n + n)) => i + (n + n) == (i + n) + n;
-                // Peano-like pointer addition:
-                i + 0 == i;
-                is_valid(i + n) => i + n == ++(i + (n – 1));
-                is_valid(++i) => (i == j => ++i != j);
-            }
-            // Subtraction:
-            I& == { i –= n };
-            I == { i – n };
-            axiom {
-                is_valid(i += –n) <=> is_valid(i –= n);
-                is_valid(i –= n) => (i –= n) == (i += –n);
-                is_valid(i –= n) => &(i –= n) == &i;
-                is_valid(i –= n) => (i – n) == (i –= n);
-            }
-        } &&
-        requires subscript (I i, DifferenceType<I> n) {
-            ValueType<I> = { i[n] };
-            axiom {
-                is_valid(i + n) && is_valid(*(i + n)) => i[n] == *(i + n);
-            }
+            { i += n } -> I&;
+            { i + n } -> I;
+            { n + i } -> I;
+            { i –= n } -> I&;
+            { i – n } -> I;
+            { i[n] } -> ValueType<I>;
         };
 
 ### Iterator Range Concepts
+
+The IteratorRange concept defines a pair of types (an Iterator and a Sentinel), that can be compared for equality. This concept is the key that allows iterator ranges to be defined by pairs of types that are not the same.
 
     concept IteratorRange<typename I, typename S> =
         Iterator<I> &&
         Regular<S> &&
         EqualityComparable<I, S>;
+
+The SizedIteratorRange allows the use of the `-` operator to compute the distance between to an Iterator and a Sentinel.
 
     concept SizedIteratorRange<typename I, typename S> =
         IteratorRange<I, S> &&
@@ -781,16 +745,6 @@ This concept is refined  by the addition of either Readable or Writable, which a
             { i - j } -> Distance_type<I>;
             { j - i } -> Distance_type<I>;
             requires SignedIntegral<DifferenceType>;
-
-            axiom {
-                using C = CommonType<I, S>;
-                is_valid(distance(i, j)) <=> is_valid(i – j) && is_valid(j – i) &&
-                                             is_valid(C{i} - C{j}) && is_valid(C{j} - C{i});
-                is_valid(i – j) => (i – j) >= 0 => i – j == distance(i, j);
-                is_valid(i – j) => (i – j) < 0 => i – j == –distance(i, j);
-                is_valid(j - j) => (j - j) == 0;
-
-            }
         };
 
 ### Iterable Concepts


### PR DESCRIPTION
Bring the concepts into line with Concepts Lite. Also, remove axioms in favor of textual descriptions (forthcoming).
