### PR TITLE
Add macro to disable all deprecated warnings

### DIFF
--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -56,6 +56,7 @@
 #endif
 #endif
 
+#ifndef RANGES_DISABLE_DEPRECATED_WARNINGS
 #if __cplusplus > 201103
 #define RANGES_DEPRECATED(MSG) [[deprecated(MSG)]]
 #else
@@ -66,6 +67,9 @@
 #else
 #define RANGES_DEPRECATED(MSG)
 #endif
+#endif
+#else
+#define RANGES_DEPRECATED(MSG)
 #endif
 
 #endif


### PR DESCRIPTION
Defining the macro `RANGES_DISABLE_DEPRECATED_WARNINGS` allows disabling all deprecated warnings from range-v3.