### PR TITLE
#include view/split.hpp in view.hpp

### DIFF
--- a/include/range/v3/view.hpp
+++ b/include/range/v3/view.hpp
@@ -47,6 +47,7 @@
 #include <range/v3/view/reverse.hpp>
 #include <range/v3/view/single.hpp>
 #include <range/v3/view/slice.hpp>
+#include <range/v3/view/split.hpp>
 #include <range/v3/view/stride.hpp>
 #include <range/v3/view/tail.hpp>
 #include <range/v3/view/take.hpp>


### PR DESCRIPTION
While playing around with ranges I discovered that `#include <range/v3/all.hpp>` doesn't pull in `range::view::split`.
