### PR TITLE
Initial C++14 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,59 +1,234 @@
+# Adapted from various sources, including:
+# - Louis Dionne's Hana: https://github.com/ldionne/hana
+# - Paul Fultz II's FIT: https://github.com/pfultz2/Fit
 language: cpp
-
 script: cmake
 
-compiler:
- - clang
- - gcc
-
-env:
-  global:
-    - GCC_VERSION="4.9"
-  matrix:
-    - BUILD_TYPE=Debug
-    - BUILD_TYPE=Release
-    - ASAN=On
-    
+# Test matrix:
+# - Build matrix per compiler: C++11/C++14 + Debug/Release
+# - Optionally: AddressSanitizer (ASAN)
+# - Valgrind: all release builds are also tested with valgrind
+# - clang 3.4, 3.5, 3.6, trunk
+#   - Note: 3.4 and trunk are tested with/without ASAN,
+#     the rest is only tested with ASAN=On.
+# - gcc 4.9, 5.0
+#
 matrix:
-  exclude:
-    - compiler: gcc
-      env: ASAN=On
+  include:
+    # Test clang-3.4: C++11, Buidd=Debug/Release, ASAN=On/Off
+    - env: CLANG_VERSION=3.4 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
+      os: linux
+      compiler: clang34
+      addons: &clang34
+        apt:
+          packages:
+            - valgrind
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - env: CLANG_VERSION=3.4 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
+      os: linux
+      compiler: clang
+      addons: *clang34
+    # - env: CLANG_VERSION=3.4 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   compiler: clang
+    #   addons: *clang34
+    # - env: CLANG_VERSION=3.4 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   compiler: clang
+    #   addons: *clang34
+
+    # Test clang-3.5: C++11/C++14, Buidd=Debug/Release, ASAN=On/Off
+    # - env: CLANG_VERSION=3.5 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
+    #   os: linux
+    #   addons: &clang35
+    #     apt:
+    #       packages:
+    #         - clang-3.5
+    #         - valgrind
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    #         - llvm-toolchain-precise-3.5
+
+    # - env: CLANG_VERSION=3.5 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
+    #   os: linux
+    #   addons: *clang35
+
+    # - env: CLANG_VERSION=3.5 BUILD_TYPE=Debug CPP=14 ASAN=On LIBCXX=On
+    #   os: linux
+    #   addons: *clang35
+
+    # - env: CLANG_VERSION=3.5 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On
+    #   os: linux
+    #   addons: *clang35
+
+    # Uncomment these to test without AddressSanitizer
+    # - env: CLANG_VERSION=3.5 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang35
+    # - env: CLANG_VERSION=3.5 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang35
+    # - env: CLANG_VERSION=3.5 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang35
+    # - env: CLANG_VERSION=3.5 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang35
+
+    # Test clang-3.6: C++11/C++14, Buidd=Debug/Release, ASAN=On/Off
+    # - env: CLANG_VERSION=3.6 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
+    #   os: linux
+    #   addons: &clang36
+    #     apt:
+    #       packages:
+    #         - clang-3.6
+    #         - valgrind
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    #         - llvm-toolchain-precise-3.6
+
+    # - env: CLANG_VERSION=3.6 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
+    #   os: linux
+    #   addons: *clang36
+
+    # - env: CLANG_VERSION=3.6 BUILD_TYPE=Debug CPP=14 ASAN=On LIBCXX=On
+    #   os: linux
+    #   addons: *clang36
+
+    # - env: CLANG_VERSION=3.6 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On
+    #   os: linux
+    #   addons: *clang36
+
+    # Uncomment these to test without AddressSanitizer
+    # - env: CLANG_VERSION=3.6 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang36
+    # - env: CLANG_VERSION=3.6 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang36
+    # - env: CLANG_VERSION=3.6 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang36
+    # - env: CLANG_VERSION=3.6 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang36
+
+    # Test clang-3.7: C++11/C++14, Buidd=Debug/Release, ASAN=On/Off
+    - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
+      os: linux
+      addons: &clang37
+        apt:
+          packages:
+            - clang-3.7
+            - valgrind
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise
+
+    - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
+      os: linux
+      addons: *clang37
+
+    - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=14 ASAN=On LIBCXX=On
+      os: linux
+      addons: *clang37
+
+    - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On
+      os: linux
+      addons: *clang37
+
+    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang37
+
+    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang37
+
+    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang37
+
+    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang37
+
+    # Test gcc-4.9: C++11, Build=Debug/Release, ASAN=Off
+    - env: GCC_VERSION=4.9 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=Off
+      os: linux
+      addons: &gcc49
+        apt:
+          packages:
+            - g++-4.9
+            - valgrind
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - env: GCC_VERSION=4.9 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off
+      os: linux
+      addons: *gcc49
+
+    # Test gcc-5.0: C++11/14, Build=Debug/Release, ASAN=Off
+    # - env: GCC_VERSION=5 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=Off
+    #   os: linux
+    #   addons: &gcc5
+    #     apt:
+    #       packages:
+    #         - gcc-5
+    #         - valgrind
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+
+    # - env: GCC_VERSION=5 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off
+    #   os: linux
+    #   addons: *gcc5
+
+    # - env: GCC_VERSION=5 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=Off
+    #   os: linux
+    #   addons: *gcc5
+
+    # - env: GCC_VERSION=5 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=Off
+    #   os: linux
+    #   addons: *gcc5
 
 # Install dependencies
 before_install:
   - export CHECKOUT_PATH=`pwd`;
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo apt-get update -qq
-  - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq -y --force-yes g++-${GCC_VERSION}; fi
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-${GCC_VERSION}" CC="gcc-${GCC_VERSION}"; fi
-
-  # Install libc++ if tests are run with clang++
-  - if [ "$CXX" == "clang++" ]; then export LIBCXX=On; fi
-  - if [ -n "$LIBCXX" -a "$CXX" == "clang++" ]; then svn co --quiet http://llvm.org/svn/llvm-project/libcxx/trunk libcxx; fi
-  - if [ -n "$LIBCXX" -a "$CXX" == "clang++" ]; then cd libcxx/lib && bash buildit; fi
-  - if [ -n "$LIBCXX" -a "$CXX" == "clang++" ]; then sudo cp ./libc++.so.1.0 /usr/lib/; fi
-  - if [ -n "$LIBCXX" -a "$CXX" == "clang++" ]; then sudo mkdir /usr/include/c++/v1; fi
-  - if [ -n "$LIBCXX" -a "$CXX" == "clang++" ]; then cd .. && sudo cp -r include/* /usr/include/c++/v1/; fi
-  - if [ -n "$LIBCXX" -a "$CXX" == "clang++" ]; then cd /usr/lib && sudo ln -sf libc++.so.1.0 libc++.so; fi
-  - if [ -n "$LIBCXX" -a "$CXX" == "clang++" ]; then sudo ln -sf libc++.so.1.0 libc++.so.1 && cd $cwd; fi
+  - if [ -n "$GCC_VERSION" ]; then export CXX="g++-${GCC_VERSION}" CC="gcc-${GCC_VERSION}"; fi
+  - if [ -n "$CLANG_VERSION" ]; then export CXX="clang++-${CLANG_VERSION}" CC="clang-${CLANG_VERSION}"; fi
+  - if [ "$CLANG_VERSION" == "3.4" ]; then export CXX="/usr/local/clang-3.4/bin/clang++" CC="/usr/local/clang-3.4/bin/clang"; fi
+  - which $CXX
+  - which $CC
+  - which valgrind
+  - if [ -n "$CLANG_VERSION" ]; then sudo CXX=$CXX CC=$CC ./install_libcxx.sh; fi
 
 install:
   - cd $CHECKOUT_PATH
+
+  # Workaround for valgrind bug: https://bugs.kde.org/show_bug.cgi?id=326469.
+  # It is fixed in valgrind 3.10 so this won't be necessary if someone
+  # replaces the current valgrind (3.7) with valgrind-3.10
+  - sed -i 's/march=native/msse4.2/' CMakeLists.txt
+
   - if [ ! -d build ]; then mkdir build; fi
   - cd build
   - export CXX_FLAGS=""
   - export CXX_LINKER_FLAGS=""
   - if [ -z "$BUILD_TYPE" ]; then export BUILD_TYPE=Release; fi
-  - if [ -n "$ASAN" ]; then export CXX_FLAGS="${CXX_FLAGS} -fsanitize=address,undefined,integer -fno-omit-frame-pointer -fno-sanitize=unsigned-integer-overflow"; fi
-  - if [ "$CXX" == "clang++" ]; then CXX_FLAGS="${CXX_FLAGS} -D__extern_always_inline=inline"; fi
-  - if [ -n "$LIBCXX" ]; then CXX_FLAGS="${CXX_FLAGS} -stdlib=libc++ -I/usr/include/c++/v1/"; fi
-  - if [ -n "$LIBCXX" ]; then CXX_LINKER_FLAGS="${CXX_FLAGS} -L/usr/lib/ -lc++"; fi
-
-  - cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" -DCMAKE_EXE_LINKER_FLAGS="${CXX_LINKER_FLAGS}"
+  - if [ "$ASAN" == "On"]; then export CXX_FLAGS="${CXX_FLAGS} -fsanitize=address,undefined,integer -fno-omit-frame-pointer -fno-sanitize=unsigned-integer-overflow"; fi
+  - if [ -n "$CLANG_VERSION" ]; then CXX_FLAGS="${CXX_FLAGS} -D__extern_always_inline=inline"; fi
+  - if [ "$LIBCXX" == "On" ]; then CXX_FLAGS="${CXX_FLAGS} -stdlib=libc++ -I/usr/include/c++/v1/"; fi
+  - if [ "$LIBCXX" == "On" ]; then CXX_LINKER_FLAGS="${CXX_FLAGS} -L/usr/lib/ -lc++"; fi
+  - cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" -DCMAKE_EXE_LINKER_FLAGS="${CXX_LINKER_FLAGS}" -DRANGES_CXX_STD=$CPP -DMEMORYCHECK_COMMAND:FILEPATH=/usr/bin/valgrind
   - make VERBOSE=1
 
 script:
   - ctest -VV
+  # Valgrind runs for clang release builds only,
+  # it fails when using gcc-4.9 + libstdc++-4.9.
+  - if [ "$BUILD_TYPE" == "Release" ] && [ ! -n "$GCC_VERSION" ]; then ctest -VV -D ExperimentalMemCheck; fi
 
 notifications:
   email: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,21 +6,39 @@ project(Range-v3 CXX)
 find_package(Doxygen)
 find_package(Git)
 
+# Select C++ standard to be used for compiling the tests,
+# for example: 11, 14, 17, 1z, 1y, ...
+#
+if(RANGES_CXX_STD)
+else()
+  # Defaults to C++11 if not set:
+  set(RANGES_CXX_STD 11) 
+endif()
+
 enable_testing()
+include(CTest)
+find_program(MEMORYCHECK_COMMAND valgrind)
+if(MEMORYCHECK_COMMAND-NOTFOUND)
+  message("[W] Valgrind not found")
+else()
+  message("Valgrind: ${MEMORYCHECK_COMMAND}")
+  set(MEMORYCHECK_COMMAND_OPTIONS "--trace-children=yes --leak-check=full")
+endif()
 
 include_directories(include)
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++11 -Wno-unused-function -ftemplate-backtrace-limit=0")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++${RANGES_CXX_STD} -Wall -Wno-unused-function -ftemplate-backtrace-limit=0")
   set(CMAKE_CXX_FLAGS_DEBUG "-O0 -fno-inline -g3 -fstack-protector-all")
   set(CMAKE_CXX_FLAGS_RELEASE "-Ofast -g0 -march=native -mtune=native -DNDEBUG")
 elseif(CMAKE_COMPILER_IS_GNUCXX)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++11 -Wno-unused-function -ftemplate-backtrace-limit=0")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++${RANGES_CXX_STD} -Wall -Wno-unused-function -ftemplate-backtrace-limit=0")
   set(CMAKE_CXX_FLAGS_DEBUG "-O0 -fno-inline -g3 -fstack-protector-all")
   set(CMAKE_CXX_FLAGS_RELEASE "-Ofast -g0 -march=native -mtune=native -DNDEBUG")
 # else()
 #   message(FATAL_ERROR "Unknown compiler.")
 endif()
+
 
 add_subdirectory(doc)
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Supported Compilers
 
 The code is known to work on the following compilers:
 
-- clang 3.4.0
+- clang 3.4.0 (C++14 support requires at least clang 3.5.0)
 - GCC 4.9.0
 
 **Development Status:** This code is fairly stable, well-tested, and suitable for casual use, although currently lacking documentation. No promise is made about support or long-term stability. This code *will* evolve without regard to backwards compatibility.
 
-**Build status (on Travis-CI):** [![Build Status](https://travis-ci.org/ericniebler/range-v3.svg?branch=master)](https://travis-ci.org/ericniebler/range-v3)  
-**Deployment status (on biicode):** [![Build Status](https://webapi.biicode.com/v1/badges/manu343726/manu343726/range/master)](https://www.biicode.com/manu343726/range) 
+**Build status (on Travis-CI):** [![Build Status](https://travis-ci.org/ericniebler/range-v3.svg?branch=master)](https://travis-ci.org/ericniebler/range-v3)
+**Deployment status (on biicode):** [![Build Status](https://webapi.biicode.com/v1/badges/manu343726/manu343726/range/master)](https://www.biicode.com/manu343726/range)
 
 Say Thanks!
 -----------

--- a/include/range/v3/begin_end.hpp
+++ b/include/range/v3/begin_end.hpp
@@ -32,7 +32,7 @@ namespace ranges
             using std::begin;
             using std::end;
 
-#if (__cplusplus >= 201402L) && \
+#if defined(RANGES_CXX_GREATER_THAN_11) && \
     ((defined(_LIBCXX_VERSION) && (_LIBCXX_VERSION >= 1101) && \
       defined(_LIBCPP_STD_VER) && (_LIBCPP_STD_VER > 11)) || \
     (defined(__GLIBCXX__) && (__GLIBCXX__ >= 20150119)))

--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -56,8 +56,16 @@
 #endif
 #endif
 
-#ifndef RANGES_DISABLE_DEPRECATED_WARNINGS
 #if __cplusplus > 201103
+#define RANGES_CXX_GREATER_THAN_11
+#endif
+
+#if __cplusplus > 201402
+#define RANGES_CXX_GREATER_THAN_14
+#endif
+
+#ifndef RANGES_DISABLE_DEPRECATED_WARNINGS
+#ifdef RANGES_CXX_GREATER_THAN_11
 #define RANGES_DEPRECATED(MSG) [[deprecated(MSG)]]
 #else
 #if defined(__clang__) || defined(__GNUC__)
@@ -70,6 +78,15 @@
 #endif
 #else
 #define RANGES_DEPRECATED(MSG)
+#endif
+
+// RANGES_CXX14_CONSTEXPR macro (see also BOOST_CXX14_CONSTEXPR)
+// Note: constexpr implies inline, to retain the same visibility
+// C++14 constexpr functions are inline in C++11
+#ifdef RANGES_CXX_GREATER_THAN_11
+#define RANGES_CXX14_CONSTEXPR constexpr
+#else
+#define RANGES_CXX14_CONSTEXPR inline
 #endif
 
 #endif

--- a/include/range/v3/view/join.hpp
+++ b/include/range/v3/view/join.hpp
@@ -65,7 +65,7 @@ namespace ranges
                     {
                         if(++it == end)
                         {
-#if __cplusplus == 201103L
+#ifndef RANGES_CXX_GREATER_THAN_11
                             rng_ = nullptr;
 #endif
                             it_ = detail::value_init{};
@@ -96,7 +96,7 @@ namespace ranges
                 bool equal(range_iterator_t<Rng> const &it, range_iterator_t<Rng> const &other_it,
                     adaptor const &other_adapt) const
                 {
-#if __cplusplus > 201103L
+#ifdef RANGES_CXX_GREATER_THAN_11
                     RANGES_ASSERT(rng_ == other_adapt.rng_);
                     return it == other_it && it_ == other_adapt.it_;
 #else
@@ -126,7 +126,7 @@ namespace ranges
             }
             adaptor end_adaptor()
             {
-#if __cplusplus > 201103L
+#ifdef RANGES_CXX_GREATER_THAN_11
                 return {*this};
 #else
                 return {};
@@ -184,7 +184,7 @@ namespace ranges
                         {
                             if(++it == end)
                             {
-#if __cplusplus == 201103L
+#ifndef RANGES_CXX_GREATER_THAN_11
                                 rng_ = nullptr;
 #endif
                                 it_ = detail::value_init{};
@@ -222,7 +222,7 @@ namespace ranges
                 bool equal(range_iterator_t<Rng> const &it, range_iterator_t<Rng> const &other_it,
                     adaptor const &other_adapt) const
                 {
-#if __cplusplus > 201103L
+#ifdef RANGES_CXX_GREATER_THAN_11
                     RANGES_ASSERT(rng_ == other_adapt.rng_);
                     return it == other_it && toggl_ == other_adapt.toggl_ &&
                         (toggl_ ? it_ == other_adapt.it_ : val_it_ == other_adapt.val_it_);
@@ -262,7 +262,7 @@ namespace ranges
             }
             adaptor end_adaptor()
             {
-#if __cplusplus > 201103L
+#ifdef RANGES_CXX_GREATER_THAN_11
                 return {*this};
 #else
                 return {};

--- a/install_libcxx.sh
+++ b/install_libcxx.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Install libc++ under travis
+
+svn --quiet co http://llvm.org/svn/llvm-project/libcxx/trunk libcxx
+mkdir libcxx/build
+(cd libcxx/build && cmake .. -DLIBCXX_CXX_ABI=libstdc++ -DLIBCXX_CXX_ABI_INCLUDE_PATHS="/usr/include/c++/4.6;/usr/include/c++/4.6/x86_64-linux-gnu")
+make -C libcxx/build cxx -j2
+sudo cp libcxx/build/lib/libc++.so.1.0 /usr/lib/
+sudo cp -r libcxx/build/include/c++/v1 /usr/include/c++/v1/
+sudo ln -sf /usr/lib/libc++.so.1.0 /usr/lib/libc++.so
+sudo ln -sf /usr/lib/libc++.so.1.0 /usr/lib/libc++.so.1

--- a/test/algorithm/CMakeLists.txt
+++ b/test/algorithm/CMakeLists.txt
@@ -62,11 +62,30 @@ add_test(test.alg.includes, alg.includes)
 add_executable(alg.inplace_merge inplace_merge.cpp)
 add_test(test.alg.inplace_merge, alg.inplace_merge)
 
-add_executable(alg.is_heap is_heap.cpp)
-add_test(test.alg.is_heap, alg.is_heap)
+add_executable(alg.is_heap1 is_heap1.cpp)
+add_test(test.alg.is_heap1, alg.is_heap1)
 
-add_executable(alg.is_heap_until is_heap_until.cpp)
-add_test(test.alg.is_heap_until, alg.is_heap_until)
+add_executable(alg.is_heap2 is_heap2.cpp)
+add_test(test.alg.is_heap2, alg.is_heap2)
+
+add_executable(alg.is_heap3 is_heap3.cpp)
+add_test(test.alg.is_heap3, alg.is_heap3)
+
+add_executable(alg.is_heap4 is_heap4.cpp)
+add_test(test.alg.is_heap4, alg.is_heap4)
+
+add_executable(alg.is_heap_until1 is_heap_until1.cpp)
+add_test(test.alg.is_heap_until1, alg.is_heap_until1)
+
+add_executable(alg.is_heap_until2 is_heap_until2.cpp)
+add_test(test.alg.is_heap_until2, alg.is_heap_until2)
+
+add_executable(alg.is_heap_until3 is_heap_until3.cpp)
+add_test(test.alg.is_heap_until3, alg.is_heap_until3)
+
+add_executable(alg.is_heap_until4 is_heap_until4.cpp)
+add_test(test.alg.is_heap_until4, alg.is_heap_until4)
+
 
 add_executable(alg.is_partitioned is_partitioned.cpp)
 add_test(test.alg.is_partitioned, alg.is_partitioned)
@@ -191,11 +210,35 @@ add_test(test.alg.set_difference1, alg.set_difference1)
 add_executable(alg.set_difference2 set_difference2.cpp)
 add_test(test.alg.set_difference2, alg.set_difference2)
 
+add_executable(alg.set_difference3 set_difference3.cpp)
+add_test(test.alg.set_difference3, alg.set_difference3)
+
+add_executable(alg.set_difference4 set_difference4.cpp)
+add_test(test.alg.set_difference4, alg.set_difference4)
+
+add_executable(alg.set_difference5 set_difference5.cpp)
+add_test(test.alg.set_difference5, alg.set_difference5)
+
+add_executable(alg.set_difference6 set_difference6.cpp)
+add_test(test.alg.set_difference6, alg.set_difference6)
+
 add_executable(alg.set_intersection1 set_intersection1.cpp)
 add_test(test.alg.set_intersection1, alg.set_intersection1)
 
 add_executable(alg.set_intersection2 set_intersection2.cpp)
 add_test(test.alg.set_intersection2, alg.set_intersection2)
+
+add_executable(alg.set_intersection3 set_intersection3.cpp)
+add_test(test.alg.set_intersection3, alg.set_intersection3)
+
+add_executable(alg.set_intersection4 set_intersection4.cpp)
+add_test(test.alg.set_intersection4, alg.set_intersection4)
+
+add_executable(alg.set_intersection5 set_intersection5.cpp)
+add_test(test.alg.set_intersection5, alg.set_intersection5)
+
+add_executable(alg.set_intersection6 set_intersection6.cpp)
+add_test(test.alg.set_intersection6, alg.set_intersection6)
 
 add_executable(alg.set_symmetric_difference1 set_symmetric_difference1.cpp)
 add_test(test.alg.set_symmetric_difference1, alg.set_symmetric_difference1)
@@ -203,11 +246,35 @@ add_test(test.alg.set_symmetric_difference1, alg.set_symmetric_difference1)
 add_executable(alg.set_symmetric_difference2 set_symmetric_difference2.cpp)
 add_test(test.alg.set_symmetric_difference2, alg.set_symmetric_difference2)
 
+add_executable(alg.set_symmetric_difference3 set_symmetric_difference3.cpp)
+add_test(test.alg.set_symmetric_difference3, alg.set_symmetric_difference3)
+
+add_executable(alg.set_symmetric_difference4 set_symmetric_difference4.cpp)
+add_test(test.alg.set_symmetric_difference4, alg.set_symmetric_difference4)
+
+add_executable(alg.set_symmetric_difference5 set_symmetric_difference5.cpp)
+add_test(test.alg.set_symmetric_difference5, alg.set_symmetric_difference5)
+
+add_executable(alg.set_symmetric_difference6 set_symmetric_difference6.cpp)
+add_test(test.alg.set_symmetric_difference6, alg.set_symmetric_difference6)
+
 add_executable(alg.set_union1 set_union1.cpp)
 add_test(test.alg.set_union1, alg.set_union1)
 
 add_executable(alg.set_union2 set_union2.cpp)
 add_test(test.alg.set_union2, alg.set_union2)
+
+add_executable(alg.set_union3 set_union3.cpp)
+add_test(test.alg.set_union3, alg.set_union3)
+
+add_executable(alg.set_union4 set_union4.cpp)
+add_test(test.alg.set_union4, alg.set_union4)
+
+add_executable(alg.set_union5 set_union5.cpp)
+add_test(test.alg.set_union5, alg.set_union5)
+
+add_executable(alg.set_union6 set_union6.cpp)
+add_test(test.alg.set_union6, alg.set_union6)
 
 add_executable(alg.shuffle shuffle.cpp)
 add_test(test.alg.shuffle, alg.shuffle)

--- a/test/algorithm/is_heap.hpp
+++ b/test/algorithm/is_heap.hpp
@@ -34,8 +34,12 @@
 
 void test()
 {
-    auto is_heap = make_testable_1(ranges::is_heap);
 
+#if defined(IS_HEAP_1) || defined(IS_HEAP_2)
+    auto is_heap = make_testable_1(ranges::is_heap);
+#endif
+
+#ifdef IS_HEAP_1
     int i1[] = {0, 0};
     is_heap(i1, i1).check([&](bool r){ CHECK(r); });
     is_heap(i1, i1+1).check([&](bool r){ CHECK(r == (std::is_heap_until(i1, i1+1) == i1+1)); });
@@ -276,6 +280,8 @@ void test()
     is_heap(i117, i117+6).check([&](bool r){ CHECK(r == (std::is_heap_until(i117, i117+6) == i117+6)); });
     is_heap(i118, i118+6).check([&](bool r){ CHECK(r == (std::is_heap_until(i118, i118+6) == i118+6)); });
     is_heap(i119, i119+6).check([&](bool r){ CHECK(r == (std::is_heap_until(i119, i119+6) == i119+6)); });
+#endif
+#ifdef IS_HEAP_2
     int i120[] = {0, 0, 0, 0, 0, 0, 0};
     int i121[] = {0, 0, 0, 0, 0, 0, 1};
     int i122[] = {0, 0, 0, 0, 0, 1, 0};
@@ -530,12 +536,16 @@ void test()
     is_heap(i244, i244+7).check([&](bool r){ CHECK(r == (std::is_heap_until(i244, i244+7) == i244+7)); });
     is_heap(i245, i245+7).check([&](bool r){ CHECK(r == (std::is_heap_until(i245, i245+7) == i245+7)); });
     is_heap(i246, i246+7).check([&](bool r){ CHECK(r == (std::is_heap_until(i246, i246+7) == i246+7)); });
+#endif
 }
 
 void test_comp()
 {
+#if defined(IS_HEAP_3) || defined(IS_HEAP_4)
     auto is_heap = make_testable_1(ranges::is_heap);
+#endif
 
+#ifdef IS_HEAP_3
     int i1[] = {0, 0};
     is_heap(i1, i1, std::greater<int>()).check([&](bool r){ CHECK(r); });
     is_heap(i1, i1+1, std::greater<int>()).check([&](bool r){ CHECK(r == (std::is_heap_until(i1, i1+1, std::greater<int>()) == i1+1)); });
@@ -776,6 +786,8 @@ void test_comp()
     is_heap(i117, i117+6, std::greater<int>()).check([&](bool r){ CHECK(r == (std::is_heap_until(i117, i117+6, std::greater<int>()) == i117+6)); });
     is_heap(i118, i118+6, std::greater<int>()).check([&](bool r){ CHECK(r == (std::is_heap_until(i118, i118+6, std::greater<int>()) == i118+6)); });
     is_heap(i119, i119+6, std::greater<int>()).check([&](bool r){ CHECK(r == (std::is_heap_until(i119, i119+6, std::greater<int>()) == i119+6)); });
+#endif
+#ifdef IS_HEAP_4
     int i120[] = {0, 0, 0, 0, 0, 0, 0};
     int i121[] = {0, 0, 0, 0, 0, 0, 1};
     int i122[] = {0, 0, 0, 0, 0, 1, 0};
@@ -1030,6 +1042,7 @@ void test_comp()
     is_heap(i244, i244+7, std::greater<int>()).check([&](bool r){ CHECK(r == (std::is_heap_until(i244, i244+7, std::greater<int>()) == i244+7)); });
     is_heap(i245, i245+7, std::greater<int>()).check([&](bool r){ CHECK(r == (std::is_heap_until(i245, i245+7, std::greater<int>()) == i245+7)); });
     is_heap(i246, i246+7, std::greater<int>()).check([&](bool r){ CHECK(r == (std::is_heap_until(i246, i246+7, std::greater<int>()) == i246+7)); });
+#endif
 }
 
 struct S

--- a/test/algorithm/is_heap1.cpp
+++ b/test/algorithm/is_heap1.cpp
@@ -1,0 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#define IS_HEAP_1
+#include "./is_heap.hpp"

--- a/test/algorithm/is_heap2.cpp
+++ b/test/algorithm/is_heap2.cpp
@@ -1,0 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#define IS_HEAP_2
+#include "./is_heap.hpp"

--- a/test/algorithm/is_heap3.cpp
+++ b/test/algorithm/is_heap3.cpp
@@ -1,0 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#define IS_HEAP_3
+#include "./is_heap.hpp"

--- a/test/algorithm/is_heap4.cpp
+++ b/test/algorithm/is_heap4.cpp
@@ -1,0 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#define IS_HEAP_4
+#include "./is_heap.hpp"

--- a/test/algorithm/is_heap_until.hpp
+++ b/test/algorithm/is_heap_until.hpp
@@ -33,8 +33,8 @@
 
 void test()
 {
+#ifdef IS_HEAP_UNTIL_1
     auto is_heap_until = make_testable_1(ranges::is_heap_until);
-
     int i1[] = {0, 0};
     is_heap_until(i1, i1).check([&](int*r){CHECK(r == i1);});
 
@@ -277,6 +277,9 @@ void test()
     is_heap_until(i117, i117+6).check([&](int *r){ CHECK(r == i117+6); });
     is_heap_until(i118, i118+6).check([&](int *r){ CHECK(r == i118+6); });
     is_heap_until(i119, i119+6).check([&](int *r){ CHECK(r == i119+6); });
+#endif
+#ifdef IS_HEAP_UNTIL_2
+    auto is_heap_until = make_testable_1(ranges::is_heap_until);
     int i120[] = {0, 0, 0, 0, 0, 0, 0};
     int i121[] = {0, 0, 0, 0, 0, 0, 1};
     int i122[] = {0, 0, 0, 0, 0, 1, 0};
@@ -531,12 +534,13 @@ void test()
     is_heap_until(i244, i244+7).check([&](int *r){ CHECK(r == i244+7); });
     is_heap_until(i245, i245+7).check([&](int *r){ CHECK(r == i245+7); });
     is_heap_until(i246, i246+7).check([&](int *r){ CHECK(r == i246+7); });
+#endif
 }
 
 void test_pred()
 {
+#ifdef IS_HEAP_UNTIL_3
     auto is_heap_until = ::make_testable_1(ranges::is_heap_until);
-
     int i1[] = {0, 0};
     is_heap_until(i1, i1, std::greater<int>()).check([&](int *r){ CHECK(r == i1); });
     is_heap_until(i1, i1+1, std::greater<int>()).check([&](int *r){ CHECK(r == i1+1); });
@@ -777,6 +781,9 @@ void test_pred()
     is_heap_until(i117, i117+6, std::greater<int>()).check([&](int *r){ CHECK(r == i117+4); });
     is_heap_until(i118, i118+6, std::greater<int>()).check([&](int *r){ CHECK(r == i118+4); });
     is_heap_until(i119, i119+6, std::greater<int>()).check([&](int *r){ CHECK(r == i119+5); });
+#endif
+#ifdef IS_HEAP_UNTIL_4
+    auto is_heap_until = ::make_testable_1(ranges::is_heap_until);
     int i120[] = {0, 0, 0, 0, 0, 0, 0};
     int i121[] = {0, 0, 0, 0, 0, 0, 1};
     int i122[] = {0, 0, 0, 0, 0, 1, 0};
@@ -1031,6 +1038,7 @@ void test_pred()
     is_heap_until(i244, i244+7, std::greater<int>()).check([&](int *r){ CHECK(r == i244+5); });
     is_heap_until(i245, i245+7, std::greater<int>()).check([&](int *r){ CHECK(r == i245+5); });
     is_heap_until(i246, i246+7, std::greater<int>()).check([&](int *r){ CHECK(r == i246+6); });
+#endif
 }
 
 struct S

--- a/test/algorithm/is_heap_until1.cpp
+++ b/test/algorithm/is_heap_until1.cpp
@@ -1,0 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#define IS_HEAP_UNTIL_1
+#include "./is_heap_until.hpp"

--- a/test/algorithm/is_heap_until2.cpp
+++ b/test/algorithm/is_heap_until2.cpp
@@ -1,0 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#define IS_HEAP_UNTIL_2
+#include "./is_heap_until.hpp"

--- a/test/algorithm/is_heap_until3.cpp
+++ b/test/algorithm/is_heap_until3.cpp
@@ -1,0 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#define IS_HEAP_UNTIL_3
+#include "./is_heap_until.hpp"

--- a/test/algorithm/is_heap_until4.cpp
+++ b/test/algorithm/is_heap_until4.cpp
@@ -1,0 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#define IS_HEAP_UNTIL_4
+#include "./is_heap_until.hpp"

--- a/test/algorithm/set_difference.hpp
+++ b/test/algorithm/set_difference.hpp
@@ -156,7 +156,8 @@ int main()
     test<input_iterator<const int*>, const int*, bidirectional_iterator<int*> >();
     test<input_iterator<const int*>, const int*, random_access_iterator<int*> >();
     test<input_iterator<const int*>, const int*, int*>();
-
+#endif
+#ifdef SET_DIFFERENCE_2
     test<forward_iterator<const int*>, input_iterator<const int*>, output_iterator<int*> >();
     test<forward_iterator<const int*>, input_iterator<const int*>, forward_iterator<int*> >();
     test<forward_iterator<const int*>, input_iterator<const int*>, bidirectional_iterator<int*> >();
@@ -186,9 +187,10 @@ int main()
     test<forward_iterator<const int*>, const int*, bidirectional_iterator<int*> >();
     test<forward_iterator<const int*>, const int*, random_access_iterator<int*> >();
     test<forward_iterator<const int*>, const int*, int*>();
-
+#endif
+#ifdef SET_DIFFERENCE_3
     test<bidirectional_iterator<const int*>, input_iterator<const int*>, output_iterator<int*> >();
-    test<bidirectional_iterator<const int*>, input_iterator<const int*>, bidirectional_iterator<int*> >();
+    test<bidirectional_iterator<const int*>, input_iterator<const int*>, forward_iterator<int*> >();
     test<bidirectional_iterator<const int*>, input_iterator<const int*>, bidirectional_iterator<int*> >();
     test<bidirectional_iterator<const int*>, input_iterator<const int*>, random_access_iterator<int*> >();
     test<bidirectional_iterator<const int*>, input_iterator<const int*>, int*>();
@@ -198,9 +200,7 @@ int main()
     test<bidirectional_iterator<const int*>, forward_iterator<const int*>, bidirectional_iterator<int*> >();
     test<bidirectional_iterator<const int*>, forward_iterator<const int*>, random_access_iterator<int*> >();
     test<bidirectional_iterator<const int*>, forward_iterator<const int*>, int*>();
-#endif
 
-#ifdef SET_DIFFERENCE_2
     test<bidirectional_iterator<const int*>, bidirectional_iterator<const int*>, output_iterator<int*> >();
     test<bidirectional_iterator<const int*>, bidirectional_iterator<const int*>, forward_iterator<int*> >();
     test<bidirectional_iterator<const int*>, bidirectional_iterator<const int*>, bidirectional_iterator<int*> >();
@@ -218,9 +218,10 @@ int main()
     test<bidirectional_iterator<const int*>, const int*, bidirectional_iterator<int*> >();
     test<bidirectional_iterator<const int*>, const int*, random_access_iterator<int*> >();
     test<bidirectional_iterator<const int*>, const int*, int*>();
-
+#endif
+#ifdef SET_DIFFERENCE_4
     test<random_access_iterator<const int*>, input_iterator<const int*>, output_iterator<int*> >();
-    test<random_access_iterator<const int*>, input_iterator<const int*>, bidirectional_iterator<int*> >();
+    test<random_access_iterator<const int*>, input_iterator<const int*>, forward_iterator<int*> >();
     test<random_access_iterator<const int*>, input_iterator<const int*>, bidirectional_iterator<int*> >();
     test<random_access_iterator<const int*>, input_iterator<const int*>, random_access_iterator<int*> >();
     test<random_access_iterator<const int*>, input_iterator<const int*>, int*>();
@@ -248,7 +249,8 @@ int main()
     test<random_access_iterator<const int*>, const int*, bidirectional_iterator<int*> >();
     test<random_access_iterator<const int*>, const int*, random_access_iterator<int*> >();
     test<random_access_iterator<const int*>, const int*, int*>();
-
+#endif
+#ifdef SET_DIFFERENCE_5
     test<const int*, input_iterator<const int*>, output_iterator<int*> >();
     test<const int*, input_iterator<const int*>, bidirectional_iterator<int*> >();    test<const int*, input_iterator<const int*>, bidirectional_iterator<int*> >();
     test<const int*, input_iterator<const int*>, random_access_iterator<int*> >();
@@ -277,7 +279,8 @@ int main()
     test<const int*, const int*, bidirectional_iterator<int*> >();
     test<const int*, const int*, random_access_iterator<int*> >();
     test<const int*, const int*, int*>();
-
+#endif
+#ifdef SET_DIFFERENCE_6
     // Test projections
     {
         S ia[] = {S{1}, S{2}, S{2}, S{3}, S{3}, S{3}, S{4}, S{4}, S{4}, S{4}};

--- a/test/algorithm/set_difference3.cpp
+++ b/test/algorithm/set_difference3.cpp
@@ -1,0 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#define SET_DIFFERENCE_3
+#include "./set_difference.hpp"

--- a/test/algorithm/set_difference4.cpp
+++ b/test/algorithm/set_difference4.cpp
@@ -1,0 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#define SET_DIFFERENCE_4
+#include "./set_difference.hpp"

--- a/test/algorithm/set_difference5.cpp
+++ b/test/algorithm/set_difference5.cpp
@@ -1,0 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#define SET_DIFFERENCE_5
+#include "./set_difference.hpp"

--- a/test/algorithm/set_difference6.cpp
+++ b/test/algorithm/set_difference6.cpp
@@ -1,0 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#define SET_DIFFERENCE_6
+#include "./set_difference.hpp"

--- a/test/algorithm/set_intersection.hpp
+++ b/test/algorithm/set_intersection.hpp
@@ -123,7 +123,8 @@ int main()
     test<input_iterator<const int*>, const int*, bidirectional_iterator<int*> >();
     test<input_iterator<const int*>, const int*, random_access_iterator<int*> >();
     test<input_iterator<const int*>, const int*, int*>();
-
+#endif
+#ifdef SET_INTERSECTION_2
     test<forward_iterator<const int*>, input_iterator<const int*>, output_iterator<int*> >();
     test<forward_iterator<const int*>, input_iterator<const int*>, forward_iterator<int*> >();
     test<forward_iterator<const int*>, input_iterator<const int*>, bidirectional_iterator<int*> >();
@@ -153,9 +154,10 @@ int main()
     test<forward_iterator<const int*>, const int*, bidirectional_iterator<int*> >();
     test<forward_iterator<const int*>, const int*, random_access_iterator<int*> >();
     test<forward_iterator<const int*>, const int*, int*>();
-
+#endif
+#ifdef SET_INTERSECTION_3
     test<bidirectional_iterator<const int*>, input_iterator<const int*>, output_iterator<int*> >();
-    test<bidirectional_iterator<const int*>, input_iterator<const int*>, bidirectional_iterator<int*> >();
+    test<bidirectional_iterator<const int*>, input_iterator<const int*>, forward_iterator<int*> >();
     test<bidirectional_iterator<const int*>, input_iterator<const int*>, bidirectional_iterator<int*> >();
     test<bidirectional_iterator<const int*>, input_iterator<const int*>, random_access_iterator<int*> >();
     test<bidirectional_iterator<const int*>, input_iterator<const int*>, int*>();
@@ -165,9 +167,7 @@ int main()
     test<bidirectional_iterator<const int*>, forward_iterator<const int*>, bidirectional_iterator<int*> >();
     test<bidirectional_iterator<const int*>, forward_iterator<const int*>, random_access_iterator<int*> >();
     test<bidirectional_iterator<const int*>, forward_iterator<const int*>, int*>();
-#endif
 
-#ifdef SET_INTERSECTION_2
     test<bidirectional_iterator<const int*>, bidirectional_iterator<const int*>, output_iterator<int*> >();
     test<bidirectional_iterator<const int*>, bidirectional_iterator<const int*>, forward_iterator<int*> >();
     test<bidirectional_iterator<const int*>, bidirectional_iterator<const int*>, bidirectional_iterator<int*> >();
@@ -185,9 +185,10 @@ int main()
     test<bidirectional_iterator<const int*>, const int*, bidirectional_iterator<int*> >();
     test<bidirectional_iterator<const int*>, const int*, random_access_iterator<int*> >();
     test<bidirectional_iterator<const int*>, const int*, int*>();
-
+#endif
+#ifdef SET_INTERSECTION_4
     test<random_access_iterator<const int*>, input_iterator<const int*>, output_iterator<int*> >();
-    test<random_access_iterator<const int*>, input_iterator<const int*>, bidirectional_iterator<int*> >();
+    test<random_access_iterator<const int*>, input_iterator<const int*>, forward_iterator<int*> >();
     test<random_access_iterator<const int*>, input_iterator<const int*>, bidirectional_iterator<int*> >();
     test<random_access_iterator<const int*>, input_iterator<const int*>, random_access_iterator<int*> >();
     test<random_access_iterator<const int*>, input_iterator<const int*>, int*>();
@@ -215,7 +216,8 @@ int main()
     test<random_access_iterator<const int*>, const int*, bidirectional_iterator<int*> >();
     test<random_access_iterator<const int*>, const int*, random_access_iterator<int*> >();
     test<random_access_iterator<const int*>, const int*, int*>();
-
+#endif
+#ifdef SET_INTERSECTION_5
     test<const int*, input_iterator<const int*>, output_iterator<int*> >();
     test<const int*, input_iterator<const int*>, bidirectional_iterator<int*> >();
     test<const int*, input_iterator<const int*>, bidirectional_iterator<int*> >();
@@ -245,7 +247,8 @@ int main()
     test<const int*, const int*, bidirectional_iterator<int*> >();
     test<const int*, const int*, random_access_iterator<int*> >();
     test<const int*, const int*, int*>();
-
+#endif
+#ifdef SET_INTERSECTION_6
     // Test projections
     {
         S ia[] = {S{1}, S{2}, S{2}, S{3}, S{3}, S{3}, S{4}, S{4}, S{4}, S{4}};

--- a/test/algorithm/set_intersection3.cpp
+++ b/test/algorithm/set_intersection3.cpp
@@ -1,0 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#define SET_INTERSECTION_3
+#include "./set_intersection.hpp"

--- a/test/algorithm/set_intersection4.cpp
+++ b/test/algorithm/set_intersection4.cpp
@@ -1,0 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#define SET_INTERSECTION_4
+#include "./set_intersection.hpp"

--- a/test/algorithm/set_intersection5.cpp
+++ b/test/algorithm/set_intersection5.cpp
@@ -1,0 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#define SET_INTERSECTION_5
+#include "./set_intersection.hpp"

--- a/test/algorithm/set_intersection6.cpp
+++ b/test/algorithm/set_intersection6.cpp
@@ -1,0 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#define SET_INTERSECTION_6
+#include "./set_intersection.hpp"

--- a/test/algorithm/set_symmetric_difference.hpp
+++ b/test/algorithm/set_symmetric_difference.hpp
@@ -150,7 +150,8 @@ int main()
     test<input_iterator<const int*>, const int*, bidirectional_iterator<int*> >();
     test<input_iterator<const int*>, const int*, random_access_iterator<int*> >();
     test<input_iterator<const int*>, const int*, int*>();
-
+#endif
+#ifdef SET_SYMMETRIC_DIFFERENCE_2
     test<forward_iterator<const int*>, input_iterator<const int*>, output_iterator<int*> >();
     test<forward_iterator<const int*>, input_iterator<const int*>, forward_iterator<int*> >();
     test<forward_iterator<const int*>, input_iterator<const int*>, bidirectional_iterator<int*> >();
@@ -180,9 +181,10 @@ int main()
     test<forward_iterator<const int*>, const int*, bidirectional_iterator<int*> >();
     test<forward_iterator<const int*>, const int*, random_access_iterator<int*> >();
     test<forward_iterator<const int*>, const int*, int*>();
-
+#endif
+#ifdef SET_SYMMETRIC_DIFFERENCE_3
     test<bidirectional_iterator<const int*>, input_iterator<const int*>, output_iterator<int*> >();
-    test<bidirectional_iterator<const int*>, input_iterator<const int*>, bidirectional_iterator<int*> >();
+    test<bidirectional_iterator<const int*>, input_iterator<const int*>, forward_iterator<int*> >();
     test<bidirectional_iterator<const int*>, input_iterator<const int*>, bidirectional_iterator<int*> >();
     test<bidirectional_iterator<const int*>, input_iterator<const int*>, random_access_iterator<int*> >();
     test<bidirectional_iterator<const int*>, input_iterator<const int*>, int*>();
@@ -198,9 +200,7 @@ int main()
     test<bidirectional_iterator<const int*>, bidirectional_iterator<const int*>, bidirectional_iterator<int*> >();
     test<bidirectional_iterator<const int*>, bidirectional_iterator<const int*>, random_access_iterator<int*> >();
     test<bidirectional_iterator<const int*>, bidirectional_iterator<const int*>, int*>();
-#endif
 
-#ifdef SET_SYMMETRIC_DIFFERENCE_2
     test<bidirectional_iterator<const int*>, random_access_iterator<const int*>, output_iterator<int*> >();
     test<bidirectional_iterator<const int*>, random_access_iterator<const int*>, forward_iterator<int*> >();
     test<bidirectional_iterator<const int*>, random_access_iterator<const int*>, bidirectional_iterator<int*> >();
@@ -212,9 +212,10 @@ int main()
     test<bidirectional_iterator<const int*>, const int*, bidirectional_iterator<int*> >();
     test<bidirectional_iterator<const int*>, const int*, random_access_iterator<int*> >();
     test<bidirectional_iterator<const int*>, const int*, int*>();
-
+#endif
+#ifdef SET_SYMMETRIC_DIFFERENCE_4
     test<random_access_iterator<const int*>, input_iterator<const int*>, output_iterator<int*> >();
-    test<random_access_iterator<const int*>, input_iterator<const int*>, bidirectional_iterator<int*> >();
+    test<random_access_iterator<const int*>, input_iterator<const int*>, forward_iterator<int*> >();
     test<random_access_iterator<const int*>, input_iterator<const int*>, bidirectional_iterator<int*> >();
     test<random_access_iterator<const int*>, input_iterator<const int*>, random_access_iterator<int*> >();
     test<random_access_iterator<const int*>, input_iterator<const int*>, int*>();
@@ -242,7 +243,8 @@ int main()
     test<random_access_iterator<const int*>, const int*, bidirectional_iterator<int*> >();
     test<random_access_iterator<const int*>, const int*, random_access_iterator<int*> >();
     test<random_access_iterator<const int*>, const int*, int*>();
-
+#endif
+#ifdef SET_SYMMETRIC_DIFFERENCE_5
     test<const int*, input_iterator<const int*>, output_iterator<int*> >();
     test<const int*, input_iterator<const int*>, bidirectional_iterator<int*> >();
     test<const int*, input_iterator<const int*>, bidirectional_iterator<int*> >();
@@ -272,7 +274,8 @@ int main()
     test<const int*, const int*, bidirectional_iterator<int*> >();
     test<const int*, const int*, random_access_iterator<int*> >();
     test<const int*, const int*, int*>();
-
+#endif
+#ifdef SET_SYMMETRIC_DIFFERENCE_6
     // Test projections
     {
         S ia[] = {S{1}, S{2}, S{2}, S{3}, S{3}, S{3}, S{4}, S{4}, S{4}, S{4}};

--- a/test/algorithm/set_symmetric_difference3.cpp
+++ b/test/algorithm/set_symmetric_difference3.cpp
@@ -1,0 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#define SET_SYMMETRIC_DIFFERENCE_3
+#include "./set_symmetric_difference.hpp"

--- a/test/algorithm/set_symmetric_difference4.cpp
+++ b/test/algorithm/set_symmetric_difference4.cpp
@@ -1,0 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#define SET_SYMMETRIC_DIFFERENCE_4
+#include "./set_symmetric_difference.hpp"

--- a/test/algorithm/set_symmetric_difference5.cpp
+++ b/test/algorithm/set_symmetric_difference5.cpp
@@ -1,0 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#define SET_SYMMETRIC_DIFFERENCE_5
+#include "./set_symmetric_difference.hpp"

--- a/test/algorithm/set_symmetric_difference6.cpp
+++ b/test/algorithm/set_symmetric_difference6.cpp
@@ -1,0 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#define SET_SYMMETRIC_DIFFERENCE_6
+#include "./set_symmetric_difference.hpp"

--- a/test/algorithm/set_union.hpp
+++ b/test/algorithm/set_union.hpp
@@ -110,7 +110,8 @@ int main()
     test<input_iterator<const int*>, const int*, bidirectional_iterator<int*> >();
     test<input_iterator<const int*>, const int*, random_access_iterator<int*> >();
     test<input_iterator<const int*>, const int*, int*>();
-
+#endif
+#ifdef SET_UNION_2
     test<forward_iterator<const int*>, input_iterator<const int*>, output_iterator<int*> >();
     test<forward_iterator<const int*>, input_iterator<const int*>, forward_iterator<int*> >();
     test<forward_iterator<const int*>, input_iterator<const int*>, bidirectional_iterator<int*> >();
@@ -140,9 +141,10 @@ int main()
     test<forward_iterator<const int*>, const int*, bidirectional_iterator<int*> >();
     test<forward_iterator<const int*>, const int*, random_access_iterator<int*> >();
     test<forward_iterator<const int*>, const int*, int*>();
-
+#endif
+#ifdef SET_UNION_3
     test<bidirectional_iterator<const int*>, input_iterator<const int*>, output_iterator<int*> >();
-    test<bidirectional_iterator<const int*>, input_iterator<const int*>, bidirectional_iterator<int*> >();
+    test<bidirectional_iterator<const int*>, input_iterator<const int*>, forward_iterator<int*> >();
     test<bidirectional_iterator<const int*>, input_iterator<const int*>, bidirectional_iterator<int*> >();
     test<bidirectional_iterator<const int*>, input_iterator<const int*>, random_access_iterator<int*> >();
     test<bidirectional_iterator<const int*>, input_iterator<const int*>, int*>();
@@ -152,9 +154,7 @@ int main()
     test<bidirectional_iterator<const int*>, forward_iterator<const int*>, bidirectional_iterator<int*> >();
     test<bidirectional_iterator<const int*>, forward_iterator<const int*>, random_access_iterator<int*> >();
     test<bidirectional_iterator<const int*>, forward_iterator<const int*>, int*>();
-#endif
 
-#ifdef SET_UNION_2
     test<bidirectional_iterator<const int*>, bidirectional_iterator<const int*>, output_iterator<int*> >();
     test<bidirectional_iterator<const int*>, bidirectional_iterator<const int*>, forward_iterator<int*> >();
     test<bidirectional_iterator<const int*>, bidirectional_iterator<const int*>, bidirectional_iterator<int*> >();
@@ -172,9 +172,10 @@ int main()
     test<bidirectional_iterator<const int*>, const int*, bidirectional_iterator<int*> >();
     test<bidirectional_iterator<const int*>, const int*, random_access_iterator<int*> >();
     test<bidirectional_iterator<const int*>, const int*, int*>();
-
+#endif
+#ifdef SET_UNION_4
     test<random_access_iterator<const int*>, input_iterator<const int*>, output_iterator<int*> >();
-    test<random_access_iterator<const int*>, input_iterator<const int*>, bidirectional_iterator<int*> >();
+    test<random_access_iterator<const int*>, input_iterator<const int*>, forward_iterator<int*> >();
     test<random_access_iterator<const int*>, input_iterator<const int*>, bidirectional_iterator<int*> >();
     test<random_access_iterator<const int*>, input_iterator<const int*>, random_access_iterator<int*> >();
     test<random_access_iterator<const int*>, input_iterator<const int*>, int*>();
@@ -202,7 +203,8 @@ int main()
     test<random_access_iterator<const int*>, const int*, bidirectional_iterator<int*> >();
     test<random_access_iterator<const int*>, const int*, random_access_iterator<int*> >();
     test<random_access_iterator<const int*>, const int*, int*>();
-
+#endif
+#ifdef SET_UNION_5
     test<const int*, input_iterator<const int*>, output_iterator<int*> >();
     test<const int*, input_iterator<const int*>, bidirectional_iterator<int*> >();
     test<const int*, input_iterator<const int*>, bidirectional_iterator<int*> >();
@@ -232,7 +234,8 @@ int main()
     test<const int*, const int*, bidirectional_iterator<int*> >();
     test<const int*, const int*, random_access_iterator<int*> >();
     test<const int*, const int*, int*>();
-
+#endif
+#ifdef SET_UNION_6
     // Test projections
     {
         S ia[] = {S{1}, S{2}, S{2}, S{3}, S{3}, S{3}, S{4}, S{4}, S{4}, S{4}};

--- a/test/algorithm/set_union3.cpp
+++ b/test/algorithm/set_union3.cpp
@@ -1,0 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#define SET_UNION_3
+#include "./set_union.hpp"

--- a/test/algorithm/set_union4.cpp
+++ b/test/algorithm/set_union4.cpp
@@ -1,0 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#define SET_UNION_4
+#include "./set_union.hpp"

--- a/test/algorithm/set_union5.cpp
+++ b/test/algorithm/set_union5.cpp
@@ -1,0 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#define SET_UNION_5
+#include "./set_union.hpp"

--- a/test/algorithm/set_union6.cpp
+++ b/test/algorithm/set_union6.cpp
@@ -1,0 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#define SET_UNION_6
+#include "./set_union.hpp"

--- a/test/view/join.cpp
+++ b/test/view/join.cpp
@@ -11,7 +11,7 @@
 
 // Work around strange glibc bug(?)
 #include <iosfwd>
-#if __cplusplus >= 201402L && defined(__GLIBCXX__)
+#if defined(RANGES_CXX_GREATER_THAN_11) && defined(__GLIBCXX__)
 int gets;
 #endif
 


### PR DESCRIPTION
- adds macros to detect the language version:
    - RANGES_CXX_GREATER_THAN_11 for C++>11 (e.g. C++14/17/...)
    - RANGES_CXX_GREATER_THAN_14 for C++>14 (e.g. C++17/...)

- adds macro to enable relaxed constexpr support in C++>11:
    - RANGES_CXX14_CONSTEXPR (in the spirit of BOOST_CXX14_CONSTEXPR)
    - Note: constexpr implies inline, so the macro is defined to
      inline in C++11 to retain the same visibility.

- add CMake option to choose with which language std the tests should be
  compiled:
    - DRANGES_CXX_STD=value, where "value" is the revision of the
      standard (value={11,14,17,1y,1z}) and defaults to 11. It is
      used to set the compiler-flag "-std=c++value".

- extend the travis test matrix to:
    - test in both C++11 and C++14
    - test multiple versions of clang starting at the minimum
      supported version: 3.4, 3.5, 3.6, trunk.
    - test with gcc 4.9
    - run all test of release builds under valgrind

- set algorithm tests:
    - further subdivide set algorithm tests (set_difference,
      set_intersection, set_symmetric_difference, and set_union)
      to avoid memory errors under travis.
    - fixed a bug in all the set algorithm tests where a
      bidirectional iterator was being tested twice instead of
      also testing forward iterators.