### PR TITLE
Updated ranges::for_each to take forwarding ref Rng&& instead of Rng&

### DIFF
--- a/include/range/v3/algorithm/for_each.hpp
+++ b/include/range/v3/algorithm/for_each.hpp
@@ -51,7 +51,7 @@ namespace ranges
                 typename X = concepts::Invokable::result_t<P, V>,
                 CONCEPT_REQUIRES_(InputIterable<Rng &>() && Invokable<P, V>() &&
                     Invokable<F, X>())>
-            I operator()(Rng &rng, F fun, P proj = P{}) const
+            I operator()(Rng &&rng, F fun, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), std::move(fun), std::move(proj));
             }


### PR DESCRIPTION
ranges::for_each should accept R-value ranges, to support use-cases such as:

```
ranges::for_each(ranges::view::ints(1,10),[](int x){ std::cout<<x<<std::endl;});
```

The proposed change is to change for_each to take a [forwarding reference](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4164.pdf) Rng&& instead of an L-value reference Rng&.
