### PR TITLE
fix take_while sentinel constraint

### DIFF
--- a/include/range/v3/view/take_while.hpp
+++ b/include/range/v3/view/take_while.hpp
@@ -61,7 +61,7 @@ namespace ranges
             {
                 return {pred_};
             }
-            CONCEPT_REQUIRES(Callable<Pred const, range_iterator_t<Rng const>>())
+            CONCEPT_REQUIRES(Callable<Pred const, range_iterator_t<Rng>>())
             sentinel_adaptor<true> end_adaptor() const
             {
                 return {pred_};

--- a/test/view/take_while.cpp
+++ b/test/view/take_while.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 #include <range/v3/core.hpp>
 #include <range/v3/view/iota.hpp>
+#include <range/v3/view/generate.hpp>
 #include <range/v3/view/take_while.hpp>
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
@@ -37,6 +38,25 @@ int main()
     ::check_equal(mutable_only, {0,1,2,3,4});
     CONCEPT_ASSERT(Range<decltype(mutable_only)>());
     CONCEPT_ASSERT(!Range<decltype(mutable_only) const>());
+
+    {
+        auto ns = view::generate([]() mutable {
+            static std::size_t N = 0;
+            return ++N;
+        });
+        auto rng = ns | view::take_while([](int i) { return i < 5; });
+        ::check_equal(rng, {1,2,3,4});
+    }
+
+    {
+        auto ns = view::generate([]() mutable {
+            static std::size_t N = 0;
+            return ++N;
+        });
+        auto rng = ns | view::take_while([](int i) mutable { return i < 5; });
+        ::check_equal(rng, {1,2,3,4});
+    }
+
 
     return test_result();
 }


### PR DESCRIPTION
A const sentinel of `view::take_while` required a const predicate and a const range. 
Was that intended? (See new tests). 