### PR TITLE
Enable GCC 4.9 travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,11 @@ env:
     - BUILD_TYPE=Debug
     - BUILD_TYPE=Release
     - ASAN=On
-    exclude:
-      - compiler: gcc
-        env: ASAN=On
+    
+matrix:
+  exclude:
+    - compiler: gcc
+      env: ASAN=On
 
 # Install dependencies
 before_install:


### PR DESCRIPTION
GCC 4.9 is available on the Ubuntu toolchain testing repositories. Add those to your apt-get and you are ready to install 4.9 (Note you already have this setup in your `.travis.yml`). The version of GCC is stored as an environment variable on the travis build file to change it easily in the future. Also the GCC travis build was enabled.

Hope it helps.
