### PR TITLE
allow selectively disabling deprecated warnings

### DIFF
--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -56,16 +56,4 @@
 #endif
 #endif
 
-#if __cplusplus > 201103
-#define RANGES_DEPRECATED(MSG) [[deprecated(MSG)]]
-#else
-#if defined(__clang__) || defined(__GNUC__)
-#define RANGES_DEPRECATED(MSG) __attribute__((deprecated(MSG)))
-#elif defined(_MSC_VER)
-#define RANGES_DEPRECATED(MSG) __declspec(deprecated(MSG))
-#else
-#define RANGES_DEPRECATED(MSG)
-#endif
-#endif
-
 #endif

--- a/include/range/v3/detail/deprecated.hpp
+++ b/include/range/v3/detail/deprecated.hpp
@@ -1,0 +1,29 @@
+/// \file
+// Range v3 library
+//
+//  Copyright Eric Niebler 2013-2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+
+#ifndef RANGES_DISABLE_DEPRECATED_WARNINGS
+#if __cplusplus > 201103
+#define RANGES_DEPRECATED(MSG) [[deprecated(MSG)]]
+#else
+#if defined(__clang__) || defined(__GNUC__)
+#define RANGES_DEPRECATED(MSG) __attribute__((deprecated(MSG)))
+#elif defined(_MSC_VER)
+#define RANGES_DEPRECATED(MSG) __declspec(deprecated(MSG))
+#else
+#define RANGES_DEPRECATED(MSG)
+#endif
+#endif
+#else
+#define RANGES_DEPRECATED(MSG)
+#endif

--- a/include/range/v3/view/filter.hpp
+++ b/include/range/v3/view/filter.hpp
@@ -18,6 +18,7 @@
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/static_const.hpp>
 #include <range/v3/view/remove_if.hpp>
+#include <range/v3/detail/deprecated.hpp>
 
 namespace ranges
 {


### PR DESCRIPTION
The macro `RANGES_DISABLE_DEPRECATED_WARNINGS` allows disabling the deprecated warnings by redefining `RANGES_DEPRECATED(MSG)` to do nothing when this is defined.

This allows to disable the deprecation warnings selectively:

```c++
#include <ranges/v3/all.hpp>
#define RANGES_DISABLE_DEPRECATED_WARNINGS
#include <ranges/v3/some_deprecated_functionality_not_included_by_all.hpp>
#undef RANGES_DISABLE_DEPRECATED_WARNINGS
```