### PR TITLE
Removes view::filter from view.hpp

### DIFF
--- a/include/range/v3/view.hpp
+++ b/include/range/v3/view.hpp
@@ -28,7 +28,6 @@
 #include <range/v3/view/drop.hpp>
 #include <range/v3/view/drop_while.hpp>
 #include <range/v3/view/empty.hpp>
-#include <range/v3/view/filter.hpp>
 #include <range/v3/view/for_each.hpp>
 #include <range/v3/view/generate.hpp>
 #include <range/v3/view/generate_n.hpp>


### PR DESCRIPTION
This removes `filter.hpp` from `view.hpp`, which will allow to: 

```c++
#include <range/v3/all.hpp> 
#define RANGES_NO_DEPRECATED_WARNING
#include <range/v3/view/filter.hpp>
#undef RANGES_NO_DEPRECATED_WARNING
```

I think it is good practice to don't pull in any deprecated functionality by default. The whole point of the deprecated warning is to warn the user that some functionality they are using can be removed in the future. Once the user knows, it should be allowed to disable this warning selectively. 

However, the deprecation attribute does not let the user disable the usage of a specific warning at the declaration level. The user can disable the warnings at the call level, but if you want to disable a specific warning (e.g. the usage of filter) for a single TU, there is no way to specify that you want to disable that warning _only_: `-Wno-deprecated` disables all deprecation warnings. 

One can _try_ to selectively disable a single deprecation warning by modifying the warning level at every point of usage. This however, requires something like: 

```c++
auto rng = stuff | stuff |
            // modify warning level
            filter
            // modify warning level
            | stuff | stuff;
```

which is far from ideal.