### PR TITLE
Fix logic error in logical_or. (See what I did there?)

### DIFF
--- a/include/range/v3/utility/logical_ops.hpp
+++ b/include/range/v3/utility/logical_ops.hpp
@@ -83,7 +83,7 @@ namespace ranges
 
         template<typename Bool, typename...Bools>
         struct logical_or<Bool, Bools...>
-          : detail::conditional_t<Bool::value, std::true_type, logical_and<Bools...>>
+          : detail::conditional_t<Bool::value, std::true_type, logical_or<Bools...>>
         {};
 
 


### PR DESCRIPTION
logical_or should NOT be implemented as (A || (B && C && ... && Z)).
