### PR TITLE
enable relaxed constexpr in core

### DIFF
--- a/include/range/v3/at.hpp
+++ b/include/range/v3/at.hpp
@@ -30,6 +30,7 @@ namespace ranges
             /// \return `begin(rng)[n]`
             template<typename Rng,
                 CONCEPT_REQUIRES_(RandomAccessIterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             auto operator()(Rng &&rng, range_difference_t<Rng> n) const ->
                 decltype(begin(rng)[n])
             {

--- a/include/range/v3/back.hpp
+++ b/include/range/v3/back.hpp
@@ -31,6 +31,7 @@ namespace ranges
             /// \return `*prev(end(rng))`
             template<typename Rng,
                 CONCEPT_REQUIRES_(BoundedIterable<Rng>() && BidirectionalIterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             range_reference_t<Rng> operator()(Rng &&rng) const
             {
                 return *prev(end(rng));

--- a/include/range/v3/begin_end.hpp
+++ b/include/range/v3/begin_end.hpp
@@ -21,6 +21,7 @@
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/utility/static_const.hpp>
 #include <range/v3/utility/dangling.hpp>
+#include <range/v3/utility/iterator.hpp>
 
 namespace ranges
 {
@@ -192,6 +193,18 @@ namespace ranges
                 {
                     return rbegin_fn::impl(static_cast<Rng &&>(rng), 0);
                 }
+                template<typename T, std::size_t N>
+                constexpr
+                ranges::reverse_iterator<T*> operator()(T (&t)[N]) const noexcept
+                {
+                    return ranges::reverse_iterator<T*>(t + N);
+                }
+                template<typename T>
+                constexpr
+                ranges::reverse_iterator<T const*> operator()(std::initializer_list<T> il) const noexcept
+                {
+                    return ranges::reverse_iterator<T const*>(il.end());
+                }
             };
 
             struct rend_fn
@@ -219,6 +232,18 @@ namespace ranges
                     decltype(rend_fn::impl(static_cast<Rng &&>(rng), 0))
                 {
                     return rend_fn::impl(static_cast<Rng &&>(rng), 0);
+                }
+                template<typename T, std::size_t N>
+                constexpr
+                ranges::reverse_iterator<T*> operator()(T (&t)[N]) const noexcept
+                {
+                    return ranges::reverse_iterator<T*>(t);
+                }
+                template<typename T>
+                constexpr
+                ranges::reverse_iterator<T const*> operator()(std::initializer_list<T> il) const noexcept
+                {
+                    return ranges::reverse_iterator<T const*>(il.begin());
                 }
             };
 

--- a/include/range/v3/empty.hpp
+++ b/include/range/v3/empty.hpp
@@ -29,6 +29,7 @@ namespace ranges
             /// \return `begin(rng) == end(rng)`
             template<typename Rng,
                 CONCEPT_REQUIRES_(Iterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             bool operator()(Rng &&rng) const
             {
                 return begin(rng) == end(rng);

--- a/include/range/v3/front.hpp
+++ b/include/range/v3/front.hpp
@@ -31,6 +31,7 @@ namespace ranges
             /// \return `*begin(rng)`
             template<typename Rng,
                 CONCEPT_REQUIRES_(Iterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             range_reference_t<Rng> operator()(Rng &&rng) const
             {
                 return *begin(rng);

--- a/include/range/v3/range_access.hpp
+++ b/include/range/v3/range_access.hpp
@@ -82,63 +82,63 @@ namespace ranges
             };
 
             template<typename Rng>
-            static auto begin_cursor(Rng & rng, long)
+            static RANGES_CXX14_CONSTEXPR auto begin_cursor(Rng & rng, long)
             RANGES_DECLTYPE_AUTO_RETURN
             (
                 rng.begin_cursor()
             )
             template<typename Rng>
-            static auto begin_cursor(Rng & rng, int)
+            static RANGES_CXX14_CONSTEXPR auto begin_cursor(Rng & rng, int)
             RANGES_DECLTYPE_AUTO_RETURN
             (
                 static_cast<Rng const &>(rng).begin_cursor()
             )
             template<typename Rng>
-            static auto end_cursor(Rng & rng, long)
+            static RANGES_CXX14_CONSTEXPR auto end_cursor(Rng & rng, long)
             RANGES_DECLTYPE_AUTO_RETURN
             (
                 rng.end_cursor()
             )
             template<typename Rng>
-            static auto end_cursor(Rng & rng, int)
+            static RANGES_CXX14_CONSTEXPR auto end_cursor(Rng & rng, int)
             RANGES_DECLTYPE_AUTO_RETURN
             (
                 static_cast<Rng const &>(rng).end_cursor()
             )
 
             template<typename Rng>
-            static auto begin_adaptor(Rng & rng, long)
+            static RANGES_CXX14_CONSTEXPR auto begin_adaptor(Rng & rng, long)
             RANGES_DECLTYPE_AUTO_RETURN
             (
                 rng.begin_adaptor()
             )
             template<typename Rng>
-            static auto begin_adaptor(Rng & rng, int)
+            static RANGES_CXX14_CONSTEXPR auto begin_adaptor(Rng & rng, int)
             RANGES_DECLTYPE_AUTO_RETURN
             (
                 static_cast<Rng const &>(rng).begin_adaptor()
             )
             template<typename Rng>
-            static auto end_adaptor(Rng & rng, long)
+            static RANGES_CXX14_CONSTEXPR auto end_adaptor(Rng & rng, long)
             RANGES_DECLTYPE_AUTO_RETURN
             (
                 rng.end_adaptor()
             )
             template<typename Rng>
-            static auto end_adaptor(Rng & rng, int)
+            static RANGES_CXX14_CONSTEXPR auto end_adaptor(Rng & rng, int)
             RANGES_DECLTYPE_AUTO_RETURN
             (
                 static_cast<Rng const &>(rng).end_adaptor()
             )
 
             template<typename Cur>
-            static auto current(Cur const &pos)
+            static RANGES_CXX14_CONSTEXPR auto current(Cur const &pos)
             RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
                 pos.current()
             )
             template<typename Cur>
-            static auto next(Cur & pos)
+            static RANGES_CXX14_CONSTEXPR auto next(Cur & pos)
             RANGES_DECLTYPE_AUTO_RETURN
             (
                 pos.next()
@@ -150,7 +150,7 @@ namespace ranges
                 pos.done()
             )
             template<typename Cur>
-            static auto equal(Cur const &pos0, Cur const &pos1)
+            static RANGES_CXX14_CONSTEXPR auto equal(Cur const &pos0, Cur const &pos1)
             RANGES_DECLTYPE_AUTO_RETURN
             (
                 pos0.equal(pos1)
@@ -162,18 +162,19 @@ namespace ranges
                 end.equal(pos)
             )
             template<typename Cur>
-            static auto prev(Cur & pos)
+            static RANGES_CXX14_CONSTEXPR auto prev(Cur & pos)
             RANGES_DECLTYPE_AUTO_RETURN
             (
                 pos.prev()
             )
             template<typename Cur, typename D>
-            static auto advance(Cur & pos, D n)
+            static RANGES_CXX14_CONSTEXPR auto advance(Cur & pos, D n)
             RANGES_DECLTYPE_AUTO_RETURN
             (
                 pos.advance(n)
             )
             template<typename Cur>
+            RANGES_CXX14_CONSTEXPR
             static auto distance_to(Cur const &pos0, Cur const &pos1)
             RANGES_DECLTYPE_AUTO_RETURN
             (
@@ -242,12 +243,12 @@ namespace ranges
             using single_pass_t = typename single_pass<Cur>::type;
 
             template<typename Cur, typename S>
-            static Cur cursor(basic_iterator<Cur, S> it)
+            static RANGES_CXX14_CONSTEXPR Cur cursor(basic_iterator<Cur, S> it)
             {
                 return std::move(it.pos());
             }
             template<typename S>
-            static S sentinel(basic_sentinel<S> s)
+            static RANGES_CXX14_CONSTEXPR S sentinel(basic_sentinel<S> s)
             {
                 return std::move(s.end());
             }

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -411,6 +411,15 @@ namespace ranges
         using counted_sentinel =
             basic_sentinel<detail::counted_sentinel>;
 
+        namespace detail
+        {
+            template<typename I> struct reverse_cursor;
+        }
+
+        template<typename I>
+        using reverse_iterator = basic_iterator<detail::reverse_cursor<I>,
+                                                detail::reverse_cursor<I>>;
+
         template<typename T>
         struct empty_view;
 

--- a/include/range/v3/size.hpp
+++ b/include/range/v3/size.hpp
@@ -34,6 +34,7 @@ namespace ranges
             }
 
             template<typename Rng>
+            constexpr
             auto size_(Rng && rng, int) ->
                 decltype(rng.size())
             {
@@ -41,6 +42,7 @@ namespace ranges
             }
 
             template<typename Rng>
+            constexpr
             auto size(Rng && rng) ->
                 decltype(adl_size_detail::size_(std::forward<Rng>(rng), 42))
             {
@@ -55,6 +57,7 @@ namespace ranges
             }
 
             template<typename T, bool RValue>
+            constexpr
             auto size(ranges::reference_wrapper<T, RValue> t) -> decltype(size(t.get()))
             {
                 return size(t.get());

--- a/include/range/v3/utility/basic_iterator.hpp
+++ b/include/range/v3/utility/basic_iterator.hpp
@@ -70,7 +70,7 @@ namespace ranges
             {
                 using type = Val;
                 template<typename I>
-                static type apply(I const & i)
+                static RANGES_CXX14_CONSTEXPR type apply(I const & i)
                 {
                     return *i;
                 }
@@ -89,14 +89,17 @@ namespace ranges
                             iterator_value_t<I>,
                             private_>;
                     I const it_;
+                    RANGES_CXX14_CONSTEXPR
                     explicit proxy(I i)
                       : it_(std::move(i))
                     {}
                     friend struct operator_brackets_const_proxy;
                 public:
+                    RANGES_CXX14_CONSTEXPR
                     proxy(proxy const&) = default;
+                    RANGES_CXX14_CONSTEXPR
                     proxy const & operator=(proxy &) const = delete;
-                    operator Ref() const
+                    RANGES_CXX14_CONSTEXPR operator Ref() const
                     {
                         return *it_;
                     }
@@ -105,12 +108,12 @@ namespace ranges
                         return *it_;
                     }
                     CONCEPT_REQUIRES(Convertible<Ref, value_t>())
-                    operator value_t() const
+                    RANGES_CXX14_CONSTEXPR operator value_t() const
                     {
                         return *it_;
                     }
                 };
-                static type apply(I i)
+                static RANGES_CXX14_CONSTEXPR type apply(I i)
                 {
                     return type{std::move(i)};
                 }
@@ -129,12 +132,13 @@ namespace ranges
                             iterator_value_t<I>,
                             private_>;
                     I const it_;
+                    RANGES_CXX14_CONSTEXPR
                     explicit proxy(I i)
                       : it_(std::move(i))
                     {}
                     friend struct operator_brackets_proxy;
                 public:
-                    operator Ref() const
+                    RANGES_CXX14_CONSTEXPR operator Ref() const
                     {
                         return *it_;
                     }
@@ -143,25 +147,29 @@ namespace ranges
                         return *it_;
                     }
                     CONCEPT_REQUIRES(Convertible<Ref, value_t>())
-                    operator value_t() const
+                    RANGES_CXX14_CONSTEXPR operator value_t() const
                     {
                         return *it_;
                     }
+                    RANGES_CXX14_CONSTEXPR
                     proxy (proxy const&) = default;
+                    RANGES_CXX14_CONSTEXPR
                     proxy const & operator=(proxy&) const = delete;
                     // BUGBUG assign from common reference? from rvalue reference?
+                    RANGES_CXX14_CONSTEXPR
                     proxy const & operator=(iterator_value_t<I> const & x) const
                     {
                         *it_ = x;
                         return *this;
                     }
+                    RANGES_CXX14_CONSTEXPR
                     proxy const & operator=(iterator_value_t<I> && x) const
                     {
                         *it_ = std::move(x);
                         return *this;
                     }
                 };
-                static type apply(I i)
+                static RANGES_CXX14_CONSTEXPR type apply(I i)
                 {
                     return type{std::move(i)};
                 }
@@ -190,7 +198,9 @@ namespace ranges
             private:
                 mutable value_type value_;
             public:
+                RANGES_CXX14_CONSTEXPR
                 postfix_increment_proxy() = default;
+                RANGES_CXX14_CONSTEXPR
                 explicit postfix_increment_proxy(I const& x)
                   : value_(*x)
                 {}
@@ -198,7 +208,7 @@ namespace ranges
                 // (*r++).mutate(), but it imposes fewer assumptions about the
                 // behavior of the value_type.  In particular, recall that
                 // (*r).mutate() is legal if operator* returns by value.
-                value_type& operator*() const
+                RANGES_CXX14_CONSTEXPR value_type& operator*() const
                 {
                     return value_;
                 }
@@ -216,7 +226,9 @@ namespace ranges
                 mutable value_type value_;
                 I it_;
             public:
+                RANGES_CXX14_CONSTEXPR
                 writable_postfix_increment_proxy() = default;
+                RANGES_CXX14_CONSTEXPR
                 explicit writable_postfix_increment_proxy(I x)
                   : value_(*x)
                   , it_(std::move(x))
@@ -225,16 +237,19 @@ namespace ranges
                 // value_type(*r++) can work.  In this case, *r is the same as
                 // *r++, and the conversion operator below is used to ensure
                 // readability.
+                RANGES_CXX14_CONSTEXPR
                 writable_postfix_increment_proxy const & operator*() const
                 {
                     return *this;
                 }
                 // So that iter_move(r++) moves the cached value out
+                RANGES_CXX14_CONSTEXPR
                 friend value_type && indirect_move(writable_postfix_increment_proxy const &ref)
                 {
                     return std::move(ref.value_);
                 }
                 // Provides readability of *r++
+                RANGES_CXX14_CONSTEXPR
                 operator value_type &() const
                 {
                     return value_;
@@ -242,6 +257,7 @@ namespace ranges
                 // Provides writability of *r++
                 template<typename T,
                     CONCEPT_REQUIRES_(Writable<I, T>())>
+                RANGES_CXX14_CONSTEXPR
                 void operator=(T const &x) const
                 {
                     *it_ = x;
@@ -249,17 +265,20 @@ namespace ranges
                 // This overload just in case only non-const objects are writable
                 template<typename T,
                     CONCEPT_REQUIRES_(Writable<I, T>())>
+                RANGES_CXX14_CONSTEXPR
                 void operator=(T &x) const
                 {
                     *it_ = x;
                 }
                 template<typename T,
                     CONCEPT_REQUIRES_(MoveWritable<I, T>())>
+                RANGES_CXX14_CONSTEXPR
                 void operator=(T &&x) const
                 {
                     *it_ = std::move(x);
                 }
                 // Provides X(r++)
+                RANGES_CXX14_CONSTEXPR
                 operator I const &() const
                 {
                     return it_;
@@ -343,14 +362,17 @@ namespace ranges
             T t_;
         public:
             constexpr basic_mixin() = default;
+            RANGES_CXX14_CONSTEXPR
             basic_mixin(T t)
               : t_(std::move(t))
             {}
+            RANGES_CXX14_CONSTEXPR
             T &get() noexcept
             {
                 return t_;
             }
             /// \overload
+            RANGES_CXX14_CONSTEXPR
             T const &get() const noexcept
             {
                 return t_;
@@ -367,10 +389,12 @@ namespace ranges
             friend range_access;
             template<typename Cur, typename OtherSentinel>
             friend struct basic_iterator;
+            RANGES_CXX14_CONSTEXPR
             S &end() noexcept
             {
                 return this->detail::mixin_base<S>::get();
             }
+            RANGES_CXX14_CONSTEXPR
             S const &end() const noexcept
             {
                 return this->detail::mixin_base<S>::get();
@@ -378,8 +402,8 @@ namespace ranges
         private:
             using detail::mixin_base<S>::get;
         public:
-            basic_sentinel() = default;
-            basic_sentinel(S end)
+            RANGES_CXX14_CONSTEXPR basic_sentinel() = default;
+            RANGES_CXX14_CONSTEXPR basic_sentinel(S end)
               : detail::mixin_base<S>(std::move(end))
             {}
             using detail::mixin_base<S>::mixin_base;
@@ -411,11 +435,11 @@ namespace ranges
                     detail::cursor_concept_t<Cur>>;
 
             using detail::mixin_base<Cur>::get;
-            Cur &pos() noexcept
+            RANGES_CXX14_CONSTEXPR Cur &pos() noexcept
             {
                 return this->detail::mixin_base<Cur>::get();
             }
-            Cur const &pos() const noexcept
+            RANGES_CXX14_CONSTEXPR Cur const &pos() const noexcept
             {
                 return this->detail::mixin_base<Cur>::get();
             }
@@ -461,7 +485,7 @@ namespace ranges
                 detail::operator_brackets_dispatch<basic_iterator, value_type, reference, common_reference>;
         public:
             constexpr basic_iterator() = default;
-            basic_iterator(Cur pos)
+            RANGES_CXX14_CONSTEXPR basic_iterator(Cur pos)
               : detail::mixin_base<Cur>{std::move(pos)}
             {}
             template<typename OtherCur, typename OtherS,
@@ -471,17 +495,18 @@ namespace ranges
             {}
             // Mix in any additional constructors defined and exported by the cursor
             using detail::mixin_base<Cur>::mixin_base;
-            reference operator*() const
+            RANGES_CXX14_CONSTEXPR reference operator*() const
                 noexcept(noexcept(range_access::current(std::declval<basic_iterator const &>().pos())))
             {
                 return range_access::current(pos());
             }
+            RANGES_CXX14_CONSTEXPR
             basic_iterator& operator++()
             {
                 range_access::next(pos());
                 return *this;
             }
-            postfix_increment_result_t operator++(int)
+            RANGES_CXX14_CONSTEXPR postfix_increment_result_t operator++(int)
             {
                 postfix_increment_result_t tmp(*this);
                 ++*this;
@@ -519,12 +544,14 @@ namespace ranges
                 return !(left == right);
             }
             CONCEPT_REQUIRES(detail::BidirectionalCursor<Cur>())
+            RANGES_CXX14_CONSTEXPR
             basic_iterator& operator--()
             {
                 range_access::prev(pos());
                 return *this;
             }
             CONCEPT_REQUIRES(detail::BidirectionalCursor<Cur>())
+            RANGES_CXX14_CONSTEXPR
             basic_iterator operator--(int)
             {
                 basic_iterator tmp(*this);
@@ -532,36 +559,42 @@ namespace ranges
                 return tmp;
             }
             CONCEPT_REQUIRES(detail::RandomAccessCursor<Cur>())
+            RANGES_CXX14_CONSTEXPR
             basic_iterator& operator+=(difference_type n)
             {
                 range_access::advance(pos(), n);
                 return *this;
             }
             CONCEPT_REQUIRES(detail::RandomAccessCursor<Cur>())
+            RANGES_CXX14_CONSTEXPR
             friend basic_iterator operator+(basic_iterator left, difference_type n)
             {
                 left += n;
                 return left;
             }
             CONCEPT_REQUIRES(detail::RandomAccessCursor<Cur>())
+            RANGES_CXX14_CONSTEXPR
             friend basic_iterator operator+(difference_type n, basic_iterator right)
             {
                 right += n;
                 return right;
             }
             CONCEPT_REQUIRES(detail::RandomAccessCursor<Cur>())
+            RANGES_CXX14_CONSTEXPR
             basic_iterator& operator-=(difference_type n)
             {
                 range_access::advance(pos(), -n);
                 return *this;
             }
             CONCEPT_REQUIRES(detail::RandomAccessCursor<Cur>())
+            RANGES_CXX14_CONSTEXPR
             friend basic_iterator operator-(basic_iterator left, difference_type n)
             {
                 left -= n;
                 return left;
             }
             CONCEPT_REQUIRES(detail::RandomAccessCursor<Cur>())
+            RANGES_CXX14_CONSTEXPR
             friend difference_type operator-(basic_iterator const &left,
                 basic_iterator const &right)
             {
@@ -569,21 +602,25 @@ namespace ranges
             }
             // symmetric comparisons
             CONCEPT_REQUIRES(detail::RandomAccessCursor<Cur>())
+            RANGES_CXX14_CONSTEXPR
             friend bool operator<(basic_iterator const &left, basic_iterator const &right)
             {
                 return 0 < (right - left);
             }
             CONCEPT_REQUIRES(detail::RandomAccessCursor<Cur>())
+            RANGES_CXX14_CONSTEXPR
             friend bool operator<=(basic_iterator const &left, basic_iterator const &right)
             {
                 return 0 <= (right - left);
             }
             CONCEPT_REQUIRES(detail::RandomAccessCursor<Cur>())
+            RANGES_CXX14_CONSTEXPR
             friend bool operator>(basic_iterator const &left, basic_iterator const &right)
             {
                 return (right - left) < 0;
             }
             CONCEPT_REQUIRES(detail::RandomAccessCursor<Cur>())
+            RANGES_CXX14_CONSTEXPR
             friend bool operator>=(basic_iterator const &left, basic_iterator const &right)
             {
                 return (right - left) <= 0;
@@ -638,6 +675,7 @@ namespace ranges
                 return true;
             }
             CONCEPT_REQUIRES(detail::RandomAccessCursor<Cur>())
+            RANGES_CXX14_CONSTEXPR
             typename operator_brackets_dispatch_t::type
             operator[](difference_type n) const
             {
@@ -649,18 +687,21 @@ namespace ranges
         struct get_cursor_fn
         {
             template<typename Cur, typename Sent>
+            RANGES_CXX14_CONSTEXPR
             Cur &operator()(basic_iterator<Cur, Sent> &it) const noexcept
             {
                 detail::mixin_base<Cur> &mix = it;
                 return mix.get();
             }
             template<typename Cur, typename Sent>
+            RANGES_CXX14_CONSTEXPR
             Cur const &operator()(basic_iterator<Cur, Sent> const &it) const noexcept
             {
                 detail::mixin_base<Cur> const &mix = it;
                 return mix.get();
             }
             template<typename Cur, typename Sent>
+            RANGES_CXX14_CONSTEXPR
             Cur operator()(basic_iterator<Cur, Sent> &&it) const
                 noexcept(std::is_nothrow_copy_constructible<Cur>::value)
             {

--- a/include/range/v3/utility/swap.hpp
+++ b/include/range/v3/utility/swap.hpp
@@ -10,6 +10,8 @@
 //
 // Project home: https://github.com/ericniebler/range-v3
 //
+// The implementation of swap (see below) has been adapted from libc++
+// (http://libcxx.llvm.org).
 
 #ifndef RANGES_V3_UTILITY_SWAP_HPP
 #define RANGES_V3_UTILITY_SWAP_HPP
@@ -46,6 +48,7 @@ namespace ranges
 
             // Forward-declarations first!
             template<typename First0, typename Second0, typename First1, typename Second1>
+            RANGES_CXX14_CONSTEXPR
             meta::if_c<is_swappable<First0, First1>::value &&
                        is_swappable<Second0, Second1>::value>
             swap(std::pair<First0, Second0> &&left, std::pair<First1, Second1> &&right)
@@ -53,6 +56,7 @@ namespace ranges
                          is_nothrow_swappable<Second0, Second1>::value);
 
             template<typename ...Ts, typename ...Us>
+            RANGES_CXX14_CONSTEXPR
             meta::if_c<meta::and_c<is_swappable<Ts, Us>::value...>::value>
             swap(std::tuple<Ts...> &&left, std::tuple<Us...> &&right)
                 noexcept(meta::and_c<is_nothrow_swappable<Ts, Us>::value...>::value);
@@ -61,6 +65,7 @@ namespace ranges
             struct swap_fn
             {
                 template<typename T, typename U>
+                RANGES_CXX14_CONSTEXPR
                 meta::if_c<is_swappable<T, U>::value>
                 operator()(T && t, U && u) const noexcept(is_nothrow_swappable<T, U>::value)
                 {
@@ -87,6 +92,7 @@ namespace ranges
             {};
 
             template<typename First0, typename Second0, typename First1, typename Second1>
+            RANGES_CXX14_CONSTEXPR
             meta::if_c<is_swappable<First0, First1>::value &&
                        is_swappable<Second0, Second1>::value>
             swap(std::pair<First0, Second0> &&left, std::pair<First1, Second1> &&right)
@@ -98,6 +104,7 @@ namespace ranges
             }
 
             template<typename ...Ts, typename ...Us, std::size_t ...Is>
+            RANGES_CXX14_CONSTEXPR
             void tuple_swap_(std::tuple<Ts...> &&left, std::tuple<Us...> &&right, meta::index_sequence<Is...>)
             {
                 detail::ignore_unused(
@@ -105,6 +112,7 @@ namespace ranges
             }
 
             template<typename ...Ts, typename ...Us>
+            RANGES_CXX14_CONSTEXPR
             meta::if_c<meta::and_c<is_swappable<Ts, Us>::value...>::value>
             swap(std::tuple<Ts...> &&left, std::tuple<Us...> &&right)
                 noexcept(meta::and_c<is_nothrow_swappable<Ts, Us>::value...>::value)
@@ -131,6 +139,7 @@ namespace ranges
 
             // Forward-declarations first!
             template<typename Readable0, typename Readable1>
+            RANGES_CXX14_CONSTEXPR
             meta::if_c<
                 is_swappable<decltype(*std::declval<Readable0>()),
                              decltype(*std::declval<Readable1>())>::value>
@@ -139,6 +148,7 @@ namespace ranges
                                               decltype(*std::declval<Readable1>())>::value);
 
             template<typename Readable0, typename Readable1>
+            RANGES_CXX14_CONSTEXPR
             meta::if_c<
                 !is_swappable<
                     decltype(*std::declval<Readable0>()),
@@ -153,6 +163,7 @@ namespace ranges
             struct indirect_swap_fn
             {
                 template<typename Readable0, typename Readable1>
+                RANGES_CXX14_CONSTEXPR
                 meta::if_c<is_indirectly_swappable<Readable0, Readable1>::value>
                 operator()(Readable0 a, Readable1 b) const
                     noexcept(is_nothrow_indirectly_swappable<Readable0, Readable1>::value)
@@ -186,6 +197,7 @@ namespace ranges
             //    properly constrain std::iter_swap and rename this.
 
             template<typename Readable0, typename Readable1>
+            RANGES_CXX14_CONSTEXPR
             meta::if_c<
                 is_swappable<decltype(*std::declval<Readable0>()),
                              decltype(*std::declval<Readable1>())>::value>
@@ -197,6 +209,7 @@ namespace ranges
             }
 
             template<typename Readable0, typename Readable1>
+            RANGES_CXX14_CONSTEXPR
             meta::if_c<
                 !is_swappable<
                     decltype(*std::declval<Readable0>()),

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,9 @@ add_subdirectory(view)
 add_executable(container_conversion container_conversion.cpp)
 add_test(test.container_conversion container_conversion)
 
+add_executable(constexpr_core constexpr_core.cpp)
+add_test(test.constexpr_core constexpr_core)
+
 add_executable(range_facade range_facade.cpp)
 add_test(test.range_facade range_facade)
 

--- a/test/array.hpp
+++ b/test/array.hpp
@@ -1,0 +1,298 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+// The implementation of array has been adapted from libc++
+// (http://libcxx.llvm.org).
+//
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef RANGES_V3_TEST_ARRAY_HPP
+#define RANGES_V3_TEST_ARRAY_HPP
+#include <stdexcept>
+#include <range/v3/range_fwd.hpp>
+#include <range/v3/utility/basic_iterator.hpp>
+#include <range/v3/utility/iterator.hpp>
+#include <range/v3/algorithm/fill_n.hpp>
+#include <range/v3/algorithm/swap_ranges.hpp>
+#include <range/v3/algorithm/equal.hpp>
+#include <range/v3/algorithm/lexicographical_compare.hpp>
+#include <range/v3/utility/swap.hpp>
+
+namespace test {
+
+    /// \addtogroup group-utility
+    /// A std::array with constexpr support
+    template<typename T, std::size_t N>
+    struct array
+    {
+        using self = array;
+        using value_type = T;
+        using reference = value_type&;
+        using const_reference = value_type const&;
+        using iterator = value_type*;
+        using const_iterator = value_type const*;
+        using pointer = value_type*;
+        using const_pointer = value_type const*;
+        using size_type = std::size_t;
+        using difference_type = std::ptrdiff_t;
+        using reverse_iterator = ranges::reverse_iterator<iterator>;
+        using const_reverse_iterator = ranges::reverse_iterator<const_iterator>;
+
+        value_type elems_[N > 0 ? N : 1];
+
+        // No explicit construct/copy/destroy for aggregate type
+        RANGES_CXX14_CONSTEXPR array() = default;
+        RANGES_CXX14_CONSTEXPR void fill(const value_type& u)
+        {
+            ranges::fill_n(elems_, N, u);
+        }
+        RANGES_CXX14_CONSTEXPR
+        void swap(array& a) noexcept(ranges::is_nothrow_swappable<T, T>::value)
+        {
+            ranges::swap_ranges(elems_, elems_ + N, a.elems_);
+        }
+         // iterators:
+        RANGES_CXX14_CONSTEXPR
+        iterator begin() noexcept
+        {
+            return iterator(elems_);
+        }
+        RANGES_CXX14_CONSTEXPR
+        const_iterator begin() const noexcept
+        {
+            return const_iterator(elems_);
+        }
+        RANGES_CXX14_CONSTEXPR
+        iterator end() noexcept
+        {
+            return iterator(elems_ + N);
+        }
+        RANGES_CXX14_CONSTEXPR
+        const_iterator end() const noexcept
+        {
+            return const_iterator(elems_ + N);
+        }
+        RANGES_CXX14_CONSTEXPR
+        reverse_iterator rbegin() noexcept
+        {
+            return reverse_iterator(end());
+        }
+        RANGES_CXX14_CONSTEXPR
+        const_reverse_iterator rbegin() const noexcept
+        {
+            return const_reverse_iterator(end());
+        }
+        RANGES_CXX14_CONSTEXPR
+        reverse_iterator rend() noexcept
+        {
+            return reverse_iterator(begin());
+        }
+        RANGES_CXX14_CONSTEXPR
+        const_reverse_iterator rend() const noexcept
+        {
+            return const_reverse_iterator(begin());
+        }
+        RANGES_CXX14_CONSTEXPR
+        const_iterator cbegin() const noexcept
+        {
+            return begin();
+        }
+        RANGES_CXX14_CONSTEXPR
+        const_iterator cend() const noexcept
+        {
+            return end();
+        }
+        RANGES_CXX14_CONSTEXPR
+        const_reverse_iterator crbegin() const noexcept
+        {
+            return rbegin();
+        }
+        RANGES_CXX14_CONSTEXPR
+        const_reverse_iterator crend() const noexcept
+        {
+            return rend();
+        }
+        // capacity:
+        RANGES_CXX14_CONSTEXPR
+        size_type size() const noexcept
+        {
+            return N;
+        }
+        RANGES_CXX14_CONSTEXPR
+        size_type max_size() const noexcept
+        {
+            return N;
+        }
+        RANGES_CXX14_CONSTEXPR
+        bool empty() const noexcept
+        {
+            return N == 0;
+        }
+         // element access:
+        RANGES_CXX14_CONSTEXPR reference operator[](size_type n)
+        {
+            return elems_[n];
+        }
+        RANGES_CXX14_CONSTEXPR const_reference operator[](size_type n) const
+        {
+            return elems_[n];
+        }
+        RANGES_CXX14_CONSTEXPR reference at(size_type n)
+        {
+            if (n >= N)
+                throw std::out_of_range("array::at");
+            return elems_[n];
+        };
+        RANGES_CXX14_CONSTEXPR const_reference at(size_type n) const
+        {
+            if (n >= N)
+                throw std::out_of_range("array::at");
+            return elems_[n];
+        }
+        RANGES_CXX14_CONSTEXPR reference front()
+        {
+            return elems_[0];
+        }
+        RANGES_CXX14_CONSTEXPR const_reference front() const
+        {
+            return elems_[0];
+        }
+        RANGES_CXX14_CONSTEXPR reference back()
+        {
+            return elems_[N > 0 ? N-1 : 0];
+        }
+        RANGES_CXX14_CONSTEXPR const_reference back() const
+        {
+            return elems_[N > 0 ? N-1 : 0];
+        }
+        RANGES_CXX14_CONSTEXPR
+        value_type* data() noexcept
+        {
+            return elems_;
+        }
+        RANGES_CXX14_CONSTEXPR
+        const value_type* data() const noexcept
+        {
+            return elems_;
+        }
+    };
+
+    template <class T, size_t N>
+    RANGES_CXX14_CONSTEXPR
+    bool
+    operator==(const array<T, N>& x, const array<T, N>& y)
+    {
+        return ranges::equal(x.elems_, x.elems_ + N, y.elems_);
+    }
+    template <class T, size_t N>
+    RANGES_CXX14_CONSTEXPR
+    bool
+    operator!=(const array<T, N>& x, const array<T, N>& y)
+    {
+        return !(x == y);
+    }
+    template <class T, size_t N>
+    RANGES_CXX14_CONSTEXPR
+    bool
+    operator<(const array<T, N>& x, const array<T, N>& y)
+    {
+        return ranges::lexicographical_compare(x.elems_, x.elems_ + N, y.elems_, y.elems_ + N);
+    }
+    template <class T, size_t N>
+    RANGES_CXX14_CONSTEXPR
+    bool
+    operator>(const array<T, N>& x, const array<T, N>& y)
+    {
+        return y < x;
+    }
+    template <class T, size_t N>
+    RANGES_CXX14_CONSTEXPR
+    bool
+    operator<=(const array<T, N>& x, const array<T, N>& y)
+    {
+        return !(y < x);
+    }
+
+    template <class T, size_t N>
+    RANGES_CXX14_CONSTEXPR
+    bool
+    operator>=(const array<T, N>& x, const array<T, N>& y)
+    {
+         return !(x < y);
+    }
+
+    template <class T, size_t N>
+    RANGES_CXX14_CONSTEXPR
+    auto swap(array<T, N>& x, array<T, N>& y)
+    noexcept(ranges::is_nothrow_swappable<T, T>::value)
+    -> typename std::enable_if<ranges::is_swappable<T, T>::value, void>::type
+    {
+        x.swap(y);
+    }
+
+    template <size_t I, class T, size_t N>
+    RANGES_CXX14_CONSTEXPR
+    T& get(array<T, N>& a) noexcept
+    {
+        static_assert(I < N, "Index out of bounds in ranges::get<> (ranges::array)");
+        return a.elems_[I];
+    }
+
+    template <size_t I, class T, size_t N>
+    RANGES_CXX14_CONSTEXPR
+    const T& get(const array<T, N>& a) noexcept
+    {
+        static_assert(I < N, "Index out of bounds in ranges::get<> (const ranges::array)");
+        return a.elems_[I];
+    }
+
+    template <size_t I, class T, size_t N>
+    RANGES_CXX14_CONSTEXPR
+    T&& get(array<T, N>&& a) noexcept
+    {
+        static_assert(I < N, "Index out of bounds in ranges::get<> (ranges::array &&)");
+        return std::move(a.elems_[I]);
+    }
+
+    template<class T, std::size_t N>
+    RANGES_CXX14_CONSTEXPR void swap(array<T, N>& a, array<T, N>& b) {
+        for(std::size_t i = 0; i != N; ++i) {
+            auto tmp = std::move(a[i]);
+            a[i] = std::move(b[i]);
+            b[i] = std::move(tmp);
+        }
+    }
+}  // namespace test
+
+namespace std
+{
+
+template <class T, size_t N>
+class tuple_size<test::array<T, N>>
+    : public integral_constant<size_t, N> {};
+
+template <size_t I, class T, size_t N>
+class tuple_element<I, test::array<T, N> >
+{
+ public:
+    using type = T;
+};
+
+}  // namespace std
+
+#endif // RANGES_V3_TEST_ARRAY_HPP

--- a/test/constexpr_core.cpp
+++ b/test/constexpr_core.cpp
@@ -1,0 +1,248 @@
+#include <range/v3/begin_end.hpp>
+#include <range/v3/empty.hpp>
+#include <range/v3/back.hpp>
+#include <range/v3/front.hpp>
+#include <range/v3/at.hpp>
+#include <range/v3/size.hpp>
+#include "array.hpp"
+#include "test_iterators.hpp"
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+
+
+// This is necessary since advance is a customization point, std::advance is imported for
+// non-range-v3 iterators, and it is not constexpr:
+template<typename T, typename I = random_access_iterator<T>>
+RANGES_CXX14_CONSTEXPR
+void advance(random_access_iterator<T> & i, ranges::iterator_difference_t<I> n) {
+    ranges::adl_advance_detail::advance_impl(i, n, ranges::iterator_concept<I>{});
+}
+
+template<typename T, typename I = bidirectional_iterator<T>>
+RANGES_CXX14_CONSTEXPR
+void advance(bidirectional_iterator<T> & i, ranges::iterator_difference_t<I> n) {
+    ranges::adl_advance_detail::advance_impl(i, n, ranges::iterator_concept<I>{});
+}
+
+template<typename T, typename I = forward_iterator<T>>
+RANGES_CXX14_CONSTEXPR
+void advance(forward_iterator<T> & i, ranges::iterator_difference_t<I> n) {
+    ranges::adl_advance_detail::advance_impl(i, n, ranges::iterator_concept<I>{});
+}
+
+template<typename T, typename I = input_iterator<T>>
+RANGES_CXX14_CONSTEXPR
+void advance(input_iterator<T> & i, ranges::iterator_difference_t<I> n) {
+    ranges::adl_advance_detail::advance_impl(i, n, ranges::iterator_concept<I>{});
+}
+
+// Test sequence 1,2,3,4
+template<typename It>
+RANGES_CXX14_CONSTEXPR auto test_it_(It beg, It end) -> bool {
+    if (*beg != 1) { return false; }
+    if (ranges::distance(beg, end) != 4) { return false; }
+    if (ranges::next(beg, 4) != end) { return false; }
+    auto end_m1 = It{ranges::next(beg, 3)};
+    if (*end_m1 != 4) { return false; }
+
+    if (std::is_convertible<ranges::iterator_concept<It>,
+                            ranges::concepts::BidirectionalIterator*>{}) {
+        auto end_m1_2 = It{ranges::prev(end, 1)};
+        if (*end_m1_2 != 4) { return false; }
+    }
+    auto end2 = beg;
+    ranges::advance(end2, end);
+    if (end2 != end) { return false; }
+    auto end3 = beg;
+    ranges::advance(end3, 4);
+    if (end3 != end) { return false; }
+    if (ranges::iter_enumerate(beg, end) != std::pair<std::ptrdiff_t, It>{4, end})
+    {
+        return false;
+    }
+    if (ranges::iter_distance(beg, end) != 4) { return false; }
+    if (ranges::iter_distance_compare(beg, end, 4) != 0) { return false; }
+    if (ranges::iter_distance_compare(beg, end, 3) != 1) { return false; }
+    if (ranges::iter_distance_compare(beg, end, 5) != -1) { return false; }
+    return true;
+}
+
+// Test sequence 4,3,2,1 (for reverse iterators)
+template<typename It>
+RANGES_CXX14_CONSTEXPR auto test_rit_(It beg, It end) -> bool {
+    if (ranges::distance(beg, end) != 4) { return false; }
+    if (ranges::next(beg, 4) != end) { return false; }
+    auto end_m1 = It{ranges::next(beg, 3)};
+    if (*end_m1 != 1) { return false; }
+    if (std::is_convertible<ranges::iterator_concept<It>,
+                            ranges::concepts::BidirectionalIterator*>{}) {
+        auto end_m1_2 = It{ranges::prev(end, 1)};
+        if (*end_m1_2 != 1) { return false; }
+    }
+    auto end2 = beg;
+    ranges::advance(end2, end);
+    if (end2 != end) { return false; }
+    auto end3 = beg;
+    ranges::advance(end3, 4);
+    if (end3 != end) { return false; }
+    if (ranges::iter_enumerate(beg, end) != std::pair<std::ptrdiff_t, It>{4, end})
+    {
+        return false;
+    }
+    if (ranges::iter_distance(beg, end) != 4) { return false; }
+    if (ranges::iter_distance_compare(beg, end, 4) != 0) { return false; }
+    if (ranges::iter_distance_compare(beg, end, 3) != 1) { return false; }
+    if (ranges::iter_distance_compare(beg, end, 5) != -1) { return false; }
+    return true;
+}
+
+template<typename It, typename Sequence1234>
+RANGES_CXX14_CONSTEXPR auto test_it(Sequence1234&& a) -> bool {
+    auto beg = It{ranges::begin(a)};
+    auto end = It{ranges::end(a)};
+    return test_it_(beg, end);
+}
+
+template<typename Sequence1234>
+RANGES_CXX14_CONSTEXPR auto test_its_c(Sequence1234&& a) -> bool {
+    return     test_it<input_iterator<int const *>>(a)
+            && test_it<forward_iterator<int const *>>(a)
+            && test_it<bidirectional_iterator<int const *>>(a)
+            && test_it<random_access_iterator<int const *>>(a);
+
+}
+
+template<typename Sequence1234>
+RANGES_CXX14_CONSTEXPR auto test_its(Sequence1234&& a) -> bool {
+    return     test_it<input_iterator<int *>>(a)
+            && test_it<forward_iterator<int *>>(a)
+            && test_it<bidirectional_iterator<int *>>(a)
+            && test_it<random_access_iterator<int *>>(a)
+            && test_its_c(a);
+
+}
+
+template<typename It, typename Sequence1234>
+RANGES_CXX14_CONSTEXPR auto test_rit(Sequence1234&& a) -> bool {
+    auto beg = It{ranges::rbegin(a)};
+    auto end = It{ranges::rend(a)};
+    return test_rit_(beg, end);
+}
+
+template<typename Sequence1234>
+RANGES_CXX14_CONSTEXPR auto test_rits(Sequence1234&& a) -> bool {
+    using rit = decltype(ranges::rbegin(a));
+    return     test_rit<bidirectional_iterator<rit>>(a)
+            && test_rit<random_access_iterator<rit>>(a);
+}
+
+template<typename It, typename Sequence1234>
+RANGES_CXX14_CONSTEXPR auto test_cit(Sequence1234&& a) -> bool {
+    auto beg = It{ranges::cbegin(a)};
+    auto end = It{ranges::cend(a)};
+    return test_it_(beg, end);
+}
+
+template<typename Sequence1234>
+RANGES_CXX14_CONSTEXPR auto test_cits(Sequence1234&& a) -> bool {
+    return     test_cit<input_iterator<int const *>>(a)
+            && test_cit<forward_iterator<int const *>>(a)
+            && test_cit<bidirectional_iterator<int const *>>(a)
+            && test_cit<random_access_iterator<int const *>>(a);
+}
+
+
+template<typename It, typename Sequence1234>
+RANGES_CXX14_CONSTEXPR auto test_crit(Sequence1234&& a) -> bool {
+    auto beg = It{ranges::crbegin(a)};
+    auto end = It{ranges::crend(a)};
+    return test_rit_(beg, end);
+}
+
+template<typename Sequence1234>
+RANGES_CXX14_CONSTEXPR auto test_crits(Sequence1234&& a) -> bool {
+    using rit = decltype(ranges::crbegin(a));
+    return     test_crit<bidirectional_iterator<rit>>(a)
+            && test_crit<random_access_iterator<rit>>(a);
+}
+
+template<typename Sequence1234>
+RANGES_CXX14_CONSTEXPR auto test_non_member_f(Sequence1234&& a) -> bool {
+    if (ranges::empty(a)) { return false; }
+    if (ranges::front(a) != 1) { return false; }
+    if (ranges::back(a) != 4) { return false; }
+    if (ranges::at(a, 2) != 3) { return false; }
+    if (ranges::size(a) != 4) { return false; }
+    return true;
+}
+
+RANGES_CXX14_CONSTEXPR auto test_array() -> bool {
+    test::array<int, 4> a{{1, 2, 3, 4}};
+
+    auto beg = ranges::begin(a);
+    auto three = ranges::next(beg, 2);
+    // ranges::iter_swap(beg, three);
+    // if (*beg != 3) { return false; }
+    // if (*three != 1) { return false; }
+    // ranges::iter_swap(beg, three);
+
+    if (!test_its(a)) { return false; }
+    if (!test_cits(a)) { return false; }
+    if (!test_rits(a)) { return false; }
+    if (!test_crits(a)) { return false; }
+    if (!test_non_member_f(a)) { return false; }
+
+    // This can be workedaround but is just bad:
+    test::array<int, 4> b{{5, 6, 7, 8}};
+    ranges::swap(a, b);
+    if (a[0] != 5 || b[0] != 1 || a[3] != 8 || b[3] != 4) { return false; }
+
+    return true;
+}
+
+RANGES_CXX14_CONSTEXPR auto test_c_array() -> bool {
+    int a[4]{1, 2, 3, 4};
+    if (!test_its(a)) { return false; }
+    if (!test_cits(a)) { return false; }
+    if (!test_rits(a)) { return false; }
+    if (!test_crits(a)) { return false; }
+    if (!test_non_member_f(a)) { return false; }
+
+    // C-arrays have no associated namespace, so this can't work:
+    // int b[4]{5, 6, 7, 8};
+    // ranges::swap(a, b);
+    // if (a[0] != 5 || b[0] != 1 || a[3] != 8 || b[3] != 4) { return false; }
+
+    return true;
+}
+
+RANGES_CXX14_CONSTEXPR auto test_init_list() -> bool {
+    std::initializer_list<int> a{1, 2, 3, 4};
+    if (!test_its_c(a)) { return false; }
+    if (!test_cits(a)) { return false; }
+    if (!test_rits(a)) { return false; }
+    if (!test_crits(a)) { return false; }
+    if (!test_non_member_f(a)) { return false; }
+
+    // std::initializer_list live in std:: so ADL will always pick std::swap
+    // std::initializer_list<int> b{5, 6, 7, 8};
+    // ranges::swap(a, b);
+    // if (ranges::at(a, 0) != 5 || ranges::at(b, 0) != 1
+    //     || ranges::at(a, 3) != 8 || ranges::at(b, 3) != 4) {
+    //     return false;
+    // }
+
+    return true;
+}
+#endif
+
+int main() {
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    static_assert(test_array(), "");
+    static_assert(test_c_array(), "");
+    static_assert(test_init_list(), "");
+#endif
+
+    return 0;
+}

--- a/test/test_iterators.hpp
+++ b/test/test_iterators.hpp
@@ -33,25 +33,25 @@ class random_access_iterator;
 
 
 template <class Iter, bool Sized>
-inline Iter base(sentinel<Iter, Sized> i) { return i.base(); }
+RANGES_CXX14_CONSTEXPR Iter base(sentinel<Iter, Sized> i) { return i.base(); }
 
 template <class Iter>
-inline Iter base(output_iterator<Iter> i) { return i.base(); }
+RANGES_CXX14_CONSTEXPR Iter base(output_iterator<Iter> i) { return i.base(); }
 
 template <class Iter>
-inline Iter base(input_iterator<Iter> i) { return i.base(); }
+RANGES_CXX14_CONSTEXPR Iter base(input_iterator<Iter> i) { return i.base(); }
 
 template <class Iter>
-inline Iter base(forward_iterator<Iter> i) { return i.base(); }
+RANGES_CXX14_CONSTEXPR Iter base(forward_iterator<Iter> i) { return i.base(); }
 
 template <class Iter>
-inline Iter base(bidirectional_iterator<Iter> i) { return i.base(); }
+RANGES_CXX14_CONSTEXPR Iter base(bidirectional_iterator<Iter> i) { return i.base(); }
 
 template <class Iter>
-inline Iter base(random_access_iterator<Iter> i) { return i.base(); }
+RANGES_CXX14_CONSTEXPR Iter base(random_access_iterator<Iter> i) { return i.base(); }
 
 template <class Iter>    // everything else
-inline Iter base(Iter i) { return i; }
+RANGES_CXX14_CONSTEXPR Iter base(Iter i) { return i; }
 
 
 template <class It, bool Sized>
@@ -59,38 +59,38 @@ class sentinel
 {
     It it_;
 public:
-    sentinel() : it_() {}
-    explicit sentinel(It it) : it_(it) {}
-    It base() const { return it_; }
-    friend bool operator==(const sentinel& x, const sentinel& y)
+    RANGES_CXX14_CONSTEXPR sentinel() : it_() {}
+    RANGES_CXX14_CONSTEXPR explicit sentinel(It it) : it_(it) {}
+    RANGES_CXX14_CONSTEXPR It base() const { return it_; }
+    RANGES_CXX14_CONSTEXPR friend bool operator==(const sentinel& x, const sentinel& y)
     {
         assert(x.it_ == y.it_);
         return true;
     }
-    friend bool operator!=(const sentinel& x, const sentinel& y)
+    RANGES_CXX14_CONSTEXPR friend bool operator!=(const sentinel& x, const sentinel& y)
     {
         assert(x.it_ == y.it_);
         return false;
     }
     template<typename I>
-    friend bool operator==(const I& x, const sentinel& y)
+    RANGES_CXX14_CONSTEXPR friend bool operator==(const I& x, const sentinel& y)
     {
         using ::base;
         return base(x) == y.it_;
     }
     template<typename I>
-    friend bool operator!=(const I& x, const sentinel& y)
+    RANGES_CXX14_CONSTEXPR friend bool operator!=(const I& x, const sentinel& y)
     {
         return !(x == y);
     }
     template<typename I>
-    friend bool operator==(const sentinel& x, const I& y)
+    RANGES_CXX14_CONSTEXPR friend bool operator==(const sentinel& x, const I& y)
     {
         using ::base;
         return x.it_ == base(y);
     }
     template<typename I>
-    friend bool operator!=(const sentinel& x, const I& y)
+    RANGES_CXX14_CONSTEXPR friend bool operator!=(const sentinel& x, const I& y)
     {
         return !(x == y);
     }
@@ -98,6 +98,7 @@ public:
 
 // For making sized iterator ranges:
 template<template<typename> class I, typename It>
+RANGES_CXX14_CONSTEXPR
 std::ptrdiff_t operator-(sentinel<It, true> end, I<It> begin)
 {
     return base(end) - base(begin);
@@ -116,18 +117,19 @@ public:
     typedef It                                                 pointer;
     typedef typename std::iterator_traits<It>::reference       reference;
 
-    It base() const {return it_;}
+    RANGES_CXX14_CONSTEXPR It base() const {return it_;}
 
-    output_iterator () {}
-    explicit output_iterator(It it) : it_(it) {}
-    template <class U>
-        output_iterator(const output_iterator<U>& u) :it_(u.it_) {}
+    RANGES_CXX14_CONSTEXPR output_iterator () {}
+    RANGES_CXX14_CONSTEXPR explicit output_iterator(It it) : it_(it) {}
+    template <class U, class = typename std::enable_if<std::is_convertible<U, It>{}>::type>
+    RANGES_CXX14_CONSTEXPR
+    output_iterator(const output_iterator<U>& u) :it_(u.it_) {}
 
-    reference operator*() const {return *it_;}
+    RANGES_CXX14_CONSTEXPR reference operator*() const {return *it_;}
 
-    output_iterator& operator++() {++it_; return *this;}
-    output_iterator operator++(int)
-        {output_iterator tmp(*this); ++(*this); return tmp;}
+    RANGES_CXX14_CONSTEXPR output_iterator& operator++() {++it_; return *this;}
+    RANGES_CXX14_CONSTEXPR output_iterator operator++(int)
+    {output_iterator tmp(*this); ++(*this); return tmp;}
 };
 
 template <class It>
@@ -143,28 +145,30 @@ public:
     typedef It                                                 pointer;
     typedef typename std::iterator_traits<It>::reference       reference;
 
-    It base() const {return it_;}
+    RANGES_CXX14_CONSTEXPR It base() const {return it_;}
 
-    input_iterator() : it_() {}
-    explicit input_iterator(It it) : it_(it) {}
-    template <class U>
-        input_iterator(const input_iterator<U>& u) :it_(u.it_) {}
+    RANGES_CXX14_CONSTEXPR input_iterator() : it_() {}
+    RANGES_CXX14_CONSTEXPR explicit input_iterator(It it) : it_(it) {}
+    template <class U, class = typename std::enable_if<std::is_convertible<U, It>{}>::type>
+    RANGES_CXX14_CONSTEXPR input_iterator(const input_iterator<U>& u) :it_(u.it_) {}
 
-    reference operator*() const {return *it_;}
-    pointer operator->() const {return it_;}
+    RANGES_CXX14_CONSTEXPR reference operator*() const {return *it_;}
+    RANGES_CXX14_CONSTEXPR pointer operator->() const {return it_;}
 
-    input_iterator& operator++() {++it_; return *this;}
-    input_iterator operator++(int)
+    RANGES_CXX14_CONSTEXPR input_iterator& operator++() {++it_; return *this;}
+    RANGES_CXX14_CONSTEXPR input_iterator operator++(int)
         {input_iterator tmp(*this); ++(*this); return tmp;}
 
+    RANGES_CXX14_CONSTEXPR
     friend bool operator==(const input_iterator& x, const input_iterator& y)
         {return x.it_ == y.it_;}
+    RANGES_CXX14_CONSTEXPR
     friend bool operator!=(const input_iterator& x, const input_iterator& y)
         {return !(x == y);}
 };
 
 template <class T, class U>
-inline
+RANGES_CXX14_CONSTEXPR
 bool
 operator==(const input_iterator<T>& x, const input_iterator<U>& y)
 {
@@ -172,7 +176,7 @@ operator==(const input_iterator<T>& x, const input_iterator<U>& y)
 }
 
 template <class T, class U>
-inline
+RANGES_CXX14_CONSTEXPR
 bool
 operator!=(const input_iterator<T>& x, const input_iterator<U>& y)
 {
@@ -192,28 +196,30 @@ public:
     typedef It                                                 pointer;
     typedef typename std::iterator_traits<It>::reference       reference;
 
-    It base() const {return it_;}
+    RANGES_CXX14_CONSTEXPR It base() const {return it_;}
 
-    forward_iterator() : it_() {}
-    explicit forward_iterator(It it) : it_(it) {}
-    template <class U>
-        forward_iterator(const forward_iterator<U>& u) :it_(u.it_) {}
+    RANGES_CXX14_CONSTEXPR forward_iterator() : it_() {}
+    RANGES_CXX14_CONSTEXPR explicit forward_iterator(It it) : it_(it) {}
+    template <class U, class = typename std::enable_if<std::is_convertible<U, It>{}>::type>
+    RANGES_CXX14_CONSTEXPR forward_iterator(const forward_iterator<U>& u) :it_(u.it_) {}
 
-    reference operator*() const {return *it_;}
-    pointer operator->() const {return it_;}
+    RANGES_CXX14_CONSTEXPR reference operator*() const {return *it_;}
+    RANGES_CXX14_CONSTEXPR pointer operator->() const {return it_;}
 
-    forward_iterator& operator++() {++it_; return *this;}
-    forward_iterator operator++(int)
-        {forward_iterator tmp(*this); ++(*this); return tmp;}
+    RANGES_CXX14_CONSTEXPR forward_iterator& operator++() {++it_; return *this;}
+    RANGES_CXX14_CONSTEXPR forward_iterator operator++(int)
+    {forward_iterator tmp(*this); ++(*this); return tmp;}
 
+    RANGES_CXX14_CONSTEXPR
     friend bool operator==(const forward_iterator& x, const forward_iterator& y)
-        {return x.it_ == y.it_;}
+    {return x.it_ == y.it_;}
+    RANGES_CXX14_CONSTEXPR
     friend bool operator!=(const forward_iterator& x, const forward_iterator& y)
-        {return !(x == y);}
+    {return !(x == y);}
 };
 
 template <class T, class U>
-inline
+RANGES_CXX14_CONSTEXPR
 bool
 operator==(const forward_iterator<T>& x, const forward_iterator<U>& y)
 {
@@ -221,7 +227,7 @@ operator==(const forward_iterator<T>& x, const forward_iterator<U>& y)
 }
 
 template <class T, class U>
-inline
+RANGES_CXX14_CONSTEXPR
 bool
 operator!=(const forward_iterator<T>& x, const forward_iterator<U>& y)
 {
@@ -241,27 +247,27 @@ public:
     typedef It                                                 pointer;
     typedef typename std::iterator_traits<It>::reference       reference;
 
-    It base() const {return it_;}
+    RANGES_CXX14_CONSTEXPR It base() const {return it_;}
 
-    bidirectional_iterator() : it_() {}
-    explicit bidirectional_iterator(It it) : it_(it) {}
-    template <class U>
-        bidirectional_iterator(const bidirectional_iterator<U>& u) :it_(u.it_) {}
+    RANGES_CXX14_CONSTEXPR bidirectional_iterator() : it_() {}
+    RANGES_CXX14_CONSTEXPR explicit bidirectional_iterator(It it) : it_(it) {}
+    template <class U, class = typename std::enable_if<std::is_convertible<U, It>{}>::type>
+    RANGES_CXX14_CONSTEXPR bidirectional_iterator(const bidirectional_iterator<U>& u) :it_(u.it_) {}
 
-    reference operator*() const {return *it_;}
-    pointer operator->() const {return it_;}
+    RANGES_CXX14_CONSTEXPR reference operator*() const {return *it_;}
+    RANGES_CXX14_CONSTEXPR pointer operator->() const {return it_;}
 
-    bidirectional_iterator& operator++() {++it_; return *this;}
-    bidirectional_iterator operator++(int)
-        {bidirectional_iterator tmp(*this); ++(*this); return tmp;}
+    RANGES_CXX14_CONSTEXPR bidirectional_iterator& operator++() {++it_; return *this;}
+    RANGES_CXX14_CONSTEXPR bidirectional_iterator operator++(int)
+    {bidirectional_iterator tmp(*this); ++(*this); return tmp;}
 
-    bidirectional_iterator& operator--() {--it_; return *this;}
-    bidirectional_iterator operator--(int)
-        {bidirectional_iterator tmp(*this); --(*this); return tmp;}
+    RANGES_CXX14_CONSTEXPR bidirectional_iterator& operator--() {--it_; return *this;}
+    RANGES_CXX14_CONSTEXPR bidirectional_iterator operator--(int)
+    {bidirectional_iterator tmp(*this); --(*this); return tmp;}
 };
 
 template <class T, class U>
-inline
+RANGES_CXX14_CONSTEXPR
 bool
 operator==(const bidirectional_iterator<T>& x, const bidirectional_iterator<U>& y)
 {
@@ -269,7 +275,7 @@ operator==(const bidirectional_iterator<T>& x, const bidirectional_iterator<U>& 
 }
 
 template <class T, class U>
-inline
+RANGES_CXX14_CONSTEXPR
 bool
 operator!=(const bidirectional_iterator<T>& x, const bidirectional_iterator<U>& y)
 {
@@ -289,38 +295,44 @@ public:
     typedef It                                                 pointer;
     typedef typename std::iterator_traits<It>::reference       reference;
 
-    It base() const {return it_;}
+    RANGES_CXX14_CONSTEXPR It base() const {return it_;}
 
-    random_access_iterator() : it_() {}
-    explicit random_access_iterator(It it) : it_(it) {}
-   template <class U>
-        random_access_iterator(const random_access_iterator<U>& u) :it_(u.it_) {}
+    RANGES_CXX14_CONSTEXPR random_access_iterator() : it_() {}
+    RANGES_CXX14_CONSTEXPR explicit random_access_iterator(It it) : it_(it) {}
+    template <class U, class = typename std::enable_if<std::is_convertible<U, It>{}>::type>
+    RANGES_CXX14_CONSTEXPR random_access_iterator(const random_access_iterator<U>& u) :it_(u.it_) {}
 
-    reference operator*() const {return *it_;}
-    pointer operator->() const {return it_;}
+    RANGES_CXX14_CONSTEXPR reference operator*() const {return *it_;}
+    RANGES_CXX14_CONSTEXPR pointer operator->() const {return it_;}
 
-    random_access_iterator& operator++() {++it_; return *this;}
-    random_access_iterator operator++(int)
-        {random_access_iterator tmp(*this); ++(*this); return tmp;}
+    RANGES_CXX14_CONSTEXPR random_access_iterator& operator++() {++it_; return *this;}
+    RANGES_CXX14_CONSTEXPR random_access_iterator operator++(int)
+    {random_access_iterator tmp(*this); ++(*this); return tmp;}
 
-    random_access_iterator& operator--() {--it_; return *this;}
-    random_access_iterator operator--(int)
-        {random_access_iterator tmp(*this); --(*this); return tmp;}
+    RANGES_CXX14_CONSTEXPR random_access_iterator& operator--() {--it_; return *this;}
+    RANGES_CXX14_CONSTEXPR random_access_iterator operator--(int)
+    {random_access_iterator tmp(*this); --(*this); return tmp;}
 
+    RANGES_CXX14_CONSTEXPR
     random_access_iterator& operator+=(difference_type n) {it_ += n; return *this;}
+    RANGES_CXX14_CONSTEXPR
     random_access_iterator operator+(difference_type n) const
-        {random_access_iterator tmp(*this); tmp += n; return tmp;}
+    {random_access_iterator tmp(*this); tmp += n; return tmp;}
+    RANGES_CXX14_CONSTEXPR
     friend random_access_iterator operator+(difference_type n, random_access_iterator x)
-        {x += n; return x;}
+    {x += n; return x;}
+    RANGES_CXX14_CONSTEXPR
     random_access_iterator& operator-=(difference_type n) {return *this += -n;}
+    RANGES_CXX14_CONSTEXPR
     random_access_iterator operator-(difference_type n) const
-        {random_access_iterator tmp(*this); tmp -= n; return tmp;}
+    {random_access_iterator tmp(*this); tmp -= n; return tmp;}
 
+    RANGES_CXX14_CONSTEXPR
     reference operator[](difference_type n) const {return it_[n];}
 };
 
 template <class T, class U>
-inline
+RANGES_CXX14_CONSTEXPR
 bool
 operator==(const random_access_iterator<T>& x, const random_access_iterator<U>& y)
 {
@@ -328,7 +340,7 @@ operator==(const random_access_iterator<T>& x, const random_access_iterator<U>& 
 }
 
 template <class T, class U>
-inline
+RANGES_CXX14_CONSTEXPR
 bool
 operator!=(const random_access_iterator<T>& x, const random_access_iterator<U>& y)
 {
@@ -336,7 +348,7 @@ operator!=(const random_access_iterator<T>& x, const random_access_iterator<U>& 
 }
 
 template <class T, class U>
-inline
+RANGES_CXX14_CONSTEXPR
 bool
 operator<(const random_access_iterator<T>& x, const random_access_iterator<U>& y)
 {
@@ -344,7 +356,7 @@ operator<(const random_access_iterator<T>& x, const random_access_iterator<U>& y
 }
 
 template <class T, class U>
-inline
+RANGES_CXX14_CONSTEXPR
 bool
 operator<=(const random_access_iterator<T>& x, const random_access_iterator<U>& y)
 {
@@ -352,7 +364,7 @@ operator<=(const random_access_iterator<T>& x, const random_access_iterator<U>& 
 }
 
 template <class T, class U>
-inline
+RANGES_CXX14_CONSTEXPR
 bool
 operator>(const random_access_iterator<T>& x, const random_access_iterator<U>& y)
 {
@@ -360,7 +372,7 @@ operator>(const random_access_iterator<T>& x, const random_access_iterator<U>& y
 }
 
 template <class T, class U>
-inline
+RANGES_CXX14_CONSTEXPR
 bool
 operator>=(const random_access_iterator<T>& x, const random_access_iterator<U>& y)
 {
@@ -368,7 +380,7 @@ operator>=(const random_access_iterator<T>& x, const random_access_iterator<U>& 
 }
 
 template <class T, class U>
-inline
+RANGES_CXX14_CONSTEXPR
 typename std::iterator_traits<T>::difference_type
 operator-(const random_access_iterator<T>& x, const random_access_iterator<U>& y)
 {

--- a/test/utility/CMakeLists.txt
+++ b/test/utility/CMakeLists.txt
@@ -11,6 +11,9 @@ add_test(test.utility.common_type utility.common_type)
 add_executable(utility.functional functional.cpp)
 add_test(test.utility.functional utility.functional)
 
+add_executable(utility.reverse_iterator reverse_iterator.cpp)
+add_test(test.utility.reverse_iterator utility.reverse_iterator)
+
 add_executable(utility.swap swap.cpp)
 add_test(test.utility.swap utility.swap)
 

--- a/test/utility/reverse_iterator.cpp
+++ b/test/utility/reverse_iterator.cpp
@@ -1,0 +1,473 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+// These tests of reverse_iterator have been adapted from libc++
+// (http://libcxx.llvm.org).
+//
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <range/v3/begin_end.hpp>
+#include <range/v3/view/iota.hpp>
+#include "../simple_test.hpp"
+#include "../test_iterators.hpp"
+
+template <class It> void test() { ranges::reverse_iterator<It> r; }
+
+template <class It> void test2(It i) {
+  ranges::reverse_iterator<It> r(i);
+  CHECK(r.base() == i);
+}
+
+template <class It, class U> void test3(U u) {
+  const ranges::reverse_iterator<U> r2(u);
+  ranges::reverse_iterator<It> r1 = r2;
+  assert(r1.base() == u);
+}
+
+struct Base {};
+struct Derived : Base {};
+
+template <class It> void test4(It i) {
+  const ranges::reverse_iterator<It> r = ranges::make_reverse_iterator(i);
+  assert(r.base() == i);
+}
+
+template <class It> void test5(It l, It r, bool x) {
+  const ranges::reverse_iterator<It> r1(l);
+  const ranges::reverse_iterator<It> r2(r);
+  assert((r1 != r2) == x);
+}
+
+template <class It> void test6(It i, It x) {
+  ranges::reverse_iterator<It> r(i);
+  ranges::reverse_iterator<It> rr = r++;
+  assert(r.base() == x);
+  assert(rr.base() == i);
+}
+
+template <class It> void test7(It i, It x) {
+  ranges::reverse_iterator<It> r(i);
+  ranges::reverse_iterator<It> &rr = ++r;
+  assert(r.base() == x);
+  assert(&rr == &r);
+}
+
+template <class It>
+void test8(It i, ranges::iterator_difference_t<It> n, It x) {
+  const ranges::reverse_iterator<It> r(i);
+  ranges::reverse_iterator<It> rr = r + n;
+  assert(rr.base() == x);
+}
+
+template <class It>
+void test9(It i, ranges::iterator_difference_t<It> n, It x) {
+  ranges::reverse_iterator<It> r(i);
+  ranges::reverse_iterator<It> &rr = r += n;
+  assert(r.base() == x);
+  assert(&rr == &r);
+}
+
+template <class It> void test10(It i, It x) {
+  ranges::reverse_iterator<It> r(i);
+  ranges::reverse_iterator<It> rr = r--;
+  assert(r.base() == x);
+  assert(rr.base() == i);
+}
+template <class It> void test11(It i, It x) {
+  ranges::reverse_iterator<It> r(i);
+  ranges::reverse_iterator<It> &rr = --r;
+  assert(r.base() == x);
+  assert(&rr == &r);
+}
+template <class It>
+void test12(It i, ranges::iterator_difference_t<It> n, It x) {
+  const ranges::reverse_iterator<It> r(i);
+  ranges::reverse_iterator<It> rr = r - n;
+  assert(rr.base() == x);
+}
+
+template <class It>
+void test13(It i, ranges::iterator_difference_t<It> n, It x) {
+  ranges::reverse_iterator<It> r(i);
+  ranges::reverse_iterator<It> &rr = r -= n;
+  assert(r.base() == x);
+  assert(&rr == &r);
+}
+
+class A {
+  int data_;
+
+public:
+  A() : data_(1) {}
+  ~A() { data_ = -1; }
+
+  friend bool operator==(const A &x, const A &y) { return x.data_ == y.data_; }
+};
+
+template <class It> void test14(It i, ranges::iterator_value_t<It> x) {
+  ranges::reverse_iterator<It> r(i);
+  assert(*r == x);
+}
+
+template <class It, class U> void test15(U u) {
+  const ranges::reverse_iterator<U> r2(u);
+  ranges::reverse_iterator<It> r1;
+  ranges::reverse_iterator<It> &rr = r1 = r2;
+  assert(r1.base() == u);
+  assert(&rr == &r1);
+}
+template <class It> void test16(It l, It r, bool x) {
+  const ranges::reverse_iterator<It> r1(l);
+  const ranges::reverse_iterator<It> r2(r);
+  assert((r1 == r2) == x);
+}
+
+template <class It1, class It2> void test17(It1 l, It2 r, std::ptrdiff_t x) {
+   const ranges::reverse_iterator<It1> r1(l);
+   const ranges::reverse_iterator<It2> r2(r);
+   assert((r1 - r2) == x);
+}
+
+template <class It> void test18(It l, It r, bool x) {
+  const ranges::reverse_iterator<It> r1(l);
+  const ranges::reverse_iterator<It> r2(r);
+  assert((r1 > r2) == x);
+}
+
+template <class It> void test19(It l, It r, bool x) {
+  const ranges::reverse_iterator<It> r1(l);
+  const ranges::reverse_iterator<It> r2(r);
+  assert((r1 >= r2) == x);
+}
+
+template <class It>
+void test20(It i, ranges::iterator_difference_t<It> n,
+            ranges::iterator_value_t<It> x) {
+  const ranges::reverse_iterator<It> r(i);
+  ranges::iterator_value_t<It> rr = r[n];
+  assert(rr == x);
+}
+
+template <class It> void test21(It l, It r, bool x) {
+  const ranges::reverse_iterator<It> r1(l);
+  const ranges::reverse_iterator<It> r2(r);
+  assert((r1 < r2) == x);
+}
+
+template <class It>
+void
+test22(It l, It r, bool x)
+{
+    const ranges::reverse_iterator<It> r1(l);
+    const ranges::reverse_iterator<It> r2(r);
+    assert((r1 < r2) == x);
+}
+
+template <class It>
+void
+test23(It l, It r, bool x)
+{
+    const ranges::reverse_iterator<It> r1(l);
+    const ranges::reverse_iterator<It> r2(r);
+    assert((r1 <= r2) == x);
+}
+
+
+class B
+{
+    int data_;
+  public:
+    B() : data_(1) {}
+    ~B() {data_ = -1;}
+
+    int get() const {return data_;}
+
+    friend bool operator==(const B& x, const B& y)
+    {return x.data_ == y.data_;}
+};
+
+template <class It>
+void
+test24(It i, ranges::iterator_value_t<It> x)
+{
+    ranges::reverse_iterator<It> r(i);
+    assert((*r).get() == x.get());
+}
+
+
+class C
+{
+    int data_;
+  public:
+    C(int d=1) : data_(d) {}
+    ~C() {data_ = -1;}
+
+    int get() const {return data_;}
+
+    friend bool operator==(const C& x, const C& y)
+    {return x.data_ == y.data_;}
+    const C *operator&() const { return nullptr; }
+    C       *operator&()       { return nullptr; }
+};
+
+template <class It>
+void
+test25(It i, ranges::iterator_difference_t<It> n, It x)
+{
+    const ranges::reverse_iterator<It> r(i);
+    ranges::reverse_iterator<It> rr = n + r;
+    assert(rr.base() == x);
+}
+
+int main() {
+  {
+
+    static_assert(
+        ranges::detail::BidirectionalCursor<
+        ranges::detail::reverse_cursor<bidirectional_iterator<const char *>>>{},
+        "");
+    static_assert(
+        ranges::detail::BidirectionalCursor<
+        ranges::detail::reverse_cursor<random_access_iterator<const char *>>>{},
+        "");
+    static_assert(
+        ranges::detail::RandomAccessCursor<
+        ranges::detail::reverse_cursor<random_access_iterator<const char *>>>{},
+        "");
+    static_assert(
+        ranges::BidirectionalIterator<
+            ranges::reverse_iterator<bidirectional_iterator<const char *>>>{},
+        "");
+    static_assert(
+        ranges::RandomAccessIterator<
+            ranges::reverse_iterator<random_access_iterator<const char *>>>{},
+        "");
+  }
+  { // test
+    test<bidirectional_iterator<const char *>>();
+    test<random_access_iterator<char *>>();
+    test<char *>();
+    test<const char *>();
+  }
+  { // test 2
+    const char s[] = "123";
+    test2(bidirectional_iterator<const char *>(s));
+    test2(random_access_iterator<const char *>(s));
+  }
+  { // test3
+    Derived d;
+    test3<bidirectional_iterator<Base *>>(
+        bidirectional_iterator<Derived *>(&d));
+    test3<random_access_iterator<const Base *>>(
+        random_access_iterator<Derived *>(&d));
+  }
+  { // test4
+    const char *s = "1234567890";
+    random_access_iterator<const char *> b(s);
+    random_access_iterator<const char *> e(s + 10);
+    while (b != e)
+      test4(b++);
+  }
+  { // test5
+    const char *s = "1234567890";
+    test5(bidirectional_iterator<const char *>(s),
+          bidirectional_iterator<const char *>(s), false);
+    test5(bidirectional_iterator<const char *>(s),
+          bidirectional_iterator<const char *>(s + 1), true);
+    test5(random_access_iterator<const char *>(s),
+          random_access_iterator<const char *>(s), false);
+    test5(random_access_iterator<const char *>(s),
+          random_access_iterator<const char *>(s + 1), true);
+    test5(s, s, false);
+    test5(s, s + 1, true);
+  }
+  {
+    const char *s = "123";
+    test6(bidirectional_iterator<const char *>(s + 1),
+          bidirectional_iterator<const char *>(s));
+    test6(random_access_iterator<const char *>(s + 1),
+          random_access_iterator<const char *>(s));
+    test6(s + 1, s);
+  }
+  {
+    const char *s = "123";
+    test7(bidirectional_iterator<const char *>(s + 1),
+          bidirectional_iterator<const char *>(s));
+    test7(random_access_iterator<const char *>(s + 1),
+          random_access_iterator<const char *>(s));
+    test7(s + 1, s);
+  }
+  {
+    const char *s = "1234567890";
+    test8(random_access_iterator<const char *>(s + 5), 5,
+          random_access_iterator<const char *>(s));
+    test8(s + 5, 5, s);
+  }
+  {
+    const char *s = "1234567890";
+    test9(random_access_iterator<const char *>(s + 5), 5,
+          random_access_iterator<const char *>(s));
+    test9(s + 5, 5, s);
+  }
+  {
+    const char *s = "123";
+    test10(bidirectional_iterator<const char *>(s + 1),
+           bidirectional_iterator<const char *>(s + 2));
+    test10(random_access_iterator<const char *>(s + 1),
+           random_access_iterator<const char *>(s + 2));
+    test10(s + 1, s + 2);
+  }
+  {
+    const char *s = "123";
+    test11(bidirectional_iterator<const char *>(s + 1),
+           bidirectional_iterator<const char *>(s + 2));
+    test11(random_access_iterator<const char *>(s + 1),
+           random_access_iterator<const char *>(s + 2));
+    test11(s + 1, s + 2);
+  }
+  {
+    const char *s = "1234567890";
+    test12(random_access_iterator<const char *>(s + 5), 5,
+           random_access_iterator<const char *>(s + 10));
+    test12(s + 5, 5, s + 10);
+  }
+  {
+    const char *s = "1234567890";
+    test13(random_access_iterator<const char *>(s + 5), 5,
+           random_access_iterator<const char *>(s + 10));
+    test13(s + 5, 5, s + 10);
+  }
+  {
+    A a;
+    test14(&a + 1, A());
+  }
+  {
+    Derived d;
+
+    test15<bidirectional_iterator<Base *>>(
+        bidirectional_iterator<Derived *>(&d));
+    test15<random_access_iterator<const Base *>>(
+        random_access_iterator<Derived *>(&d));
+    test15<Base *>(&d);
+  }
+  {
+    const char *s = "1234567890";
+    test16(bidirectional_iterator<const char *>(s),
+           bidirectional_iterator<const char *>(s), true);
+    test16(bidirectional_iterator<const char *>(s),
+           bidirectional_iterator<const char *>(s + 1), false);
+    test16(random_access_iterator<const char *>(s),
+           random_access_iterator<const char *>(s), true);
+    test16(random_access_iterator<const char *>(s),
+           random_access_iterator<const char *>(s + 1), false);
+    test16(s, s, true);
+    test16(s, s + 1, false);
+  }
+  {
+    char s[3] = {0};
+    test17(random_access_iterator<const char *>(s),
+           random_access_iterator<char *>(s), 0);
+    random_access_iterator<char *> inp1(s);
+    test17(random_access_iterator<char *>(s),
+           random_access_iterator<const char *>(s + 1), 1);
+    test17(random_access_iterator<const char *>(s + 1),
+           random_access_iterator<char *>(s), -1);
+    test17(s, s, 0);
+    test17(s, s + 1, 1);
+    test17(s + 1, s, -1);
+  }
+  {
+    const char *s = "1234567890";
+    test18(random_access_iterator<const char *>(s),
+           random_access_iterator<const char *>(s), false);
+    test18(random_access_iterator<const char *>(s),
+           random_access_iterator<const char *>(s + 1), true);
+    test18(random_access_iterator<const char *>(s + 1),
+           random_access_iterator<const char *>(s), false);
+    test18(s, s, false);
+    test18(s, s + 1, true);
+    test18(s + 1, s, false);
+  }
+  {
+    const char *s = "1234567890";
+    test19(random_access_iterator<const char *>(s),
+           random_access_iterator<const char *>(s), true);
+    test19(random_access_iterator<const char *>(s),
+           random_access_iterator<const char *>(s + 1), true);
+    test19(random_access_iterator<const char *>(s + 1),
+           random_access_iterator<const char *>(s), false);
+    test19(s, s, true);
+    test19(s, s + 1, true);
+    test19(s + 1, s, false);
+  }
+  {
+    const char *s = "1234567890";
+    test20(random_access_iterator<const char *>(s + 5), 4, '1');
+    test20(s + 5, 4, '1');
+  }
+  {
+    const char *s = "1234567890";
+    test21(random_access_iterator<const char *>(s),
+         random_access_iterator<const char *>(s), false);
+    test21(random_access_iterator<const char *>(s),
+         random_access_iterator<const char *>(s + 1), false);
+    test21(random_access_iterator<const char *>(s + 1),
+         random_access_iterator<const char *>(s), true);
+    test21(s, s, false);
+    test21(s, s + 1, false);
+    test21(s + 1, s, true);
+  }
+  {
+      const char* s = "1234567890";
+      test22(random_access_iterator<const char*>(s), random_access_iterator<const char*>(s), false);
+      test22(random_access_iterator<const char*>(s), random_access_iterator<const char*>(s+1), false);
+      test22(random_access_iterator<const char*>(s+1), random_access_iterator<const char*>(s), true);
+      test22(s, s, false);
+      test22(s, s+1, false);
+      test22(s+1, s, true);
+  }
+  {
+      const char* s = "1234567890";
+      test23(random_access_iterator<const char*>(s), random_access_iterator<const char*>(s), true);
+      test23(random_access_iterator<const char*>(s), random_access_iterator<const char*>(s+1), false);
+      test23(random_access_iterator<const char*>(s+1), random_access_iterator<const char*>(s), true);
+      test23(s, s, true);
+      test23(s, s+1, false);
+      test23(s+1, s, true);
+  }
+  {
+      B a;
+      test24(&a+1, B());
+  }
+  {
+      C l[3] = {C(0), C(1), C(2)};
+
+      auto ri = ranges::rbegin(l);
+      assert ( (*ri).get() == 2 );  ++ri;
+      assert ( (*ri).get() == 1 );  ++ri;
+      assert ( (*ri).get() == 0 );  ++ri;
+      assert ( ri == ranges::rend(l));
+  }
+  {
+      const char* s = "1234567890";
+      test25(random_access_iterator<const char*>(s+5), 5, random_access_iterator<const char*>(s));
+      test25(s+5, 5, s);
+  }
+
+  return test_result();
+}

--- a/test/utility/swap.cpp
+++ b/test/utility/swap.cpp
@@ -18,6 +18,7 @@
 #include <tuple>
 #include <memory>
 #include <vector>
+#include <complex>
 #include <range/v3/utility/swap.hpp>
 #include <range/v3/utility/concepts.hpp>
 #include <range/v3/utility/iterator.hpp> // for iter_swap, which uses indirect_swap
@@ -25,6 +26,12 @@
 #include <range/v3/to_container.hpp>
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
+
+template<typename T>
+struct S
+{
+    T t;
+};
 
 struct MoveOnlyString
 {
@@ -124,6 +131,17 @@ int main()
         ranges::iter_swap(rng.begin(), rng.begin()+2);
         ::check_equal(v0, {"c","b","a"});
         ::check_equal(v1, {"z","y","x"});
+    }
+
+    {
+        using T = std::complex<float>;
+        T s,t;
+        ranges::swap(s,t);
+    }
+    {
+        using T = S<std::complex<float>>;
+        T s,t;
+        ranges::swap(s,t);
     }
 
     return ::test_result();

--- a/test/view/CMakeLists.txt
+++ b/test/view/CMakeLists.txt
@@ -53,13 +53,6 @@ add_test(test.view.iota, view.iota)
 add_executable(view.join join.cpp)
 add_test(test.view.join, view.join)
 
-add_executable(view.join.cxx1y join.cpp)
-add_test(test.view.join.cxx1y, view.join.cxx1y)
-
-set_target_properties(
-    view.join.cxx1y
-    PROPERTIES COMPILE_FLAGS "-std=c++1y")
-
 add_executable(view.map keys_value.cpp)
 add_test(test.view.map, view.map)
 


### PR DESCRIPTION
- adds constexpr to:
  - begin, end, rbegin, rend, cbegin, cend, crbegin, crend
    - note: i've hijacked ADL for C-arrays and initializer lists in ranges::rbegin/rend/crbegin/crend 
      because std::rbegin/rend/crbegin/crend are not constexpr (while std::begin/std::end are...). 
        - a constexpr reverse_iterator is added to utility to make this work.
  - advance, next, prev, distance, iter_size, swap, indirect_swap
    - note 1: i've hijacked std::advance for pointers since it is not constexpr
    - note 2: for the test iterators I have to define advance overloads that forward
      to range-v3 ones. I think it would be better to allow customizing advance's implementation
      via a different name (e.g. advance_customization_point), and not import std::advance at all. 
  - front, back, empty, size, at

- adds constexpr tests to test/constexpr_core.cpp
   - test iterators are constexpr
   - test::array is fully tested, C-arrays and initializer_lists are partially tested (since swap for them
     is not constexpr and iter_swap cannot work). view::iota tests can be added in the future.

- adds reverse_iterator to utilities
- adds testing utility array
- fix: remove c++1y test for view::join, it is already tested in C++14 mode.