### PR TITLE
constexpr algorithms

### DIFF
--- a/include/range/v3/algorithm/adjacent_find.hpp
+++ b/include/range/v3/algorithm/adjacent_find.hpp
@@ -39,6 +39,7 @@ namespace ranges
                 CONCEPT_REQUIRES_(ForwardIterator<I>() && IteratorRange<I, S>() &&
                     IndirectCallableRelation<C, Project<I, P>>())>
             I
+            RANGES_CXX14_CONSTEXPR
             operator()(I begin, S end, C pred_ = C{}, P proj_ = P{}) const
             {
                 auto &&pred = as_function(pred_);
@@ -57,6 +58,7 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(ForwardIterable<Rng>() &&
                     IndirectCallableRelation<C, Project<I, P>>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng>
             operator()(Rng &&rng, C pred = C{}, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/all_of.hpp
+++ b/include/range/v3/algorithm/all_of.hpp
@@ -34,6 +34,7 @@ namespace ranges
             template<typename I, typename S, typename F, typename P = ident,
                 CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
                     IndirectCallablePredicate<F, Project<I, P> >())>
+            RANGES_CXX14_CONSTEXPR
             bool
             operator()(I first, S last, F pred, P proj = P{}) const
             {
@@ -48,6 +49,7 @@ namespace ranges
             template<typename Rng, typename F, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(InputIterable<Rng>() && IndirectCallablePredicate<F, Project<I, P> >())>
+            RANGES_CXX14_CONSTEXPR
             bool
             operator()(Rng &&rng, F pred, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/any_of.hpp
+++ b/include/range/v3/algorithm/any_of.hpp
@@ -35,6 +35,7 @@ namespace ranges
             template<typename I, typename S, typename F, typename P = ident,
                 CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
                     IndirectCallablePredicate<F, Project<I, P> >())>
+            RANGES_CXX14_CONSTEXPR
             bool
             operator()(I first, S last, F pred, P proj = P{}) const
             {
@@ -49,6 +50,7 @@ namespace ranges
             template<typename Rng, typename F, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(InputIterable<Rng>() && IndirectCallablePredicate<F, Project<I, P> >())>
+            RANGES_CXX14_CONSTEXPR
             bool
             operator()(Rng &&rng, F pred, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/aux_/equal_range_n.hpp
+++ b/include/range/v3/algorithm/aux_/equal_range_n.hpp
@@ -36,6 +36,7 @@ namespace ranges
             {
                 template<typename I, typename V, typename R = ordered_less, typename P = ident,
                     CONCEPT_REQUIRES_(BinarySearchable<I, V, R, P>())>
+                RANGES_CXX14_CONSTEXPR
                 range<I>
                 operator()(I begin, iterator_difference_t<I> dist, V const & val, R pred_ = R{},
                     P proj_ = P{}) const
@@ -57,8 +58,8 @@ namespace ranges
                             dist = half;
                         }
                         else
-                            return {lower_bound_n(std::move(begin), half, val, std::ref(pred)),
-                                    upper_bound_n(next(middle), dist - half - 1, val, std::ref(pred))};
+                            return {lower_bound_n(std::move(begin), half, val, ranges::ref(pred)),
+                                    upper_bound_n(next(middle), dist - half - 1, val, ranges::ref(pred))};
                     }
                     return {begin, begin};
                 }

--- a/include/range/v3/algorithm/aux_/lower_bound_n.hpp
+++ b/include/range/v3/algorithm/aux_/lower_bound_n.hpp
@@ -32,6 +32,7 @@ namespace ranges
             {
                 template<typename I, typename V2, typename C = ordered_less, typename P = ident,
                     CONCEPT_REQUIRES_(BinarySearchable<I, V2, C, P>())>
+                RANGES_CXX14_CONSTEXPR
                 I operator()(I begin, iterator_difference_t<I> d, V2 const &val, C pred_ = C{},
                     P proj_ = P{}) const
                 {

--- a/include/range/v3/algorithm/aux_/upper_bound_n.hpp
+++ b/include/range/v3/algorithm/aux_/upper_bound_n.hpp
@@ -37,6 +37,7 @@ namespace ranges
                 /// \pre `Rng` is a model of the `Iterable` concept
                 template<typename I, typename V2, typename C = ordered_less, typename P = ident,
                     CONCEPT_REQUIRES_(BinarySearchable<I, V2, C, P>())>
+                RANGES_CXX14_CONSTEXPR
                 I operator()(I begin, iterator_difference_t<I> d, V2 const &val, C pred_ = C{},
                     P proj_ = P{}) const
                 {

--- a/include/range/v3/algorithm/binary_search.hpp
+++ b/include/range/v3/algorithm/binary_search.hpp
@@ -41,6 +41,7 @@ namespace ranges
             template<typename I, typename S, typename V2, typename C = ordered_less,
                 typename P = ident,
                 CONCEPT_REQUIRES_(IteratorRange<I, S>() && BinarySearchable<I, V2, C, P>())>
+            RANGES_CXX14_CONSTEXPR
             bool
             operator()(I begin, S end, V2 const &val, C pred = C{}, P proj = P{}) const
             {
@@ -54,6 +55,7 @@ namespace ranges
             template<typename Rng, typename V2, typename C = ordered_less, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(Iterable<Rng>() && BinarySearchable<I, V2, C, P>())>
+            RANGES_CXX14_CONSTEXPR
             bool
             operator()(Rng &&rng, V2 const &val, C pred = C{}, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/copy.hpp
+++ b/include/range/v3/algorithm/copy.hpp
@@ -41,6 +41,7 @@ namespace ranges
                     WeaklyIncrementable<O>() &&
                     IndirectlyCopyable<I, O>()
                 )>
+            RANGES_CXX14_CONSTEXPR
             std::pair<I, O>
             operator()(I begin, S end, O out) const
             {
@@ -56,6 +57,7 @@ namespace ranges
                     WeaklyIncrementable<O>() &&
                     IndirectlyCopyable<I, O>()
                 )>
+            RANGES_CXX14_CONSTEXPR
             std::pair<range_safe_iterator_t<Rng>, O>
             operator()(Rng &&rng, O out) const
             {

--- a/include/range/v3/algorithm/copy_backward.hpp
+++ b/include/range/v3/algorithm/copy_backward.hpp
@@ -37,6 +37,7 @@ namespace ranges
                     BidirectionalIterator<O>() &&
                     IndirectlyCopyable<I, O>()
                 )>
+            RANGES_CXX14_CONSTEXPR
             std::pair<I, O> operator()(I begin, S end_, O out) const
             {
                 I i = ranges::next(begin, end_), end = i;
@@ -52,6 +53,7 @@ namespace ranges
                     BidirectionalIterator<O>() &&
                     IndirectlyCopyable<I, O>()
                 )>
+            RANGES_CXX14_CONSTEXPR
             std::pair<range_safe_iterator_t<Rng>, O>
             operator()(Rng &&rng, O out) const
             {

--- a/include/range/v3/algorithm/copy_if.hpp
+++ b/include/range/v3/algorithm/copy_if.hpp
@@ -36,6 +36,7 @@ namespace ranges
                 CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
                     WeaklyIncrementable<O>() && IndirectCallablePredicate<F, Project<I, P> >() &&
                     IndirectlyCopyable<I, O>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<I, O>
             operator()(I begin, S end, O out, F pred_, P proj_ = P{}) const
             {
@@ -57,6 +58,7 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(InputIterable<Rng>() && WeaklyIncrementable<O>() &&
                     IndirectCallablePredicate<F, Project<I, P> >() && IndirectlyCopyable<I, O>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<range_safe_iterator_t<Rng>, O>
             operator()(Rng &&rng, O out, F pred, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/copy_n.hpp
+++ b/include/range/v3/algorithm/copy_n.hpp
@@ -13,7 +13,6 @@
 #ifndef RANGES_V3_ALGORITHM_COPY_N_HPP
 #define RANGES_V3_ALGORITHM_COPY_N_HPP
 
-#include <tuple>
 #include <utility>
 #include <functional>
 #include <range/v3/range_fwd.hpp>
@@ -40,6 +39,7 @@ namespace ranges
                     WeaklyIncrementable<O>() &&
                     IndirectlyCopyable<I, O>()
                 )>
+            RANGES_CXX14_CONSTEXPR
             std::pair<I, O>
             operator()(I begin, iterator_difference_t<I> n, O out) const
             {

--- a/include/range/v3/algorithm/count.hpp
+++ b/include/range/v3/algorithm/count.hpp
@@ -34,6 +34,7 @@ namespace ranges
             template<typename I, typename S, typename V, typename P = ident,
                 CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
                     IndirectCallableRelation<equal_to, Project<I, P>, V const *>())>
+            RANGES_CXX14_CONSTEXPR
             iterator_difference_t<I>
             operator()(I begin, S end, V const & val, P proj_ = P{}) const
             {
@@ -49,6 +50,7 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(InputIterable<Rng>() &&
                     IndirectCallableRelation<equal_to, Project<I, P>, V const *>())>
+            RANGES_CXX14_CONSTEXPR
             iterator_difference_t<I>
             operator()(Rng &&rng, V const & val, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/count_if.hpp
+++ b/include/range/v3/algorithm/count_if.hpp
@@ -34,6 +34,7 @@ namespace ranges
             template<typename I, typename S, typename R, typename P = ident,
                 CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
                     IndirectCallablePredicate<R, Project<I, P> >())>
+            RANGES_CXX14_CONSTEXPR
             iterator_difference_t<I>
             operator()(I begin, S end, R pred_, P proj_ = P{}) const
             {
@@ -49,6 +50,7 @@ namespace ranges
             template<typename Rng, typename R, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(InputIterable<Rng>() && IndirectCallablePredicate<R, Project<I, P> >())>
+            RANGES_CXX14_CONSTEXPR
             iterator_difference_t<I>
             operator()(Rng &&rng, R pred, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/equal.hpp
+++ b/include/range/v3/algorithm/equal.hpp
@@ -35,6 +35,7 @@ namespace ranges
         private:
             template<typename I0, typename S0, typename I1, typename S1,
                 typename C, typename P0, typename P1>
+            RANGES_CXX14_CONSTEXPR
             bool nocheck(I0 begin0, S0 end0, I1 begin1, S1 end1, C pred_,
                 P0 proj0_, P1 proj1_) const
             {
@@ -54,6 +55,7 @@ namespace ranges
                     IteratorRange<I0, S0>() &&
                     WeaklyComparable<I0, I1, C, P0, P1>()
                 )>
+            RANGES_CXX14_CONSTEXPR
             bool operator()(I0 begin0, S0 end0, I1 begin1, C pred_ = C{},
                 P0 proj0_ = P0{}, P1 proj1_ = P1{}) const
             {
@@ -67,17 +69,32 @@ namespace ranges
             }
 
             template<typename I0, typename S0, typename I1, typename S1,
+                     CONCEPT_REQUIRES_(!SizedIteratorRange<I0, S0>() ||
+                                       !SizedIteratorRange<I1, S1>())>
+            RANGES_CXX14_CONSTEXPR
+            static bool are_sized_with_different_size(I0&, S0&, I1&, S1&) {
+                return false;
+            }
+            template<typename I0, typename S0, typename I1, typename S1,
+                     CONCEPT_REQUIRES_(SizedIteratorRange<I0, S0>() &&
+                                       SizedIteratorRange<I1, S1>())>
+            RANGES_CXX14_CONSTEXPR
+            static bool are_sized_with_different_size(I0& begin0, S0& end0, I1& begin1, S1& end1) {
+                return distance(begin0, end0) != distance(begin1, end1);
+            }
+
+            template<typename I0, typename S0, typename I1, typename S1,
                 typename C = equal_to, typename P0 = ident, typename P1 = ident,
                 CONCEPT_REQUIRES_(
                     IteratorRange<I0, S0>() && IteratorRange<I1, S1>() &&
                     Comparable<I0, I1, C, P0, P1>()
                 )>
+            RANGES_CXX14_CONSTEXPR
             bool operator()(I0 begin0, S0 end0, I1 begin1, S1 end1, C pred_ = C{},
                 P0 proj0_ = P0{}, P1 proj1_ = P1{}) const
             {
-                if(SizedIteratorRange<I0, S0>() && SizedIteratorRange<I1, S1>())
-                    if(distance(begin0, end0) != distance(begin1, end1))
-                        return false;
+                if(are_sized_with_different_size(begin0, end0, begin1, end1))
+                    return false;
                 return this->nocheck(std::move(begin0), std::move(end0), std::move(begin1),
                     std::move(end1), std::move(pred_), std::move(proj0_), std::move(proj1_));
             }
@@ -90,11 +107,25 @@ namespace ranges
                     Iterable<Rng0>() && Iterator<I1>() &&
                     WeaklyComparable<I0, I1, C, P0, P1>()
                 )>
+            RANGES_CXX14_CONSTEXPR
             bool operator()(Rng0 && rng0, I1Ref && begin1, C pred_ = C{}, P0 proj0_ = P0{},
                 P1 proj1_ = P1{}) const
             {
                 return (*this)(begin(rng0), end(rng0), (I1Ref &&) begin1, std::move(pred_),
                     std::move(proj0_), std::move(proj1_));
+            }
+
+            template<typename Rng0, typename Rng1,
+                     CONCEPT_REQUIRES_(!SizedIterable<Rng0>() || !SizedIterable<Rng1>())>
+            RANGES_CXX14_CONSTEXPR
+            static bool are_sized_with_different_size(Rng0&, Rng1&) {
+                return false;
+            }
+            template<typename Rng0, typename Rng1,
+                     CONCEPT_REQUIRES_(SizedIterable<Rng0>() && SizedIterable<Rng1>())>
+            RANGES_CXX14_CONSTEXPR
+            static bool are_sized_with_different_size(Rng0& rng0, Rng1& rng1) {
+                return distance(rng0) != distance(rng1);
             }
 
             template<typename Rng0, typename Rng1,
@@ -105,12 +136,12 @@ namespace ranges
                     Iterable<Rng0>() && Iterable<Rng1>() &&
                     Comparable<I0, I1, C, P0, P1>()
                 )>
+            RANGES_CXX14_CONSTEXPR
             bool operator()(Rng0 && rng0, Rng1 && rng1, C pred_ = C{}, P0 proj0_ = P0{},
                 P1 proj1_ = P1{}) const
             {
-                if(SizedIterable<Rng0>() && SizedIterable<Rng1>())
-                    if(distance(rng0) != distance(rng1))
-                        return false;
+                if(are_sized_with_different_size(rng0, rng1))
+                    return false;
                 return this->nocheck(begin(rng0), end(rng0), begin(rng1), end(rng1),
                     std::move(pred_), std::move(proj0_), std::move(proj1_));
             }

--- a/include/range/v3/algorithm/equal_range.hpp
+++ b/include/range/v3/algorithm/equal_range.hpp
@@ -33,6 +33,7 @@ namespace ranges
         {
             template<typename I, typename S, typename V, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(IteratorRange<I, S>() && BinarySearchable<I, V, C, P>())>
+            RANGES_CXX14_CONSTEXPR
             range<I>
             operator()(I begin, S end, V const & val, C pred = C{}, P proj = P{}) const
             {
@@ -43,6 +44,7 @@ namespace ranges
             template<typename Rng, typename V, typename C = ordered_less, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(Iterable<Rng>() && BinarySearchable<I, V, C, P>())>
+            RANGES_CXX14_CONSTEXPR
             meta::if_<std::is_lvalue_reference<Rng>, range<I>, dangling<range<I>>>
             operator()(Rng &&rng, V const & val, C pred = C{}, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/fill.hpp
+++ b/include/range/v3/algorithm/fill.hpp
@@ -30,6 +30,7 @@ namespace ranges
         {
             template<typename O, typename S, typename V,
                 CONCEPT_REQUIRES_(OutputIterator<O, V>() && IteratorRange<O, S>())>
+            RANGES_CXX14_CONSTEXPR
             O operator()(O begin, S end, V const & val) const
             {
                 for(; begin != end; ++begin)
@@ -40,6 +41,7 @@ namespace ranges
             template<typename Rng, typename V,
                 typename O = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(OutputIterable<Rng, V>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng> operator()(Rng &&rng, V const & val) const
             {
                 return (*this)(begin(rng), end(rng), val);

--- a/include/range/v3/algorithm/fill_n.hpp
+++ b/include/range/v3/algorithm/fill_n.hpp
@@ -32,6 +32,7 @@ namespace ranges
         {
             template<typename O, typename V,
                 CONCEPT_REQUIRES_(WeakOutputIterator<O, V>())>
+            RANGES_CXX14_CONSTEXPR
             O operator()(O begin, iterator_difference_t<O> n, V const & val) const
             {
                 RANGES_ASSERT(n >= 0);

--- a/include/range/v3/algorithm/find.hpp
+++ b/include/range/v3/algorithm/find.hpp
@@ -43,6 +43,7 @@ namespace ranges
             template<typename I, typename S, typename V, typename P = ident,
                 CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
                     IndirectCallableRelation<equal_to, Project<I, P>, V const *>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end, V const &val, P proj_ = P{}) const
             {
                 auto &&proj = as_function(proj_);
@@ -57,6 +58,7 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(InputIterable<Rng>() &&
                     IndirectCallableRelation<equal_to, Project<I, P>, V const *>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng> operator()(Rng &&rng, V const &val, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), val, std::move(proj));

--- a/include/range/v3/algorithm/find_end.hpp
+++ b/include/range/v3/algorithm/find_end.hpp
@@ -33,6 +33,7 @@ namespace ranges
         {
             template<typename I, typename S,
                 CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>())>
+            RANGES_CXX14_CONSTEXPR
             I next_to_if(I i, S s, std::true_type)
             {
                 return ranges::next(i, s);
@@ -40,6 +41,7 @@ namespace ranges
 
             template<typename I, typename S,
                 CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>())>
+            RANGES_CXX14_CONSTEXPR
             S next_to_if(I, S s, std::false_type)
             {
                 return s;
@@ -47,6 +49,7 @@ namespace ranges
 
             template<bool B, typename I, typename S,
                 CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>())>
+            RANGES_CXX14_CONSTEXPR
             meta::if_c<B, I, S> next_to_if(I i, S s)
             {
                 return detail::next_to_if(std::move(i), std::move(s), meta::bool_<B>{});
@@ -60,6 +63,7 @@ namespace ranges
         {
         private:
             template<typename I1, typename S1, typename I2, typename S2, typename R, typename P>
+            RANGES_CXX14_CONSTEXPR
             static I1
             impl(I1 begin1, S1 end1, I2 begin2, S2 end2, R pred_, P proj_,
                  concepts::ForwardIterator*, concepts::ForwardIterator*)
@@ -102,6 +106,7 @@ namespace ranges
             }
 
             template<typename I1, typename I2, typename R, typename P>
+            RANGES_CXX14_CONSTEXPR
             static I1
             impl(I1 begin1, I1 end1, I2 begin2, I2 end2, R pred_, P proj_,
                  concepts::BidirectionalIterator*, concepts::BidirectionalIterator*)
@@ -134,6 +139,7 @@ namespace ranges
             }
 
             template<typename I1, typename I2, typename R, typename P>
+            RANGES_CXX14_CONSTEXPR
             static I1
             impl(I1 begin1, I1 end1, I2 begin2, I2 end2, R pred_, P proj_,
                  concepts::RandomAccessIterator*, concepts::RandomAccessIterator*)
@@ -169,6 +175,7 @@ namespace ranges
                 CONCEPT_REQUIRES_(ForwardIterator<I1>() && IteratorRange<I1, S1>() &&
                     ForwardIterator<I2>() && IteratorRange<I2, S2>() &&
                     IndirectCallableRelation<R, Project<I1, P>, I2>())>
+            RANGES_CXX14_CONSTEXPR
             I1 operator()(I1 begin1, S1 end1, I2 begin2, S2 end2, R pred = R{}, P proj = P{}) const
             {
                 constexpr bool Bidi = BidirectionalIterator<I1>() && BidirectionalIterator<I2>();
@@ -184,6 +191,7 @@ namespace ranges
                 typename I2 = range_iterator_t<Rng2>,
                 CONCEPT_REQUIRES_(ForwardIterable<Rng1>() && ForwardIterable<Rng2>() &&
                     IndirectCallableRelation<R, Project<I1, P>, I2>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng1> operator()(Rng1 &&rng1, Rng2 &&rng2, R pred = R{}, P proj = P{}) const
             {
                 return (*this)(begin(rng1), end(rng1), begin(rng2), end(rng2), std::move(pred),

--- a/include/range/v3/algorithm/find_first_of.hpp
+++ b/include/range/v3/algorithm/find_first_of.hpp
@@ -40,6 +40,7 @@ namespace ranges
                      typename R = equal_to, typename P0 = ident, typename P1 = ident,
                      CONCEPT_REQUIRES_(IteratorRange<I0, S0>() && IteratorRange<I1, S1>() &&
                         ForwardIterator<I1>() && AsymmetricallyComparable<I0, I1, R, P0, P1>())>
+            RANGES_CXX14_CONSTEXPR
             I0 operator()(I0 begin0, S0 end0, I1 begin1, S1 end1, R pred_ = R{}, P0 proj0_ = P0{},
                 P1 proj1_ = P1{}) const
             {
@@ -59,6 +60,7 @@ namespace ranges
                      typename I1 = range_iterator_t<Rng1>,
                      CONCEPT_REQUIRES_(Iterable<Rng0>() && Iterable<Rng1>() &&
                         ForwardIterator<I1>() && AsymmetricallyComparable<I0, I1, R, P0, P1>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng0> operator()(Rng0 &&rng0, Rng1 &&rng1, R pred = R{}, P0 proj0 = P0{},
                 P1 proj1 = P1{}) const
             {

--- a/include/range/v3/algorithm/find_if.hpp
+++ b/include/range/v3/algorithm/find_if.hpp
@@ -45,6 +45,7 @@ namespace ranges
             template<typename I, typename S, typename F, typename P = ident,
                 CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
                     IndirectCallablePredicate<F, Project<I, P> >())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end, F pred_, P proj_ = P{}) const
             {
                 auto &&pred = as_function(pred_);
@@ -60,6 +61,7 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(InputIterable<Rng>() &&
                     IndirectCallablePredicate<F, Project<I, P>>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng> operator()(Rng &&rng, F pred, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));

--- a/include/range/v3/algorithm/find_if_not.hpp
+++ b/include/range/v3/algorithm/find_if_not.hpp
@@ -45,6 +45,7 @@ namespace ranges
             template<typename I, typename S, typename F, typename P = ident,
                 CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
                     IndirectCallablePredicate<F, Project<I, P> >())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end, F pred_, P proj_ = P{}) const
             {
                 auto &&pred = as_function(pred_);
@@ -60,6 +61,7 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(InputIterable<Rng>() &&
                     IndirectCallablePredicate<F, Project<I, P> >())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng> operator()(Rng &&rng, F pred, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));

--- a/include/range/v3/algorithm/for_each.hpp
+++ b/include/range/v3/algorithm/for_each.hpp
@@ -33,6 +33,7 @@ namespace ranges
             template<typename I, typename S, typename F, typename P = ident,
                 CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
                     IndirectCallable<F, Project<I, P>>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end, F fun_, P proj_ = P{}) const
             {
                 auto &&fun = as_function(fun_);
@@ -47,6 +48,7 @@ namespace ranges
             template<typename Rng, typename F, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(InputIterable<Rng>() && IndirectCallable<F, Project<I, P>>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng> operator()(Rng &&rng, F fun, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), std::move(fun), std::move(proj));

--- a/include/range/v3/algorithm/generate.hpp
+++ b/include/range/v3/algorithm/generate.hpp
@@ -33,6 +33,7 @@ namespace ranges
                 CONCEPT_REQUIRES_(Function<F>() &&
                     OutputIterator<O, concepts::Function::result_t<F>>() &&
                     IteratorRange<O, S>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<O, F> operator()(O begin, S end, F fun) const
             {
                 for(; begin != end; ++begin)
@@ -44,6 +45,7 @@ namespace ranges
                 typename O = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(Function<F>() &&
                     OutputIterable<Rng, concepts::Function::result_t<F>>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<range_safe_iterator_t<Rng>, F> operator()(Rng &&rng, F fun) const
             {
                 return (*this)(begin(rng), end(rng), std::move(fun));

--- a/include/range/v3/algorithm/generate_n.hpp
+++ b/include/range/v3/algorithm/generate_n.hpp
@@ -13,7 +13,6 @@
 #ifndef RANGES_V3_ALGORITHM_GENERATE_N_HPP
 #define RANGES_V3_ALGORITHM_GENERATE_N_HPP
 
-#include <tuple>
 #include <utility>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
@@ -34,6 +33,7 @@ namespace ranges
             template<typename O, typename F,
                 CONCEPT_REQUIRES_(Function<F>() &&
                     WeakOutputIterator<O, concepts::Function::result_t<F>>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<O, F> operator()(O begin, iterator_difference_t<O> n, F fun) const
             {
                 RANGES_ASSERT(n >= 0);

--- a/include/range/v3/algorithm/heap_algorithm.hpp
+++ b/include/range/v3/algorithm/heap_algorithm.hpp
@@ -51,6 +51,7 @@ namespace ranges
             {
                 template<typename I, typename C = ordered_less, typename P = ident,
                     CONCEPT_REQUIRES_(IsHeapable<I, C, P>())>
+                RANGES_CXX14_CONSTEXPR
                 I operator()(I const begin_, iterator_difference_t<I> const n_, C pred_ = C{}, P proj_ = P{}) const
                 {
                     RANGES_ASSERT(0 <= n_);
@@ -84,6 +85,7 @@ namespace ranges
             {
                 template<typename I, typename C = ordered_less, typename P = ident,
                     CONCEPT_REQUIRES_(IsHeapable<I, C, P>())>
+                RANGES_CXX14_CONSTEXPR
                 bool operator()(I begin, iterator_difference_t<I> n, C pred = C{}, P proj = P{}) const
                 {
                     return is_heap_until_n(begin, n, std::move(pred), std::move(proj)) == begin + n;
@@ -103,6 +105,7 @@ namespace ranges
         {
             template<typename I, typename S, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(IsHeapable<I, C, P>() && IteratorRange<I, S>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end, C pred = C{}, P proj = P{}) const
             {
                 return detail::is_heap_until_n(std::move(begin), distance(begin, end), std::move(pred),
@@ -112,6 +115,7 @@ namespace ranges
             template<typename Rng, typename C = ordered_less, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(IsHeapable<I, C, P>() && Iterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng> operator()(Rng &&rng, C pred = C{}, P proj = P{}) const
             {
                 return detail::is_heap_until_n(begin(rng), distance(rng), std::move(pred),
@@ -130,6 +134,7 @@ namespace ranges
         {
             template<typename I, typename S, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(IsHeapable<I, C, P>() && IteratorRange<I, S>())>
+            RANGES_CXX14_CONSTEXPR
             bool operator()(I begin, S end, C pred = C{}, P proj = P{}) const
             {
                 return detail::is_heap_n(std::move(begin), distance(begin, end), std::move(pred),
@@ -139,6 +144,7 @@ namespace ranges
             template<typename Rng, typename C = ordered_less, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(IsHeapable<I, C, P>() && Iterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             bool operator()(Rng &&rng, C pred = C{}, P proj = P{}) const
             {
                 return detail::is_heap_n(begin(rng), distance(rng), std::move(pred), std::move(proj));
@@ -159,6 +165,7 @@ namespace ranges
             struct sift_up_n_fn
             {
                 template<typename I, typename C = ordered_less, typename P = ident>
+                RANGES_CXX14_CONSTEXPR
                 void operator()(I begin, iterator_difference_t<I> len, C pred_ = C{}, P proj_ = P{}) const
                 {
                     if(len > 1)
@@ -194,6 +201,7 @@ namespace ranges
             struct sift_down_n_fn
             {
                 template<typename I, typename C = ordered_less, typename P = ident>
+                RANGES_CXX14_CONSTEXPR
                 void operator()(I begin, iterator_difference_t<I> len, I start, C pred_ = C {}, P proj_ = P{}) const
                 {
                     // left-child of start is at 2 * start + 1
@@ -261,6 +269,7 @@ namespace ranges
         {
             template<typename I, typename S, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(RandomAccessIterator<I>() && IteratorRange<I, S>() && Sortable<I, C, P>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end, C pred = C{}, P proj = P{}) const
             {
                 auto n = distance(begin, end);
@@ -271,6 +280,7 @@ namespace ranges
             template<typename Rng, typename C = ordered_less, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(RandomAccessIterable<Rng>() && Sortable<I, C, P>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng> operator()(Rng &&rng, C pred = C{}, P proj = P{}) const
             {
                 I begin = ranges::begin(rng);
@@ -295,6 +305,7 @@ namespace ranges
             {
                 template<typename I, typename C = ordered_less, typename P = ident,
                     CONCEPT_REQUIRES_(RandomAccessIterator<I>() && Sortable<I, C, P>())>
+                RANGES_CXX14_CONSTEXPR
                 void operator()(I begin, iterator_difference_t<I> len, C pred = C{},
                     P proj = P{}) const
                 {
@@ -319,6 +330,7 @@ namespace ranges
         {
             template<typename I, typename S, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(RandomAccessIterator<I>() && IteratorRange<I, S>() && Sortable<I, C, P>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end, C pred = C{}, P proj = P{}) const
             {
                 auto n = distance(begin, end);
@@ -329,6 +341,7 @@ namespace ranges
             template<typename Rng, typename C = ordered_less, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(RandomAccessIterable<Rng>() && Sortable<I, C, P>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng> operator()(Rng &&rng, C pred = C{}, P proj = P{}) const
             {
                 I begin = ranges::begin(rng);
@@ -349,6 +362,7 @@ namespace ranges
         {
             template<typename I, typename S, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(RandomAccessIterator<I>() && IteratorRange<I, S>() && Sortable<I, C, P>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end, C pred_ = C{}, P proj_ = P{}) const
             {
                 auto &&pred = as_function(pred_);
@@ -357,13 +371,14 @@ namespace ranges
                 if(n > 1)
                     // start from the first parent, there is no need to consider children
                     for(auto start = (n - 2) / 2; start >= 0; --start)
-                        detail::sift_down_n(begin, n, begin + start, std::ref(pred), std::ref(proj));
+                        detail::sift_down_n(begin, n, begin + start, ranges::ref(pred), ranges::ref(proj));
                 return begin + n;
             }
 
             template<typename Rng, typename C = ordered_less, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(RandomAccessIterable<Rng>() && Sortable<I, C, P>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng> operator()(Rng &&rng, C pred_ = C{}, P proj_ = P{}) const
             {
                 auto &&pred = as_function(pred_);
@@ -373,7 +388,7 @@ namespace ranges
                 if(n > 1)
                     // start from the first parent, there is no need to consider children
                     for(auto start = (n - 2) / 2; start >= 0; --start)
-                        detail::sift_down_n(begin, n, begin + start, std::ref(pred), std::ref(proj));
+                        detail::sift_down_n(begin, n, begin + start, ranges::ref(pred), ranges::ref(proj));
                 return begin + n;
             }
         };
@@ -389,19 +404,21 @@ namespace ranges
         {
             template<typename I, typename S, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(RandomAccessIterator<I>() && IteratorRange<I, S>() && Sortable<I, C, P>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end, C pred_ = C{}, P proj_ = P{}) const
             {
                 auto &&pred = as_function(pred_);
                 auto &&proj = as_function(proj_);
                 iterator_difference_t<I> const n = distance(begin, end);
                 for(auto i = n; i > 1; --i)
-                    detail::pop_heap_n(begin, i, std::ref(pred), std::ref(proj));
+                    detail::pop_heap_n(begin, i, ranges::ref(pred), ranges::ref(proj));
                 return begin + n;
             }
 
             template<typename Rng, typename C = ordered_less, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(RandomAccessIterable<Rng &>() && Sortable<I, C, P>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng> operator()(Rng &&rng, C pred_ = C{}, P proj_ = P{}) const
             {
                 auto &&pred = as_function(pred_);
@@ -409,7 +426,7 @@ namespace ranges
                 I begin = ranges::begin(rng);
                 iterator_difference_t<I> const n = distance(rng);
                 for(auto i = n; i > 1; --i)
-                    detail::pop_heap_n(begin, i, std::ref(pred), std::ref(proj));
+                    detail::pop_heap_n(begin, i, ranges::ref(pred), ranges::ref(proj));
                 return begin + n;
             }
         };

--- a/include/range/v3/algorithm/inplace_merge.hpp
+++ b/include/range/v3/algorithm/inplace_merge.hpp
@@ -53,9 +53,14 @@ namespace ranges
         {
             struct merge_adaptive_fn
             {
+                using buffered_t = std::true_type;
+                static constexpr buffered_t buffered{};
+                using unbuffered_t = std::false_type;
+                static constexpr unbuffered_t unbuffered{};
+
             private:
                 template<typename I, typename C, typename P>
-                static void impl(I begin, I middle, I end, iterator_difference_t<I> len1,
+                static void impl(buffered_t, I begin, I middle, I end, iterator_difference_t<I> len1,
                     iterator_difference_t<I> len2, iterator_value_t<I> *buf, C &pred, P &proj)
                 {
                     using value_type = iterator_value_t<I>;
@@ -65,7 +70,7 @@ namespace ranges
                     {
                         p = ranges::move(begin, middle, p).second;
                         merge_move(buf, p.base().base(), std::move(middle), std::move(end),
-                            std::move(begin), std::ref(pred), std::ref(proj), std::ref(proj));
+                            std::move(begin), ranges::ref(pred), ranges::ref(proj), ranges::ref(proj));
                     }
                     else
                     {
@@ -74,14 +79,22 @@ namespace ranges
                         using Rv = std::reverse_iterator<value_type*>;
                         merge_move(RBi{std::move(middle)}, RBi{std::move(begin)},
                             Rv{p.base().base()}, Rv{buf}, RBi{std::move(end)},
-                            not_(std::ref(pred)), std::ref(proj), std::ref(proj));
+                            not_(ranges::ref(pred)), ranges::ref(proj), ranges::ref(proj));
                     }
                 }
+                template<typename I, typename C, typename P>
+                RANGES_CXX14_CONSTEXPR
+                static void impl(unbuffered_t, I, I, I, iterator_difference_t<I>,
+                    iterator_difference_t<I>, iterator_value_t<I>*, C &, P &)
+                {}
+
+
 
             public:
-                template<typename I, typename C = ordered_less, typename P = ident,
+                template<typename Impl, typename I, typename C = ordered_less, typename P = ident,
                     CONCEPT_REQUIRES_(BidirectionalIterator<I>() && Sortable<I, C, P>())>
-                void operator()(I begin, I middle, I end, iterator_difference_t<I> len1,
+                RANGES_CXX14_CONSTEXPR
+                void operator()(Impl, I begin, I middle, I end, iterator_difference_t<I> len1,
                     iterator_difference_t<I> len2, iterator_value_t<I> *buf,
                     std::ptrdiff_t buf_size, C pred_ = C{}, P proj_ = P{}) const
                 {
@@ -103,7 +116,7 @@ namespace ranges
                         }
                         if(len1 <= buf_size || len2 <= buf_size)
                         {
-                            merge_adaptive_fn::impl(std::move(begin), std::move(middle),
+                            merge_adaptive_fn::impl(Impl{}, std::move(begin), std::move(middle),
                                 std::move(end), len1, len2, buf, pred, proj);
                             return;
                         }
@@ -115,16 +128,16 @@ namespace ranges
                         //         [middle, m2) <  [m1, middle)
                         //         [m1, middle) <= [m2, end)
                         //     and m1 or m2 is in the middle of its range
-                        I m1;  // "median" of [begin, middle)
-                        I m2;  // "median" of [middle, end)
-                        D len11;      // distance(begin, m1)
-                        D len21;      // distance(middle, m2)
+                        I m1{};  // "median" of [begin, middle)
+                        I m2{};  // "median" of [middle, end)
+                        D len11{};      // distance(begin, m1)
+                        D len21{};      // distance(middle, m2)
                         // binary search smaller range
                         if(len1 < len2)
                         {   // len >= 1, len2 >= 2
                             len21 = len2 / 2;
                             m2 = next(middle, len21);
-                            m1 = upper_bound(begin, middle, proj(*m2), std::ref(pred), std::ref(proj));
+                            m1 = upper_bound(begin, middle, proj(*m2), ranges::ref(pred), ranges::ref(proj));
                             len11 = distance(begin, m1);
                         }
                         else
@@ -138,7 +151,7 @@ namespace ranges
                             // len1 >= 2, len2 >= 1
                             len11 = len1 / 2;
                             m1 = next(begin, len11);
-                            m2 = lower_bound(middle, end, proj(*m1), std::ref(pred), std::ref(proj));
+                            m2 = lower_bound(middle, end, proj(*m1), ranges::ref(pred), ranges::ref(proj));
                             len21 = distance(middle, m2);
                         }
                         D len12 = len1 - len11;  // distance(m1, middle)
@@ -150,8 +163,8 @@ namespace ranges
                         // merge smaller range with recursive call and larger with tail recursion elimination
                         if(len11 + len21 < len12 + len22)
                         {
-                            (*this)(std::move(begin), std::move(m1), middle, len11, len21, buf, buf_size,
-                                std::ref(pred), std::ref(proj));
+                            (*this)(Impl{}, std::move(begin), std::move(m1), middle, len11, len21, buf, buf_size,
+                                ranges::ref(pred), ranges::ref(proj));
                             begin = std::move(middle);
                             middle = std::move(m2);
                             len1 = len12;
@@ -159,14 +172,24 @@ namespace ranges
                         }
                         else
                         {
-                            (*this)(middle, std::move(m2), std::move(end), len12, len22, buf, buf_size,
-                                std::ref(pred), std::ref(proj));
+                            (*this)(Impl{}, middle, std::move(m2), std::move(end), len12, len22, buf, buf_size,
+                                ranges::ref(pred), ranges::ref(proj));
                             end = std::move(middle);
                             middle = std::move(m1);
                             len1 = len11;
                             len2 = len21;
                         }
                     }
+                }
+                template<typename I, typename C = ordered_less, typename P = ident,
+                         CONCEPT_REQUIRES_(BidirectionalIterator<I>() && Sortable<I, C, P>())>
+                void operator()(I begin, I middle, I end, iterator_difference_t<I> len1,
+                                iterator_difference_t<I> len2, iterator_value_t<I> *buf,
+                                std::ptrdiff_t buf_size, C pred_ = C{}, P proj_ = P{}) const
+                {
+                    (*this)(buffered, std::move(begin), std::move(middle),
+                            std::move(end), len1, len2, buf, buf_size,
+                            std::move(pred_), std::move(proj_));
                 }
             };
 
@@ -179,11 +202,28 @@ namespace ranges
             {
                 template<typename I, typename C = ordered_less, typename P = ident,
                     CONCEPT_REQUIRES_(BidirectionalIterator<I>() && Sortable<I, C, P>())>
-                void operator()(I begin, I middle, I end, iterator_difference_t<I> len1,
-                    iterator_difference_t<I> len2, C pred = C{}, P proj = P{}) const
+                RANGES_CXX14_CONSTEXPR
+                I operator()(I begin, I middle, I end, C pred = C{}, P proj = P{}) const
                 {
-                    merge_adaptive(std::move(begin), std::move(middle), std::move(end), len1, len2,
+                    auto len1 = distance(begin, middle);
+                    auto len2_and_end = enumerate(middle, end);
+                    merge_adaptive(merge_adaptive.unbuffered,
+                                   std::move(begin), std::move(middle),
+                                   len2_and_end.second,
+                                   len1, len2_and_end.first,
                         nullptr, 0, std::move(pred), std::move(proj));
+                    return len2_and_end.second;
+                }
+
+                template<typename Rng, typename C = ordered_less, typename P = ident,
+                         typename I = range_iterator_t<Rng>,
+                         CONCEPT_REQUIRES_(BidirectionalIterable<Rng>() && Sortable<I, C, P>())>
+                RANGES_CXX14_CONSTEXPR
+                range_safe_iterator_t<Rng>
+                operator()(Rng &&rng, I middle, C pred = C{}, P proj = P{}) const
+                {
+                    return (*this)(begin(rng), std::move(middle), end(rng), std::move(pred),
+                                   std::move(proj));
                 }
             };
 
@@ -214,7 +254,8 @@ namespace ranges
                     buf = std::get_temporary_buffer<value_type>(buf_size);
                     h.reset(buf.first);
                 }
-                detail::merge_adaptive(std::move(begin), std::move(middle), len2_and_end.second,
+                detail::merge_adaptive(detail::merge_adaptive.buffered,
+                    std::move(begin), std::move(middle), len2_and_end.second,
                     len1, len2_and_end.first, buf.first, buf.second, std::move(pred),
                     std::move(proj));
                 return len2_and_end.second;
@@ -223,11 +264,32 @@ namespace ranges
             template<typename Rng, typename C = ordered_less, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(BidirectionalIterable<Rng>() && Sortable<I, C, P>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng>
             operator()(Rng &&rng, I middle, C pred = C{}, P proj = P{}) const
             {
                 return (*this)(begin(rng), std::move(middle), end(rng), std::move(pred),
                     std::move(proj));
+            }
+
+            template<typename I, typename S, typename C = ordered_less, typename P = ident,
+                CONCEPT_REQUIRES_(BidirectionalIterator<I>() && Sortable<I, C, P>())>
+            I inplace(I begin, I middle, S end, C pred = C{}, P proj = P{}) const
+            {
+                return detail::inplace_merge_no_buffer(std::move(begin), std::move(middle),
+                                                       std::move(end),
+                                                       std::move(pred), std::move(proj));
+            }
+
+            template<typename Rng, typename C = ordered_less, typename P = ident,
+                typename I = range_iterator_t<Rng>,
+                CONCEPT_REQUIRES_(BidirectionalIterable<Rng>() && Sortable<I, C, P>())>
+            RANGES_CXX14_CONSTEXPR
+            range_safe_iterator_t<Rng>
+            inplace(Rng &&rng, I middle, C pred = C{}, P proj = P{}) const
+            {
+                return detail::inplace_merge_no_buffer(std::forward<Rng>(rng), std::move(middle),
+                                                       std::move(pred), std::move(proj));
             }
         };
 

--- a/include/range/v3/algorithm/is_partitioned.hpp
+++ b/include/range/v3/algorithm/is_partitioned.hpp
@@ -47,6 +47,7 @@ namespace ranges
         {
             template<typename I, typename S, typename C, typename P = ident,
                 CONCEPT_REQUIRES_(IsPartitionedable<I, C, P>() && IteratorRange<I, S>())>
+            RANGES_CXX14_CONSTEXPR
             bool operator()(I begin, S end, C pred_, P proj_ = P{}) const
             {
                 auto && pred = as_function(pred_);
@@ -63,6 +64,7 @@ namespace ranges
             template<typename Rng, typename C, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(IsPartitionedable<I, C, P>() && Iterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             bool operator()(Rng &&rng, C pred, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));

--- a/include/range/v3/algorithm/is_sorted.hpp
+++ b/include/range/v3/algorithm/is_sorted.hpp
@@ -42,6 +42,7 @@ namespace ranges
             template<typename I, typename S, typename R = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(ForwardIterator<I>() && IteratorRange<I, S>() &&
                        IndirectCallableRelation<R, Project<I, P>>())>
+            RANGES_CXX14_CONSTEXPR
             bool operator()(I begin, S end, R rel = R{}, P proj_ = P{}) const
             {
                 return is_sorted_until(std::move(begin), end, std::move(rel),
@@ -52,6 +53,7 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(ForwardIterable<Rng>() &&
                     IndirectCallableRelation<R, Project<I, P>>())>
+            RANGES_CXX14_CONSTEXPR
             bool operator()(Rng &&rng, R rel = R{}, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), std::move(rel), std::move(proj));

--- a/include/range/v3/algorithm/is_sorted_until.hpp
+++ b/include/range/v3/algorithm/is_sorted_until.hpp
@@ -44,6 +44,7 @@ namespace ranges
             template<typename I, typename S, typename R = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(ForwardIterator<I>() && IteratorRange<I, S>() &&
                     IndirectCallableRelation<R, Project<I, P>>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end, R pred_ = R{}, P proj_ = P{}) const
             {
                 auto &&pred = as_function(pred_);
@@ -65,6 +66,7 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(ForwardIterable<Rng>() &&
                     IndirectCallableRelation<R, Project<I, P>>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng> operator()(Rng &&rng, R pred = R{}, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));

--- a/include/range/v3/algorithm/lexicographical_compare.hpp
+++ b/include/range/v3/algorithm/lexicographical_compare.hpp
@@ -34,6 +34,7 @@ namespace ranges
                 typename C = ordered_less, typename P0 = ident, typename P1 = ident,
                 CONCEPT_REQUIRES_(IteratorRange<I0, S0>() && IteratorRange<I1, S1>() &&
                     Comparable<I0, I1, C, P0, P1>())>
+            RANGES_CXX14_CONSTEXPR
             bool operator()(I0 begin0, S0 end0, I1 begin1, S1 end1, C pred_ = C{}, P0 proj0_ = P0{},
                 P1 proj1_ = P1{}) const
             {
@@ -56,6 +57,7 @@ namespace ranges
                 typename I1 = range_iterator_t<Rng1>,
                 CONCEPT_REQUIRES_(InputIterable<Rng0>() && InputIterable<Rng1>() &&
                     Comparable<I0, I1, C, P0, P1>())>
+            RANGES_CXX14_CONSTEXPR
             bool operator()(Rng0 &&rng0, Rng1 &&rng1, C pred = C{}, P0 proj0 = P0{},
                 P1 proj1 = P1{}) const
             {

--- a/include/range/v3/algorithm/lower_bound.hpp
+++ b/include/range/v3/algorithm/lower_bound.hpp
@@ -33,6 +33,7 @@ namespace ranges
         {
             template<typename I, typename S, typename V, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(IteratorRange<I, S>() && BinarySearchable<I, V, C, P>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end, V const &val, C pred = C{}, P proj = P{}) const
             {
                 return aux::lower_bound_n(std::move(begin), distance(begin, end), val, std::move(pred),
@@ -42,6 +43,7 @@ namespace ranges
             template<typename Rng, typename V, typename C = ordered_less, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(Iterable<Rng>() && BinarySearchable<I, V, C, P>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng> operator()(Rng &&rng, V const &val, C pred = C{}, P proj = P{}) const
             {
                 static_assert(!is_infinite<Rng>::value, "Trying to binary search an infinite range");

--- a/include/range/v3/algorithm/max_element.hpp
+++ b/include/range/v3/algorithm/max_element.hpp
@@ -34,6 +34,7 @@ namespace ranges
             template<typename I, typename S, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(ForwardIterator<I>() && IteratorRange<I, S>() &&
                     IndirectCallableRelation<C, Project<I, P>>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end, C pred_ = C{}, P proj_ = P{}) const
             {
                 auto && pred = as_function(pred_);
@@ -49,6 +50,7 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(ForwardIterable<Rng>() &&
                     IndirectCallableRelation<C, Project<I, P>>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng> operator()(Rng &&rng, C pred = C{}, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));

--- a/include/range/v3/algorithm/merge.hpp
+++ b/include/range/v3/algorithm/merge.hpp
@@ -53,6 +53,7 @@ namespace ranges
                     IteratorRange<I1, S1>() &&
                     Mergeable<I0, I1, O, C, P0, P1>()
                 )>
+            RANGES_CXX14_CONSTEXPR
             std::tuple<I0, I1, O>
             operator()(I0 begin0, S0 end0, I1 begin1, S1 end1, O out, C pred_ = C{},
                 P0 proj0_ = P0{}, P1 proj1_ = P1{}) const
@@ -87,6 +88,7 @@ namespace ranges
                     Iterable<Rng1>() &&
                     Mergeable<I0, I1, O, C, P0, P1>()
                 )>
+            RANGES_CXX14_CONSTEXPR
             std::tuple<range_safe_iterator_t<Rng0>, range_safe_iterator_t<Rng1>, O>
             operator()(Rng0 &&rng0, Rng1 &&rng1, O out, C pred = C{}, P0 proj0 = P0{},
                 P1 proj1 = P1{}) const

--- a/include/range/v3/algorithm/merge_move.hpp
+++ b/include/range/v3/algorithm/merge_move.hpp
@@ -53,6 +53,7 @@ namespace ranges
                     IteratorRange<I1, S1>() &&
                     MergeMovable<I0, I1, O, C, P0, P1>()
                 )>
+            RANGES_CXX14_CONSTEXPR
             std::tuple<I0, I1, O>
             operator()(I0 begin0, S0 end0, I1 begin1, S1 end1, O out, C pred_ = C{},
                 P0 proj0_ = P0{}, P1 proj1_ = P1{}) const
@@ -87,6 +88,7 @@ namespace ranges
                     Iterable<Rng1>() &&
                     MergeMovable<I0, I1, O, C, P0, P1>()
                 )>
+            RANGES_CXX14_CONSTEXPR
             std::tuple<range_safe_iterator_t<Rng0>, range_safe_iterator_t<Rng1>, O>
             operator()(Rng0 &&rng0, Rng1 &&rng1, O out, C pred = C{}, P0 proj0 = P0{},
                 P1 proj1 = P1{}) const

--- a/include/range/v3/algorithm/min_element.hpp
+++ b/include/range/v3/algorithm/min_element.hpp
@@ -34,6 +34,7 @@ namespace ranges
             template<typename I, typename S, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(ForwardIterator<I>() && IteratorRange<I, S>() &&
                     IndirectCallableRelation<C, Project<I, P>>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end, C pred_ = C{}, P proj_ = P{}) const
             {
                 auto && pred = as_function(pred_);
@@ -49,6 +50,7 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(ForwardIterable<Rng>() &&
                     IndirectCallableRelation<C, Project<I, P>>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng> operator()(Rng &&rng, C pred = C{}, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));

--- a/include/range/v3/algorithm/minmax_element.hpp
+++ b/include/range/v3/algorithm/minmax_element.hpp
@@ -37,6 +37,7 @@ namespace ranges
             template<typename I, typename S, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(ForwardIterator<I>() && IteratorRange<I, S>() &&
                     IndirectCallableRelation<C, Project<I, P>>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<I, I> operator()(I begin, S end, C pred_ = C{}, P proj_ = P{}) const
             {
                 auto && pred = as_function(pred_);
@@ -84,6 +85,7 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(ForwardIterable<Rng>() &&
                     IndirectCallableRelation<C, Project<I, P>>())>
+            RANGES_CXX14_CONSTEXPR
             meta::if_<std::is_lvalue_reference<Rng>, std::pair<I, I>, dangling<std::pair<I, I>>>
             operator()(Rng &&rng, C pred = C{}, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/mismatch.hpp
+++ b/include/range/v3/algorithm/mismatch.hpp
@@ -54,6 +54,7 @@ namespace ranges
             template<typename I1, typename S1, typename I2, typename C = equal_to,
                 typename P1 = ident, typename P2 = ident,
                 CONCEPT_REQUIRES_(Mismatchable1<I1, I2, C, P1, P2>() && IteratorRange<I1, S1>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<I1, I2>
             operator()(I1 begin1, S1 end1, I2 begin2, C pred_ = C{}, P1 proj1_ = P1{},
                 P2 proj2_ = P2{}) const
@@ -71,6 +72,7 @@ namespace ranges
                 typename P1 = ident, typename P2 = ident,
                 CONCEPT_REQUIRES_(Mismatchable2<I1, I2, C, P1, P2>() && IteratorRange<I1, S1>() &&
                     IteratorRange<I2, S2>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<I1, I2>
             operator()(I1 begin1, S1 end1, I2 begin2, S2 end2, C pred_ = C{}, P1 proj1_ = P1{},
                 P2 proj2_ = P2{}) const
@@ -90,6 +92,7 @@ namespace ranges
                 typename I2 = uncvref_t<I2Ref>, // [*] See below
                 CONCEPT_REQUIRES_(InputIterable<Rng1>() && Iterator<I2>() &&
                     Mismatchable1<I1, I2, C, P1, P2>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<range_safe_iterator_t<Rng1>, I2>
             operator()(Rng1 &&rng1, I2Ref &&begin2, C pred = C{}, P1 proj1 = P1{},
                 P2 proj2 = P2{}) const
@@ -104,6 +107,7 @@ namespace ranges
                 typename I2 = range_iterator_t<Rng2>,
                 CONCEPT_REQUIRES_(InputIterable<Rng1>() && InputIterable<Rng2>() &&
                     Mismatchable2<I1, I2, C, P1, P2>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<range_safe_iterator_t<Rng1>, range_safe_iterator_t<Rng2>>
             operator()(Rng1 &&rng1, Rng2 &&rng2, C pred = C{}, P1 proj1 = P1{}, P2 proj2 = P2{}) const
             {

--- a/include/range/v3/algorithm/move.hpp
+++ b/include/range/v3/algorithm/move.hpp
@@ -37,6 +37,7 @@ namespace ranges
             template<typename I, typename S, typename O,
                 CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
                     WeaklyIncrementable<O>() && IndirectlyMovable<I, O>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<I, O> operator()(I begin, S end, O out) const
             {
                 for(; begin != end; ++begin, ++out)
@@ -48,6 +49,7 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(InputIterable<Rng>() && WeaklyIncrementable<O>() &&
                     IndirectlyMovable<I, O>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<range_safe_iterator_t<Rng>, O> operator()(Rng &&rng, O out) const
             {
                 return (*this)(begin(rng), end(rng), std::move(out));

--- a/include/range/v3/algorithm/move_backward.hpp
+++ b/include/range/v3/algorithm/move_backward.hpp
@@ -35,6 +35,7 @@ namespace ranges
             template<typename I, typename S, typename O,
                 CONCEPT_REQUIRES_(BidirectionalIterator<I>() && IteratorRange<I, S>() &&
                     BidirectionalIterator<O>() && IndirectlyMovable<I, O>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<I, O> operator()(I begin, S end_, O out) const
             {
                 I i = ranges::next(begin, end_), end = i;
@@ -47,6 +48,7 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(BidirectionalIterable<Rng>() && BidirectionalIterator<O>() &&
                     IndirectlyMovable<I, O>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<range_safe_iterator_t<Rng>, O> operator()(Rng &&rng, O out) const
             {
                 return (*this)(begin(rng), end(rng), std::move(out));

--- a/include/range/v3/algorithm/none_of.hpp
+++ b/include/range/v3/algorithm/none_of.hpp
@@ -35,6 +35,7 @@ namespace ranges
             template<typename I, typename S, typename F, typename P = ident,
                 CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
                     IndirectCallablePredicate<F, Project<I, P>>())>
+            RANGES_CXX14_CONSTEXPR
             bool
             operator()(I first, S last, F pred, P proj = P{}) const
             {
@@ -49,6 +50,7 @@ namespace ranges
             template<typename Rng, typename F, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(InputIterable<Rng>() && IndirectCallablePredicate<F, Project<I, P>>())>
+            RANGES_CXX14_CONSTEXPR
             bool
             operator()(Rng &&rng, F pred, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/nth_element.hpp
+++ b/include/range/v3/algorithm/nth_element.hpp
@@ -92,7 +92,7 @@ namespace ranges
                 RANGES_ASSERT(begin != end);
                 for(I lm1 = ranges::prev(end); begin != lm1; ++begin)
                 {
-                    I i = ranges::min_element(begin, end, std::ref(pred), std::ref(proj));
+                    I i = ranges::min_element(begin, end, ranges::ref(pred), ranges::ref(proj));
                     if(i != begin)
                         ranges::iter_swap(begin, i);
                 }

--- a/include/range/v3/algorithm/partial_sort.hpp
+++ b/include/range/v3/algorithm/partial_sort.hpp
@@ -35,12 +35,13 @@ namespace ranges
         {
             template<typename I, typename S, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(Sortable<I, C, P>() && RandomAccessIterator<I>() && IteratorRange<I, S>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, I middle, S end, C pred_ = C{}, P proj_ = P{}) const
             {
                 auto && pred = as_function(pred_);
                 auto && proj = as_function(proj_);
 
-                make_heap(begin, middle, std::ref(pred), std::ref(proj));
+                make_heap(begin, middle, ranges::ref(pred), ranges::ref(proj));
                 auto const len = middle - begin;
                 I i = middle;
                 for(; i != end; ++i)
@@ -48,16 +49,17 @@ namespace ranges
                     if(pred(proj(*i), proj(*begin)))
                     {
                         iter_swap(i, begin);
-                        detail::sift_down_n(begin, len, begin, std::ref(pred), std::ref(proj));
+                        detail::sift_down_n(begin, len, begin, ranges::ref(pred), ranges::ref(proj));
                     }
                 }
-                sort_heap(begin, middle, std::ref(pred), std::ref(proj));
+                sort_heap(begin, middle, ranges::ref(pred), ranges::ref(proj));
                 return i;
             }
 
             template<typename Rng, typename C = ordered_less, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(Sortable<I, C, P>() && RandomAccessIterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng> operator()(Rng &&rng, I middle, C pred = C{},
                 P proj = P{}) const
             {

--- a/include/range/v3/algorithm/partial_sort_copy.hpp
+++ b/include/range/v3/algorithm/partial_sort_copy.hpp
@@ -47,6 +47,7 @@ namespace ranges
                 typename PI = ident, typename PO = ident,
                 CONCEPT_REQUIRES_(PartialSortCopyConcept<I, O, C, PI, PO>() &&
                     IteratorRange<I, SI>() && IteratorRange<O, SO>())>
+            RANGES_CXX14_CONSTEXPR
             O operator()(I begin, SI end, O out_begin, SO out_end, C pred_ = C{}, PI in_proj_ = PI{},
                 PO out_proj_ = PO{}) const
             {
@@ -58,7 +59,7 @@ namespace ranges
                 {
                     for(; begin != end && r != out_end; ++begin, ++r)
                         *r = *begin;
-                    make_heap(out_begin, r, std::ref(pred), std::ref(out_proj));
+                    make_heap(out_begin, r, ranges::ref(pred), ranges::ref(out_proj));
                     auto len = r - out_begin;
                     for(; begin != end; ++begin)
                     {
@@ -66,10 +67,10 @@ namespace ranges
                         if(pred(in_proj(x), out_proj(*out_begin)))
                         {
                             *out_begin = (decltype(x) &&) x;
-                            detail::sift_down_n(out_begin, len, out_begin, std::ref(pred), std::ref(out_proj));
+                            detail::sift_down_n(out_begin, len, out_begin, ranges::ref(pred), ranges::ref(out_proj));
                         }
                     }
-                    sort_heap(out_begin, r, std::ref(pred), std::ref(out_proj));
+                    sort_heap(out_begin, r, ranges::ref(pred), ranges::ref(out_proj));
                 }
                 return r;
             }
@@ -80,6 +81,7 @@ namespace ranges
                 typename O = range_iterator_t<OutRng>,
                 CONCEPT_REQUIRES_(PartialSortCopyConcept<I, O, C, PI, PO>() &&
                     Iterable<InRng>() && Iterable<OutRng>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<OutRng>
             operator()(InRng && in_rng, OutRng &&out_rng, C pred = C{}, PI in_proj = PI{},
                 PO out_proj = PO{}) const

--- a/include/range/v3/algorithm/partition.hpp
+++ b/include/range/v3/algorithm/partition.hpp
@@ -49,6 +49,7 @@ namespace ranges
         {
         private:
             template<typename I, typename S, typename C, typename P>
+            RANGES_CXX14_CONSTEXPR
             static I impl(I begin, S end, C pred_, P proj_, concepts::ForwardIterator*)
             {
                 auto && pred = as_function(pred_);
@@ -73,6 +74,7 @@ namespace ranges
             }
 
             template<typename I, typename S, typename C, typename P>
+            RANGES_CXX14_CONSTEXPR
             static I impl(I begin, S end_, C pred_, P proj_, concepts::BidirectionalIterator*)
             {
                 auto && pred = as_function(pred_);
@@ -100,6 +102,7 @@ namespace ranges
         public:
             template<typename I, typename S, typename C, typename P = ident,
                 CONCEPT_REQUIRES_(Partitionable<I, C, P>() && IteratorRange<I, S>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end, C pred, P proj = P{}) const
             {
                 return partition_fn::impl(std::move(begin), std::move(end), std::move(pred),
@@ -109,6 +112,7 @@ namespace ranges
             template<typename Rng, typename C, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(Partitionable<I, C, P>() && Iterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng> operator()(Rng &&rng, C pred, P proj = P{}) const
             {
                 return partition_fn::impl(begin(rng), end(rng), std::move(pred),

--- a/include/range/v3/algorithm/partition_copy.hpp
+++ b/include/range/v3/algorithm/partition_copy.hpp
@@ -46,6 +46,7 @@ namespace ranges
         {
             template<typename I, typename S, typename O0, typename O1, typename C, typename P = ident,
                 CONCEPT_REQUIRES_(PartitionCopyable<I, O0, O1, C, P>() && IteratorRange<I, S>())>
+            RANGES_CXX14_CONSTEXPR
             std::tuple<I, O0, O1> operator()(I begin, S end, O0 o0, O1 o1, C pred_, P proj_ = P{}) const
             {
                 auto && pred = as_function(pred_);
@@ -70,6 +71,7 @@ namespace ranges
             template<typename Rng, typename O0, typename O1, typename C, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(PartitionCopyable<I, O0, O1, C, P>() && Iterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             std::tuple<range_safe_iterator_t<Rng>, O0, O1>
             operator()(Rng &&rng, O0 o0, O1 o1, C pred, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/partition_move.hpp
+++ b/include/range/v3/algorithm/partition_move.hpp
@@ -46,6 +46,7 @@ namespace ranges
         {
             template<typename I, typename S, typename O0, typename O1, typename C, typename P = ident,
                 CONCEPT_REQUIRES_(PartitionMovable<I, O0, O1, C, P>() && IteratorRange<I, S>())>
+            RANGES_CXX14_CONSTEXPR
             std::tuple<I, O0, O1> operator()(I begin, S end, O0 o0, O1 o1, C pred_, P proj_ = P{}) const
             {
                 auto && pred = as_function(pred_);
@@ -69,6 +70,7 @@ namespace ranges
             template<typename Rng, typename O0, typename O1, typename C, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(PartitionMovable<I, O0, O1, C, P>() && Iterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             std::tuple<range_safe_iterator_t<Rng>, O0, O1>
             operator()(Rng &&rng, O0 o0, O1 o1, C pred, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/partition_point.hpp
+++ b/include/range/v3/algorithm/partition_point.hpp
@@ -52,6 +52,7 @@ namespace ranges
         {
             template<typename I, typename S, typename C, typename P = ident,
                 CONCEPT_REQUIRES_(PartitionPointable<I, C, P>() && IteratorRange<I, S>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end, C pred_, P proj_ = P{}) const
             {
                 auto && pred = as_function(pred_);
@@ -75,6 +76,7 @@ namespace ranges
             template<typename Rng, typename C, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(PartitionPointable<I, C, P>() && Iterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng> operator()(Rng &&rng, C pred, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));

--- a/include/range/v3/algorithm/permutation.hpp
+++ b/include/range/v3/algorithm/permutation.hpp
@@ -207,6 +207,7 @@ namespace ranges
         {
             template<typename I, typename S, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(BidirectionalIterator<I>() && IteratorRange<I, S>() && Sortable<I, C, P>())>
+            RANGES_CXX14_CONSTEXPR
             bool operator()(I begin, S end_, C pred_ = C{}, P proj_ = P{}) const
             {
                 auto &&pred = as_function(pred_);
@@ -239,6 +240,7 @@ namespace ranges
             template<typename Rng, typename C = ordered_less, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(BidirectionalIterable<Rng>() && Sortable<I, C, P>())>
+            RANGES_CXX14_CONSTEXPR
             bool operator()(Rng &&rng, C pred = C{}, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));
@@ -256,6 +258,7 @@ namespace ranges
         {
             template<typename I, typename S, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(BidirectionalIterator<I>() && IteratorRange<I, S>() && Sortable<I, C, P>())>
+            RANGES_CXX14_CONSTEXPR
             bool operator()(I begin, S end_, C pred_ = C{}, P proj_ = P{}) const
             {
                 auto &&pred = as_function(pred_);
@@ -288,6 +291,7 @@ namespace ranges
             template<typename Rng, typename C = ordered_less, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(BidirectionalIterable<Rng>() && Sortable<I, C, P>())>
+            RANGES_CXX14_CONSTEXPR
             bool operator()(Rng &&rng, C pred = C{}, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));

--- a/include/range/v3/algorithm/random_shuffle.hpp
+++ b/include/range/v3/algorithm/random_shuffle.hpp
@@ -88,6 +88,7 @@ namespace ranges
                 CONCEPT_REQUIRES_(RandomAccessIterator<I>() && IteratorRange<I, S>() &&
                                   Permutable<I>() &&
                                   RandomNumberGenerator<Gen, iterator_difference_t<I>>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end_, Gen && rand) const
             {
                 I end = ranges::next(begin, end_), orig = end;
@@ -106,6 +107,7 @@ namespace ranges
             template<typename Rng, typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(RandomAccessIterable<Rng>() &&
                                   Permutable<I>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng> operator()(Rng &&rng) const
             {
                 return (*this)(begin(rng), end(rng));
@@ -115,6 +117,7 @@ namespace ranges
                 CONCEPT_REQUIRES_(RandomAccessIterable<Rng>() &&
                                   Permutable<I>() &&
                                   RandomNumberGenerator<Gen, iterator_difference_t<I>>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng> operator()(Rng &&rng, Gen && rand) const
             {
                 return (*this)(begin(rng), end(rng), std::forward<Gen>(rand));

--- a/include/range/v3/algorithm/remove.hpp
+++ b/include/range/v3/algorithm/remove.hpp
@@ -42,10 +42,11 @@ namespace ranges
         {
             template<typename I, typename S, typename T, typename P = ident,
                 CONCEPT_REQUIRES_(Removable<I, T, P>() && IteratorRange<I, S>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end, T const &val, P proj_ = P{}) const
             {
                 auto &&proj = as_function(proj_);
-                begin = find(std::move(begin), end, val, std::ref(proj));
+                begin = find(std::move(begin), end, val, ranges::ref(proj));
                 if(begin != end)
                 {
                     for(I i = next(begin); i != end; ++i)
@@ -63,6 +64,7 @@ namespace ranges
             template<typename Rng, typename T, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(Removable<I, T, P>() && ForwardIterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng> operator()(Rng &&rng, T const &val, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), val, std::move(proj));

--- a/include/range/v3/algorithm/remove_copy.hpp
+++ b/include/range/v3/algorithm/remove_copy.hpp
@@ -41,6 +41,7 @@ namespace ranges
         {
             template<typename I, typename S, typename O, typename T, typename P = ident,
                 CONCEPT_REQUIRES_(RemoveCopyable<I, O, T, P>() && IteratorRange<I, S>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<I, O> operator()(I begin, S end, O out, T const &val, P proj_ = P{}) const
             {
                 auto &&proj = as_function(proj_);
@@ -59,6 +60,7 @@ namespace ranges
             template<typename Rng, typename O, typename T, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(RemoveCopyable<I, O, T, P>() && InputIterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<range_safe_iterator_t<Rng>, O> operator()(Rng &&rng, O out, T const &val, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), std::move(out), val, std::move(proj));

--- a/include/range/v3/algorithm/remove_copy_if.hpp
+++ b/include/range/v3/algorithm/remove_copy_if.hpp
@@ -41,6 +41,7 @@ namespace ranges
         {
             template<typename I, typename S, typename O, typename C, typename P = ident,
                 CONCEPT_REQUIRES_(RemoveCopyableIf<I, O, C, P>() && IteratorRange<I, S>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<I, O> operator()(I begin, S end, O out, C pred_, P proj_ = P{}) const
             {
                 auto &&pred = as_function(pred_);
@@ -60,6 +61,7 @@ namespace ranges
             template<typename Rng, typename O, typename C, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(RemoveCopyableIf<I, O, C, P>() && InputIterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<range_safe_iterator_t<Rng>, O> operator()(Rng &&rng, O out, C pred, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), std::move(out), std::move(pred), std::move(proj));

--- a/include/range/v3/algorithm/remove_if.hpp
+++ b/include/range/v3/algorithm/remove_if.hpp
@@ -42,11 +42,12 @@ namespace ranges
         {
             template<typename I, typename S, typename C, typename P = ident,
                 CONCEPT_REQUIRES_(RemovableIf<I, C, P>() && IteratorRange<I, S>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end, C pred_, P proj_ = P{}) const
             {
                 auto &&pred = as_function(pred_);
                 auto &&proj = as_function(proj_);
-                begin = find_if(std::move(begin), end, std::ref(pred), std::ref(proj));
+                begin = find_if(std::move(begin), end, ranges::ref(pred), ranges::ref(proj));
                 if(begin != end)
                 {
                     for(I i = next(begin); i != end; ++i)
@@ -64,6 +65,7 @@ namespace ranges
             template<typename Rng, typename C, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(RemovableIf<I, C, P>() && ForwardIterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng> operator()(Rng &&rng, C pred, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));

--- a/include/range/v3/algorithm/replace.hpp
+++ b/include/range/v3/algorithm/replace.hpp
@@ -40,6 +40,7 @@ namespace ranges
         {
             template<typename I, typename S, typename T0, typename T1, typename P = ident,
                 CONCEPT_REQUIRES_(Replaceable<I, T0, T1, P>() && IteratorRange<I, S>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end, T0 const & old_value, T1 const & new_value, P proj_ = {}) const
             {
                 auto &&proj = as_function(proj_);
@@ -52,6 +53,7 @@ namespace ranges
             template<typename Rng, typename T0, typename T1, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(Replaceable<I, T0, T1, P>() && Iterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng>
             operator()(Rng &&rng, T0 const & old_value, T1 const & new_value, P proj = {}) const
             {

--- a/include/range/v3/algorithm/replace_copy.hpp
+++ b/include/range/v3/algorithm/replace_copy.hpp
@@ -41,6 +41,7 @@ namespace ranges
         {
             template<typename I, typename S, typename O, typename T0, typename T1, typename P = ident,
                 CONCEPT_REQUIRES_(ReplaceCopyable<I, O, T0, T1, P>() && IteratorRange<I, S>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<I, O> operator()(I begin, S end, O out, T0 const & old_value, T1 const & new_value, P proj_ = {}) const
             {
                 auto &&proj = as_function(proj_);
@@ -58,6 +59,7 @@ namespace ranges
             template<typename Rng, typename O, typename T0, typename T1, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(ReplaceCopyable<I, O, T0, T1, P>() && Iterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<range_safe_iterator_t<Rng>, O>
             operator()(Rng &&rng, O out, T0 const & old_value, T1 const & new_value,
                 P proj = {}) const

--- a/include/range/v3/algorithm/replace_copy_if.hpp
+++ b/include/range/v3/algorithm/replace_copy_if.hpp
@@ -41,6 +41,7 @@ namespace ranges
         {
             template<typename I, typename S, typename O, typename C, typename T, typename P = ident,
                 CONCEPT_REQUIRES_(ReplaceCopyIfable<I, O, C, T, P>() && IteratorRange<I, S>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<I, O> operator()(I begin, S end, O out, C pred_, T const & new_value, P proj_ = {}) const
             {
                 auto &&pred = as_function(pred_);
@@ -59,6 +60,7 @@ namespace ranges
             template<typename Rng, typename O, typename C, typename T, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(ReplaceCopyIfable<I, O, C, T, P>() && Iterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<range_safe_iterator_t<Rng>, O>
             operator()(Rng &&rng, O out, C pred, T const & new_value, P proj = {}) const
             {

--- a/include/range/v3/algorithm/replace_if.hpp
+++ b/include/range/v3/algorithm/replace_if.hpp
@@ -40,6 +40,7 @@ namespace ranges
         {
             template<typename I, typename S, typename C, typename T, typename P = ident,
                 CONCEPT_REQUIRES_(ReplaceIfable<I, C, T, P>() && IteratorRange<I, S>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end, C pred_, T const & new_value, P proj_ = P{}) const
             {
                 auto &&pred = as_function(pred_);
@@ -53,6 +54,7 @@ namespace ranges
             template<typename Rng, typename C, typename T, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(ReplaceIfable<I, C, T, P>() && Iterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng>
             operator()(Rng &&rng, C pred, T const & new_value, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/reverse.hpp
+++ b/include/range/v3/algorithm/reverse.hpp
@@ -33,6 +33,7 @@ namespace ranges
         {
         private:
             template<typename I>
+            RANGES_CXX14_CONSTEXPR
             static void impl(I begin, I end, concepts::BidirectionalIterator*)
             {
                 while(begin != end)
@@ -45,6 +46,7 @@ namespace ranges
             }
 
             template<typename I>
+            RANGES_CXX14_CONSTEXPR
             static void impl(I begin, I end, concepts::RandomAccessIterator*)
             {
                 if(begin != end)
@@ -55,6 +57,7 @@ namespace ranges
         public:
             template<typename I, typename S,
                 CONCEPT_REQUIRES_(BidirectionalIterator<I>() && IteratorRange<I, S>() && Permutable<I>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end_) const
             {
                 I end = ranges::next(begin, end_);
@@ -64,6 +67,7 @@ namespace ranges
 
             template<typename Rng, typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(BidirectionalIterable<Rng>() && Permutable<I>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng> operator()(Rng &&rng) const
             {
                 return (*this)(begin(rng), end(rng));

--- a/include/range/v3/algorithm/reverse_copy.hpp
+++ b/include/range/v3/algorithm/reverse_copy.hpp
@@ -41,6 +41,7 @@ namespace ranges
         {
             template<typename I, typename S, typename O,
                 CONCEPT_REQUIRES_(IteratorRange<I, S>() && ReverseCopyable<I, O>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<I, O> operator()(I begin, S end_, O out) const
             {
                 I end = ranges::next(begin, end_), res = end;
@@ -52,6 +53,7 @@ namespace ranges
             template<typename Rng, typename O,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(Iterable<Rng>() && ReverseCopyable<I, O>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<range_safe_iterator_t<Rng>, O> operator()(Rng &&rng, O out) const
             {
                 return (*this)(begin(rng), end(rng), std::move(out));

--- a/include/range/v3/algorithm/rotate.hpp
+++ b/include/range/v3/algorithm/rotate.hpp
@@ -47,6 +47,7 @@ namespace ranges
         {
         private:
             template<typename I> // Forward
+            RANGES_CXX14_CONSTEXPR
             static range<I> rotate_left(I begin, I end)
             {
                 iterator_value_t<I> tmp = iter_move(begin);
@@ -56,6 +57,7 @@ namespace ranges
             }
 
             template<typename I> // Bidirectional
+            RANGES_CXX14_CONSTEXPR
             static range<I> rotate_right(I begin, I end)
             {
                 I lm1 = prev(end);
@@ -66,6 +68,7 @@ namespace ranges
             }
 
             template<typename I, typename S> // Forward
+            RANGES_CXX14_CONSTEXPR
             static range<I> rotate_forward(I begin, I middle, S end)
             {
                 I i = middle;
@@ -100,6 +103,7 @@ namespace ranges
             }
 
             template<typename D>
+            RANGES_CXX14_CONSTEXPR
             static D gcd(D x, D y)
             {
                 do
@@ -112,6 +116,7 @@ namespace ranges
             }
 
             template<typename I> // Random
+            RANGES_CXX14_CONSTEXPR
             static range<I> rotate_gcd(I begin, I middle, I end)
             {
                 auto const m1 = middle - begin;
@@ -143,12 +148,14 @@ namespace ranges
             }
 
             template<typename I, typename S>
+            RANGES_CXX14_CONSTEXPR
             static range<I> rotate_(I begin, I middle, S end, concepts::ForwardIterator*)
             {
                 return rotate_fn::rotate_forward(begin, middle, end);
             }
 
             template<typename I>
+            RANGES_CXX14_CONSTEXPR
             static range<I> rotate_(I begin, I middle, I end, concepts::ForwardIterator*)
             {
                 using value_type = iterator_value_t<I>;
@@ -161,6 +168,7 @@ namespace ranges
             }
 
             template<typename I>
+            RANGES_CXX14_CONSTEXPR
             static range<I> rotate_(I begin, I middle, I end, concepts::BidirectionalIterator*)
             {
                 using value_type = iterator_value_t<I>;
@@ -175,6 +183,7 @@ namespace ranges
             }
 
             template<typename I>
+            RANGES_CXX14_CONSTEXPR
             static range<I> rotate_(I begin, I middle, I end, concepts::RandomAccessIterator*)
             {
                 using value_type = iterator_value_t<I>;
@@ -192,6 +201,7 @@ namespace ranges
         public:
             template<typename I, typename S,
                 CONCEPT_REQUIRES_(Permutable<I>() && IteratorRange<I, S>())>
+            RANGES_CXX14_CONSTEXPR
             range<I> operator()(I begin, I middle, S end) const
             {
                 if(begin == middle)
@@ -208,6 +218,7 @@ namespace ranges
 
             template<typename Rng, typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(Iterable<Rng>() && Permutable<I>())>
+            RANGES_CXX14_CONSTEXPR
             meta::if_<std::is_lvalue_reference<Rng>, range<I>, dangling<range<I>>>
             operator()(Rng &&rng, I middle) const
             {

--- a/include/range/v3/algorithm/rotate_copy.hpp
+++ b/include/range/v3/algorithm/rotate_copy.hpp
@@ -35,6 +35,7 @@ namespace ranges
             template<typename I, typename S, typename O, typename P = ident,
                 CONCEPT_REQUIRES_(ForwardIterator<I>() && IteratorRange<I, S>() && WeaklyIncrementable<O>() &&
                     IndirectlyCopyable<I, O>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<I, O> operator()(I begin, I middle, S end, O out) const
             {
                 auto res = copy(middle, std::move(end), std::move(out));
@@ -48,6 +49,7 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(Iterable<Rng>() && WeaklyIncrementable<O>() &&
                     IndirectlyCopyable<I, O>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<range_safe_iterator_t<Rng>, O>
             operator()(Rng &&rng, I middle, O out) const
             {

--- a/include/range/v3/algorithm/search.hpp
+++ b/include/range/v3/algorithm/search.hpp
@@ -54,6 +54,7 @@ namespace ranges
             template<typename I1, typename D1, typename I2, typename S2, typename D2,
                 typename C, typename P1, typename P2,
                 CONCEPT_REQUIRES_(RandomAccessIterator<I1>())>
+            RANGES_CXX14_CONSTEXPR
             static I1 sized_impl(I1 const begin1_, I1 end1, D1 d1, I2 begin2, S2 end2, D2 d2,
                 C &pred, P1 &proj1, P2 &proj2)
             {
@@ -91,6 +92,7 @@ namespace ranges
 
             template<typename I1, typename S1, typename D1, typename I2, typename S2, typename D2,
                 typename C, typename P1, typename P2>
+            RANGES_CXX14_CONSTEXPR
             static I1 sized_impl(I1 const begin1_, S1 end1, D1 const d1_, I2 begin2, S2 end2, D2 d2,
                 C &pred, P1 &proj1, P2 &proj2)
             {
@@ -127,6 +129,7 @@ namespace ranges
             }
 
             template<typename I1, typename S1, typename I2, typename S2, typename C, typename P1, typename P2>
+            RANGES_CXX14_CONSTEXPR
             static I1 impl(I1 begin1, S1 end1, I2 begin2, S2 end2, C &pred, P1 &proj1, P2 &proj2)
             {
                 while(true)
@@ -165,6 +168,7 @@ namespace ranges
                     IteratorRange<I1, S1>() &&
                     IteratorRange<I2, S2>()
                 )>
+            RANGES_CXX14_CONSTEXPR
             I1 operator()(I1 begin1, S1 end1, I2 begin2, S2 end2,
                 C pred_ = C{}, P1 proj1_ = P1{}, P2 proj2_ = P2{}) const
             {
@@ -191,6 +195,7 @@ namespace ranges
                     Iterable<Rng1>() &&
                     Iterable<Rng2>()
                 )>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng1>
             operator()(Rng1 &&rng1, Rng2 &&rng2, C pred_ = C{}, P1 proj1_ = P1{},
                 P2 proj2_ = P2{}) const

--- a/include/range/v3/algorithm/search_n.hpp
+++ b/include/range/v3/algorithm/search_n.hpp
@@ -51,6 +51,7 @@ namespace ranges
         private:
             template<typename I, typename D, typename V, typename C, typename P,
                 CONCEPT_REQUIRES_(RandomAccessIterator<I>())>
+            RANGES_CXX14_CONSTEXPR
             static I sized_impl(I const begin_, I end, D d, D count, V const &val,
                 C &pred, P &proj)
             {
@@ -87,6 +88,7 @@ namespace ranges
             }
 
             template<typename I, typename S, typename D, typename V, typename C, typename P>
+            RANGES_CXX14_CONSTEXPR
             static I sized_impl(I const begin_, S end, D const d_, D count,
                 V const &val, C &pred, P &proj)
             {
@@ -123,6 +125,7 @@ namespace ranges
             }
 
             template<typename I, typename S, typename D, typename V, typename C, typename P>
+            RANGES_CXX14_CONSTEXPR
             static I impl(I begin, S end, D count, V const &val, C &pred, P &proj)
             {
                 while(true)
@@ -156,6 +159,7 @@ namespace ranges
         public:
             template<typename I, typename S, typename V, typename C = equal_to, typename P = ident,
                 CONCEPT_REQUIRES_(Searchnable<I, V, C, P>() && IteratorRange<I, S>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end, iterator_difference_t<I> count, V const &val,
                 C pred_ = C{}, P proj_ = P{}) const
             {
@@ -174,6 +178,7 @@ namespace ranges
             template<typename Rng, typename V, typename C = equal_to, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(Searchnable<I, V, C, P>() && Iterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng>
             operator()(Rng &&rng, iterator_difference_t<I> count, V const &val, C pred_ = C{},
                 P proj_ = P{}) const

--- a/include/range/v3/algorithm/set_algorithm.hpp
+++ b/include/range/v3/algorithm/set_algorithm.hpp
@@ -45,6 +45,7 @@ namespace ranges
                 typename C = ordered_less, typename P1 = ident, typename P2 = ident,
                 CONCEPT_REQUIRES_(Comparable<I1, I2, C, P1, P2>() &&
                     IteratorRange<I1, S1>() && IteratorRange<I2, S2>())>
+            RANGES_CXX14_CONSTEXPR
             bool operator()(I1 begin1, S1 end1, I2 begin2, S2 end2,
                 C pred_ = C{}, P1 proj1_ = P1{}, P2 proj2_ = P2{}) const
             {
@@ -67,6 +68,7 @@ namespace ranges
                 typename I2 = range_iterator_t<Rng2>,
                 CONCEPT_REQUIRES_(Comparable<I1, I2, C, P1, P2>() &&
                     Iterable<Rng1>() && Iterable<Rng2>())>
+            RANGES_CXX14_CONSTEXPR
             bool operator()(Rng1 && rng1, Rng2 && rng2,
                 C pred = C{}, P1 proj1 = P1{}, P2 proj2 = P2{}) const
             {
@@ -89,6 +91,7 @@ namespace ranges
                 typename Tup = std::tuple<I1, I2, O>,
                 CONCEPT_REQUIRES_(Mergeable<I1, I2, O, C, P1, P2>() &&
                     IteratorRange<I1, S1>() && IteratorRange<I2, S2>())>
+            RANGES_CXX14_CONSTEXPR
             Tup operator()(I1 begin1, S1 end1, I2 begin2, S2 end2, O out,
                 C pred_ = C{}, P1 proj1_ = P1{}, P2 proj2_ = P2{}) const
             {
@@ -125,6 +128,7 @@ namespace ranges
                 typename I2 = range_iterator_t<Rng2>,
                 CONCEPT_REQUIRES_(Mergeable<I1, I2, O, C, P1, P2>() &&
                     Iterable<Rng1>() && Iterable<Rng2>())>
+            RANGES_CXX14_CONSTEXPR
             std::tuple<range_safe_iterator_t<Rng1>, range_safe_iterator_t<Rng2>, O>
             operator()(Rng1 &&rng1, Rng2 &&rng2, O out, C pred = C{}, P1 proj1 = P1{},
                 P2 proj2 = P2{}) const
@@ -147,6 +151,7 @@ namespace ranges
                 typename C = ordered_less, typename P1 = ident, typename P2 = ident,
                 CONCEPT_REQUIRES_(Mergeable<I1, I2, O, C, P1, P2>() &&
                     IteratorRange<I1, S1>() && IteratorRange<I2, S2>())>
+            RANGES_CXX14_CONSTEXPR
             O operator()(I1 begin1, S1 end1, I2 begin2, S2 end2, O out,
                 C pred_ = C{}, P1 proj1_ = P1{}, P2 proj2_ = P2{}) const
             {
@@ -177,6 +182,7 @@ namespace ranges
                 typename I2 = range_iterator_t<Rng2>,
                 CONCEPT_REQUIRES_(Mergeable<I1, I2, O, C, P1, P2>() &&
                     Iterable<Rng1>() && Iterable<Rng2>())>
+            RANGES_CXX14_CONSTEXPR
             O operator()(Rng1 && rng1, Rng2 && rng2, O out,
                 C pred = C{}, P1 proj1 = P1{}, P2 proj2 = P2{}) const
             {
@@ -198,6 +204,7 @@ namespace ranges
                 typename C = ordered_less, typename P1 = ident, typename P2 = ident,
                 CONCEPT_REQUIRES_(Mergeable<I1, I2, O, C, P1, P2>() &&
                     IteratorRange<I1, S1>() && IteratorRange<I2, S2>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<I1, O> operator()(I1 begin1, S1 end1, I2 begin2, S2 end2, O out,
                 C pred_ = C{}, P1 proj1_ = P1{}, P2 proj2_ = P2{}) const
             {
@@ -230,6 +237,7 @@ namespace ranges
                 typename I2 = range_iterator_t<Rng2>,
                 CONCEPT_REQUIRES_(Mergeable<I1, I2, O, C, P1, P2>() &&
                     Iterable<Rng1>() && Iterable<Rng2>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<range_safe_iterator_t<Rng1>, O> operator()(Rng1 &&rng1, Rng2 && rng2, O out,
                 C pred = C{}, P1 proj1 = P1{}, P2 proj2 = P2{}) const
             {
@@ -251,6 +259,7 @@ namespace ranges
                 typename C = ordered_less, typename P1 = ident, typename P2 = ident,
                 CONCEPT_REQUIRES_(Mergeable<I1, I2, O, C, P1, P2>() &&
                     IteratorRange<I1, S1>() && IteratorRange<I2, S2>())>
+            RANGES_CXX14_CONSTEXPR
             std::tuple<I1, I2, O> operator()(I1 begin1, S1 end1, I2 begin2, S2 end2, O out,
                 C pred_ = C{}, P1 proj1_ = P1{}, P2 proj2_ = P2{}) const
             {
@@ -292,6 +301,7 @@ namespace ranges
                 typename I2 = range_iterator_t<Rng2>,
                 CONCEPT_REQUIRES_(Mergeable<I1, I2, O, C, P1, P2>() &&
                     Iterable<Rng1>() && Iterable<Rng2>())>
+            RANGES_CXX14_CONSTEXPR
             std::tuple<range_safe_iterator_t<Rng1>, range_safe_iterator_t<Rng2>, O>
             operator()(Rng1 &&rng1, Rng2 &&rng2, O out,
                 C pred = C{}, P1 proj1 = P1{}, P2 proj2 = P2{}) const

--- a/include/range/v3/algorithm/shuffle.hpp
+++ b/include/range/v3/algorithm/shuffle.hpp
@@ -10,9 +10,13 @@
 //
 // Project home: https://github.com/ericniebler/range-v3
 //
+// The constexpr random-number generator functionality has been
+// adapted from libc++: https://libcxx.llvm.org
+//
 #ifndef RANGES_V3_ALGORITHM_SHUFFLE_HPP
 #define RANGES_V3_ALGORITHM_SHUFFLE_HPP
 
+#include <climits>
 #include <random>
 #include <utility>
 #include <range/v3/range_fwd.hpp>
@@ -48,6 +52,286 @@ namespace ranges
         using UniformRandomNumberGenerator = concepts::models<concepts::UniformRandomNumberGenerator, Gen>;
         /// @}
 
+        /// \addtogroup group-utility
+        /// @{
+        namespace random_detail
+        {
+
+            RANGES_CXX14_CONSTEXPR
+            unsigned
+            clz(unsigned x)
+            {
+                return static_cast<unsigned>(__builtin_clz(x));
+            }
+
+            RANGES_CXX14_CONSTEXPR
+            unsigned long
+            clz(unsigned long x)
+            {
+                return static_cast<unsigned long>(__builtin_clzl (x));
+            }
+
+            RANGES_CXX14_CONSTEXPR
+            unsigned long long
+            clz(unsigned long long x)
+            {
+                return static_cast<unsigned long long>(__builtin_clzll(x));
+            }
+
+            template <unsigned long long Xp, size_t Rp>
+            struct log2_imp
+            {
+                static const size_t value = Xp & ((unsigned long long)(1) << Rp) ? Rp
+                                            : log2_imp<Xp, Rp - 1>::value;
+            };
+
+            template <unsigned long long Xp>
+            struct log2_imp<Xp, 0>
+            {
+                static const size_t value = 0;
+            };
+
+            template <size_t Rp>
+            struct log2_imp<0, Rp>
+            {
+                static const size_t value = Rp + 1;
+            };
+
+            template <class UI, UI Xp>
+            struct log2
+            {
+                static const size_t value = log2_imp<Xp,
+                                                     sizeof(UI) * CHAR_BIT - 1>::value;
+            };
+
+            template<class Engine, class UInt>
+            class independent_bits_engine
+            {
+            public:
+                // types
+                typedef UInt result_type;
+
+            private:
+                typedef typename Engine::result_type Engine_result_type;
+                typedef typename std::conditional
+                <
+                    sizeof(Engine_result_type) <= sizeof(result_type),
+                    result_type,
+                    Engine_result_type
+                >::type Working_result_type;
+
+                Engine& e_;
+                size_t w_;
+                size_t n_;
+                size_t w0_;
+                size_t n0_;
+                Working_result_type y0_;
+                Working_result_type y1_;
+                Engine_result_type mask0_;
+                Engine_result_type mask1_;
+
+                static constexpr const Working_result_type Rp = Engine::max() - Engine::min()
+                                                                 + Working_result_type(1);
+
+                static constexpr const size_t m = log2<Working_result_type, Rp>::value;
+                static constexpr const size_t WDt = std::numeric_limits<Working_result_type>::digits;
+                static constexpr const size_t EDt = std::numeric_limits<Engine_result_type>::digits;
+
+            public:
+                // constructors and seeding functions
+                RANGES_CXX14_CONSTEXPR
+                independent_bits_engine(Engine& e, size_t w);
+
+                // generating functions
+                RANGES_CXX14_CONSTEXPR
+                result_type operator()() {return eval(std::integral_constant<bool, Rp != 0>());}
+
+            private:
+                RANGES_CXX14_CONSTEXPR
+                result_type eval(std::false_type);
+                RANGES_CXX14_CONSTEXPR
+                result_type eval(std::true_type);
+            };
+
+            template<class Engine, class UInt>
+            RANGES_CXX14_CONSTEXPR
+            independent_bits_engine<Engine, UInt>
+            ::independent_bits_engine(Engine& e, size_t w)
+                : e_(e),
+                  w_(w),
+                  n_(w_ / m + (w_ % m != 0)),
+                  w0_(w_ / n_),
+                  n0_(n_ - w_ % n_),
+                  y0_(0), y1_(0), mask0_(0), mask1_(0)
+            {
+                if (Rp == 0)
+                    y0_ = Rp;
+                else if (w0_ < WDt)
+                    y0_ = (Rp >> w0_) << w0_;
+                else
+                    y0_ = 0;
+                if (Rp - y0_ > y0_ / n_)
+                {
+                    ++n_;
+                    w0_ = w_ / n_;
+                    if (w0_ < WDt)
+                        y0_ = (Rp >> w0_) << w0_;
+                    else
+                        y0_ = 0;
+                }
+                if (w0_ < WDt - 1)
+                    y1_ = (Rp >> (w0_ + 1)) << (w0_ + 1);
+                else
+                    y1_ = 0;
+                mask0_ = w0_ > 0 ? Engine_result_type(~0) >> (EDt - w0_) :
+                                   Engine_result_type(0);
+                mask1_ = w0_ < EDt - 1 ?
+                         Engine_result_type(~0) >> (EDt - (w0_ + 1)) :
+                         Engine_result_type(~0);
+            }
+
+            template<class Engine, class UInt>
+            RANGES_CXX14_CONSTEXPR
+            UInt
+            independent_bits_engine<Engine, UInt>::eval(std::false_type)
+            {
+                return static_cast<result_type>(e_() & mask0_);
+            }
+
+            template<class Engine, class UInt>
+            RANGES_CXX14_CONSTEXPR
+            UInt
+            independent_bits_engine<Engine, UInt>::eval(std::true_type)
+            {
+                result_type Sp = 0;
+                for (size_t k = 0; k < n0_; ++k)
+                {
+                    Engine_result_type u{};
+                    do
+                    {
+                        u = e_() - Engine::min();
+                    } while (u >= y0_);
+                    if (w0_ < WDt)
+                        Sp <<= w0_;
+                    else
+                        Sp = 0;
+                    Sp += u & mask0_;
+                }
+                for (size_t k = n0_; k < n_; ++k)
+                {
+                    Engine_result_type u{};
+                    do
+                    {
+                        u = e_() - Engine::min();
+                    } while (u >= y1_);
+                    if (w0_ < WDt - 1)
+                        Sp <<= w0_ + 1;
+                    else
+                        Sp = 0;
+                    Sp += u & mask1_;
+                }
+                return Sp;
+            }
+
+            template<class Int = int>
+            class uniform_int_distribution
+            {
+            public:
+                using result_type = Int;
+
+                class param_type
+                {
+                    result_type a_;
+                    result_type b_;
+                public:
+                    using distribution_type = uniform_int_distribution;
+
+                    RANGES_CXX14_CONSTEXPR
+                    explicit param_type(result_type a = 0,
+                                        result_type b = std::numeric_limits<result_type>::max())
+                        : a_(a), b_(b) {}
+
+                    RANGES_CXX14_CONSTEXPR result_type a() const {return a_;}
+                    RANGES_CXX14_CONSTEXPR result_type b() const {return b_;}
+
+                    RANGES_CXX14_CONSTEXPR
+                    friend bool operator==(const param_type& x, const param_type& y)
+                    {return x.a_ == y.a_ && x.b_ == y.b_;}
+                    RANGES_CXX14_CONSTEXPR
+                    friend bool operator!=(const param_type& x, const param_type& y)
+                    {return !(x == y);}
+                };
+
+            private:
+                param_type p_;
+
+            public:
+                RANGES_CXX14_CONSTEXPR
+                explicit uniform_int_distribution(result_type a = 0,
+                                                  result_type b = std::numeric_limits<result_type>::max())
+                    : p_(param_type(a, b)) {}
+                RANGES_CXX14_CONSTEXPR
+                explicit uniform_int_distribution(const param_type& __p) : p_(__p) {}
+                RANGES_CXX14_CONSTEXPR void reset() {}
+
+                template<class URNG>
+                RANGES_CXX14_CONSTEXPR
+                result_type operator()(URNG& g)
+                {return (*this)(g, p_);}
+
+                template<class URNG>
+                RANGES_CXX14_CONSTEXPR
+                result_type operator()(URNG& g, const param_type& p);
+
+                RANGES_CXX14_CONSTEXPR result_type a() const {return p_.a();}
+                RANGES_CXX14_CONSTEXPR result_type b() const {return p_.b();}
+
+                RANGES_CXX14_CONSTEXPR param_type param() const {return p_;}
+                RANGES_CXX14_CONSTEXPR void param(const param_type& p) {p_ = p;}
+
+                RANGES_CXX14_CONSTEXPR result_type min() const {return a();}
+                RANGES_CXX14_CONSTEXPR result_type max() const {return b();}
+
+                RANGES_CXX14_CONSTEXPR
+                friend bool operator==(const uniform_int_distribution& x,
+                                       const uniform_int_distribution& y)
+                {return x.p_ == y.p_;}
+
+                RANGES_CXX14_CONSTEXPR
+                friend bool operator!=(const uniform_int_distribution& x,
+                                       const uniform_int_distribution& y)
+                {return !(x == y);}
+            };
+
+            template<class Int>
+            template<class URNG>
+            RANGES_CXX14_CONSTEXPR
+            typename uniform_int_distribution<Int>::result_type
+            uniform_int_distribution<Int>::operator()(URNG& g, const param_type& p)
+            {
+                typedef typename std::conditional<sizeof(result_type) <= sizeof(uint32_t),
+                                             uint32_t, uint64_t>::type UInt;
+                const UInt Rp = p.b() - p.a() + UInt(1);
+                if (Rp == 1)
+                    return p.a();
+                const size_t Dt = std::numeric_limits<UInt>::digits;
+                typedef independent_bits_engine<URNG, UInt> Eng;
+                if (Rp == 0)
+                    return static_cast<result_type>(Eng(g, Dt)());
+                size_t w = Dt - clz(Rp) - 1;
+                if ((Rp & (UInt(~0) >> (Dt - w))) != 0)
+                    ++w;
+                Eng e(g, w);
+                UInt u = UInt{};
+                do
+                {
+                    u = e();
+                } while (u >= Rp);
+                return static_cast<result_type>(u + p.a());
+            }
+        }
+        /// @}
+
         /// \addtogroup group-algorithms
         /// @{
         struct shuffle_fn
@@ -58,14 +342,15 @@ namespace ranges
                     Convertible<
                         concepts::UniformRandomNumberGenerator::result_t<Gen>,
                         concepts::WeaklyIncrementable::difference_t<I>>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end_, Gen && gen) const
             {
                 I end = ranges::next(begin, end_), orig = end;
                 auto d = end - begin;
                 if(d > 1)
                 {
-                    using param_t = std::uniform_int_distribution<std::ptrdiff_t>::param_type;
-                    std::uniform_int_distribution<std::ptrdiff_t> uid;
+                    using param_t = random_detail::uniform_int_distribution<std::ptrdiff_t>::param_type;
+                    random_detail::uniform_int_distribution<std::ptrdiff_t> uid;
                     for(--end, --d; begin < end; ++begin, --d)
                     {
                         auto i = uid(gen, param_t{0, d});
@@ -82,6 +367,7 @@ namespace ranges
                     UniformRandomNumberGenerator<Gen>() && Convertible<
                         concepts::UniformRandomNumberGenerator::result_t<Gen>,
                         concepts::WeaklyIncrementable::difference_t<I>>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng> operator()(Rng &&rng, Gen && rand) const
             {
                 return (*this)(begin(rng), end(rng), std::forward<Gen>(rand));

--- a/include/range/v3/algorithm/sort.hpp
+++ b/include/range/v3/algorithm/sort.hpp
@@ -57,7 +57,8 @@ namespace ranges
         namespace detail
         {
             template<typename I, typename C, typename P>
-            inline I unguarded_partition(I begin, I end, C &pred, P &proj)
+            RANGES_CXX14_CONSTEXPR
+            I unguarded_partition(I begin, I end, C &pred, P &proj)
             {
                 I mid = begin + (end - begin) / 2, last = ranges::prev(end);
                 auto &&x = *begin, &&y = *mid, &&z = *last;
@@ -87,7 +88,8 @@ namespace ranges
             }
 
             template<typename I, typename C, typename P>
-            inline void unguarded_linear_insert(I end, iterator_value_t<I> val, C &pred, P &proj)
+            RANGES_CXX14_CONSTEXPR
+            void unguarded_linear_insert(I end, iterator_value_t<I> val, C &pred, P &proj)
             {
                 I next = prev(end);
                 while(pred(proj(val), proj(*next)))
@@ -100,7 +102,8 @@ namespace ranges
             }
 
             template<typename I, typename C, typename P>
-            inline void linear_insert(I begin, I end, C &pred, P &proj)
+            RANGES_CXX14_CONSTEXPR
+            void linear_insert(I begin, I end, C &pred, P &proj)
             {
                 iterator_value_t<I> val = iter_move(end);
                 if(pred(proj(val), proj(*begin)))
@@ -113,7 +116,8 @@ namespace ranges
             }
 
             template<typename I, typename C, typename P>
-            inline void insertion_sort(I begin, I end, C &pred, P &proj)
+            RANGES_CXX14_CONSTEXPR
+            void insertion_sort(I begin, I end, C &pred, P &proj)
             {
                 if(begin == end)
                     return;
@@ -122,7 +126,8 @@ namespace ranges
             }
 
             template<typename I, typename C, typename P>
-            inline void unguarded_insertion_sort(I begin, I end, C &pred, P &proj)
+            RANGES_CXX14_CONSTEXPR
+            void unguarded_insertion_sort(I begin, I end, C &pred, P &proj)
             {
                 for(I i = begin; i != end; ++i)
                     detail::unguarded_linear_insert(i, iter_move(i), pred, proj);
@@ -142,6 +147,7 @@ namespace ranges
             static constexpr int introsort_threshold() { return 16; }
 
             template<typename I, typename C, typename P>
+            RANGES_CXX14_CONSTEXPR
             static void final_insertion_sort(I begin, I end, C &pred, P &proj)
             {
                 if(end - begin > sort_fn::introsort_threshold())
@@ -154,6 +160,7 @@ namespace ranges
             }
 
             template<typename Size>
+            RANGES_CXX14_CONSTEXPR
             static Size log2(Size n)
             {
                 Size k = 0;
@@ -163,12 +170,13 @@ namespace ranges
             }
 
             template<typename I, typename Size, typename C, typename P>
+            RANGES_CXX14_CONSTEXPR
             static void introsort_loop(I begin, I end, Size depth_limit, C &pred, P &proj)
             {
                 while(end - begin > sort_fn::introsort_threshold())
                 {
                     if(depth_limit == 0)
-                        return partial_sort(begin, end, end, std::ref(pred), std::ref(proj)), void();
+                        return partial_sort(begin, end, end, ranges::ref(pred), ranges::ref(proj)), void();
                     I cut = detail::unguarded_partition(begin, end, pred, proj);
                     sort_fn::introsort_loop(cut, end, --depth_limit, pred, proj);
                     end = cut;
@@ -179,6 +187,7 @@ namespace ranges
             template<typename I, typename S, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(Sortable<I, C, P>() && RandomAccessIterator<I>() &&
                     IteratorRange<I, S>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end_, C pred_ = C{}, P proj_ = P{}) const
             {
                 auto &&pred = as_function(pred_);
@@ -194,6 +203,7 @@ namespace ranges
             template<typename Rng, typename C = ordered_less, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(Sortable<I, C, P>() && RandomAccessIterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng> operator()(Rng &&rng, C pred = C{}, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));

--- a/include/range/v3/algorithm/swap_ranges.hpp
+++ b/include/range/v3/algorithm/swap_ranges.hpp
@@ -34,6 +34,7 @@ namespace ranges
                 CONCEPT_REQUIRES_(InputIterator<I1>() && IteratorRange<I1, S1>() &&
                                   WeakInputIterator<I2>() &&
                                   IndirectlySwappable<I1, I2>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<I1, I2> operator()(I1Ref&& begin1, S1 end1, I2 begin2) const
             {
                 for(; begin1 != end1; ++begin1, ++begin2)
@@ -45,6 +46,7 @@ namespace ranges
                 CONCEPT_REQUIRES_(InputIterator<I1>() && IteratorRange<I1, S1>() &&
                                   InputIterator<I2>() && IteratorRange<I2, S2>() &&
                                   IndirectlySwappable<I1, I2>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<I1, I2> operator()(I1 begin1, S1 end1, I2 begin2, S2 end2) const
             {
                 for(; begin1 != end1 && begin2 != end2; ++begin1, ++begin2)
@@ -57,6 +59,7 @@ namespace ranges
                 CONCEPT_REQUIRES_(InputIterable<Rng1>() &&
                                   WeakInputIterator<I2>() &&
                                   IndirectlySwappable<I1, I2>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<I1, I2> operator()(Rng1 & rng1, I2 begin2) const
             {
                 return (*this)(begin(rng1), end(rng1), std::move(begin2));
@@ -68,6 +71,7 @@ namespace ranges
                 CONCEPT_REQUIRES_(InputIterable<Rng1>() &&
                                   InputIterable<Rng2>() &&
                                   IndirectlySwappable<I1, I2>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<range_safe_iterator_t<Rng1>, range_safe_iterator_t<Rng2>>
             operator()(Rng1 &&rng1, Rng2 &&rng2) const
             {

--- a/include/range/v3/algorithm/transform.hpp
+++ b/include/range/v3/algorithm/transform.hpp
@@ -63,6 +63,7 @@ namespace ranges
             // Single-range variant
             template<typename I, typename S, typename O, typename F, typename P = ident,
                 CONCEPT_REQUIRES_(IteratorRange<I, S>() && Transformable1<I, O, F, P>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<I, O> operator()(I begin, S end, O out, F fun_, P proj_ = P{}) const
             {
                 auto &&fun = as_function(fun_);
@@ -75,6 +76,7 @@ namespace ranges
             template<typename Rng, typename O, typename F, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(Iterable<Rng>() && Transformable1<I, O, F, P>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<range_safe_iterator_t<Rng>, O>
             operator()(Rng &&rng, O out, F fun, P proj = P{}) const
             {
@@ -86,6 +88,7 @@ namespace ranges
                 typename P0 = ident, typename P1 = ident,
                 CONCEPT_REQUIRES_(IteratorRange<I0, S0>() && IteratorRange<I1, S1>() &&
                     Transformable2<I0, I1, O, F, P0, P1>())>
+            RANGES_CXX14_CONSTEXPR
             std::tuple<I0, I1, O> operator()(I0 begin0, S0 end0, I1 begin1, S1 end1, O out, F fun_,
                 P0 proj0_ = P0{}, P1 proj1_ = P1{}) const
             {
@@ -103,6 +106,7 @@ namespace ranges
                 typename I1 = range_iterator_t<Rng1>,
                 CONCEPT_REQUIRES_(Iterable<Rng0>() && Iterable<Rng1>() &&
                     Transformable2<I0, I1, O, F, P0, P1>())>
+            RANGES_CXX14_CONSTEXPR
             std::tuple<range_safe_iterator_t<Rng0>, range_safe_iterator_t<Rng1>, O>
             operator()(Rng0 &&rng0, Rng1 &&rng1, O out, F fun, P0 proj0 = P0{},
                 P1 proj1 = P1{}) const
@@ -115,6 +119,7 @@ namespace ranges
             template<typename I0, typename S0, typename I1, typename O, typename F,
                 typename P0 = ident, typename P1 = ident,
                 CONCEPT_REQUIRES_(IteratorRange<I0, S0>() && Transformable2<I0, I1, O, F, P0, P1>())>
+            RANGES_CXX14_CONSTEXPR
             std::tuple<I0, I1, O> operator()(I0 begin0, S0 end0, I1 begin1, O out, F fun,
                 P0 proj0 = P0{}, P1 proj1 = P1{}) const
             {
@@ -127,6 +132,7 @@ namespace ranges
                 typename I0 = range_iterator_t<Rng0>,
                 CONCEPT_REQUIRES_(Iterable<Rng0>() && Iterator<I1>() &&
                     Transformable2<I0, I1, O, F, P0, P1>())>
+            RANGES_CXX14_CONSTEXPR
             std::tuple<range_safe_iterator_t<Rng0>, I1, O> operator()(Rng0 &&rng0, I1Ref &&begin1,
                 O out, F fun, P0 proj0 = P0{}, P1 proj1 = P1{}) const
             {

--- a/include/range/v3/algorithm/unique.hpp
+++ b/include/range/v3/algorithm/unique.hpp
@@ -43,12 +43,13 @@ namespace ranges
             ///
             template<typename I, typename S, typename C = equal_to, typename P = ident,
                 CONCEPT_REQUIRES_(Sortable<I, C, P>() && IteratorRange<I, S>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end, C pred_ = C{}, P proj_ = P{}) const
             {
                 auto &&pred = as_function(pred_);
                 auto &&proj = as_function(proj_);
 
-                begin = adjacent_find(std::move(begin), end, std::ref(pred), std::ref(proj));
+                begin = adjacent_find(std::move(begin), end, ranges::ref(pred), ranges::ref(proj));
 
                 if(begin != end)
                 {
@@ -63,6 +64,7 @@ namespace ranges
             template<typename Rng, typename C = equal_to, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(Sortable<I, C, P>() && Iterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng>
             operator()(Rng &&rng, C pred = C{}, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/unique_copy.hpp
+++ b/include/range/v3/algorithm/unique_copy.hpp
@@ -41,6 +41,7 @@ namespace ranges
         {
         private:
             template<typename I, typename S, typename O, typename C, typename P>
+            RANGES_CXX14_CONSTEXPR
             static std::pair<I, O> impl(I begin, S end, O out, C pred_, P proj_,
                 concepts::InputIterator*, std::false_type)
             {
@@ -68,6 +69,7 @@ namespace ranges
             }
 
             template<typename I, typename S, typename O, typename C, typename P>
+            RANGES_CXX14_CONSTEXPR
             static std::pair<I, O> impl(I begin, S end, O out, C pred_, P proj_,
                 concepts::ForwardIterator*, std::false_type)
             {
@@ -93,6 +95,7 @@ namespace ranges
             }
 
             template<typename I, typename S, typename O, typename C, typename P>
+            RANGES_CXX14_CONSTEXPR
             static std::pair<I, O> impl(I begin, S end, O out, C pred_, P proj_,
                 concepts::InputIterator*, std::true_type)
             {
@@ -122,6 +125,7 @@ namespace ranges
             /// \pre `C` is a model of the `CallableRelation` concept
             template<typename I, typename S, typename O, typename C = equal_to, typename P = ident,
                 CONCEPT_REQUIRES_(UniqueCopyable<I, O, C, P>() && IteratorRange<I, S>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<I, O> operator()(I begin, S end, O out, C pred = C{}, P proj = P{}) const
             {
                 return unique_copy_fn::impl(std::move(begin), std::move(end), std::move(out),
@@ -132,6 +136,7 @@ namespace ranges
             template<typename Rng, typename O, typename C = equal_to, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(UniqueCopyable<I, O, C, P>() && Iterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<range_safe_iterator_t<Rng>, O>
             operator()(Rng &&rng, O out, C pred = C{}, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/upper_bound.hpp
+++ b/include/range/v3/algorithm/upper_bound.hpp
@@ -33,6 +33,7 @@ namespace ranges
         {
             template<typename I, typename S, typename V2, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(IteratorRange<I, S>() && BinarySearchable<I, V2, C, P>())>
+            RANGES_CXX14_CONSTEXPR
             I operator()(I begin, S end, V2 const &val, C pred = C{}, P proj = P{}) const
             {
                 return aux::upper_bound_n(std::move(begin), distance(begin, end), val, std::move(pred),
@@ -43,6 +44,7 @@ namespace ranges
             template<typename Rng, typename V2, typename C = ordered_less, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(Iterable<Rng>() && BinarySearchable<I, V2, C, P>())>
+            RANGES_CXX14_CONSTEXPR
             range_safe_iterator_t<Rng>
             operator()(Rng &&rng, V2 const &val, C pred = C{}, P proj = P{}) const
             {

--- a/include/range/v3/distance.hpp
+++ b/include/range/v3/distance.hpp
@@ -36,11 +36,13 @@ namespace ranges
         {
         private:
             template<typename Rng, typename D, typename I = range_iterator_t<Rng>>
+            RANGES_CXX14_CONSTEXPR
             std::pair<D, I> impl_r(Rng &rng, D d, concepts::Iterable*, concepts::Iterable*) const
             {
                 return iter_enumerate(begin(rng), end(rng), d);
             }
             template<typename Rng, typename D, typename I = range_iterator_t<Rng>>
+            RANGES_CXX14_CONSTEXPR
             std::pair<D, I> impl_r(Rng &rng, D d, concepts::BoundedIterable*, concepts::SizedIterable*) const
             {
                 return {static_cast<D>(size(rng)) + d, end(rng)};
@@ -51,6 +53,7 @@ namespace ranges
             template<typename Rng, typename D = range_difference_t<Rng>,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(Integral<D>() && Iterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             std::pair<D, I> operator()(Rng &&rng, D d = 0) const
             {
                 // Better not be trying to compute the distance of an infinite range:
@@ -71,11 +74,13 @@ namespace ranges
         {
         private:
             template<typename Rng, typename D>
+            RANGES_CXX14_CONSTEXPR
             D impl_r(Rng &rng, D d, concepts::Iterable*) const
             {
                 return enumerate(rng, d).first;
             }
             template<typename Rng, typename D>
+            RANGES_CXX14_CONSTEXPR
             D impl_r(Rng &rng, D d, concepts::SizedIterable*) const
             {
                 return static_cast<D>(size(rng)) + d;
@@ -85,6 +90,7 @@ namespace ranges
 
             template<typename Rng, typename D = range_difference_t<Rng>,
                 CONCEPT_REQUIRES_(Integral<D>() && Iterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             D operator()(Rng &&rng, D d = 0) const
             {
                 // Better not be trying to compute the distance of an infinite range:
@@ -106,18 +112,21 @@ namespace ranges
         private:
             template<typename Rng,
                 CONCEPT_REQUIRES_(!is_infinite<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             int impl_r(Rng &rng, range_difference_t<Rng> n, concepts::Iterable*) const
             {
                 return iter_distance_compare(begin(rng), end(rng), n);
             }
             template<typename Rng,
                 CONCEPT_REQUIRES_(is_infinite<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             int impl_r(Rng &rng, range_difference_t<Rng> n, concepts::Iterable*) const
             {
                 // Infinite ranges are always compared to be larger than a finite number.
                 return 1;
             }
             template<typename Rng>
+            RANGES_CXX14_CONSTEXPR
             int impl_r(Rng &rng, range_difference_t<Rng> n, concepts::SizedIterable*) const
             {
                 auto dist = distance(rng); // O(1) since rng is a SizedIterable
@@ -133,6 +142,7 @@ namespace ranges
 
             template<typename Rng,
                 CONCEPT_REQUIRES_(Iterable<Rng>())>
+            RANGES_CXX14_CONSTEXPR
             int operator()(Rng &&rng, range_difference_t<Rng> n) const
             {
                 return this->impl_r(rng, n, sized_iterable_concept<Rng>());

--- a/include/range/v3/range.hpp
+++ b/include/range/v3/range.hpp
@@ -55,7 +55,7 @@ namespace ranges
             using compressed_pair<I, S>::first;
             using compressed_pair<I, S>::second;
 
-            range() = default;
+            RANGES_CXX14_CONSTEXPR range() = default;
             constexpr range(iterator begin, sentinel end)
               : compressed_pair<I, S>{detail::move(begin), detail::move(end)}
             {}
@@ -69,10 +69,12 @@ namespace ranges
             constexpr range(std::pair<X, Y> rng)
               : compressed_pair<I, S>{detail::move(rng.first), detail::move(rng.second)}
             {}
+            RANGES_CXX14_CONSTEXPR
             iterator begin() const
             {
                 return first;
             }
+            RANGES_CXX14_CONSTEXPR
             sentinel end() const
             {
                 return second;
@@ -83,11 +85,13 @@ namespace ranges
             {
                 return {first, second};
             }
+            RANGES_CXX14_CONSTEXPR
             void pop_front()
             {
                 ++first;
             }
             CONCEPT_REQUIRES(BidirectionalIterator<sentinel>())
+            RANGES_CXX14_CONSTEXPR
             void pop_back()
             {
                 --second;
@@ -110,22 +114,26 @@ namespace ranges
         private:
             template<typename X, typename Y>
             friend struct sized_range;
+            RANGES_CXX14_CONSTEXPR
             I && move_first()
             {
                 return detail::unsafe_move(this->first);
             }
+            RANGES_CXX14_CONSTEXPR
             S && move_second()
             {
                 return detail::unsafe_move(this->second);
             }
             template<typename J = I,
                 CONCEPT_REQUIRES_(ForwardIterator<J>() && IteratorRange<J, S>())>
+            RANGES_CXX14_CONSTEXPR
             void check() const
             {
                 RANGES_ASSERT(static_cast<iterator_size_t<I>>(iter_distance(first, second)) == third);
             }
             template<typename J = I,
                 CONCEPT_REQUIRES_(!ForwardIterator<J>() || !IteratorRange<J, S>())>
+            RANGES_CXX14_CONSTEXPR
             void check() const
             {}
         public:
@@ -141,32 +149,39 @@ namespace ranges
             constexpr sized_range()
               : compressed_pair<I const, S const>{}, third{}
             {}
+            RANGES_CXX14_CONSTEXPR
             sized_range(I begin, S end, iterator_size_t<I> size)
               : compressed_pair<I const, S const>{std::move(begin), std::move(end)}, third(size)
             {
                 check();
             }
+            RANGES_CXX14_CONSTEXPR
             sized_range(sized_range<I, S> const &rng)
               : compressed_pair<I const, S const>{rng.first, rng.second}, third(rng.third)
             {}
+            RANGES_CXX14_CONSTEXPR
             sized_range(sized_range<I, S> &&rng)
               : compressed_pair<I const, S const>{rng.move_first(), rng.move_second()}, third(rng.third)
             {}
             template<typename X, typename Y,
                 CONCEPT_REQUIRES_(Convertible<X, I>() && Convertible<Y, S>())>
+            RANGES_CXX14_CONSTEXPR
             sized_range(std::pair<X, Y> rng, iterator_size_t<I> size)
               : sized_range{std::move(rng).first, std::move(rng).second, size}
             {}
             template<typename X, typename Y,
                 CONCEPT_REQUIRES_(Convertible<X, I>() && Convertible<Y, S>())>
+            RANGES_CXX14_CONSTEXPR
             sized_range(range<X, Y> rng, iterator_size_t<I> size)
               : sized_range{std::move(rng).first, std::move(rng).second, size}
             {}
             template<typename X, typename Y,
                 CONCEPT_REQUIRES_(Convertible<X, I>() && Convertible<Y, S>())>
+            RANGES_CXX14_CONSTEXPR
             sized_range(sized_range<X, Y> rng)
               : sized_range{rng.move_first(), rng.move_second(), rng.third}
             {}
+            RANGES_CXX14_CONSTEXPR
             sized_range &operator=(sized_range<I, S> const &rng)
             {
                 const_cast<I &>(first) = rng.first;
@@ -174,6 +189,7 @@ namespace ranges
                 const_cast<iterator_size_t<I> &>(third) = rng.third;
                 return *this;
             }
+            RANGES_CXX14_CONSTEXPR
             sized_range &operator=(sized_range<I, S> &&rng)
             {
                 const_cast<I &>(first) = rng.move_first();
@@ -183,6 +199,7 @@ namespace ranges
             }
             template<typename X, typename Y,
                 CONCEPT_REQUIRES_(Assignable<I &, X &&>() && Assignable<S &, Y &&>())>
+            RANGES_CXX14_CONSTEXPR
             sized_range &operator=(sized_range<X, Y> rng)
             {
                 const_cast<I &>(first) = rng.move_first();
@@ -190,14 +207,17 @@ namespace ranges
                 const_cast<iterator_size_t<I> &>(third) = rng.third;
                 return *this;
             }
+            RANGES_CXX14_CONSTEXPR
             iterator begin() const
             {
                 return first;
             }
+            RANGES_CXX14_CONSTEXPR
             sentinel end() const
             {
                 return second;
             }
+            RANGES_CXX14_CONSTEXPR
             iterator_size_t<I> size() const
             {
                 return third;
@@ -220,6 +240,7 @@ namespace ranges
         {
             /// \return `{begin, end}`
             template<typename I, typename S>
+            RANGES_CXX14_CONSTEXPR
             range<I, S> operator()(I begin, S end) const
             {
                 CONCEPT_ASSERT(IteratorRange<I, S>());
@@ -228,6 +249,7 @@ namespace ranges
 
             /// \return `{begin, end, size}`
             template<typename I, typename S>
+            RANGES_CXX14_CONSTEXPR
             sized_range<I, S> operator()(I begin, S end, iterator_size_t<I> size) const
             {
                 CONCEPT_ASSERT(IteratorRange<I, S>());

--- a/include/range/v3/range_facade.hpp
+++ b/include/range/v3/range_facade.hpp
@@ -71,33 +71,39 @@ namespace ranges
             using range_facade_t = range_facade;
             using range_interface<Derived, Inf>::derived;
             // Default implementations
+            RANGES_CXX14_CONSTEXPR
             Derived begin_cursor() const
             {
                 return derived();
             }
+            RANGES_CXX14_CONSTEXPR
             default_sentinel end_cursor() const
             {
                 return {};
             }
         public:
             template<typename D = Derived, CONCEPT_REQUIRES_(Same<D, Derived>())>
+            RANGES_CXX14_CONSTEXPR
             detail::facade_iterator_t<D> begin()
             {
                 return {range_access::begin_cursor(derived(), 42)};
             }
             /// \overload
             template<typename D = Derived, CONCEPT_REQUIRES_(Same<D, Derived>())>
+            RANGES_CXX14_CONSTEXPR
             detail::facade_iterator_t<D const> begin() const
             {
                 return {range_access::begin_cursor(derived(), 42)};
             }
             template<typename D = Derived, CONCEPT_REQUIRES_(Same<D, Derived>())>
+            RANGES_CXX14_CONSTEXPR
             detail::facade_sentinel_t<D> end()
             {
                 return {range_access::end_cursor(derived(), 42)};
             }
             /// \overload
             template<typename D = Derived, CONCEPT_REQUIRES_(Same<D, Derived>())>
+            RANGES_CXX14_CONSTEXPR
             detail::facade_sentinel_t<D const> end() const
             {
                 return {range_access::end_cursor(derived(), 42)};

--- a/include/range/v3/range_interface.hpp
+++ b/include/range/v3/range_interface.hpp
@@ -38,6 +38,7 @@ namespace ranges
                 To to;
                 template<typename F, typename T,
                     CONCEPT_REQUIRES_(Convertible<F, From>() && Convertible<T, To>())>
+                RANGES_CXX14_CONSTEXPR
                 slice_bounds(F from, T to)
                   : from(from), to(to)
                 {}
@@ -50,6 +51,7 @@ namespace ranges
 
                 template<typename Other,
                     CONCEPT_REQUIRES_(Integral<Other>() && Convertible<Other, Int>())>
+                RANGES_CXX14_CONSTEXPR
                 operator from_end_<Other> () const
                 {
                     return {static_cast<Other>(dist_)};
@@ -65,25 +67,30 @@ namespace ranges
           : private basic_range<Inf>
         {
         protected:
+            RANGES_CXX14_CONSTEXPR
             Derived & derived()
             {
                 return static_cast<Derived &>(*this);
             }
             /// \overload
+            RANGES_CXX14_CONSTEXPR
             Derived const & derived() const
             {
                 return static_cast<Derived const &>(*this);
             }
         public:
             // A few ways of testing whether a range can be empty:
+            RANGES_CXX14_CONSTEXPR
             bool empty() const
             {
                 return derived().begin() == derived().end();
             }
+            RANGES_CXX14_CONSTEXPR
             bool operator!() const
             {
                 return empty();
             }
+            RANGES_CXX14_CONSTEXPR
             explicit operator bool() const
             {
                 return !empty();
@@ -92,6 +99,7 @@ namespace ranges
             template<typename D = Derived,
                 CONCEPT_REQUIRES_(Same<D, Derived>() &&
                     SizedIteratorRange<range_iterator_t<D>, range_sentinel_t<D>>())>
+            RANGES_CXX14_CONSTEXPR
             range_size_t<D> size() const
             {
                 return iter_size(derived().begin(), derived().end());
@@ -99,6 +107,7 @@ namespace ranges
             /// Access the first element in a range:
             template<typename D = Derived,
                 CONCEPT_REQUIRES_(Same<D, Derived>())>
+            RANGES_CXX14_CONSTEXPR
             range_reference_t<D> front()
             {
                 return *derived().begin();
@@ -106,6 +115,7 @@ namespace ranges
             /// \overload
             template<typename D = Derived,
                 CONCEPT_REQUIRES_(Same<D, Derived>())>
+            RANGES_CXX14_CONSTEXPR
             range_reference_t<D const> front() const
             {
                 return *derived().begin();
@@ -113,6 +123,7 @@ namespace ranges
             /// Access the last element in a range:
             template<typename D = Derived,
                 CONCEPT_REQUIRES_(Same<D, Derived>() && BoundedRange<D>() && BidirectionalRange<D>())>
+            RANGES_CXX14_CONSTEXPR
             range_reference_t<D> back()
             {
                 return *prev(derived().end());
@@ -120,6 +131,7 @@ namespace ranges
             /// \overload
             template<typename D = Derived,
                 CONCEPT_REQUIRES_(Same<D, Derived>() && BoundedRange<D const>() && BidirectionalRange<D const>())>
+            RANGES_CXX14_CONSTEXPR
             range_reference_t<D const> back() const
             {
                 return *prev(derived().end());
@@ -127,6 +139,7 @@ namespace ranges
             /// Simple indexing:
             template<typename D = Derived,
                 CONCEPT_REQUIRES_(Same<D, Derived>() && RandomAccessRange<D>())>
+            RANGES_CXX14_CONSTEXPR
             auto operator[](range_difference_t<D> n) ->
                 decltype(std::declval<D &>().begin()[n])
             {
@@ -135,6 +148,7 @@ namespace ranges
             /// \overload
             template<typename D = Derived,
                 CONCEPT_REQUIRES_(Same<D, Derived>() && RandomAccessRange<D const>())>
+            RANGES_CXX14_CONSTEXPR
             auto operator[](range_difference_t<D> n) const ->
                 decltype(std::declval<D const &>().begin()[n])
             {
@@ -144,6 +158,7 @@ namespace ranges
             //      rng[{4,6}]
             template<typename D = Derived, typename Slice = view::slice_fn,
                 CONCEPT_REQUIRES_(Same<D, Derived>())>
+            RANGES_CXX14_CONSTEXPR
             auto operator[](detail::slice_bounds<range_difference_t<D>> offs) ->
                 decltype(std::declval<Slice>()(std::declval<D &>(), offs.from, offs.to))
             {
@@ -152,6 +167,7 @@ namespace ranges
             /// \overload
             template<typename D = Derived, typename Slice = view::slice_fn,
                 CONCEPT_REQUIRES_(Same<D, Derived>())>
+            RANGES_CXX14_CONSTEXPR
             auto operator[](detail::slice_bounds<range_difference_t<D>> offs) const ->
                 decltype(std::declval<Slice>()(std::declval<D const &>(), offs.from, offs.to))
             {
@@ -161,6 +177,7 @@ namespace ranges
             /// \overload
             template<typename D = Derived, typename Slice = view::slice_fn,
                 CONCEPT_REQUIRES_(Same<D, Derived>())>
+            RANGES_CXX14_CONSTEXPR
             auto operator[](detail::slice_bounds<range_difference_t<D>,
                 detail::from_end_<range_difference_t<D>>> offs) ->
                 decltype(std::declval<Slice>()(std::declval<D &>(), offs.from, offs.to))
@@ -170,6 +187,7 @@ namespace ranges
             /// \overload
             template<typename D = Derived, typename Slice = view::slice_fn,
                 CONCEPT_REQUIRES_(Same<D, Derived>())>
+            RANGES_CXX14_CONSTEXPR
             auto operator[](detail::slice_bounds<range_difference_t<D>,
                 detail::from_end_<range_difference_t<D>>> offs) const ->
                 decltype(std::declval<Slice>()(std::declval<D const &>(), offs.from, offs.to))
@@ -180,6 +198,7 @@ namespace ranges
             /// \overload
             template<typename D = Derived, typename Slice = view::slice_fn,
                 CONCEPT_REQUIRES_(Same<D, Derived>())>
+            RANGES_CXX14_CONSTEXPR
             auto operator[](detail::slice_bounds<detail::from_end_<range_difference_t<D>>,
                 detail::from_end_<range_difference_t<D>>> offs) ->
                 decltype(std::declval<Slice>()(std::declval<D &>(), offs.from, offs.to))
@@ -189,6 +208,7 @@ namespace ranges
             /// \overload
             template<typename D = Derived, typename Slice = view::slice_fn,
                 CONCEPT_REQUIRES_(Same<D, Derived>())>
+            RANGES_CXX14_CONSTEXPR
             auto operator[](detail::slice_bounds<detail::from_end_<range_difference_t<D>>,
                 detail::from_end_<range_difference_t<D>>> offs) const ->
                 decltype(std::declval<Slice>()(std::declval<D const &>(), offs.from, offs.to))
@@ -199,6 +219,7 @@ namespace ranges
             /// \overload
             template<typename D = Derived, typename Slice = view::slice_fn,
                 CONCEPT_REQUIRES_(Same<D, Derived>())>
+            RANGES_CXX14_CONSTEXPR
             auto operator[](detail::slice_bounds<range_difference_t<D>, end_fn> offs) ->
                 decltype(std::declval<Slice>()(std::declval<D &>(), offs.from, offs.to))
             {
@@ -207,6 +228,7 @@ namespace ranges
             /// \overload
             template<typename D = Derived, typename Slice = view::slice_fn,
                 CONCEPT_REQUIRES_(Same<D, Derived>())>
+            RANGES_CXX14_CONSTEXPR
             auto operator[](detail::slice_bounds<range_difference_t<D>, end_fn> offs) const ->
                 decltype(std::declval<Slice>()(std::declval<D const &>(), offs.from, offs.to))
             {
@@ -216,6 +238,7 @@ namespace ranges
             /// \overload
             template<typename D = Derived, typename Slice = view::slice_fn,
                 CONCEPT_REQUIRES_(Same<D, Derived>())>
+            RANGES_CXX14_CONSTEXPR
             auto operator[](detail::slice_bounds<detail::from_end_<range_difference_t<D>>, end_fn> offs) ->
                 decltype(std::declval<Slice>()(std::declval<D &>(), offs.from, offs.to))
             {
@@ -224,6 +247,7 @@ namespace ranges
             /// \overload
             template<typename D = Derived, typename Slice = view::slice_fn,
                 CONCEPT_REQUIRES_(Same<D, Derived>())>
+            RANGES_CXX14_CONSTEXPR
             auto operator[](detail::slice_bounds<detail::from_end_<range_difference_t<D>>, end_fn> offs) const ->
                 decltype(std::declval<Slice>()(std::declval<D const &>(), offs.from, offs.to))
             {
@@ -233,6 +257,7 @@ namespace ranges
             template<typename Container, typename D = Derived,
                 typename Alloc = typename Container::allocator_type, // HACKHACK
                 CONCEPT_REQUIRES_(detail::ConvertibleToContainer<D, Container>())>
+            RANGES_CXX14_CONSTEXPR
             operator Container ()
             {
                 return ranges::to_<Container>(derived());
@@ -241,12 +266,14 @@ namespace ranges
             template<typename Container, typename D = Derived,
                 typename Alloc = typename Container::allocator_type, // HACKHACK
                 CONCEPT_REQUIRES_(detail::ConvertibleToContainer<D const, Container>())>
+            RANGES_CXX14_CONSTEXPR
             operator Container () const
             {
                 return ranges::to_<Container>(derived());
             }
             /// \brief Print a range to an ostream
             template<bool B = true, typename Stream = meta::if_c<B, std::ostream>>
+            RANGES_CXX14_CONSTEXPR
             friend Stream &operator<<(Stream &sout, Derived &rng)
             {
                 auto it = ranges::begin(rng);
@@ -261,6 +288,7 @@ namespace ranges
             /// \overload
             template<bool B = true, typename Stream = meta::if_c<B, std::ostream>,
                 typename D = Derived, CONCEPT_REQUIRES_(InputRange<D const>())>
+            RANGES_CXX14_CONSTEXPR
             friend Stream &operator<<(Stream &sout, Derived const &rng)
             {
                 auto it = ranges::begin(rng);
@@ -274,6 +302,7 @@ namespace ranges
             }
             /// \overload
             template<bool B = true, typename Stream = meta::if_c<B, std::ostream>>
+            RANGES_CXX14_CONSTEXPR
             friend Stream &operator<<(Stream &sout, Derived &&rng)
             {
                 return sout << rng;

--- a/include/range/v3/utility/addressof.hpp
+++ b/include/range/v3/utility/addressof.hpp
@@ -1,0 +1,78 @@
+/// \file
+// Range v3 library
+//
+//  Copyright Eric Niebler 2013-2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+// The code below is adapted from the Eggs.Variant library which can be found
+// here: https://github.com/eggs-cpp/variant
+//
+// Copyright Agustin K-ballo Berge, Fusion Fenix 2014-2015
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+#ifndef RANGES_V3_UTILITY_ADDRESSOF_HPP
+#define RANGES_V3_UTILITY_ADDRESSOF_HPP
+
+#include <range/v3/range_fwd.hpp>
+#include <range/v3/utility/static_const.hpp>
+#include <memory>
+
+namespace ranges
+{
+    inline namespace v3
+    {
+
+        namespace addressof_detail
+        {
+            struct fallback {};
+
+            template <typename T>
+            fallback operator&(T&&);
+
+            template <typename T>
+            struct has_addressof_operator
+            {
+                static constexpr bool value =
+                    (std::is_class<T>::value || std::is_union<T>::value)
+                    && !std::is_same<decltype(&std::declval<T&>()), fallback>::value;
+            };
+        }  //  namespace addressof_detail
+
+        struct addressof_fn {
+            template <typename T>
+            constexpr typename std::enable_if<
+                !addressof_detail::has_addressof_operator<T>::value, T* >::type
+            operator()(T& r) const noexcept
+            {
+                return &r;
+            }
+
+            template <typename T>
+            typename std::enable_if<
+                addressof_detail::has_addressof_operator<T>::value, T*>::type
+            operator()(T& r) const noexcept
+            {
+                return std::addressof(r);
+            }
+        };
+
+       /// \ingroup group-utility
+       /// \sa `addressof_fn`
+       namespace
+       {
+           constexpr auto&& addressof = static_const<addressof_fn>::value;
+       }
+
+}  // namespace v3
+}  // namespace ranges
+
+#endif

--- a/include/range/v3/utility/safe_int.hpp
+++ b/include/range/v3/utility/safe_int.hpp
@@ -118,11 +118,13 @@ namespace ranges
             {
                 return i_;
             }
+            RANGES_CXX14_CONSTEXPR
             SignedInteger get() const noexcept
             {
                 RANGES_ASSERT(is_finite());
                 return i_;
             }
+            RANGES_CXX14_CONSTEXPR
             explicit operator SignedInteger() const noexcept
             {
                 return get();
@@ -157,24 +159,28 @@ namespace ranges
                 // This handles infinity because of how we've define neg_inf_
                 return i_ == NaN_ ? NaN_ : -i_;
             }
+            RANGES_CXX14_CONSTEXPR
             safe_int & operator++() noexcept
             {
                 if(is_finite())
                     ++i_;
                 return *this;
             }
+            RANGES_CXX14_CONSTEXPR
             safe_int & operator++(int) noexcept
             {
                 auto tmp = *this;
                 ++*this;
                 return tmp;
             }
+            RANGES_CXX14_CONSTEXPR
             safe_int & operator--() noexcept
             {
                 if(is_finite())
                     --i_;
                 return *this;
             }
+            RANGES_CXX14_CONSTEXPR
             safe_int & operator--(int) noexcept
             {
                 auto tmp = *this;
@@ -224,11 +230,13 @@ namespace ranges
             {
                 return left + -right;
             }
+            RANGES_CXX14_CONSTEXPR
             safe_int & operator+=(safe_int that)
             {
                 *this = *this + that;
                 return *this;
             }
+            RANGES_CXX14_CONSTEXPR
             safe_int & operator-=(safe_int that)
             {
                 *this = *this - that;
@@ -242,6 +250,7 @@ namespace ranges
                        !left.is_finite() ? (right < 0 ? -left : left) :
                        left.i_ / right.i_;
             }
+            RANGES_CXX14_CONSTEXPR
             safe_int & operator/=(safe_int that)
             {
                 *this = *this / that;
@@ -251,6 +260,7 @@ namespace ranges
             {
                 return (left.is_finite() && right.is_finite()) ? left.i_ % right.i_ : NaN();
             }
+            RANGES_CXX14_CONSTEXPR
             safe_int & operator%=(safe_int that)
             {
                 *this = *this % that;
@@ -267,6 +277,7 @@ namespace ranges
                     // Do the multiplication
                     left.i_ * right.i_;
             }
+            RANGES_CXX14_CONSTEXPR
             safe_int & operator*=(safe_int that)
             {
                 *this = *this * that;

--- a/perf/sort_patterns.cpp
+++ b/perf/sort_patterns.cpp
@@ -247,7 +247,6 @@ int main() {
   return 0;
 }
 
-
 #else
 
 #pragma message("sort_patterns requires C++ 14 or greater")

--- a/test/algorithm/CMakeLists.txt
+++ b/test/algorithm/CMakeLists.txt
@@ -20,6 +20,12 @@ add_test(test.alg.copy, alg.copy)
 add_executable(alg.copy_backward copy_backward.cpp)
 add_test(test.alg.copy_backward, alg.copy_backward)
 
+add_executable(alg.copy_if copy_if.cpp)
+add_test(test.alg.copy_if, alg.copy_if)
+
+add_executable(alg.copy_n copy_n.cpp)
+add_test(test.alg.copy_n, alg.copy_n)
+
 add_executable(alg.count count.cpp)
 add_test(test.alg.count, alg.count)
 
@@ -43,6 +49,9 @@ add_test(test.alg.find_end, alg.find_end)
 
 add_executable(alg.find_if find_if.cpp)
 add_test(test.alg.find_if, alg.find_if)
+
+add_executable(alg.find_if_not find_if_not.cpp)
+add_test(test.alg.find_if_not, alg.find_if_not)
 
 add_executable(alg.find_first_of find_first_of.cpp)
 add_test(test.alg.find_first_of, alg.find_first_of)
@@ -86,7 +95,6 @@ add_test(test.alg.is_heap_until3, alg.is_heap_until3)
 add_executable(alg.is_heap_until4 is_heap_until4.cpp)
 add_test(test.alg.is_heap_until4, alg.is_heap_until4)
 
-
 add_executable(alg.is_partitioned is_partitioned.cpp)
 add_test(test.alg.is_partitioned, alg.is_partitioned)
 
@@ -113,6 +121,9 @@ add_test(test.alg.max_element, alg.max_element)
 
 add_executable(alg.merge merge.cpp)
 add_test(test.alg.merge, alg.merge)
+
+add_executable(alg.merge_move merge_move.cpp)
+add_test(test.alg.merge_move, alg.merge_move)
 
 add_executable(alg.min_element min_element.cpp)
 add_test(test.alg.min_element, alg.min_element)
@@ -146,6 +157,9 @@ add_test(test.alg.partition, alg.partition)
 
 add_executable(alg.partition_copy partition_copy.cpp)
 add_test(test.alg.partition_copy, alg.partition_copy)
+
+add_executable(alg.partition_move partition_move.cpp)
+add_test(test.alg.partition_move, alg.partition_move)
 
 add_executable(alg.partition_point partition_point.cpp)
 add_test(test.alg.partition_point, alg.partition_point)

--- a/test/algorithm/adjacent_find.cpp
+++ b/test/algorithm/adjacent_find.cpp
@@ -10,6 +10,7 @@
 // Project home: https://github.com/ericniebler/range-v3
 
 #include <range/v3/core.hpp>
+#include "../array.hpp"
 #include <range/v3/algorithm/adjacent_find.hpp>
 #include "../simple_test.hpp"
 
@@ -26,5 +27,16 @@ int main()
     static_assert(std::is_same<std::pair<int,int>*,
                                decltype(ranges::adjacent_find(v2, ranges::equal_to{},
                                     &std::pair<int, int>::second))>::value, "");
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        using namespace ranges;
+        constexpr auto a1 = array<int, 5>{{0, 2, 2, 4, 6}};
+        static_assert(adjacent_find(begin(a1), end(a1)) == (begin(a1) + 1), "");
+        static_assert(adjacent_find(a1) == (begin(a1) + 1), "");
+        constexpr std::pair<int, int> a2[] = {{0, 0}, {0, 2}, {0, 2}, {0, 4}, {0, 6}};
+        static_assert(adjacent_find(a2, ranges::equal_to{}) == (begin(a2) + 1), "");
+    }
+#endif
     return test_result();
 }

--- a/test/algorithm/all_of.cpp
+++ b/test/algorithm/all_of.cpp
@@ -14,7 +14,7 @@
 #include <range/v3/algorithm/all_of.hpp>
 #include "../simple_test.hpp"
 
-bool even(int n) { return n % 2 == 0; }
+constexpr bool even(int n) { return n % 2 == 0; }
 
 struct S {
   S(bool p) : test(p) { }
@@ -55,6 +55,13 @@ int main()
   CHECK(ranges::all_of({S(true), S(true), S(true)}, &S::p));
   CHECK(!ranges::all_of({S(false), S(true), S(false)}, &S::p));
   CHECK(!ranges::all_of({S(false), S(false), S(false)}, &S::p));
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+  static_assert(ranges::all_of({0, 2, 4, 6}, even), "");
+  static_assert(!ranges::all_of({0, 2, 4, 5}, even), "");
+  static_assert(!ranges::all_of({1, 3, 4, 7}, even), "");
+  static_assert(!ranges::all_of({1, 3, 5, 7}, even), "");
+#endif
 
   return ::test_result();
 }

--- a/test/algorithm/any_of.cpp
+++ b/test/algorithm/any_of.cpp
@@ -15,7 +15,7 @@
 #include <range/v3/algorithm/any_of.hpp>
 #include "../simple_test.hpp"
 
-bool even(int n) { return n % 2 == 0; }
+constexpr bool even(int n) { return n % 2 == 0; }
 
 struct S {
   S(bool p) : test(p) { }
@@ -56,6 +56,12 @@ int main()
   CHECK(ranges::any_of({S(true), S(true), S(true)}, &S::p));
   CHECK(ranges::any_of({S(false), S(true), S(false)}, &S::p));
   CHECK(!ranges::any_of({S(false), S(false), S(false)}, &S::p));
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+  static_assert(ranges::any_of({0, 2, 4, 6}, even), "");
+  static_assert(ranges::any_of({1, 3, 4, 7}, even), "");
+  static_assert(!ranges::any_of({1, 3, 5, 7}, even), "");
+#endif
 
   return ::test_result();
 }

--- a/test/algorithm/binary_search.cpp
+++ b/test/algorithm/binary_search.cpp
@@ -50,5 +50,18 @@ int main()
     CHECK(!ranges::binary_search(a, 4, less(), &std::pair<int, int>::first));
     CHECK(!ranges::binary_search(c, 4, less(), &std::pair<int, int>::first));
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        using namespace ranges;
+        constexpr std::pair<int, int> a[] = {{0, 0}, {0, 1}, {1, 2}, {1, 3}, {3, 4}, {3, 5}};
+
+        static_assert(binary_search(begin(a), end(a), a[0]), "");
+        static_assert(binary_search(begin(a), end(a), a[1], less()), "");
+        static_assert(binary_search(a, a[2]), "");
+        static_assert(binary_search(a, a[4], less()), "");
+        static_assert(!binary_search(a, std::make_pair(-1, -1), less()), "");
+    }
+#endif
+
     return test_result();
 }

--- a/test/algorithm/copy.cpp
+++ b/test/algorithm/copy.cpp
@@ -14,8 +14,21 @@
 #include <algorithm>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/copy.hpp>
+#include <range/v3/algorithm/equal.hpp>
 #include <range/v3/view/delimit.hpp>
+#include "../array.hpp"
 #include "../simple_test.hpp"
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+template<typename Rng>
+RANGES_CXX14_CONSTEXPR auto copy_rng(Rng&& input)  {
+    array<int, 4> tmp{{0, 0, 0, 0}};
+    auto res = ranges::copy(input, ranges::begin(tmp));
+    if (res.first != ranges::end(input)) { throw 0; };
+    if (res.second != ranges::end(tmp)) { throw 0; };
+    return tmp;
+}
+#endif
 
 int main()
 {
@@ -64,6 +77,13 @@ int main()
         CHECK(res3.second == buf + std::strlen(sz));
         CHECK(std::strcmp(sz, buf) == 0);
     }
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        constexpr auto a1 = copy_rng(array<int,4>{{0, 1, 2, 3}});
+        static_assert(ranges::equal(a1, {0, 1, 2, 3}), "");
+    }
+#endif
 
     return test_result();
 }

--- a/test/algorithm/copy_backward.cpp
+++ b/test/algorithm/copy_backward.cpp
@@ -15,7 +15,19 @@
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/copy_backward.hpp>
 #include <range/v3/view/delimit.hpp>
+#include "../array.hpp"
 #include "../simple_test.hpp"
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+template<typename Rng>
+RANGES_CXX14_CONSTEXPR auto copy_rng(Rng&& input)  {
+    array<int, 4> tmp{{0, 0, 0, 0}};
+    auto res = ranges::copy_backward(input, ranges::end(tmp));
+    if (res.first != ranges::end(input)) { throw 0; };
+    if (res.second != ranges::begin(tmp)) { throw 0; };
+    return tmp;
+}
+#endif
 
 int main()
 {
@@ -46,5 +58,11 @@ int main()
     CHECK(res2.second == begin(out));
     CHECK(std::equal(a, a + size(a), out));
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        constexpr auto a1 = copy_rng(array<int,4>{{0, 1, 2, 3}});
+        static_assert(ranges::equal(a1, {0, 1, 2, 3}), "");
+    }
+#endif
     return test_result();
 }

--- a/test/algorithm/copy_if.cpp
+++ b/test/algorithm/copy_if.cpp
@@ -1,0 +1,47 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+
+#include <range/v3/algorithm/copy_if.hpp>
+#include "../array.hpp"
+#include "../simple_test.hpp"
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+constexpr bool is_even(int i) { return i % 2 == 0; }
+RANGES_CXX14_CONSTEXPR bool test_constexpr()  {
+    using namespace ranges;
+    array<int, 4> a{{1, 2, 3, 4}};
+    array<int, 4> b{{0, 0, 0, 0}};
+    auto res = copy_if(a, ranges::begin(b), is_even);
+    if (res.first != end(a)) { return false;  };
+    if (res.second != begin(b) + 2) { return false; };
+    if (a[0] != 1) { return false; }
+    if (a[1] != 2) { return false; }
+    if (a[2] != 3) { return false; }
+    if (a[3] != 4) { return false; }
+    if (b[0] != 2) { return false; }
+    if (b[1] != 4) { return false; }
+    if (b[2] != 0) { return false; }
+    if (b[3] != 0) { return false; }
+    return true;
+}
+#endif
+
+int main()
+{
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
+
+    return test_result();
+}

--- a/test/algorithm/copy_n.cpp
+++ b/test/algorithm/copy_n.cpp
@@ -1,0 +1,46 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+
+#include <range/v3/algorithm/copy_n.hpp>
+#include "../array.hpp"
+#include "../simple_test.hpp"
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()  {
+    using namespace ranges;
+    array<int, 4> a{{1, 2, 3, 4}};
+    array<int, 4> b{{0, 0, 0, 0}};
+    auto res = copy_n(begin(a), 2, ranges::begin(b));
+    if (res.first != begin(a) + 2) { return false;  };
+    if (res.second != begin(b) + 2) { return false; };
+    if (a[0] != 1) { return false; }
+    if (a[1] != 2) { return false; }
+    if (a[2] != 3) { return false; }
+    if (a[3] != 4) { return false; }
+    if (b[0] != 1) { return false; }
+    if (b[1] != 2) { return false; }
+    if (b[2] != 0) { return false; }
+    if (b[3] != 0) { return false; }
+    return true;
+}
+#endif
+
+int main()
+{
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
+
+    return test_result();
+}

--- a/test/algorithm/count.cpp
+++ b/test/algorithm/count.cpp
@@ -57,5 +57,12 @@ int main()
     CHECK(count(make_range(input_iterator<const S*>(sa),
                       sentinel<const S*>(sa)), 2, &S::i) == 0);
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(ranges::count({0, 1, 2, 1, 3, 1, 4}, 1)  == 3, "");
+        static_assert(ranges::count({0, 1, 2, 1, 3, 1, 4}, 5)  == 0, "");
+    }
+#endif
+
     return ::test_result();
 }

--- a/test/algorithm/count_if.cpp
+++ b/test/algorithm/count_if.cpp
@@ -25,6 +25,8 @@ struct T
     bool m() { return b; }
 };
 
+constexpr bool even(int i) { return i % 2 == 0; }
+
 int main()
 {
     using namespace ranges;
@@ -73,6 +75,13 @@ int main()
                          sentinel<T*>(ta + size(ta))), &T::m) == 4);
     CHECK(count_if(make_range(input_iterator<T*>(ta),
                          sentinel<T*>(ta + size(ta))), &T::b) == 4);
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(ranges::count_if({0, 1, 2, 1, 3, 1, 4}, even)  == 3, "");
+        static_assert(ranges::count_if({1, 1, 3, 1}, even)  == 0, "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/equal.cpp
+++ b/test/algorithm/equal.cpp
@@ -281,5 +281,13 @@ int main()
     static_assert(std::is_same<bool, decltype(ranges::equal({1, 2, 3, 4}, {1, 2, 3, 4}))>::value, "");
     static_assert(std::is_same<bool, decltype(ranges::equal({1, 2, 3, 4}, ranges::view::unbounded(p)))>::value, "");
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+    static_assert(ranges::equal({1, 2, 3, 4}, {1, 2, 3, 4}), "");
+    static_assert(!ranges::equal({1, 2, 3, 4}, {1, 2, 3}), "");
+    static_assert(!ranges::equal({1, 2, 3, 4}, {1, 2, 4, 3}), "");
+    static_assert(ranges::equal(std::initializer_list<int>{},
+                                std::initializer_list<int>{}), "");
+#endif
+
     return ::test_result();
 }

--- a/test/algorithm/equal_range.cpp
+++ b/test/algorithm/equal_range.cpp
@@ -28,6 +28,7 @@
 #include <range/v3/view/repeat_n.hpp>
 #include <range/v3/view/take.hpp>
 #include <range/v3/utility/iterator.hpp>
+#include "../array.hpp"
 #include <range/v3/algorithm/copy.hpp>
 #include <range/v3/algorithm/equal_range.hpp>
 #include "../simple_test.hpp"
@@ -71,13 +72,74 @@ test()
         test(Iter(v.data()), Sent(v.data()+v.size()), x);
 }
 
-int main()
+#ifdef RANGES_CXX_GREATER_THAN_11
+
+template <class Iter, class Sent, class T>
+RANGES_CXX14_CONSTEXPR bool
+test_constexpr(Iter first, Sent last, const T& value)
+{
+    bool result = true;
+    ranges::range<Iter, Iter> i = ranges::equal_range(first, last, value);
+    for (Iter j = first; j != i.begin(); ++j)
+        if(!(*j < value)) { result = false; }
+    for (Iter j = i.begin(); j != last; ++j)
+        if(!(!(*j < value))) { result = false; }
+    for (Iter j = first; j != i.end(); ++j)
+        if(!(!(value < *j))) { result = false; }
+    for (Iter j = i.end(); j != last; ++j)
+        if(!(value < *j)) { result = false; }
+
+    auto res = ranges::equal_range(ranges::make_range(first, last), value);
+    for (Iter j = first; j != res.get_unsafe().begin(); ++j)
+        if(!(*j < value)) { result = false; }
+    for (Iter j = res.get_unsafe().begin(); j != last; ++j)
+        if(!(!(*j < value))) { result = false; }
+    for (Iter j = first; j != res.get_unsafe().end(); ++j)
+        if(!(!(value < *j))) { result = false; }
+    for (Iter j = res.get_unsafe().end(); j != last; ++j)
+        if(!(value < *j)) { result = false; }
+
+    return result;
+}
+
+
+// TODO: constexpr
+// need to make views constexpr before adding this test
+// template <class Iter, class Sent = Iter>
+// RANGES_CXX14_CONSTEXPR bool
+// test_constexpr()
+// {
+//     using namespace ranges::view;
+//     constexpr unsigned M = 10;
+//     constexpr unsigned N = 10;
+//     array<int, N * M> v{{0}};
+//     auto input = ints | take(N)
+//                  | transform(transform_f{M}) | join;
+//     ranges::copy(input, ranges::begin(v));
+//     bool result = true;
+//     for (int x = 0; x <= (int)M; ++x)
+//         if(!test_constexpr(Iter(v.data()), Sent(v.data()+v.size()), x)) {
+//             result = false;
+//         }
+//     return result;
+// }
+
+RANGES_CXX14_CONSTEXPR bool
+test_constexpr_some()
 {
     int d[] = {0, 1, 2, 3};
-    for (int* e = d; e <= d+4; ++e)
+    int* end = d+4;
+    bool result = true;
+    for (int* e = d; e < end; ++e)
         for (int x = -1; x <= 4; ++x)
-            test(d, e, x);
+            if(!test_constexpr(d, e, x)) { result = false; };
+    return result;
+}
 
+#endif
+
+int main()
+{
     test<forward_iterator<const int*> >();
     test<bidirectional_iterator<const int*> >();
     test<random_access_iterator<const int*> >();
@@ -86,6 +148,21 @@ int main()
     test<forward_iterator<const int*>, sentinel<const int*> >();
     test<bidirectional_iterator<const int*>, sentinel<const int*> >();
     test<random_access_iterator<const int*>, sentinel<const int*> >();
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr_some(), "");
+        // TODO: constexpr
+        // need to make views constexpr before adding these tests
+        // static_assert(test_constexpr<forward_iterator<const int*> >(), "");
+        // static_assert(test_constexpr<bidirectional_iterator<const int*> >(), "");
+        // static_assert(test_constexpr<random_access_iterator<const int*> >(), "");
+        // static_assert(test_constexpr<const int*>(), "");
+        // static_assert(test_constexpr<forward_iterator<const int*>, sentinel<const int*> >(), "");
+        // static_assert(test_constexpr<bidirectional_iterator<const int*>, sentinel<const int*> >(), "");
+        // static_assert(test_constexpr<random_access_iterator<const int*>, sentinel<const int*> >(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/fill.cpp
+++ b/test/algorithm/fill.cpp
@@ -23,6 +23,8 @@
 #include <vector>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/fill.hpp>
+#include <range/v3/algorithm/equal.hpp>
+#include "../array.hpp"
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
@@ -76,6 +78,22 @@ test_int()
     CHECK(ia[3] == 2);
 }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+
+RANGES_CXX14_CONSTEXPR auto fives() {
+    array<int, 4> a{{0}};
+    ranges::fill(a, 5);
+    return a;
+}
+
+RANGES_CXX14_CONSTEXPR auto fives(int n) {
+    array<int, 4> a{{0}};
+    ranges::fill_n(ranges::begin(a), n, 5);
+    return a;
+}
+
+#endif
+
 int main()
 {
     test_char<forward_iterator<char*> >();
@@ -95,6 +113,14 @@ int main()
     test_int<forward_iterator<int*>, sentinel<int*> >();
     test_int<bidirectional_iterator<int*>, sentinel<int*> >();
     test_int<random_access_iterator<int*>, sentinel<int*> >();
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(ranges::equal(fives(), {5, 5, 5, 5}), "");
+        static_assert(ranges::equal(fives(2), {5, 5, 0, 0}), "");
+        static_assert(!ranges::equal(fives(2), {5, 5, 5, 5}), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/find.cpp
+++ b/test/algorithm/find.cpp
@@ -29,6 +29,21 @@ struct S
     int i_;
 };
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+template<class Rng, class T>
+RANGES_CXX14_CONSTEXPR T ret_val(Rng r, T val) {
+    auto rng = r;
+    auto pi = ranges::find(rng, val);
+    return *pi;
+}
+template<class Rng, class T>
+RANGES_CXX14_CONSTEXPR bool found(Rng r, T val) {
+    auto rng = r;
+    auto pi = ranges::find(rng, val);
+    return pi != ranges::end(rng);
+}
+#endif
+
 int main()
 {
     using namespace ranges;
@@ -64,6 +79,14 @@ int main()
     CHECK(ps->i_ == 3);
     ps = find(sa, 10, &S::i_);
     CHECK(ps == end(sa));
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(ret_val(std::initializer_list<int>{1, 2}, 2) == 2, "");
+        static_assert(found(std::initializer_list<int>{1, 3, 4}, 4), "");
+        static_assert(!found(std::initializer_list<int>{1, 3, 4}, 5), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/find_end.cpp
+++ b/test/algorithm/find_end.cpp
@@ -24,6 +24,57 @@
 #include "../simple_test.hpp"
 #include "../test_iterators.hpp"
 
+RANGES_CXX14_CONSTEXPR bool test_constexpr() {
+    using namespace ranges;
+    bool r = true;
+    int ia[] = {0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 0, 1, 2, 3, 0, 1, 2, 0, 1, 0};
+    auto ia_b = begin(ia);
+    auto ia_e = end(ia);
+
+    constexpr unsigned sa = size(ia);
+    int b[] = {0};
+    int c[] = {0, 1};
+    int d[] = {0, 1, 2};
+    int e[] = {0, 1, 2, 3};
+    int f[] = {0, 1, 2, 3, 4};
+    int g[] = {0, 1, 2, 3, 4, 5};
+    int h[] = {0, 1, 2, 3, 4, 5, 6};
+    if(!(find_end(ia_b, ia_e, begin(b), b + 1) == ia + sa - 1)) { r = false; }
+    if(!(find_end(ia_b, ia_e, begin(c), c + 2) == ia + 18)) { r = false; }
+    if(!(find_end(ia_b, ia_e, begin(d), d + 3) == ia + 15)) { r = false; }
+    if(!(find_end(ia_b, ia_e, begin(e), e + 4) == ia + 11)) { r = false; }
+    if(!(find_end(ia_b, ia_e, begin(f), f + 5) == ia + 6)) { r = false; }
+    if(!(find_end(ia_b, ia_e, begin(g), g + 6) == ia)) { r = false; }
+    if(!(find_end(ia_b, ia_e, begin(h), h + 7) == ia + sa)) { r = false; }
+    if(!(find_end(ia_b, ia_e, begin(b), b) == ia + sa)) { r = false; }
+    if(!(find_end(ia_b, ia_b, begin(b), b + 1) == ia)) { r = false; }
+
+    auto ir = make_range(ia_b, ia_e);
+    if(!(find_end(ir, make_range(begin(b), b + 1)) == ia + sa - 1)) { r = false; }
+    if(!(find_end(ir, make_range(begin(c), c + 2)) == ia + 18)) { r = false; }
+    if(!(find_end(ir, make_range(begin(d), d + 3)) == ia + 15)) { r = false; }
+    if(!(find_end(ir, make_range(begin(e), e + 4)) == ia + 11)) { r = false; }
+    if(!(find_end(ir, make_range(begin(f), f + 5)) == ia + 6)) { r = false; }
+    if(!(find_end(ir, make_range(begin(g), g + 6)) == ia)) { r = false; }
+    if(!(find_end(ir, make_range(begin(h), h + 7)) == ia + sa)) { r = false; }
+    if(!(find_end(ir, make_range(begin(b), b)) == ia + sa)) { r = false; }
+
+    if(!(find_end(std::move(ir), make_range(begin(b), b + 1)).get_unsafe() == ia + sa - 1)) { r = false; }
+    if(!(find_end(std::move(ir), make_range(begin(c), c + 2)).get_unsafe() == ia + 18)) { r = false; }
+    if(!(find_end(std::move(ir), make_range(begin(d), d + 3)).get_unsafe() == ia + 15)) { r = false; }
+    if(!(find_end(std::move(ir), make_range(begin(e), e + 4)).get_unsafe() == ia + 11)) { r = false; }
+    if(!(find_end(std::move(ir), make_range(begin(f), f + 5)).get_unsafe() == ia + 6)) { r = false; }
+    if(!(find_end(std::move(ir), make_range(begin(g), g + 6)).get_unsafe() == ia)) { r = false; }
+    if(!(find_end(std::move(ir), make_range(begin(h), h + 7)).get_unsafe() == ia + sa)) { r = false; }
+    if(!(find_end(std::move(ir), make_range(begin(b), b)).get_unsafe() == ia + sa)) { r = false; }
+
+    auto er = make_range(ia_b, ia);
+    if(!(find_end(er, make_range(b, b + 1)) == ia)) { r = false; }
+    if(!(find_end(std::move(er), make_range(b, b + 1)).get_unsafe() == ia)) { r = false; }
+    return r;
+}
+
+
 template <class Iter1, class Iter2, typename Sent1 = Iter1, typename Sent2 = Iter2>
 void
 test()
@@ -266,6 +317,13 @@ int main()
     test_proj<random_access_iterator<const S*>, forward_iterator<const int*>, sentinel<const S*>, sentinel<const int *> >();
     test_proj<random_access_iterator<const S*>, bidirectional_iterator<const int*>, sentinel<const S*>, sentinel<const int *> >();
     test_proj<random_access_iterator<const S*>, random_access_iterator<const int*>, sentinel<const S*>, sentinel<const int *> >();
+
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/find_first_of.cpp
+++ b/test/algorithm/find_first_of.cpp
@@ -213,6 +213,44 @@ void test_rng_pred_proj()
                              input_iterator<const S*>(ia));
 }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    int ia[] = {0, 1, 2, 3, 0, 1, 2, 3};
+    constexpr unsigned sa = size(ia);
+    int ib[] = {1, 3, 5, 7};
+    constexpr unsigned sb = size(ib);
+    if(rng::find_first_of(as_lvalue(make_range(input_iterator<const int*>(ia),
+                             input_iterator<const int*>(ia + sa))),
+                             make_range(forward_iterator<const int*>(ib),
+                             forward_iterator<const int*>(ib + sb)),
+                             equal_to{}) !=
+                             input_iterator<const int*>(ia+1)) { return false; }
+    int ic[] = {7};
+    if(rng::find_first_of(as_lvalue(make_range(input_iterator<const int*>(ia),
+                             input_iterator<const int*>(ia + sa))),
+                             make_range(forward_iterator<const int*>(ic),
+                             forward_iterator<const int*>(ic + 1)),
+                             equal_to{}) !=
+                             input_iterator<const int*>(ia+sa)) { return false; }
+    if(rng::find_first_of(as_lvalue(make_range(input_iterator<const int*>(ia),
+                             input_iterator<const int*>(ia + sa))),
+                             make_range(forward_iterator<const int*>(ic),
+                             forward_iterator<const int*>(ic)),
+                             equal_to{}) !=
+                             input_iterator<const int*>(ia+sa)) { return false; }
+    if(rng::find_first_of(as_lvalue(make_range(input_iterator<const int*>(ia),
+                             input_iterator<const int*>(ia))),
+                             make_range(forward_iterator<const int*>(ic),
+                             forward_iterator<const int*>(ic+1)),
+                             equal_to{}) !=
+                             input_iterator<const int*>(ia)) { return false; }
+
+    return true;
+}
+#endif
+
 
 int main()
 {
@@ -221,5 +259,10 @@ int main()
     ::test_rng();
     ::test_rng_pred();
     ::test_rng_pred_proj();
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
     return ::test_result();
 }

--- a/test/algorithm/find_if.cpp
+++ b/test/algorithm/find_if.cpp
@@ -29,6 +29,16 @@ struct S
     int i_;
 };
 
+constexpr bool is_three(int i) { return i == 3; }
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+template<class Rng>
+RANGES_CXX14_CONSTEXPR bool contains_three(Rng r) {
+    auto it = ranges::find_if(r, is_three);
+    return it != ranges::end(r);
+}
+#endif
+
 int main()
 {
     using namespace ranges;
@@ -68,6 +78,13 @@ int main()
     CHECK(ps->i_ == 3);
     ps = find_if(sa, [](int i){return i == 10;}, &S::i_);
     CHECK(ps == end(sa));
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(contains_three(std::initializer_list<int>{0, 1, 2, 3}), "");
+        static_assert(!contains_three(std::initializer_list<int>{0, 1, 2}), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/find_if_not.cpp
+++ b/test/algorithm/find_if_not.cpp
@@ -1,0 +1,50 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <utility>
+#include <range/v3/core.hpp>
+#include <range/v3/algorithm/find_if_not.hpp>
+#include "../simple_test.hpp"
+#include "../test_iterators.hpp"
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+constexpr bool is_three(int i) { return i == 3; }
+
+template<class Rng>
+RANGES_CXX14_CONSTEXPR bool contains_other_than_three(Rng r) {
+    auto it = ranges::find_if_not(r, is_three);
+    return it != ranges::end(r);
+}
+#endif
+
+int main()
+{
+    using namespace ranges;
+
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(contains_other_than_three(std::initializer_list<int>{3, 3, 2, 3}), "");
+        static_assert(!contains_other_than_three(std::initializer_list<int>{3, 3, 3}), "");
+    }
+#endif
+
+    return ::test_result();
+}

--- a/test/algorithm/for_each.cpp
+++ b/test/algorithm/for_each.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/for_each.hpp>
+#include "../array.hpp"
 #include "../simple_test.hpp"
 
 struct S
@@ -20,6 +21,8 @@ struct S
     int *p_;
     int i_;
 };
+
+constexpr int void_f(int const&) { return 3; }
 
 int main()
 {
@@ -45,6 +48,13 @@ int main()
     sum = 0;
     CHECK(ranges::for_each(ranges::make_range(v1.begin(), v1.end()), fun).get_unsafe() == v1.end());
     CHECK(sum == 12);
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        constexpr auto rng = array<int, 4>{{0, 2, 4, 6}};
+        static_assert(ranges::for_each(rng, void_f) == ranges::end(rng), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/generate.cpp
+++ b/test/algorithm/generate.cpp
@@ -29,9 +29,9 @@
 struct gen_test
 {
     int i_;
-    gen_test() = default;
-    gen_test(int i) : i_(i) {}
-    int operator()() {return i_++;}
+    RANGES_CXX14_CONSTEXPR gen_test() : i_{} {}
+    RANGES_CXX14_CONSTEXPR gen_test(int i) : i_(i) {}
+    RANGES_CXX14_CONSTEXPR int operator()() {return i_++;}
 };
 
 template <class Iter, class Sent = Iter>
@@ -80,6 +80,42 @@ void test2()
     CHECK(v[4] == 5);
 }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+
+template <class Iter, class Sent = Iter>
+RANGES_CXX14_CONSTEXPR bool test_constexpr() {
+    bool r = true;
+    const unsigned n = 4;
+    int ia[n] = {0};
+    std::pair<Iter, gen_test> res(ranges::generate(Iter(ia), Sent(ia + n), gen_test(1)));
+    if(ia[0] != 1) { r = false; };
+    if(ia[1] != 2){ r = false; };
+    if(ia[2] != 3){ r = false; };
+    if(ia[3] != 4){ r = false; };
+    if(res.first != Iter(ia + n)){ r = false; };
+    if(res.second.i_ != 5){ r = false; };
+
+    auto rng = ranges::make_range(Iter(ia), Sent(ia + n));
+    auto res2(ranges::generate(rng, res.second));
+    if(ia[0] != 5){ r = false; };
+    if(ia[1] != 6){ r = false; };
+    if(ia[2] != 7){ r = false; };
+    if(ia[3] != 8){ r = false; };
+    if(res2.first != Iter(ia + n)){ r = false; };
+    if(res2.second.i_ != 9){ r = false; };
+
+    auto res3(ranges::generate(std::move(rng), res2.second));
+    if(ia[0] != 9){ r = false; };
+    if(ia[1] != 10){ r = false; };
+    if(ia[2] != 11){ r = false; };
+    if(ia[3] != 12){ r = false; };
+    if(res3.first.get_unsafe() != Iter(ia + n)){ r = false; };
+    if(res3.second.i_ != 13){ r = false; };
+    return r;
+}
+
+#endif
+
 int main()
 {
     test<forward_iterator<int*> >();
@@ -93,5 +129,14 @@ int main()
 
     test2();
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+    static_assert(test_constexpr<forward_iterator<int*> >(), "");
+    static_assert(test_constexpr<bidirectional_iterator<int*> >(), "");
+    static_assert(test_constexpr<random_access_iterator<int*> >(), "");
+    static_assert(test_constexpr<int*>(), "");
+    static_assert(test_constexpr<forward_iterator<int*>, sentinel<int*> >(), "");
+    static_assert(test_constexpr<bidirectional_iterator<int*>, sentinel<int*> >(), "");
+    static_assert(test_constexpr<random_access_iterator<int*>, sentinel<int*> >(), "");
+#endif
     return ::test_result();
 }

--- a/test/algorithm/generate_n.cpp
+++ b/test/algorithm/generate_n.cpp
@@ -28,9 +28,9 @@
 struct gen_test
 {
     int i_;
-    gen_test() = default;
-    gen_test(int i) : i_(i) {}
-    int operator()() {return i_++;}
+    RANGES_CXX14_CONSTEXPR gen_test() : i_{} {}
+    RANGES_CXX14_CONSTEXPR gen_test(int i) : i_(i) {}
+    RANGES_CXX14_CONSTEXPR int operator()() {return i_++;}
 };
 
 template <class Iter, class Sent = Iter>
@@ -61,6 +61,24 @@ void test2()
     CHECK(v[4] == 5);
 }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+template<class Iter, class Sent = Iter>
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    bool r = true;
+    const unsigned n = 4;
+    int ia[n] = {0};
+    std::pair<Iter, gen_test> res(ranges::generate_n(Iter(ia), n, gen_test(1)));
+    if(ia[0] != 1) { r = false; }
+    if(ia[1] != 2) { r = false; }
+    if(ia[2] != 3) { r = false; }
+    if(ia[3] != 4) { r = false; }
+    if(res.first != Iter(ia + n)) { r = false; }
+    if(res.second.i_ != 5) { r = false; }
+    return r;
+}
+#endif
+
 int main()
 {
     test<forward_iterator<int*> >();
@@ -73,6 +91,19 @@ int main()
     test<random_access_iterator<int*>, sentinel<int*> >();
 
     test2();
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr<forward_iterator<int*> >(), "");
+        static_assert(test_constexpr<bidirectional_iterator<int*> >(), "");
+        static_assert(test_constexpr<random_access_iterator<int*> >(), "");
+        static_assert(test_constexpr<int*>(), "");
+
+        static_assert(test_constexpr<forward_iterator<int*>, sentinel<int*> >(), "");
+        static_assert(test_constexpr<bidirectional_iterator<int*>, sentinel<int*> >(), "");
+        static_assert(test_constexpr<random_access_iterator<int*>, sentinel<int*> >(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/includes.cpp
+++ b/test/algorithm/includes.cpp
@@ -154,5 +154,12 @@ int main()
         ));
     }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(ranges::includes({1, 2, 2, 3, 3, 3, 4, 4, 4, 4}, {3, 3, 3},
+                      std::less<int>()), "");
+    }
+#endif
+
     return ::test_result();
 }

--- a/test/algorithm/is_heap.hpp
+++ b/test/algorithm/is_heap.hpp
@@ -1062,5 +1062,11 @@ int main()
     // Test initializer_list
     CHECK(ranges::is_heap({S{0}, S{1}, S{1}, S{1}, S{1}, S{1}, S{1}}, std::greater<int>(), &S::i));
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(ranges::is_heap({0, 1, 1, 1, 1, 1, 1}, ranges::greater{}), "");
+    }
+#endif
+
     return ::test_result();
 }

--- a/test/algorithm/is_heap_until.hpp
+++ b/test/algorithm/is_heap_until.hpp
@@ -30,6 +30,7 @@
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
+#include "../array.hpp"
 
 void test()
 {
@@ -1046,6 +1047,14 @@ struct S
     int i;
 };
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    array<int, 7> i{{1, 0, 0, 0, 0, 0, 1}};
+    return ranges::is_heap_until(i, ranges::greater{}) == ranges::begin(i) + 1;
+}
+#endif
+
 int main()
 {
     test();
@@ -1059,6 +1068,12 @@ int main()
     // Test rvalue range
     auto res = ranges::is_heap_until(ranges::view::all(i185), std::greater<int>(), &S::i);
     CHECK(res.get_unsafe() == i185+1);
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/is_partitioned.cpp
+++ b/test/algorithm/is_partitioned.cpp
@@ -32,7 +32,7 @@
 
 struct is_odd
 {
-    bool operator()(const int& i) const {return i & 1;}
+    RANGES_CXX14_CONSTEXPR bool operator()(const int& i) const {return i & 1;}
 };
 
 template <class Iter, class Sent = Iter>
@@ -126,6 +126,13 @@ int main()
 
     // Test initializer list
     CHECK( ranges::is_partitioned({S{1}, S{3}, S{5}, S{2}, S{4}, S{6}}, is_odd(), &S::i) );
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(ranges::is_partitioned({1,3,5,2,4,6}, is_odd()), "");
+        static_assert(!ranges::is_partitioned({1,3,1,2,5,6}, is_odd()), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/is_sorted.cpp
+++ b/test/algorithm/is_sorted.cpp
@@ -396,5 +396,14 @@ int main()
         CHECK(!ranges::is_sorted(as, std::greater<int>{}, &A::a));
     }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(ranges::is_sorted({0, 1, 2, 3}), "");
+        static_assert(ranges::is_sorted({0, 1, 2, 3}, std::less<>{}), "");
+        static_assert(!ranges::is_sorted({3, 2, 1, 0}), "");
+        static_assert(ranges::is_sorted({3, 2, 1, 0}, std::greater<>{}), "");
+    }
+#endif
+
     return ::test_result();
 }

--- a/test/algorithm/is_sorted_until.cpp
+++ b/test/algorithm/is_sorted_until.cpp
@@ -28,9 +28,11 @@
 
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/is_sorted_until.hpp>
+#include <range/v3/view/iota.hpp>
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
+#include "../array.hpp"
 
 /// Calls the iterator interface of the algorithm
 template <class Iter>
@@ -373,6 +375,20 @@ void test()
 
 struct A { int a; };
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    array<int, 4> a{{1, 2, 3, 4}};
+    auto b = ranges::begin(a);
+    auto b1 = ++b;
+    auto end = ranges::end(a);
+    if(ranges::is_sorted_until(a) != end) { return false; }
+    if(ranges::is_sorted_until(a, std::less<>{}) != end) { return false; }
+    if(ranges::is_sorted_until(a, std::greater<>{}) != b1) { return false; }
+    return true;
+}
+#endif
+
 int main()
 {
     test<forward_iterator<const int*>, iter_call>();
@@ -404,6 +420,12 @@ int main()
         CHECK(ranges::is_sorted_until(ranges::view::all(as), std::less<int>{}, &A::a).get_unsafe() == ranges::end(as));
         CHECK(ranges::is_sorted_until(ranges::view::all(as), std::greater<int>{}, &A::a).get_unsafe() == ranges::next(ranges::begin(as),1));
     }
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/lexicographical_compare.cpp
+++ b/test/algorithm/lexicographical_compare.cpp
@@ -20,6 +20,7 @@
 
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/lexicographical_compare.hpp>
+#include "../array.hpp"
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
@@ -167,10 +168,50 @@ void test_iter_comp()
 }
 
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+
+RANGES_CXX14_CONSTEXPR bool test_constexpr() {
+    bool r = true;
+    array<int, 4> ia{{1, 2, 3, 4}};
+    array<int, 3> ib{{1, 2, 3}};
+    unsigned sa = ranges::size(ia);
+    auto ia_b = ranges::begin(ia);
+    auto ia_e = ranges::end(ia);
+    auto ib_b = ranges::begin(ib);
+    auto ib_1 = ib_b + 1;
+    auto ib_2 = ib_b + 2;
+    auto ib_3 = ib_b + 3;
+
+    if(!(!ranges::lexicographical_compare(ia_b, ia_e, ib_b, ib_2))) { r = false; }
+    if(!(ranges::lexicographical_compare(ib_b, ib_2, ia_b, ia_e))) { r = false; }
+    if(!(!ranges::lexicographical_compare(ia_b, ia_e, ib_b, ib_3))) { r = false; }
+    if(!(ranges::lexicographical_compare(ib_b, ib_3, ia_b, ia_e))) { r = false; }
+    if(!(ranges::lexicographical_compare(ia_b, ia_e, ib_1, ib_3))) { r = false; }
+    if(!(!ranges::lexicographical_compare(ib_1, ib_3, ia_b, ia_e))) { r = false; }
+
+    typedef std::greater<int> C;
+    C c;
+    if(!(!ranges::lexicographical_compare(ia_b, ia_e, ib_b, ib_2, c))) { r = false; }
+    if(!(ranges::lexicographical_compare(ib_b, ib_2, ia_b, ia_e, c))) { r = false; }
+    if(!(!ranges::lexicographical_compare(ia_b, ia_e, ib_b, ib_3, c))) { r = false; }
+    if(!(ranges::lexicographical_compare(ib_b, ib_3, ia_b, ia_e, c))) { r = false; }
+    if(!(!ranges::lexicographical_compare(ia_b, ia_e, ib_1, ib_3, c))) { r = false; }
+    if(!(ranges::lexicographical_compare(ib_1, ib_3, ia_b, ia_e, c))) { r = false; }
+    return r;
+}
+
+#endif
+
 int main()
 {
     test_iter();
     test_iter_comp();
 
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
     return test_result();
 }

--- a/test/algorithm/lower_bound.cpp
+++ b/test/algorithm/lower_bound.cpp
@@ -48,5 +48,25 @@ int main()
     CHECK(ranges::lower_bound(ranges::view::all(a), 1, less(), &std::pair<int, int>::first).get_unsafe() == &a[2]);
     CHECK(ranges::lower_bound(ranges::view::all(c), 1, less(), &std::pair<int, int>::first).get_unsafe() == &c[2]);
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        using namespace ranges;
+        constexpr std::pair<int, int> a[] = {{0, 0}, {0, 1}, {1, 2}, {1, 3}, {3, 4}, {3, 5}};
+
+        static_assert(aux::lower_bound_n(begin(a), size(a), a[0]) == &a[0], "");
+        static_assert(aux::lower_bound_n(begin(a), size(a), a[1], less()) == &a[1], "");
+
+        static_assert(lower_bound(begin(a), end(a), a[0]) == &a[0], "");
+        static_assert(lower_bound(begin(a), end(a), a[1], less()) == &a[1], "");
+        static_assert(lower_bound(a, a[2]) == &a[2], "");
+        static_assert(lower_bound(a, a[4], less()) == &a[4], "");
+
+        // TODO: constexpr
+        // view all has to be constexpr
+        static_assert(lower_bound(a, std::make_pair(1, 2), less()) == &a[2], "");
+        // static_assert(lower_bound(view::all(a), std::make_pair(1, 2), less()).get_unsafe() == &a[2], "");
+    }
+#endif
+
     return test_result();
 }

--- a/test/algorithm/make_heap.cpp
+++ b/test/algorithm/make_heap.cpp
@@ -27,6 +27,7 @@
 #include <functional>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/heap_algorithm.hpp>
+#include "../array.hpp"
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
@@ -176,6 +177,25 @@ void test_10(int N)
     delete [] ib;
 }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr() {
+    using namespace ranges;
+    bool r = true;
+    constexpr int N = 100;
+    array<int, N> ia{{0}};
+    for (int i = 0; i < N; ++i)
+        ia[i] = N - 1 - i;
+    if(make_heap(begin(ia), end(ia), std::less<int>{}) != end(ia)) {
+        r = false;
+    }
+    if (!is_heap(begin(ia), end(ia))) {
+        r = false;
+    }
+    return r;
+}
+#endif
+
+
 void test(int N)
 {
     test_1(N);
@@ -198,6 +218,12 @@ int main()
     test(1000);
     test_9(1000);
     test_10(1000);
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return test_result();
 }

--- a/test/algorithm/max_element.cpp
+++ b/test/algorithm/max_element.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/max_element.hpp>
+#include "../array.hpp"
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
@@ -164,6 +165,13 @@ int main()
     S s[] = {S{1},S{2},S{3},S{4},S{40},S{5},S{6},S{7},S{8},S{9}};
     S const *ps = ranges::max_element(s, std::less<int>{}, &S::i);
     CHECK(ps->i == 40);
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        constexpr auto a = array<int, 10>{{1, 2, 3, 4, 40, 5, 6, 7, 8, 9}};
+        static_assert(ranges::max_element(a) == ranges::begin(a) + 4, "");
+    }
+#endif
 
     return test_result();
 }

--- a/test/algorithm/merge.cpp
+++ b/test/algorithm/merge.cpp
@@ -18,7 +18,31 @@
 #include <algorithm>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/merge.hpp>
+#include <range/v3/algorithm/is_sorted.hpp>
+#include "../array.hpp"
 #include "../simple_test.hpp"
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr() {
+    using namespace ranges;
+    constexpr unsigned N = 100;
+    array<int, N> ia{{0}};
+    array<int, N> ib{{0}};
+    array<int, 2*N> ic{{0}};
+    for(unsigned i = 0; i < N; ++i)
+        ia[i] = 2 * i;
+    for(unsigned i = 0; i < N; ++i)
+        ib[i] = 2 * i + 1;
+    auto r = merge(ia, ib, begin(ic));
+    if(get<0>(r) != end(ia)) { return false; }
+    if(get<1>(r) != end(ib)) { return false; }
+    if(get<2>(r) != end(ic)) { return false; }
+    if(ic[0] != 0) { return false; }
+    if(ic[2 * N - 1] != (int)(2 * N - 1)) { return false; }
+    if(!is_sorted(ic)) { return false; }
+    return true;
+}
+#endif
 
 int main()
 {
@@ -90,6 +114,12 @@ int main()
         auto r4 = ranges::sanitize(std::move(r));
         static_assert(std::is_same<decltype(r4), std::tuple<ranges::dangling<>, ranges::dangling<>, int *>>::value, "");
     }
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/merge_move.cpp
+++ b/test/algorithm/merge_move.cpp
@@ -1,0 +1,57 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+//  Copyright 2005 - 2007 Adobe Systems Incorporated
+//  Distributed under the MIT License(see accompanying file LICENSE_1_0_0.txt
+//  or a copy at http://stlab.adobe.com/licenses.html)
+
+#include <memory>
+#include <utility>
+#include <algorithm>
+#include <range/v3/core.hpp>
+#include <range/v3/algorithm/merge_move.hpp>
+#include <range/v3/algorithm/is_sorted.hpp>
+#include "../array.hpp"
+#include "../simple_test.hpp"
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr() {
+    using namespace ranges;
+    constexpr unsigned N = 100;
+    array<int, N> ia{{0}};
+    array<int, N> ib{{0}};
+    array<int, 2*N> ic{{0}};
+    for(unsigned i = 0; i < N; ++i)
+        ia[i] = 2 * i;
+    for(unsigned i = 0; i < N; ++i)
+        ib[i] = 2 * i + 1;
+    auto r = merge_move(ia, ib, begin(ic));
+    if(get<0>(r) != end(ia)) { return false; }
+    if(get<1>(r) != end(ib)) { return false; }
+    if(get<2>(r) != end(ic)) { return false; }
+    if(ic[0] != 0) { return false; }
+    if(ic[2 * N - 1] != (int)(2 * N - 1)) { return false; }
+    if(!is_sorted(ic)) { return false; }
+    return true;
+}
+#endif
+
+int main()
+{
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
+
+    return ::test_result();
+}

--- a/test/algorithm/min_element.cpp
+++ b/test/algorithm/min_element.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/min_element.hpp>
+#include "../array.hpp"
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
@@ -164,6 +165,13 @@ int main()
     S s[] = {S{1},S{2},S{3},S{4},S{-4},S{5},S{6},S{7},S{8},S{9}};
     S const *ps = ranges::min_element(s, std::less<int>{}, &S::i);
     CHECK(ps->i == -4);
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        constexpr auto a = array<int, 10>{{1, 2, 3, 4, -4, 5, 6, 7, 8, 9}};
+        static_assert(ranges::min_element(a) == ranges::begin(a) + 4, "");
+    }
+#endif
 
     return test_result();
 }

--- a/test/algorithm/minmax_element.cpp
+++ b/test/algorithm/minmax_element.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/minmax_element.hpp>
+#include "../array.hpp"
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
@@ -223,6 +224,14 @@ int main()
     std::pair<S const *, S const *> ps = ranges::minmax_element(s, std::less<int>{}, &S::i);
     CHECK(ps.first->i == -4);
     CHECK(ps.second->i == 40);
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        constexpr auto a = array<int, 10>{{1, 2, 3, 4, -4, 5, 6, 40, 8, 9}};
+        static_assert(ranges::minmax_element(a).first == ranges::begin(a) + 4, "");
+        static_assert(ranges::minmax_element(a).second == ranges::begin(a) + 7, "");
+    }
+#endif
 
     return test_result();
 }

--- a/test/algorithm/mismatch.cpp
+++ b/test/algorithm/mismatch.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/mismatch.hpp>
+#include "../array.hpp"
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
@@ -132,6 +133,18 @@ int main()
         = ranges::mismatch(s1, s2, std::equal_to<int>(), &S::i, &S::i);
     CHECK(ps2.first->i == -4);
     CHECK(ps2.second->i == 5);
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        constexpr auto r1 = array<int, 11>{{1, 2, 3, 4, -4, 5, 6, 40, 7, 8, 9}};
+        constexpr auto r11 = array<int, 9>{{1, 2, 3, 4, 5, 6, 7, 8, 9}};
+        constexpr auto r2 = array<int, 10>{{1, 2, 3, 4, 5, 6, 40, 7, 8, 9}};
+        static_assert(*ranges::mismatch(r1, r11, std::equal_to<int>{}).first == -4, "");
+        static_assert(*ranges::mismatch(r1, r11, std::equal_to<int>{}).second == 5, "");
+        static_assert(*ranges::mismatch(r1, r2, std::equal_to<int>{}).first == -4, "");
+        static_assert(*ranges::mismatch(r1, r2, std::equal_to<int>{}).second == 5, "");
+    }
+#endif
 
     return test_result();
 }

--- a/test/algorithm/move.cpp
+++ b/test/algorithm/move.cpp
@@ -59,6 +59,43 @@ test()
     }
 }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+template<typename InIter, typename OutIter, typename Sent = InIter>
+RANGES_CXX14_CONSTEXPR
+bool test_constexpr()
+{
+    {
+        constexpr int N = 1000;
+        int ia[N]{1};
+        for(int i = 0; i < N; ++i)
+            ia[i] = i;
+        int ib[N] = {0};
+
+        std::pair<InIter, OutIter> r = ranges::move(InIter(ia), Sent(ia+N), OutIter(ib));
+        if(base(r.first) != ia+N) { return false; }
+        if(base(r.second) != ib+N) { return false; }
+        for(int i = 0; i < N; ++i)
+            if(ia[i] != ib[i]) { return false; }
+    }
+
+    {
+        constexpr int N = 1000;
+        int ia[N]{1};
+        for(int i = 0; i < N; ++i)
+            ia[i] = i;
+        int ib[N] = {0};
+
+        std::pair<InIter, OutIter> r = ranges::move(as_lvalue(ranges::make_range(InIter(ia), Sent(ia+N))), OutIter(ib));
+        if(base(r.first) != ia+N) { return false; }
+        if(base(r.second) != ib+N) { return false; }
+        for(int i = 0; i < N; ++i)
+            if(ia[i] != ib[i]) { return false; }
+    }
+
+    return true;
+}
+#endif
+
 struct S
 {
     std::unique_ptr<int> p;
@@ -236,6 +273,69 @@ int main()
     test1<random_access_iterator<std::unique_ptr<int>*>, forward_iterator<std::unique_ptr<int>*>, sentinel<std::unique_ptr<int>*> >();
     test1<random_access_iterator<std::unique_ptr<int>*>, bidirectional_iterator<std::unique_ptr<int>*>, sentinel<std::unique_ptr<int>*> >();
     test1<random_access_iterator<std::unique_ptr<int>*>, random_access_iterator<std::unique_ptr<int>*>, sentinel<std::unique_ptr<int>*> >();
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+    static_assert(test_constexpr<input_iterator<const int*>, output_iterator<int*> >(), "");
+    static_assert(test_constexpr<input_iterator<const int*>, input_iterator<int*> >(), "");
+    static_assert(test_constexpr<input_iterator<const int*>, forward_iterator<int*> >(), "");
+    static_assert(test_constexpr<input_iterator<const int*>, bidirectional_iterator<int*> >(), "");
+    static_assert(test_constexpr<input_iterator<const int*>, random_access_iterator<int*> >(), "");
+    static_assert(test_constexpr<input_iterator<const int*>, int*>(), "");
+
+    static_assert(test_constexpr<forward_iterator<const int*>, output_iterator<int*> >(), "");
+    static_assert(test_constexpr<forward_iterator<const int*>, input_iterator<int*> >(), "");
+    static_assert(test_constexpr<forward_iterator<const int*>, forward_iterator<int*> >(), "");
+    static_assert(test_constexpr<forward_iterator<const int*>, bidirectional_iterator<int*> >(), "");
+    static_assert(test_constexpr<forward_iterator<const int*>, random_access_iterator<int*> >(), "");
+    static_assert(test_constexpr<forward_iterator<const int*>, int*>(), "");
+
+    static_assert(test_constexpr<bidirectional_iterator<const int*>, output_iterator<int*> >(), "");
+    static_assert(test_constexpr<bidirectional_iterator<const int*>, input_iterator<int*> >(), "");
+    static_assert(test_constexpr<bidirectional_iterator<const int*>, forward_iterator<int*> >(), "");
+    static_assert(test_constexpr<bidirectional_iterator<const int*>, bidirectional_iterator<int*> >(), "");
+    static_assert(test_constexpr<bidirectional_iterator<const int*>, random_access_iterator<int*> >(), "");
+    static_assert(test_constexpr<bidirectional_iterator<const int*>, int*>(), "");
+
+    static_assert(test_constexpr<random_access_iterator<const int*>, output_iterator<int*> >(), "");
+    static_assert(test_constexpr<random_access_iterator<const int*>, input_iterator<int*> >(), "");
+    static_assert(test_constexpr<random_access_iterator<const int*>, forward_iterator<int*> >(), "");
+    static_assert(test_constexpr<random_access_iterator<const int*>, bidirectional_iterator<int*> >(), "");
+    static_assert(test_constexpr<random_access_iterator<const int*>, random_access_iterator<int*> >(), "");
+    static_assert(test_constexpr<random_access_iterator<const int*>, int*>(), "");
+
+    static_assert(test_constexpr<const int*, output_iterator<int*> >(), "");
+    static_assert(test_constexpr<const int*, input_iterator<int*> >(), "");
+    static_assert(test_constexpr<const int*, forward_iterator<int*> >(), "");
+    static_assert(test_constexpr<const int*, bidirectional_iterator<int*> >(), "");
+    static_assert(test_constexpr<const int*, random_access_iterator<int*> >(), "");
+    static_assert(test_constexpr<const int*, int*>(), "");
+
+    static_assert(test_constexpr<input_iterator<const int*>, output_iterator<int*>, sentinel<const int*>>(), "");
+    static_assert(test_constexpr<input_iterator<const int*>, input_iterator<int*>, sentinel<const int*> >(), "");
+    static_assert(test_constexpr<input_iterator<const int*>, forward_iterator<int*>, sentinel<const int*> >(), "");
+    static_assert(test_constexpr<input_iterator<const int*>, bidirectional_iterator<int*>, sentinel<const int*> >(), "");
+    static_assert(test_constexpr<input_iterator<const int*>, random_access_iterator<int*>, sentinel<const int*> >(), "");
+
+    static_assert(test_constexpr<forward_iterator<const int*>, output_iterator<int*>, sentinel<const int*> >(), "");
+    static_assert(test_constexpr<forward_iterator<const int*>, input_iterator<int*>, sentinel<const int*> >(), "");
+    static_assert(test_constexpr<forward_iterator<const int*>, forward_iterator<int*>, sentinel<const int*> >(), "");
+    static_assert(test_constexpr<forward_iterator<const int*>, bidirectional_iterator<int*>, sentinel<const int*> >(), "");
+    static_assert(test_constexpr<forward_iterator<const int*>, random_access_iterator<int*>, sentinel<const int*> >(), "");
+
+    static_assert(test_constexpr<bidirectional_iterator<const int*>, output_iterator<int*>, sentinel<const int*> >(), "");
+    static_assert(test_constexpr<bidirectional_iterator<const int*>, input_iterator<int*>, sentinel<const int*> >(), "");
+    static_assert(test_constexpr<bidirectional_iterator<const int*>, forward_iterator<int*>, sentinel<const int*> >(), "");
+    static_assert(test_constexpr<bidirectional_iterator<const int*>, bidirectional_iterator<int*>, sentinel<const int*> >(), "");
+    static_assert(test_constexpr<bidirectional_iterator<const int*>, random_access_iterator<int*>, sentinel<const int*> >(), "");
+
+    static_assert(test_constexpr<random_access_iterator<const int*>, output_iterator<int*>, sentinel<const int*> >(), "");
+    static_assert(test_constexpr<random_access_iterator<const int*>, input_iterator<int*>, sentinel<const int*> >(), "");
+    static_assert(test_constexpr<random_access_iterator<const int*>, forward_iterator<int*>, sentinel<const int*> >(), "");
+    static_assert(test_constexpr<random_access_iterator<const int*>, bidirectional_iterator<int*>, sentinel<const int*> >(), "");
+    static_assert(test_constexpr<random_access_iterator<const int*>, random_access_iterator<int*>, sentinel<const int*> >(), "");
+    }
+#endif
 
     return test_result();
 }

--- a/test/algorithm/move_backward.cpp
+++ b/test/algorithm/move_backward.cpp
@@ -59,6 +59,43 @@ test()
     }
 }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+template<typename InIter, typename OutIter, typename Sent = InIter>
+RANGES_CXX14_CONSTEXPR
+bool test_constexpr()
+{
+    {
+        constexpr int N = 1000;
+        int ia[N]{1};
+        for(int i = 0; i < N; ++i)
+            ia[i] = i;
+        int ib[N] = {0};
+
+        std::pair<InIter, OutIter> r = ranges::move_backward(InIter(ia), Sent(ia+N), OutIter(ib+N));
+        if(base(r.first) != ia+N) { return false; }
+        if(base(r.second) != ib) { return false; }
+        for(int i = 0; i < N; ++i)
+            if(ia[i] != ib[i]) { return false; }
+    }
+
+    {
+        constexpr int N = 1000;
+        int ia[N]{1};
+        for(int i = 0; i < N; ++i)
+            ia[i] = i;
+        int ib[N] = {0};
+
+        std::pair<InIter, OutIter> r = ranges::move_backward(as_lvalue(ranges::make_range(InIter(ia), Sent(ia+N))), OutIter(ib+N));
+        if(base(r.first) != ia+N) { return false; }
+        if(base(r.second) != ib) { return false; }
+        for(int i = 0; i < N; ++i)
+            if(ia[i] != ib[i]) { return false; }
+    }
+
+    return true;
+}
+#endif
+
 struct S
 {
     std::unique_ptr<int> p;
@@ -139,6 +176,20 @@ int main()
     test1<std::unique_ptr<int>*, bidirectional_iterator<std::unique_ptr<int>*> >();
     test1<std::unique_ptr<int>*, random_access_iterator<std::unique_ptr<int>*> >();
     test1<std::unique_ptr<int>*, std::unique_ptr<int>*>();
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    static_assert(test_constexpr<bidirectional_iterator<const int*>, bidirectional_iterator<int*> >(), "");
+    static_assert(test_constexpr<bidirectional_iterator<const int*>, random_access_iterator<int*> >(), "");
+    static_assert(test_constexpr<bidirectional_iterator<const int*>, int*>(), "");
+
+    static_assert(test_constexpr<random_access_iterator<const int*>, bidirectional_iterator<int*> >(), "");
+    static_assert(test_constexpr<random_access_iterator<const int*>, random_access_iterator<int*> >(), "");
+    static_assert(test_constexpr<random_access_iterator<const int*>, int*>(), "");
+
+    static_assert(test_constexpr<const int*, bidirectional_iterator<int*> >(), "");
+    static_assert(test_constexpr<const int*, random_access_iterator<int*> >(), "");
+    static_assert(test_constexpr<const int*, int*>(), "");
+#endif
 
     return test_result();
 }

--- a/test/algorithm/next_permutation.cpp
+++ b/test/algorithm/next_permutation.cpp
@@ -27,6 +27,8 @@
 #include <algorithm>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/permutation.hpp>
+#include <range/v3/algorithm/equal.hpp>
+#include "../safe_int_swap.hpp"
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
@@ -170,6 +172,21 @@ std::ostream &operator<<(std::ostream& sout, std::pair<int, c_str> p)
     return sout << "{" << p.first << "," << p.second.value << "}";
 }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    safe_int<int> ia[] = {6, 5, 4, 3, 2, 1};
+    next_permutation(ia, greater{});
+    if (!equal(ia, {6, 5, 4, 3, 1, 2})) { return false; }
+    next_permutation(ia, greater{});
+    if (!equal(ia, {6, 5, 4, 2, 3, 1})) { return false; }
+    next_permutation(ia, greater{});
+    if (!equal(ia, {6, 5, 4, 2, 1, 3})) { return false; }
+    return true;
+}
+#endif
+
 int main()
 {
     test_iter<bidirectional_iterator<int*> >();
@@ -211,6 +228,12 @@ int main()
     CHECK(ranges::next_permutation(ia, C(), &std::pair<int,c_str>::first));
     ::check_equal<std::pair<int, c_str>>(ia, {{6, {"six"}}, {5,{"five"}}, {4,{"four"}}, {2,{"two"}}, {1,{"one"}}, {3,{"three"}}});
     // etc..
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/none_of.cpp
+++ b/test/algorithm/none_of.cpp
@@ -15,7 +15,7 @@
 #include <range/v3/algorithm/none_of.hpp>
 #include "../simple_test.hpp"
 
-bool even(int n) { return n % 2 == 0; }
+constexpr bool even(int n) { return n % 2 == 0; }
 
 struct S {
   S(bool p) : test(p) { }
@@ -56,6 +56,12 @@ int main()
   CHECK(!ranges::none_of({S(true), S(true), S(true)}, &S::p));
   CHECK(!ranges::none_of({S(false), S(true), S(false)}, &S::p));
   CHECK(ranges::none_of({S(false), S(false), S(false)}, &S::p));
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+  static_assert(!ranges::none_of({0, 2, 4, 6}, even), "");
+  static_assert(!ranges::none_of({1, 3, 4, 7}, even), "");
+  static_assert(ranges::none_of({1, 3, 5, 7}, even), "");
+#endif
 
   return ::test_result();
 }

--- a/test/algorithm/nth_element.cpp
+++ b/test/algorithm/nth_element.cpp
@@ -26,6 +26,7 @@
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
+#include "../array.hpp"
 
 void
 test_one(unsigned N, unsigned M)

--- a/test/algorithm/partial_sort.cpp
+++ b/test/algorithm/partial_sort.cpp
@@ -27,6 +27,8 @@
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
+#include "../array.hpp"
+#include "../safe_int_swap.hpp"
 
 struct indirect_less
 {
@@ -130,6 +132,25 @@ struct S
     int i, j;
 };
 
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    array<ranges::safe_int<int>, 10> v{{0}};
+    for(int i = 0; (std::size_t)i < v.size(); ++i)
+    {
+        v[i] = v.size() - i - 1;
+    }
+    ranges::partial_sort(v, v.begin() + v.size()/2, ranges::less{});
+    for(int i = 0; (std::size_t)i < v.size()/2; ++i)
+    {
+        if (v[i] != i) { return false; };
+    }
+    return true;
+}
+#endif
+
+
 int main()
 {
     int i = 0;
@@ -170,6 +191,12 @@ int main()
             CHECK((std::size_t)v[i].j == v.size() - i - 1);
         }
     }
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/partial_sort_copy.cpp
+++ b/test/algorithm/partial_sort_copy.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/partial_sort_copy.hpp>
+#include "../safe_int_swap.hpp"
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
@@ -107,6 +108,21 @@ struct U
     }
 };
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    safe_int<int> output[9] = {0};
+    safe_int<int>* r = partial_sort_copy({5, 3, 4, 1, 8, 2, 6, 7, 0, 9}, output, less{});
+    safe_int<int>* e = output + 9;
+    if(r != e) { return false; }
+    safe_int<int> i = 0;
+    for (safe_int<int>* x = output; x < e; ++x, ++i)
+        if(*x != i) { return false; }
+    return true;
+}
+#endif
+
 int main()
 {
     int i = 0;
@@ -165,6 +181,12 @@ int main()
         for (U* x = output; x < e; ++x, ++i)
             CHECK(x->i == i);
     }
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/partition_copy.cpp
+++ b/test/algorithm/partition_copy.cpp
@@ -32,7 +32,7 @@
 
 struct is_odd
 {
-    bool operator()(const int& i) const {return i & 1;}
+    constexpr bool operator()(const int& i) const {return i & 1;}
 };
 
 template <class Iter, class Sent = Iter>
@@ -129,6 +129,30 @@ void test_rvalue()
     CHECK(r2[3].i == 8);
 }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    const int ia[] = {1, 2, 3, 4, 6, 8, 5, 7};
+    int r1[10] = {0};
+    int r2[10] = {0};
+    typedef std::tuple<int const *, int*,  int*> P;
+    P p = partition_copy(ia, r1, r2, is_odd());
+    if(std::get<0>(p) != std::end(ia)) { return false; }
+    if(std::get<1>(p) != r1 + 4) { return false; }
+    if(r1[0] != 1) { return false; }
+    if(r1[1] != 3) { return false; }
+    if(r1[2] != 5) { return false; }
+    if(r1[3] != 7) { return false; }
+    if(std::get<2>(p) != r2 + 4) { return false; }
+    if(r2[0] != 2) { return false; }
+    if(r2[1] != 4) { return false; }
+    if(r2[2] != 6) { return false; }
+    if(r2[3] != 8) { return false; }
+    return true;
+}
+#endif
+
 int main()
 {
     test_iter<input_iterator<const int*> >();
@@ -139,6 +163,12 @@ int main()
 
     test_proj();
     test_rvalue();
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/partition_move.cpp
+++ b/test/algorithm/partition_move.cpp
@@ -1,0 +1,69 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+//  Copyright 2005 - 2007 Adobe Systems Incorporated
+//  Distributed under the MIT License(see accompanying file LICENSE_1_0_0.txt
+//  or a copy at http://stlab.adobe.com/licenses.html)
+
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <tuple>
+#include <range/v3/core.hpp>
+#include <range/v3/algorithm/partition_move.hpp>
+#include "../simple_test.hpp"
+
+struct is_odd
+{
+    constexpr bool operator()(const int& i) const {return i & 1;}
+};
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    const int ia[] = {1, 2, 3, 4, 6, 8, 5, 7};
+    int r1[10] = {0};
+    int r2[10] = {0};
+    typedef std::tuple<int const *, int*,  int*> P;
+    P p = partition_move(ia, r1, r2, is_odd());
+    if(std::get<0>(p) != std::end(ia)) { return false; }
+    if(std::get<1>(p) != r1 + 4) { return false; }
+    if(r1[0] != 1) { return false; }
+    if(r1[1] != 3) { return false; }
+    if(r1[2] != 5) { return false; }
+    if(r1[3] != 7) { return false; }
+    if(std::get<2>(p) != r2 + 4) { return false; }
+    if(r2[0] != 2) { return false; }
+    if(r2[1] != 4) { return false; }
+    if(r2[2] != 6) { return false; }
+    if(r2[3] != 8) { return false; }
+    return true;
+}
+#endif
+
+int main()
+{
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
+
+    return ::test_result();
+}

--- a/test/algorithm/partition_point.cpp
+++ b/test/algorithm/partition_point.cpp
@@ -30,10 +30,11 @@
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
+#include "../array.hpp"
 
 struct is_odd
 {
-    bool operator()(const int& i) const {return i & 1;}
+    constexpr bool operator()(const int& i) const {return i & 1;}
 };
 
 template <class Iter, class Sent = Iter>
@@ -224,6 +225,14 @@ int main()
     // Test projections
     const S ia[] = {S{1}, S{3}, S{5}, S{2}, S{4}, S{6}};
     CHECK(ranges::partition_point(ia, is_odd(), &S::i) == ia + 3);
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        constexpr array<int, 6> a{{1, 3, 5, 2, 4, 6}};
+        static_assert(ranges::partition_point(a, is_odd())
+                      == ranges::begin(a) + 3, "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/pop_heap.cpp
+++ b/test/algorithm/pop_heap.cpp
@@ -27,6 +27,8 @@
 #include <functional>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/heap_algorithm.hpp>
+#include "../safe_int_swap.hpp"
+#include "../array.hpp"
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
@@ -244,6 +246,31 @@ void test_10(int N)
     delete [] ib;
 }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr() {
+    using namespace ranges;
+    bool r = true;
+    constexpr int N = 100;
+    array<safe_int<int>, N> ia{{0}};
+    for (int i = 0; i < N; ++i)
+        ia[i] = i;
+    make_heap(ia);
+    for (int i = N; i > 0 ; --i)
+    {
+        if (pop_heap(make_range(begin(ia), begin(ia)+i), less{}).get_unsafe() != begin(ia) + i) {
+            r = false;
+        }
+        if (!is_heap(begin(ia), begin(ia) + i - 1)) {
+            r = false;
+        }
+    }
+    if (pop_heap(make_range(begin(ia), begin(ia)), less{}).get_unsafe() != begin(ia)) {
+        r = false;
+    }
+    return r;
+}
+#endif
+
 int main()
 {
     test_1(1000);
@@ -256,6 +283,12 @@ int main()
     test_8(1000);
     test_9(1000);
     test_10(1000);
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return test_result();
 }

--- a/test/algorithm/prev_permutation.cpp
+++ b/test/algorithm/prev_permutation.cpp
@@ -27,6 +27,8 @@
 #include <algorithm>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/permutation.hpp>
+#include <range/v3/algorithm/equal.hpp>
+#include "../safe_int_swap.hpp"
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
@@ -170,6 +172,21 @@ std::ostream &operator<<(std::ostream& sout, std::pair<int, c_str> p)
     return sout << "{" << p.first << "," << p.second.value << "}";
 }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    safe_int<int> ia[] = {6, 5, 4, 3, 2, 1};
+    prev_permutation(ia);
+    if (!equal(ia, {6, 5, 4, 3, 1, 2})) { return false; }
+    prev_permutation(ia);
+    if (!equal(ia, {6, 5, 4, 2, 3, 1})) { return false; }
+    prev_permutation(ia);
+    if (!equal(ia, {6, 5, 4, 2, 1, 3})) { return false; }
+    return true;
+}
+#endif
+
 int main()
 {
     test_iter<bidirectional_iterator<int*> >();
@@ -211,6 +228,12 @@ int main()
     CHECK(ranges::prev_permutation(ia, C(), &std::pair<int,c_str>::first));
     ::check_equal<std::pair<int, c_str>>(ia, {{6, {"six"}}, {5,{"five"}}, {4,{"four"}}, {2,{"two"}}, {1,{"one"}}, {3,{"three"}}});
     // etc..
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/push_heap.cpp
+++ b/test/algorithm/push_heap.cpp
@@ -35,6 +35,7 @@
 #include <functional>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/heap_algorithm.hpp>
+#include "../array.hpp"
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
@@ -117,6 +118,27 @@ void test_move_only(int N)
     delete [] ia;
 }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr() {
+    using namespace ranges;
+    bool r = true;
+    constexpr int N = 100;
+    array<int, N> ia{{0}};
+    for (int i = 0; i < N; ++i)
+        ia[i] = i;
+    for (int i = 0; i <= N; ++i)
+    {
+        if (push_heap(make_range(begin(ia), begin(ia)+i), std::greater<int>()).get_unsafe() != begin(ia) + i) {
+            r = false;
+        }
+        if (!is_heap(begin(ia), begin(ia) + i, std::greater<int>())) {
+            r = false;
+        }
+    }
+    return r;
+}
+#endif
+
 int main()
 {
     test(1000);
@@ -140,6 +162,12 @@ int main()
         delete [] ia;
         delete [] ib;
     }
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return test_result();
 }

--- a/test/algorithm/remove.cpp
+++ b/test/algorithm/remove.cpp
@@ -111,6 +111,24 @@ struct S
     int i;
 };
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    int  ia[] = {0, 1, 2, 3, 4, 2, 3, 4, 2};
+    constexpr unsigned sa = ranges::size(ia);
+    auto r = ranges::remove(ia, 2);
+    if(r != ia + sa-3) { return false; }
+    if(ia[0] != 0) { return false; }
+    if(ia[1] != 1) { return false; }
+    if(ia[2] != 3) { return false; }
+    if(ia[3] != 4) { return false; }
+    if(ia[4] != 3) { return false; }
+    if(ia[5] != 4) { return false; }
+    return true;
+}
+#endif
+
 int main()
 {
     test_iter<forward_iterator<int*> >();
@@ -168,6 +186,12 @@ int main()
     CHECK(ia2[3].i == 4);
     CHECK(ia2[4].i == 3);
     CHECK(ia2[5].i == 4);
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/remove_copy.cpp
+++ b/test/algorithm/remove_copy.cpp
@@ -79,6 +79,26 @@ struct S
     int i;
 };
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    int  ia[] = {0, 1, 2, 3, 4, 2, 3, 4, 2};
+    int  ib[6] = {0};
+    constexpr unsigned sa = ranges::size(ia);
+    auto r = ranges::remove_copy(ia, ib, 2);
+    if(r.first != ia + sa) { return false; }
+    if(r.second != ib + (sa-3)) { return false; }
+    if(ib[0] != 0) { return false; }
+    if(ib[1] != 1) { return false; }
+    if(ib[2] != 3) { return false; }
+    if(ib[3] != 4) { return false; }
+    if(ib[4] != 3) { return false; }
+    if(ib[5] != 4) { return false; }
+    return true;
+}
+#endif
+
 int main()
 {
     test<input_iterator<const int*>, output_iterator<int*>>();
@@ -175,6 +195,12 @@ int main()
         auto r4 = ranges::sanitize(std::move(r));
         static_assert(std::is_same<decltype(r4), std::pair<ranges::dangling<>, S *>>::value, "");
     }
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/remove_copy_if.cpp
+++ b/test/algorithm/remove_copy_if.cpp
@@ -80,6 +80,28 @@ struct S
     int i;
 };
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+constexpr bool equals_two(int i) { return i == 2; }
+
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    int  ia[] = {0, 1, 2, 3, 4, 2, 3, 4, 2};
+    int  ib[6] = {0};
+    constexpr unsigned sa = ranges::size(ia);
+    auto r = ranges::remove_copy_if(ia, ib, equals_two);
+    if(r.first != ia + sa) { return false; }
+    if(r.second != ib + (sa-3)) { return false; }
+    if(ib[0] != 0) { return false; }
+    if(ib[1] != 1) { return false; }
+    if(ib[2] != 3) { return false; }
+    if(ib[3] != 4) { return false; }
+    if(ib[4] != 3) { return false; }
+    if(ib[5] != 4) { return false; }
+    return true;
+}
+#endif
+
 int main()
 {
     test<input_iterator<const int*>, output_iterator<int*>>();
@@ -167,6 +189,12 @@ int main()
         CHECK(ib[4].i == 3);
         CHECK(ib[5].i == 4);
     }
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/remove_if.cpp
+++ b/test/algorithm/remove_if.cpp
@@ -126,6 +126,26 @@ struct S
     int i;
 };
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+constexpr bool equals_two(int i) { return i == 2; }
+
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    int  ia[] = {0, 1, 2, 3, 4, 2, 3, 4, 2};
+    constexpr unsigned sa = ranges::size(ia);
+    auto r = ranges::remove_if(ia, equals_two);
+    if(r != ia + sa-3) { return false; }
+    if(ia[0] != 0) { return false; }
+    if(ia[1] != 1) { return false; }
+    if(ia[2] != 3) { return false; }
+    if(ia[3] != 4) { return false; }
+    if(ia[4] != 3) { return false; }
+    if(ia[5] != 4) { return false; }
+    return true;
+}
+#endif
+
 int main()
 {
     test_iter<forward_iterator<int*> >();
@@ -198,6 +218,12 @@ int main()
         auto r4 = ranges::sanitize(std::move(r));
         static_assert(std::is_same<decltype(r4), ranges::dangling<>>::value, "");
     }
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/replace.cpp
+++ b/test/algorithm/replace.cpp
@@ -58,6 +58,23 @@ void test_rng()
     CHECK(base(i) == ia + sa);
 }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    int  ia[] = {0, 1, 2, 3, 4};
+    constexpr unsigned sa = ranges::size(ia);
+    auto r = ranges::replace(ia, 2, 42);
+    if(r != ia + sa) { return false; }
+    if(ia[0] != 0) { return false; }
+    if(ia[1] != 1) { return false; }
+    if(ia[2] != 42) { return false; }
+    if(ia[3] != 3) { return false; }
+    if(ia[4] != 4) { return false; }
+    return true;
+}
+#endif
+
 int main()
 {
     test_iter<forward_iterator<int*> >();
@@ -103,6 +120,12 @@ int main()
         CHECK(ia[4] == P{4,"4"});
         CHECK(i.get_unsafe() == ranges::end(ia));
     }
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/replace_copy.cpp
+++ b/test/algorithm/replace_copy.cpp
@@ -72,6 +72,25 @@ void test()
     test_rng<InIter, OutIter, Sent>();
 }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    int  ia[] = {0, 1, 2, 3, 4};
+    int  ib[5] = {0};
+    constexpr unsigned sa = ranges::size(ia);
+    auto r = ranges::replace_copy(ia, ib, 2, 42);
+    if(r.first != ia + sa) { return false; }
+    if(r.second != ib + sa) { return false; }
+    if(ib[0] != 0) { return false; }
+    if(ib[1] != 1) { return false; }
+    if(ib[2] != 42) { return false; }
+    if(ib[3] != 3) { return false; }
+    if(ib[4] != 4) { return false; }
+    return true;
+}
+#endif
+
 int main()
 {
     test<input_iterator<const int*>, output_iterator<int*> >();
@@ -118,6 +137,12 @@ int main()
         CHECK(out[3] == P{3, "3"});
         CHECK(out[4] == P{4, "4"});
     }
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/replace_copy_if.cpp
+++ b/test/algorithm/replace_copy_if.cpp
@@ -74,6 +74,27 @@ void test()
     test_rng<InIter, OutIter, Sent>();
 }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+constexpr bool equals_two(int i) { return i == 2; }
+
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    int  ia[] = {0, 1, 2, 3, 4};
+    int  ib[5] = {0};
+    constexpr unsigned sa = ranges::size(ia);
+    auto r = ranges::replace_copy_if(ia, ib, equals_two, 42);
+    if(r.first != ia + sa) { return false; }
+    if(r.second != ib + sa) { return false; }
+    if(ib[0] != 0) { return false; }
+    if(ib[1] != 1) { return false; }
+    if(ib[2] != 42) { return false; }
+    if(ib[3] != 3) { return false; }
+    if(ib[4] != 4) { return false; }
+    return true;
+}
+#endif
+
 int main()
 {
     test<input_iterator<const int*>, output_iterator<int*> >();
@@ -121,6 +142,12 @@ int main()
         CHECK(out[3] == P{3, "3"});
         CHECK(out[4] == P{4, "4"});
     }
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/replace_if.cpp
+++ b/test/algorithm/replace_if.cpp
@@ -58,6 +58,25 @@ void test_rng()
     CHECK(base(i) == ia + sa);
 }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+constexpr bool equals_two(int i) { return i == 2; }
+
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    int  ia[] = {0, 1, 2, 3, 4};
+    constexpr unsigned sa = ranges::size(ia);
+    auto r = ranges::replace_if(ia, equals_two, 42);
+    if(r != ia + sa) { return false; }
+    if(ia[0] != 0) { return false; }
+    if(ia[1] != 1) { return false; }
+    if(ia[2] != 42) { return false; }
+    if(ia[3] != 3) { return false; }
+    if(ia[4] != 4) { return false; }
+    return true;
+}
+#endif
+
 int main()
 {
     test_iter<forward_iterator<int*> >();
@@ -105,6 +124,12 @@ int main()
         CHECK(ia[4] == P{4,"4"});
         CHECK(i.get_unsafe() == ranges::end(ia));
     }
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/reverse.cpp
+++ b/test/algorithm/reverse.cpp
@@ -25,6 +25,7 @@
 #include <utility>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/reverse.hpp>
+#include "../safe_int_swap.hpp"
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
@@ -98,6 +99,23 @@ void test()
     }
 }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+        using namespace ranges;
+        safe_int<int>  ia[] = {0, 1, 2, 3, 4};
+        constexpr unsigned sa = ranges::size(ia);
+        auto r = ranges::reverse(ia);
+        if(r != ia + sa) { return false; }
+        if(ia[0] != 4) { return false; }
+        if(ia[1] != 3) { return false; }
+        if(ia[2] != 2) { return false; }
+        if(ia[3] != 1) { return false; }
+        if(ia[4] != 0) { return false; }
+        return true;
+}
+#endif
+
 int main()
 {
     test<bidirectional_iterator<int *>>();
@@ -106,6 +124,12 @@ int main()
 
     test<bidirectional_iterator<int *>, sentinel<int*>>();
     test<random_access_iterator<int *>, sentinel<int*>>();
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+            static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/reverse_copy.cpp
+++ b/test/algorithm/reverse_copy.cpp
@@ -120,6 +120,35 @@ void test()
     }
 }
 
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    int ia[] = {0, 1, 2, 3, 4};
+    int  ib[5] = {0};
+    constexpr unsigned sa = ranges::size(ia);
+    auto r = ranges::reverse_copy(ia, ib);
+    if(r.first != ia + sa) { return false; }
+    if(r.second != ib + sa) { return false; }
+
+    if(ia[0] != 0) { return false; }
+    if(ia[1] != 1) { return false; }
+    if(ia[2] != 2) { return false; }
+    if(ia[3] != 3) { return false; }
+    if(ia[4] != 4) { return false; }
+
+
+    if(ib[0] != 4) { return false; }
+    if(ib[1] != 3) { return false; }
+    if(ib[2] != 2) { return false; }
+    if(ib[3] != 1) { return false; }
+    if(ib[4] != 0) { return false; }
+
+    return true;
+}
+#endif
+
 int main()
 {
     test<bidirectional_iterator<const int*>, output_iterator<int*> >();
@@ -157,6 +186,12 @@ int main()
     test<const int*, bidirectional_iterator<int*>, sentinel<const int *> >();
     test<const int*, random_access_iterator<int*>, sentinel<const int *> >();
     test<const int*, int*>();
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/rotate.cpp
+++ b/test/algorithm/rotate.cpp
@@ -250,6 +250,22 @@ void test()
     CHECK(ig[5] == 2);
 }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr() {
+    int rgi[] = {0,1,2,3,4,5};
+    auto r = ranges::rotate(rgi, rgi+2);
+    if(r.begin() != rgi+4) { return false; }
+    if(r.end() != ranges::end(rgi)) { return false; }
+    if(rgi[0] != 2) { return false; }
+    if(rgi[1] != 3) { return false; }
+    if(rgi[2] != 4) { return false; }
+    if(rgi[3] != 5) { return false; }
+    if(rgi[4] != 0) { return false; }
+    if(rgi[5] != 1) { return false; }
+    return true;
+}
+#endif
+
 int main()
 {
     test<forward_iterator<int *>>();
@@ -273,6 +289,12 @@ int main()
         CHECK(rgi[4] == 0);
         CHECK(rgi[5] == 1);
     }
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/rotate_copy.cpp
+++ b/test/algorithm/rotate_copy.cpp
@@ -257,6 +257,25 @@ struct S
     int i;
 };
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr() {
+    using namespace ranges;
+    int rgi[] = {0,1,2,3,4,5};
+    int rgo[6] = {0};
+    auto r = ranges::rotate_copy(rgi, rgi+2, rgo);
+    if(r.first != ranges::end(rgi)) { return false; }
+    if(r.second != ranges::end(rgo)) { return false; }
+    if(rgo[0] != 2) { return false; }
+    if(rgo[1] != 3) { return false; }
+    if(rgo[2] != 4) { return false; }
+    if(rgo[3] != 5) { return false; }
+    if(rgo[4] != 0) { return false; }
+    if(rgo[5] != 1) { return false; }
+
+    return true;
+}
+#endif
+
 int main()
 {
     test<forward_iterator<const int*>, output_iterator<int*> >();
@@ -315,6 +334,12 @@ int main()
         CHECK(rgo[4] == 0);
         CHECK(rgo[5] == 1);
     }
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/search.cpp
+++ b/test/algorithm/search.cpp
@@ -157,6 +157,23 @@ struct T
     int i;
 };
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    int  ia[] = {0, 1, 2, 3, 4};
+    int  ib[] = {2, 3};
+    int  ic[] = {2, 4};
+    constexpr auto sa = size(ia);
+    auto r = search(ia, ib, equal_to{});
+    if(r != ia + 2) { return false; }
+    auto r2 = search(ia, ic, equal_to{});
+    if(r2 != ia + sa) { return false; }
+
+    return true;
+}
+#endif
+
 int main()
 {
     test<forward_iterator<const int*>, forward_iterator<const int*> >();
@@ -205,6 +222,13 @@ int main()
         int ie[] = {1, 2, 3};
         CHECK(ranges::search(ranges::view::all(ib), ie).get_unsafe() == ib+4);
     }
+
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/search_n.cpp
+++ b/test/algorithm/search_n.cpp
@@ -158,6 +158,18 @@ struct S
     int i;
 };
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    int  ia[] = {0, 1, 2, 2, 4, 5};
+    auto r = search_n(ia, 2, 2, equal_to{});
+    if(r != ia + 2) { return false; }
+
+    return true;
+}
+#endif
+
 int main()
 {
     test<forward_iterator<const int*>, forward_iterator<const int*> >();
@@ -196,6 +208,12 @@ int main()
         int ib[] = {0, 0, 1, 1, 2, 2};
         CHECK(ranges::search_n(ranges::view::all(ib), 2, 1).get_unsafe() == ib+2);
     }
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/set_difference.hpp
+++ b/test/algorithm/set_difference.hpp
@@ -124,6 +124,39 @@ struct U
     U& operator=(T t) { k = t.j; return *this;}
 };
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    int ia[] = {1, 2, 2, 3, 3, 3, 4, 4, 4, 4};
+    const int sa = sizeof(ia)/sizeof(ia[0]);
+    int ib[] = {2, 4, 4, 6};
+    const int sb = sizeof(ib)/sizeof(ib[0]);
+    int ic[20] = {0};
+    int ir[] = {1, 2, 3, 3, 3, 4, 4};
+    const int sr = sizeof(ir)/sizeof(ir[0]);
+
+    std::pair<int *, int *> res = set_difference(ia, {2, 4, 4, 6}, ic, less{});
+    if((res.first - ia) != sa) { return false; }
+    if((res.second - ic) != sr) { return false; }
+    if(lexicographical_compare(ic, res.second, ir, ir+sr, less{}) != 0) { return false; }
+    fill(ic, 0);
+
+    int irr[] = {6};
+    const int srr = sizeof(irr)/sizeof(irr[0]);
+    std::pair<int *, int *> res2 = set_difference(
+            ib,
+            {1, 2, 2, 3, 3, 3, 4, 4, 4, 4},
+            ic,
+            less{});
+    if((res2.first - ib) != sb) { return false; }
+    if((res2.second - ic) != srr) { return false; }
+    if(lexicographical_compare(ic, res2.second, irr, irr+srr, less{}) != 0) { return false; }
+
+    return true;
+}
+#endif
+
 int main()
 {
 #ifdef SET_DIFFERENCE_1
@@ -252,7 +285,8 @@ int main()
 #endif
 #ifdef SET_DIFFERENCE_5
     test<const int*, input_iterator<const int*>, output_iterator<int*> >();
-    test<const int*, input_iterator<const int*>, bidirectional_iterator<int*> >();    test<const int*, input_iterator<const int*>, bidirectional_iterator<int*> >();
+    test<const int*, input_iterator<const int*>, bidirectional_iterator<int*> >();
+    test<const int*, input_iterator<const int*>, forward_iterator<int*> >();
     test<const int*, input_iterator<const int*>, random_access_iterator<int*> >();
     test<const int*, input_iterator<const int*>, int*>();
 
@@ -326,7 +360,7 @@ int main()
         auto res2 = ranges::set_difference(ranges::view::all(ib), ranges::view::all(ia), ic, std::less<int>(), &T::j, &S::i);
         CHECK((res2.first.get_unsafe() - ib) == sb);
         CHECK((res2.second - ic) == srr);
-        CHECK(ranges::lexicographical_compare(ic, res2.second, ir, irr+srr, std::less<int>(), &U::k) == 0);
+        CHECK(ranges::lexicographical_compare(ic, res2.second, irr, irr+srr, std::less<int>(), &U::k) == 0);
     }
 
     // Test initializer list
@@ -358,8 +392,13 @@ int main()
             std::less<int>(), &T::j, &S::i);
         CHECK((res2.first - ib) == sb);
         CHECK((res2.second - ic) == srr);
-        CHECK(ranges::lexicographical_compare(ic, res2.second, ir, irr+srr, std::less<int>(), &U::k) == 0);
+        CHECK(ranges::lexicographical_compare(ic, res2.second, irr, irr+srr, std::less<int>(), &U::k) == 0);
     }
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 #endif
 
     return ::test_result();

--- a/test/algorithm/set_intersection.hpp
+++ b/test/algorithm/set_intersection.hpp
@@ -91,6 +91,23 @@ struct U
     U& operator=(T t) { k = t.j; return *this;}
 };
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    int ic[20] = {0};
+    int ia[] = {1, 2, 2, 3, 3, 3, 4, 4, 4, 4};
+    int ib[4] = {2, 4, 4, 6};
+    int ir[3] = {2, 4, 4};
+    constexpr int sr = size(ir);
+
+    int * res = set_intersection(ia, ib, ic, less{});
+    if((res - ic) != sr) { return false; }
+    if(lexicographical_compare(ic, res, ir, ir+sr, less{}) != 0) { return false; }
+    return true;
+}
+#endif
+
 int main()
 {
 #ifdef SET_INTERSECTION_1
@@ -275,6 +292,11 @@ int main()
         CHECK((res - ic) == sr);
         CHECK(ranges::lexicographical_compare(ic, res, ir, ir+sr, std::less<int>(), &U::k) == 0);
     }
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 #endif
 
     return ::test_result();

--- a/test/algorithm/set_symmetric_difference.hpp
+++ b/test/algorithm/set_symmetric_difference.hpp
@@ -118,6 +118,33 @@ struct U
     U& operator=(T t) { k = t.j; return *this;}
 };
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    int ia[] = {1, 2, 2, 3, 3, 3, 4, 4, 4, 4};
+    int ib[] = {2, 4, 4, 6};
+    int ic[20] = {0};
+    int ir[] = {1, 2, 3, 3, 3, 4, 4, 6};
+    const int sr = sizeof(ir)/sizeof(ir[0]);
+
+    auto res1 = set_symmetric_difference(ia, ib, ic, less{});
+    if(std::get<0>(res1) != end(ia)) { return false; }
+    if(std::get<1>(res1) != end(ib)) { return false; }
+    if((std::get<2>(res1) - begin(ic)) != sr) { return false; }
+    if(lexicographical_compare(ic, std::get<2>(res1), ir, ir+sr, less{}) != 0) { return false; }
+    fill(ic, 0);
+
+    auto res2 = set_symmetric_difference(ib, ia, ic, less{});
+    if(std::get<0>(res2) != end(ib)) { return false; }
+    if(std::get<1>(res2) != end(ia)) { return false; }
+    if(std::get<2>(res2) - begin(ic) != sr) { return false; }
+    if(lexicographical_compare(ic, std::get<2>(res2), ir, ir+sr, less{}) != 0) { return false; }
+
+    return true;
+}
+#endif
+
 int main()
 {
 #ifdef SET_SYMMETRIC_DIFFERENCE_1
@@ -319,6 +346,11 @@ int main()
         CHECK((std::get<2>(res2) - ic) == sr);
         CHECK(ranges::lexicographical_compare(ic, std::get<2>(res2), ir, ir+sr, std::less<int>(), &U::k) == 0);
     }
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 #endif
 
     return ::test_result();

--- a/test/algorithm/set_union.hpp
+++ b/test/algorithm/set_union.hpp
@@ -78,6 +78,33 @@ struct U
     U& operator=(T t) { k = t.j; return *this;}
 };
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    int ia[] = {1, 2, 2, 3, 3, 3, 4, 4, 4, 4};
+    int ib[] = {2, 4, 4, 6};
+    int ic[20] = {0};
+    int ir[] = {1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 6};
+    const int sr = sizeof(ir)/sizeof(ir[0]);
+
+    auto res1 = set_union(ia, ib, ic, less{});
+    if(std::get<0>(res1) != end(ia)) { return false; }
+    if(std::get<1>(res1) != end(ib)) { return false; }
+    if((std::get<2>(res1) - begin(ic)) != sr) { return false; }
+    if(lexicographical_compare(ic, std::get<2>(res1), ir, ir+sr, less{}) != 0) { return false; }
+    fill(ic, 0);
+
+    auto res2 = set_union(ib, ia, ic, less{});
+    if(std::get<0>(res2) != end(ib)) { return false; }
+    if(std::get<1>(res2) != end(ia)) { return false; }
+    if(std::get<2>(res2) - begin(ic) != sr) { return false; }
+    if(lexicographical_compare(ic, std::get<2>(res2), ir, ir+sr, less{}) != 0) { return false; }
+
+    return true;
+}
+#endif
+
 int main()
 {
 #ifdef SET_UNION_1
@@ -277,6 +304,11 @@ int main()
         CHECK((std::get<2>(res2) - ic) == sr);
         CHECK(ranges::lexicographical_compare(ic, std::get<2>(res2), ir, ir+sr, std::less<int>(), &U::k) == 0);
     }
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 #endif
 
     return ::test_result();

--- a/test/algorithm/shuffle.cpp
+++ b/test/algorithm/shuffle.cpp
@@ -26,10 +26,322 @@
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/equal.hpp>
 #include <range/v3/algorithm/shuffle.hpp>
+#include "../safe_int_swap.hpp"
 #include <range/v3/numeric/iota.hpp>
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
+
+template <unsigned long long a, unsigned long long c,
+          unsigned long long m, unsigned long long Mp,
+          bool _MightOverflow = (a != 0 && m != 0 && m-1 > (Mp-c)/a)>
+struct lce_ta;
+
+// 64
+
+template <unsigned long long a, unsigned long long c, unsigned long long m>
+struct lce_ta<a, c, m, (unsigned long long)(~0), true>
+{
+    typedef unsigned long long result_type;
+    static RANGES_CXX14_CONSTEXPR result_type next(result_type x)
+    {
+        // Schrage's algorithm
+        const result_type q = m / a;
+        const result_type r = m % a;
+        const result_type t0 = a * (x % q);
+        const result_type t1 = r * (x / q);
+        x = t0 + (t0 < t1) * m - t1;
+        x += c - (x >= m - c) * m;
+        return x;
+    }
+};
+
+template <unsigned long long a, unsigned long long m>
+struct lce_ta<a, 0, m, (unsigned long long)(~0), true>
+{
+    typedef unsigned long long result_type;
+
+    static RANGES_CXX14_CONSTEXPR result_type next(result_type x)
+    {
+        // Schrage's algorithm
+        const result_type q = m / a;
+        const result_type r = m % a;
+        const result_type t0 = a * (x % q);
+        const result_type t1 = r * (x / q);
+        x = t0 + (t0 < t1) * m - t1;
+        return x;
+    }
+};
+
+template <unsigned long long a, unsigned long long c, unsigned long long m>
+struct lce_ta<a, c, m, (unsigned long long)(~0), false>
+{
+    typedef unsigned long long result_type;
+
+    static RANGES_CXX14_CONSTEXPR result_type next(result_type x)
+    {
+        return (a * x + c) % m;
+    }
+};
+
+template <unsigned long long a, unsigned long long c>
+struct lce_ta<a, c, 0, (unsigned long long)(~0), false>
+{
+    typedef unsigned long long result_type;
+
+    static RANGES_CXX14_CONSTEXPR result_type next(result_type x)
+    {
+        return a * x + c;
+    }
+};
+
+// 32
+
+template <unsigned long long Ap, unsigned long long Cp, unsigned long long Mp>
+struct lce_ta<Ap, Cp, Mp, unsigned(~0), true>
+{
+    typedef unsigned result_type;
+
+    static RANGES_CXX14_CONSTEXPR result_type next(result_type x)
+    {
+        const result_type a = static_cast<result_type>(Ap);
+        const result_type c = static_cast<result_type>(Cp);
+        const result_type m = static_cast<result_type>(Mp);
+        // Schrage's algorithm
+        const result_type q = m / a;
+        const result_type r = m % a;
+        const result_type t0 = a * (x % q);
+        const result_type t1 = r * (x / q);
+        x = t0 + (t0 < t1) * m - t1;
+        x += c - (x >= m - c) * m;
+        return x;
+    }
+};
+
+template <unsigned long long Ap, unsigned long long Mp>
+struct lce_ta<Ap, 0, Mp, unsigned(~0), true>
+{
+    typedef unsigned result_type;
+
+    static RANGES_CXX14_CONSTEXPR result_type next(result_type x)
+    {
+        const result_type a = static_cast<result_type>(Ap);
+        const result_type m = static_cast<result_type>(Mp);
+        // Schrage's algorithm
+        const result_type q = m / a;
+        const result_type r = m % a;
+        const result_type t0 = a * (x % q);
+        const result_type t1 = r * (x / q);
+        x = t0 + (t0 < t1) * m - t1;
+        return x;
+    }
+};
+
+template <unsigned long long Ap, unsigned long long Cp, unsigned long long Mp>
+struct lce_ta<Ap, Cp, Mp, unsigned(~0), false>
+{
+    typedef unsigned result_type;
+
+    static RANGES_CXX14_CONSTEXPR  result_type next(result_type x)
+    {
+        const result_type a = static_cast<result_type>(Ap);
+        const result_type c = static_cast<result_type>(Cp);
+        const result_type m = static_cast<result_type>(Mp);
+        return (a * x + c) % m;
+    }
+};
+
+template <unsigned long long Ap, unsigned long long Cp>
+struct lce_ta<Ap, Cp, 0, unsigned(~0), false>
+{
+    typedef unsigned result_type;
+
+    static RANGES_CXX14_CONSTEXPR result_type next(result_type x)
+    {
+        const result_type a = static_cast<result_type>(Ap);
+        const result_type c = static_cast<result_type>(Cp);
+        return a * x + c;
+    }
+};
+
+// 16
+
+template <unsigned long long a, unsigned long long c, unsigned long long m, bool b>
+struct lce_ta<a, c, m, (unsigned short)(~0), b>
+{
+    typedef unsigned short result_type;
+
+    static RANGES_CXX14_CONSTEXPR result_type next(result_type x)
+    {
+        return static_cast<result_type>(lce_ta<a, c, m, unsigned(~0)>::next(x));
+    }
+};
+
+
+template <class Sseq, class Engine>
+struct is_seed_sequence
+{
+        static constexpr const bool value =
+                        !std::is_convertible<Sseq, typename Engine::result_type>::value &&
+                        !std::is_same<typename std::remove_cv<Sseq>::type, Engine>::value;
+};
+
+template <class UInt, UInt a, UInt c, UInt m>
+class linear_congruential_engine
+{
+public:
+    // types
+    typedef UInt result_type;
+
+private:
+    result_type x_;
+
+    static constexpr const result_type Mp = result_type(~0);
+
+    static_assert(m == 0 || a < m, "linear_congruential_engine invalid parameters");
+    static_assert(m == 0 || c < m, "linear_congruential_engine invalid parameters");
+public:
+    static constexpr const result_type Min = c == 0u ? 1u: 0u;
+    static constexpr const result_type Max = m - 1u;
+    static_assert(Min < Max,           "linear_congruential_engine invalid parameters");
+
+    // engine characteristics
+    static constexpr const result_type multiplier = a;
+    static constexpr const result_type increment = c;
+    static constexpr const result_type modulus = m;
+
+    static constexpr result_type min() {return Min;}
+
+    static constexpr result_type max() {return Max;}
+    static constexpr const result_type default_seed = 1u;
+
+    // constructors and seeding functions
+    RANGES_CXX14_CONSTEXPR
+    explicit linear_congruential_engine(result_type s = default_seed) : x_(0)
+    { seed(s); }
+
+    template<class Sseq>
+    RANGES_CXX14_CONSTEXPR
+    explicit linear_congruential_engine(Sseq& q,
+    typename std::enable_if<is_seed_sequence<Sseq, linear_congruential_engine>::value>::type* = 0)
+    {seed(q);}
+
+    RANGES_CXX14_CONSTEXPR
+    void seed(result_type s = default_seed)
+        {seed(std::integral_constant<bool, m == 0>(),
+              std::integral_constant<bool, c == 0>(), s);}
+    template<class Sseq>
+    typename std::enable_if
+    <
+        is_seed_sequence<Sseq, linear_congruential_engine>::value,
+                         void
+    >::type
+    RANGES_CXX14_CONSTEXPR
+    seed(Sseq& q)
+    {seed(q, std::integral_constant<unsigned,
+                1 + (m == 0 ? (sizeof(result_type) * CHAR_BIT - 1)/32
+                             :  (m > 0x100000000ull))>());}
+
+    RANGES_CXX14_CONSTEXPR
+    result_type operator()()
+        {return x_ = static_cast<result_type>(lce_ta<a, c, m, Mp>::next(x_));}
+
+    RANGES_CXX14_CONSTEXPR
+    void discard(unsigned long long __z) {for (; __z; --__z) operator()();}
+
+    friend RANGES_CXX14_CONSTEXPR
+    bool operator==(const linear_congruential_engine& x,
+                    const linear_congruential_engine& __y)
+        {return x.x_ == __y.x_;}
+    friend RANGES_CXX14_CONSTEXPR
+    bool operator!=(const linear_congruential_engine& x,
+                    const linear_congruential_engine& __y)
+        {return !(x == __y);}
+
+private:
+
+    RANGES_CXX14_CONSTEXPR
+    void seed(std::true_type, std::true_type, result_type s) {x_ = s == 0 ? 1 : s;}
+    RANGES_CXX14_CONSTEXPR
+    void seed(std::true_type, std::false_type, result_type s) {x_ = s;}
+    RANGES_CXX14_CONSTEXPR
+    void seed(std::false_type, std::true_type, result_type s) {x_ = s % m == 0 ?
+                                                                 1 : s % m;}
+    RANGES_CXX14_CONSTEXPR
+    void seed(std::false_type, std::false_type, result_type s) {x_ = s % m;}
+
+    template<class Sseq>
+    RANGES_CXX14_CONSTEXPR
+    void seed(Sseq& q, std::integral_constant<unsigned, 1>);
+    template<class Sseq>
+    RANGES_CXX14_CONSTEXPR
+    void seed(Sseq& q, std::integral_constant<unsigned, 2>);
+};
+
+template <class UInt, UInt a, UInt c, UInt m>
+constexpr const typename linear_congruential_engine<UInt, a, c, m>::result_type
+linear_congruential_engine<UInt, a, c, m>::multiplier;
+
+template <class UInt, UInt a, UInt c, UInt m>
+constexpr const typename linear_congruential_engine<UInt, a, c, m>::result_type
+linear_congruential_engine<UInt, a, c, m>::increment;
+
+template <class UInt, UInt a, UInt c, UInt m>
+constexpr const typename linear_congruential_engine<UInt, a, c, m>::result_type
+linear_congruential_engine<UInt, a, c, m>::modulus;
+
+template <class UInt, UInt a, UInt c, UInt m>
+constexpr const typename linear_congruential_engine<UInt, a, c, m>::result_type
+linear_congruential_engine<UInt, a, c, m>::default_seed;
+
+template <class UInt, UInt a, UInt c, UInt m>
+template<class Sseq>
+RANGES_CXX14_CONSTEXPR
+void
+linear_congruential_engine<UInt, a, c, m>::seed(Sseq& q,
+                                                 std::integral_constant<unsigned, 1>)
+{
+    const unsigned k = 1;
+    uint32_t ar[k+3] = {0};
+    q.generate(ar, ar + k + 3);
+    result_type s = static_cast<result_type>(ar[3] % m);
+    x_ = c == 0 && s == 0 ? result_type(1) : s;
+}
+
+template <class UInt, UInt a, UInt c, UInt m>
+template<class Sseq>
+RANGES_CXX14_CONSTEXPR
+void
+linear_congruential_engine<UInt, a, c, m>::seed(Sseq& q,
+                                                 std::integral_constant<unsigned, 2>)
+{
+    const unsigned k = 2;
+    uint32_t ar[k+3] = {0};
+    q.generate(ar, ar + k + 3);
+    result_type s = static_cast<result_type>((ar[3] +
+                                              ((uint64_t)ar[4] << 32)) % m);
+    x_ = c == 0 && s == 0 ? result_type(1) : s;
+}
+
+typedef linear_congruential_engine<uint_fast32_t, 48271, 0, 2147483647>
+                                                                    minstd_rand;
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+        using namespace ranges;
+        safe_int<int> ia[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+        safe_int<int> ia1[] = {2, 7, 1, 4, 3, 6, 5, 10, 9, 8};
+        safe_int<int> ia2[] = {1, 8, 3, 4, 6, 9, 5, 7, 2, 10};
+        const unsigned sa = sizeof(ia)/sizeof(ia[0]);
+        minstd_rand g;
+        shuffle(ia, ia+sa, g);
+        if(!equal(ia, ia+sa, ia1)) { return false; }
+        shuffle(ia, ia+sa, g);
+        if(!equal(ia, ia+sa, ia2)) { return false; }
+        return true;
+}
+#endif
 
 int main()
 {
@@ -67,6 +379,12 @@ int main()
         CHECK(ranges::shuffle(std::move(rng), g).get_unsafe().base() == ranges::end(ia));
         CHECK(!ranges::equal(ia, orig));
     }
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/sort_heap.cpp
+++ b/test/algorithm/sort_heap.cpp
@@ -27,6 +27,9 @@
 #include <functional>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/heap_algorithm.hpp>
+#include <range/v3/algorithm/is_sorted.hpp>
+#include "../safe_int_swap.hpp"
+#include "../array.hpp"
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
@@ -173,6 +176,25 @@ void test_10(int N)
     delete [] ib;
 }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr() {
+    using namespace ranges;
+    bool r = true;
+    constexpr int N = 100;
+    array<safe_int<int>, N> ia{{0}};
+    for (int i = 0; i < N; ++i)
+        ia[i] = N - 1 - i;
+    make_heap(begin(ia), end(ia));
+    if(sort_heap(begin(ia), end(ia), ranges::less{}) != end(ia)) {
+        r = false;
+    }
+    if (!is_sorted(ia)) {
+        r = false;
+    }
+    return r;
+}
+#endif
+
 void test(int N)
 {
     test_1(N);
@@ -195,6 +217,12 @@ int main()
     test(1000);
     test_9(1000);
     test_10(1000);
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return test_result();
 }

--- a/test/algorithm/stable_partition.cpp
+++ b/test/algorithm/stable_partition.cpp
@@ -26,6 +26,7 @@
 #include <utility>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/stable_partition.hpp>
+#include "../safe_int_swap.hpp"
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
@@ -35,6 +36,11 @@ struct is_odd
     bool operator()(const int& i) const
     {
         return i & 1;
+    }
+    RANGES_CXX14_CONSTEXPR
+    bool operator()(const ranges::safe_int<int>& i) const
+    {
+        return i % ranges::safe_int<int>{2} != 0;
     }
 };
 
@@ -373,6 +379,27 @@ struct S
     std::pair<int,int> p;
 };
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    safe_int<int> ap[] = {0, 0, 1, 1, 2, 2, 3, 3, 4, 4};
+    auto r = stable_partition.inplace(ap, is_odd());
+    if(r != ap + 4) { return false; }
+    if(ap[0] != 1) { return false; }
+    if(ap[1] != 1) { return false; }
+    if(ap[2] != 3) { return false; }
+    if(ap[3] != 3) { return false; }
+    if(ap[4] != 0) { return false; }
+    if(ap[5] != 0) { return false; }
+    if(ap[6] != 2) { return false; }
+    if(ap[7] != 2) { return false; }
+    if(ap[8] != 4) { return false; }
+    if(ap[9] != 4) { return false; }
+    return true;
+}
+#endif
+
 int main()
 {
     test_iter<forward_iterator<std::pair<int,int>*> >();
@@ -431,6 +458,12 @@ int main()
         CHECK(ap[8].p == P{4, 1});
         CHECK(ap[9].p == P{4, 2});
     }
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/algorithm/stable_sort.cpp
+++ b/test/algorithm/stable_sort.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/stable_sort.hpp>
+#include "../safe_int_swap.hpp"
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
@@ -159,6 +160,27 @@ struct S
     int i, j;
 };
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    safe_int<int> ap[] = {0, 0, 1, 1, 2, 2, 3, 3, 4, 4};
+    auto r = stable_sort.inplace(ap, greater{});
+    if(r != ap + 10) { return false; }
+    if(ap[0] != 4) { return false; }
+    if(ap[1] != 4) { return false; }
+    if(ap[2] != 3) { return false; }
+    if(ap[3] != 3) { return false; }
+    if(ap[4] != 2) { return false; }
+    if(ap[5] != 2) { return false; }
+    if(ap[6] != 1) { return false; }
+    if(ap[7] != 1) { return false; }
+    if(ap[8] != 0) { return false; }
+    if(ap[9] != 0) { return false; }
+    return true;
+}
+#endif
+
 int main()
 {
     // test null range
@@ -228,5 +250,10 @@ int main()
         }
     }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
     return ::test_result();
 }

--- a/test/algorithm/swap_ranges.cpp
+++ b/test/algorithm/swap_ranges.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/swap_ranges.hpp>
+#include "../safe_int_swap.hpp"
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
@@ -186,6 +187,26 @@ void test()
     test_rng_4<Iter1, Iter2>();
 }
 
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    safe_int<int> i[3] = {1, 2, 3};
+    safe_int<int> j[3] = {4, 5, 6};
+    auto r = ranges::swap_ranges(i, j);
+    if(r.first != i+3) { return false; }
+    if(r.second != j+3) { return false; }
+    if(i[0] != 4) { return false; }
+    if(i[1] != 5) { return false; }
+    if(i[2] != 6) { return false; }
+    if(j[0] != 1) { return false; }
+    if(j[1] != 2) { return false; }
+    if(j[2] != 3) { return false; }
+    return true;
+}
+#endif
+
 int main()
 {
     test<forward_iterator<int*>, forward_iterator<int*> >();
@@ -228,5 +249,10 @@ int main()
     test_move_only<std::unique_ptr<int>*, random_access_iterator<std::unique_ptr<int>*> >();
     test_move_only<std::unique_ptr<int>*, std::unique_ptr<int>*>();
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
     return ::test_result();
 }

--- a/test/algorithm/transform.cpp
+++ b/test/algorithm/transform.cpp
@@ -199,6 +199,27 @@ struct S
     int i;
 };
 
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR int plus_one(int i) { return i + 1; }
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    int ia[] = {0, 1, 2, 3, 4};
+    constexpr unsigned sa = ranges::size(ia);
+    int ib[sa] = {0};
+    auto r = transform(ia, ib, plus_one);
+    if(r.first != ia + sa) { return false; }
+    if(r.second != ib + sa) { return false; }
+    if(ib[0] != 1) { return false; }
+    if(ib[1] != 2) { return false; }
+    if(ib[2] != 3) { return false; }
+    if(ib[3] != 4) { return false; }
+    if(ib[4] != 5) { return false; }
+    return true;
+}
+#endif
+
 int main()
 {
     test1<input_iterator<const int*>, output_iterator<int*> >();
@@ -423,6 +444,10 @@ int main()
         decltype(ranges::transform(s, i, p, binary, &S::i))>::value, "");
     static_assert(std::is_same<std::tuple<S const*, S const *, int*>,
         decltype(ranges::transform(s, s, p, binary, &S::i, &S::i))>::value, "");
-
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
     return ::test_result();
 }

--- a/test/algorithm/unique.cpp
+++ b/test/algorithm/unique.cpp
@@ -135,6 +135,21 @@ void test()
     }
 }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    int a[] = {0, 1, 1, 1, 2, 2, 2};
+    const unsigned sa = sizeof(a) / sizeof(a[0]);
+    auto r = unique(a, a + sa);
+    if(r != a + 3) { return false; }
+    if(a[0] != 0) { return false; }
+    if(a[1] != 1) { return false; }
+    if(a[2] != 2) { return false; }
+    return true;
+}
+#endif
+
 int main()
 {
     test<forward_iterator<int*>, iter_call>();
@@ -156,6 +171,10 @@ int main()
         CHECK(a[1] == 1);
         CHECK(a[2] == 2);
     }
-
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
     return ::test_result();
 }

--- a/test/algorithm/unique_copy.cpp
+++ b/test/algorithm/unique_copy.cpp
@@ -249,6 +249,31 @@ bool operator==(S l, S r)
     return l.i == r.i && l.j == r.j;
 }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    int a[] = {0, 1, 1, 1, 2, 2, 2};
+    int b[] = {0, 0, 0};
+    const unsigned sa = sizeof(a) / sizeof(a[0]);
+    const unsigned sb = sizeof(b) / sizeof(b[0]);
+    auto r = unique_copy(a, b);
+    if(r.first != a + sa) { return false; }
+    if(r.second != b + sb) { return false; }
+    if(a[0] != 0) { return false; }
+    if(a[1] != 1) { return false; }
+    if(a[2] != 1) { return false; }
+    if(a[3] != 1) { return false; }
+    if(a[4] != 2) { return false; }
+    if(a[5] != 2) { return false; }
+    if(a[6] != 2) { return false; }
+    if(b[0] != 0) { return false; }
+    if(b[1] != 1) { return false; }
+    if(b[2] != 2) { return false; }
+    return true;
+}
+#endif
+
 int main()
 {
     test<input_iterator<const int*>, output_iterator<int*> >();
@@ -300,6 +325,10 @@ int main()
         CHECK(r.second == ib + 7);
         check_equal(ranges::make_range(ib, ib+7), {S{1,1},S{2,2},S{3,3},S{4,5},S{5,6},S{6,9},S{7,10}});
     }
-
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
     return ::test_result();
 }

--- a/test/algorithm/upper_bound.cpp
+++ b/test/algorithm/upper_bound.cpp
@@ -54,5 +54,26 @@ int main()
     CHECK(ranges::upper_bound(ranges::view::all(a), 1, less(), &std::pair<int, int>::first).get_unsafe() == &a[4]);
     CHECK(ranges::upper_bound(ranges::view::all(c), 1, less(), &std::pair<int, int>::first).get_unsafe() == &c[4]);
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        using namespace ranges;
+        constexpr std::pair<int, int> a[] = {{0, 0}, {0, 1}, {1, 2}, {1, 3}, {3, 4}, {3, 5}};
+
+        static_assert(aux::upper_bound_n(begin(a), size(a), a[0]) == &a[1], "");
+        static_assert(aux::upper_bound_n(begin(a), size(a), a[1], less()) == &a[2], "");
+
+        static_assert(upper_bound(begin(a), end(a), a[0]) == &a[1], "");
+        static_assert(upper_bound(begin(a), end(a), a[1], less()) == &a[2], "");
+        static_assert(upper_bound(a, a[2]) == &a[3], "");
+        static_assert(upper_bound(a, a[3], less()) == &a[4], "");
+
+        static_assert(upper_bound(a, std::make_pair(1, 3), less()) == &a[4], "");
+        // TODO: constexpr
+        // requires view::all to be constexpr
+        // static_assert(upper_bound(view::all(a), std::make_pair(1, 3), less()).get_unsafe() == &a[4], "");
+    }
+#endif
+
+
     return test_result();
 }

--- a/test/array.hpp
+++ b/test/array.hpp
@@ -33,261 +33,253 @@
 #include <range/v3/algorithm/lexicographical_compare.hpp>
 #include <range/v3/utility/swap.hpp>
 
-namespace test {
-
-    /// \addtogroup group-utility
-    /// A std::array with constexpr support
-    template<typename T, std::size_t N>
-    struct array
+/// \addtogroup group-utility
+/// A std::array with constexpr support
+template<typename T, std::size_t N>
+struct array
+{
+    using self = array;
+    using value_type = T;
+    using reference = value_type&;
+    using const_reference = value_type const&;
+    using iterator = value_type*;
+    using const_iterator = value_type const*;
+    using pointer = value_type*;
+    using const_pointer = value_type const*;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using reverse_iterator = ranges::reverse_iterator<iterator>;
+    using const_reverse_iterator = ranges::reverse_iterator<const_iterator>;
+     value_type elems_[N > 0 ? N : 1];
+     // No explicit construct/copy/destroy for aggregate type
+    RANGES_CXX14_CONSTEXPR array() = default;
+    RANGES_CXX14_CONSTEXPR void fill(const value_type& u)
     {
-        using self = array;
-        using value_type = T;
-        using reference = value_type&;
-        using const_reference = value_type const&;
-        using iterator = value_type*;
-        using const_iterator = value_type const*;
-        using pointer = value_type*;
-        using const_pointer = value_type const*;
-        using size_type = std::size_t;
-        using difference_type = std::ptrdiff_t;
-        using reverse_iterator = ranges::reverse_iterator<iterator>;
-        using const_reverse_iterator = ranges::reverse_iterator<const_iterator>;
-
-        value_type elems_[N > 0 ? N : 1];
-
-        // No explicit construct/copy/destroy for aggregate type
-        RANGES_CXX14_CONSTEXPR array() = default;
-        RANGES_CXX14_CONSTEXPR void fill(const value_type& u)
-        {
-            ranges::fill_n(elems_, N, u);
-        }
-        RANGES_CXX14_CONSTEXPR
-        void swap(array& a) noexcept(ranges::is_nothrow_swappable<T, T>::value)
-        {
-            ranges::swap_ranges(elems_, elems_ + N, a.elems_);
-        }
-         // iterators:
-        RANGES_CXX14_CONSTEXPR
-        iterator begin() noexcept
-        {
-            return iterator(elems_);
-        }
-        RANGES_CXX14_CONSTEXPR
-        const_iterator begin() const noexcept
-        {
-            return const_iterator(elems_);
-        }
-        RANGES_CXX14_CONSTEXPR
-        iterator end() noexcept
-        {
-            return iterator(elems_ + N);
-        }
-        RANGES_CXX14_CONSTEXPR
-        const_iterator end() const noexcept
-        {
-            return const_iterator(elems_ + N);
-        }
-        RANGES_CXX14_CONSTEXPR
-        reverse_iterator rbegin() noexcept
-        {
-            return reverse_iterator(end());
-        }
-        RANGES_CXX14_CONSTEXPR
-        const_reverse_iterator rbegin() const noexcept
-        {
-            return const_reverse_iterator(end());
-        }
-        RANGES_CXX14_CONSTEXPR
-        reverse_iterator rend() noexcept
-        {
-            return reverse_iterator(begin());
-        }
-        RANGES_CXX14_CONSTEXPR
-        const_reverse_iterator rend() const noexcept
-        {
-            return const_reverse_iterator(begin());
-        }
-        RANGES_CXX14_CONSTEXPR
-        const_iterator cbegin() const noexcept
-        {
-            return begin();
-        }
-        RANGES_CXX14_CONSTEXPR
-        const_iterator cend() const noexcept
-        {
-            return end();
-        }
-        RANGES_CXX14_CONSTEXPR
-        const_reverse_iterator crbegin() const noexcept
-        {
-            return rbegin();
-        }
-        RANGES_CXX14_CONSTEXPR
-        const_reverse_iterator crend() const noexcept
-        {
-            return rend();
-        }
-        // capacity:
-        RANGES_CXX14_CONSTEXPR
-        size_type size() const noexcept
-        {
-            return N;
-        }
-        RANGES_CXX14_CONSTEXPR
-        size_type max_size() const noexcept
-        {
-            return N;
-        }
-        RANGES_CXX14_CONSTEXPR
-        bool empty() const noexcept
-        {
-            return N == 0;
-        }
-         // element access:
-        RANGES_CXX14_CONSTEXPR reference operator[](size_type n)
-        {
-            return elems_[n];
-        }
-        RANGES_CXX14_CONSTEXPR const_reference operator[](size_type n) const
-        {
-            return elems_[n];
-        }
-        RANGES_CXX14_CONSTEXPR reference at(size_type n)
-        {
-            if (n >= N)
-                throw std::out_of_range("array::at");
-            return elems_[n];
-        };
-        RANGES_CXX14_CONSTEXPR const_reference at(size_type n) const
-        {
-            if (n >= N)
-                throw std::out_of_range("array::at");
-            return elems_[n];
-        }
-        RANGES_CXX14_CONSTEXPR reference front()
-        {
-            return elems_[0];
-        }
-        RANGES_CXX14_CONSTEXPR const_reference front() const
-        {
-            return elems_[0];
-        }
-        RANGES_CXX14_CONSTEXPR reference back()
-        {
-            return elems_[N > 0 ? N-1 : 0];
-        }
-        RANGES_CXX14_CONSTEXPR const_reference back() const
-        {
-            return elems_[N > 0 ? N-1 : 0];
-        }
-        RANGES_CXX14_CONSTEXPR
-        value_type* data() noexcept
-        {
-            return elems_;
-        }
-        RANGES_CXX14_CONSTEXPR
-        const value_type* data() const noexcept
-        {
-            return elems_;
-        }
+        ranges::fill_n(elems_, N, u);
+    }
+    RANGES_CXX14_CONSTEXPR
+    void swap(array& a) noexcept(ranges::is_nothrow_swappable<T, T>::value)
+    {
+        ranges::swap_ranges(elems_, elems_ + N, a.elems_);
+    }
+     // iterators:
+    RANGES_CXX14_CONSTEXPR
+    iterator begin() noexcept
+    {
+        return iterator(elems_);
+    }
+    RANGES_CXX14_CONSTEXPR
+    const_iterator begin() const noexcept
+    {
+        return const_iterator(elems_);
+    }
+    RANGES_CXX14_CONSTEXPR
+    iterator end() noexcept
+    {
+        return iterator(elems_ + N);
+    }
+    RANGES_CXX14_CONSTEXPR
+    const_iterator end() const noexcept
+    {
+        return const_iterator(elems_ + N);
+    }
+    RANGES_CXX14_CONSTEXPR
+    reverse_iterator rbegin() noexcept
+    {
+        return reverse_iterator(end());
+    }
+    RANGES_CXX14_CONSTEXPR
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+    RANGES_CXX14_CONSTEXPR
+    reverse_iterator rend() noexcept
+    {
+        return reverse_iterator(begin());
+    }
+    RANGES_CXX14_CONSTEXPR
+    const_reverse_iterator rend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+    RANGES_CXX14_CONSTEXPR
+    const_iterator cbegin() const noexcept
+    {
+        return begin();
+    }
+    RANGES_CXX14_CONSTEXPR
+    const_iterator cend() const noexcept
+    {
+        return end();
+    }
+    RANGES_CXX14_CONSTEXPR
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return rbegin();
+    }
+    RANGES_CXX14_CONSTEXPR
+    const_reverse_iterator crend() const noexcept
+    {
+        return rend();
+    }
+    // capacity:
+    RANGES_CXX14_CONSTEXPR
+    size_type size() const noexcept
+    {
+        return N;
+    }
+    RANGES_CXX14_CONSTEXPR
+    size_type max_size() const noexcept
+    {
+        return N;
+    }
+    RANGES_CXX14_CONSTEXPR
+    bool empty() const noexcept
+    {
+        return N == 0;
+    }
+     // element access:
+    RANGES_CXX14_CONSTEXPR reference operator[](size_type n)
+    {
+        return elems_[n];
+    }
+    RANGES_CXX14_CONSTEXPR const_reference operator[](size_type n) const
+    {
+        return elems_[n];
+    }
+    RANGES_CXX14_CONSTEXPR reference at(size_type n)
+    {
+        if (n >= N)
+            throw std::out_of_range("array::at");
+        return elems_[n];
     };
+    RANGES_CXX14_CONSTEXPR const_reference at(size_type n) const
+    {
+        if (n >= N)
+            throw std::out_of_range("array::at");
+        return elems_[n];
+    }
+    RANGES_CXX14_CONSTEXPR reference front()
+    {
+        return elems_[0];
+    }
+    RANGES_CXX14_CONSTEXPR const_reference front() const
+    {
+        return elems_[0];
+    }
+    RANGES_CXX14_CONSTEXPR reference back()
+    {
+        return elems_[N > 0 ? N-1 : 0];
+    }
+    RANGES_CXX14_CONSTEXPR const_reference back() const
+    {
+        return elems_[N > 0 ? N-1 : 0];
+    }
+    RANGES_CXX14_CONSTEXPR
+    value_type* data() noexcept
+    {
+        return elems_;
+    }
+    RANGES_CXX14_CONSTEXPR
+    const value_type* data() const noexcept
+    {
+        return elems_;
+    }
+};
+template <class T, size_t N>
+RANGES_CXX14_CONSTEXPR
+bool
+operator==(const array<T, N>& x, const array<T, N>& y)
+{
+    return ranges::equal(x.elems_, x.elems_ + N, y.elems_);
+}
+template <class T, size_t N>
+RANGES_CXX14_CONSTEXPR
+bool
+operator!=(const array<T, N>& x, const array<T, N>& y)
+{
+    return !(x == y);
+}
+template <class T, size_t N>
+RANGES_CXX14_CONSTEXPR
+bool
+operator<(const array<T, N>& x, const array<T, N>& y)
+{
+    return ranges::lexicographical_compare(x.elems_, x.elems_ + N, y.elems_, y.elems_ + N);
+}
+template <class T, size_t N>
+RANGES_CXX14_CONSTEXPR
+bool
+operator>(const array<T, N>& x, const array<T, N>& y)
+{
+    return y < x;
+}
+template <class T, size_t N>
+RANGES_CXX14_CONSTEXPR
+bool
+operator<=(const array<T, N>& x, const array<T, N>& y)
+{
+    return !(y < x);
+}
+template <class T, size_t N>
+RANGES_CXX14_CONSTEXPR
+bool
+operator>=(const array<T, N>& x, const array<T, N>& y)
+{
+    return !(x < y);
+}
 
-    template <class T, size_t N>
-    RANGES_CXX14_CONSTEXPR
-    bool
-    operator==(const array<T, N>& x, const array<T, N>& y)
-    {
-        return ranges::equal(x.elems_, x.elems_ + N, y.elems_);
-    }
-    template <class T, size_t N>
-    RANGES_CXX14_CONSTEXPR
-    bool
-    operator!=(const array<T, N>& x, const array<T, N>& y)
-    {
-        return !(x == y);
-    }
-    template <class T, size_t N>
-    RANGES_CXX14_CONSTEXPR
-    bool
-    operator<(const array<T, N>& x, const array<T, N>& y)
-    {
-        return ranges::lexicographical_compare(x.elems_, x.elems_ + N, y.elems_, y.elems_ + N);
-    }
-    template <class T, size_t N>
-    RANGES_CXX14_CONSTEXPR
-    bool
-    operator>(const array<T, N>& x, const array<T, N>& y)
-    {
-        return y < x;
-    }
-    template <class T, size_t N>
-    RANGES_CXX14_CONSTEXPR
-    bool
-    operator<=(const array<T, N>& x, const array<T, N>& y)
-    {
-        return !(y < x);
-    }
+template <class T, size_t N>
+RANGES_CXX14_CONSTEXPR
+auto swap(array<T, N>& x, array<T, N>& y)
+noexcept(ranges::is_nothrow_swappable<T, T>::value)
+-> typename std::enable_if<ranges::is_swappable<T, T>::value, void>::type
+{
+    x.swap(y);
+}
+template <size_t I, class T, size_t N>
+RANGES_CXX14_CONSTEXPR
+T& get(array<T, N>& a) noexcept
+{
+    static_assert(I < N, "Index out of bounds in ranges::get<> (ranges::array)");
+    return a.elems_[I];
+}
 
-    template <class T, size_t N>
-    RANGES_CXX14_CONSTEXPR
-    bool
-    operator>=(const array<T, N>& x, const array<T, N>& y)
-    {
-         return !(x < y);
-    }
+template <size_t I, class T, size_t N>
+RANGES_CXX14_CONSTEXPR
+const T& get(const array<T, N>& a) noexcept
+{
+    static_assert(I < N, "Index out of bounds in ranges::get<> (const ranges::array)");
+    return a.elems_[I];
+}
 
-    template <class T, size_t N>
-    RANGES_CXX14_CONSTEXPR
-    auto swap(array<T, N>& x, array<T, N>& y)
-    noexcept(ranges::is_nothrow_swappable<T, T>::value)
-    -> typename std::enable_if<ranges::is_swappable<T, T>::value, void>::type
-    {
-        x.swap(y);
-    }
+template <size_t I, class T, size_t N>
+RANGES_CXX14_CONSTEXPR
+T&& get(array<T, N>&& a) noexcept
+{
+    static_assert(I < N, "Index out of bounds in ranges::get<> (ranges::array &&)");
+    return std::move(a.elems_[I]);
+}
 
-    template <size_t I, class T, size_t N>
-    RANGES_CXX14_CONSTEXPR
-    T& get(array<T, N>& a) noexcept
-    {
-        static_assert(I < N, "Index out of bounds in ranges::get<> (ranges::array)");
-        return a.elems_[I];
+template<class T, std::size_t N>
+RANGES_CXX14_CONSTEXPR void swap(array<T, N>& a, array<T, N>& b) {
+    for(std::size_t i = 0; i != N; ++i) {
+        auto tmp = std::move(a[i]);
+        a[i] = std::move(b[i]);
+        b[i] = std::move(tmp);
     }
-
-    template <size_t I, class T, size_t N>
-    RANGES_CXX14_CONSTEXPR
-    const T& get(const array<T, N>& a) noexcept
-    {
-        static_assert(I < N, "Index out of bounds in ranges::get<> (const ranges::array)");
-        return a.elems_[I];
-    }
-
-    template <size_t I, class T, size_t N>
-    RANGES_CXX14_CONSTEXPR
-    T&& get(array<T, N>&& a) noexcept
-    {
-        static_assert(I < N, "Index out of bounds in ranges::get<> (ranges::array &&)");
-        return std::move(a.elems_[I]);
-    }
-
-    template<class T, std::size_t N>
-    RANGES_CXX14_CONSTEXPR void swap(array<T, N>& a, array<T, N>& b) {
-        for(std::size_t i = 0; i != N; ++i) {
-            auto tmp = std::move(a[i]);
-            a[i] = std::move(b[i]);
-            b[i] = std::move(tmp);
-        }
-    }
-}  // namespace test
+}
 
 namespace std
 {
 
 template <class T, size_t N>
-class tuple_size<test::array<T, N>>
+class tuple_size<::array<T, N>>
     : public integral_constant<size_t, N> {};
 
 template <size_t I, class T, size_t N>
-class tuple_element<I, test::array<T, N> >
+class tuple_element<I, ::array<T, N> >
 {
  public:
     using type = T;

--- a/test/constexpr_core.cpp
+++ b/test/constexpr_core.cpp
@@ -177,7 +177,7 @@ RANGES_CXX14_CONSTEXPR auto test_non_member_f(Sequence1234&& a) -> bool {
 }
 
 RANGES_CXX14_CONSTEXPR auto test_array() -> bool {
-    test::array<int, 4> a{{1, 2, 3, 4}};
+    array<int, 4> a{{1, 2, 3, 4}};
 
     auto beg = ranges::begin(a);
     auto three = ranges::next(beg, 2);
@@ -193,7 +193,7 @@ RANGES_CXX14_CONSTEXPR auto test_array() -> bool {
     if (!test_non_member_f(a)) { return false; }
 
     // This can be workedaround but is just bad:
-    test::array<int, 4> b{{5, 6, 7, 8}};
+    array<int, 4> b{{5, 6, 7, 8}};
     ranges::swap(a, b);
     if (a[0] != 5 || b[0] != 1 || a[3] != 8 || b[3] != 4) { return false; }
 

--- a/test/distance.cpp
+++ b/test/distance.cpp
@@ -18,6 +18,7 @@
 #include <range/v3/view/iota.hpp>
 #include "./simple_test.hpp"
 #include "./test_utils.hpp"
+#include "./array.hpp"
 
 template <typename I, typename S>
 void test_iterators(I begin, S end, ranges::iterator_difference_t<I> n)
@@ -66,6 +67,46 @@ void test_infinite_range(Rng&& rng)
     }
 }
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+
+RANGES_CXX14_CONSTEXPR bool test_constexpr() {
+    using namespace ranges;
+
+    auto rng = array<int, 10>{{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}};
+    using Rng = decltype(rng);
+    auto bit = ranges::begin(rng);
+    using I = decltype(bit);
+    auto it = bit + 5;
+    auto eit = ranges::end(rng);
+    auto n = ranges::size(rng);
+    auto en = ranges::enumerate(rng);
+    if(n != 10) { return false; }
+    if(distance(bit, eit) != n) { return false; }
+    if(distance(it, eit) != 5) { return false; }
+    if(distance_compare(bit, eit, n) != 0) { return false; }
+    if(distance_compare(bit, eit, n - 1) <= 0) { return false; }
+    if(distance_compare(bit, eit, n + 1) >= 0) { return false; }
+    if(distance_compare(bit, eit, (std::numeric_limits<iterator_difference_t<I>>::min)()) <= 0)
+    { return false; }
+    if(distance_compare(bit, eit, (std::numeric_limits<iterator_difference_t<I>>::max)()) >= 0)
+    { return false; }
+    if(distance(rng) != n) { return false; }
+    if(distance_compare(rng, n) != 0) { return false; }
+    if(distance_compare(rng, n - 1) <= 0) { return false; }
+    if(distance_compare(rng, n + 1) >= 0) { return false; }
+    if(distance_compare(rng, (std::numeric_limits<range_difference_t<Rng>>::min)()) <= 0)
+    { return false; }
+    if(distance_compare(rng, (std::numeric_limits<range_difference_t<Rng>>::max)()) >= 0)
+    { return false; }
+
+    if(en.first != 10) { return false; }
+    if(en.second != eit) { return false; }
+
+    return true;
+}
+
+#endif
+
 int main()
 {
     using namespace ranges;
@@ -111,6 +152,13 @@ int main()
     {
         test_infinite_range(view::ints(0u));
     }
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
+
 
     return ::test_result();
 }

--- a/test/range_adaptor.cpp
+++ b/test/range_adaptor.cpp
@@ -16,6 +16,7 @@
 #include <range/v3/view/delimit.hpp>
 #include "./simple_test.hpp"
 #include "./test_utils.hpp"
+#include "./array.hpp"
 
 template<typename BidiRange>
 struct my_reverse_view
@@ -30,42 +31,51 @@ private:
     struct adaptor : ranges::adaptor_base
     {
         // Cross-wire begin and end.
+        RANGES_CXX14_CONSTEXPR
         base_iterator_t begin(my_reverse_view const &rng) const
         {
             return ranges::end(rng.base());
         }
+        RANGES_CXX14_CONSTEXPR
         base_iterator_t end(my_reverse_view const &rng) const
         {
             return ranges::begin(rng.base());
         }
+        RANGES_CXX14_CONSTEXPR
         void next(base_iterator_t &it)
         {
             --it;
         }
+        RANGES_CXX14_CONSTEXPR
         void prev(base_iterator_t &it)
         {
             ++it;
         }
+        RANGES_CXX14_CONSTEXPR
         ranges::range_reference_t<BidiRange> current(base_iterator_t it) const
         {
             return *ranges::prev(it);
         }
         CONCEPT_REQUIRES(ranges::RandomAccessIterable<BidiRange>())
+        RANGES_CXX14_CONSTEXPR
         void advance(base_iterator_t &it, ranges::range_difference_t<BidiRange> n)
         {
             it -= n;
         }
         CONCEPT_REQUIRES(ranges::RandomAccessIterable<BidiRange>())
+        RANGES_CXX14_CONSTEXPR
         ranges::range_difference_t<BidiRange>
         distance_to(base_iterator_t const &here, base_iterator_t const &there)
         {
             return here - there;
         }
     };
+    RANGES_CXX14_CONSTEXPR
     adaptor begin_adaptor() const
     {
         return {};
     }
+    RANGES_CXX14_CONSTEXPR
     adaptor end_adaptor() const
     {
         return {};
@@ -81,6 +91,22 @@ struct my_delimited_range
 {
     using range_adaptor_t::range_adaptor_t;
 };
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+RANGES_CXX14_CONSTEXPR bool test_constexpr()
+{
+    using namespace ranges;
+    // TODO: constexpr
+    // requires view::all to be constexpr
+    // array<int, 4> a{{1,2,3,4}};
+    // my_reverse_view<array<int, 4>& > retro{a};
+    // ::models<concepts::BoundedRange>(retro);
+    // ::models<concepts::RandomAccessIterator>(retro.begin());
+    // ::check_equal(retro, {4, 3, 2, 1});
+
+    return true;
+}
+#endif
 
 int main()
 {
@@ -105,6 +131,12 @@ int main()
     ::models<concepts::InputIterator>(r.begin());
     ::models_not<concepts::ForwardIterator>(r.begin());
     ::check_equal(r, {1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4});
+
+#ifdef RANGES_CXX_GREATER_THAN_11
+    {
+        static_assert(test_constexpr(), "");
+    }
+#endif
 
     return ::test_result();
 }

--- a/test/safe_int_swap.hpp
+++ b/test/safe_int_swap.hpp
@@ -1,0 +1,32 @@
+/// \file
+// Range v3 library
+//
+//  Copyright Eric Niebler 2013-2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#ifndef RANGES_V3_TEST_SAFE_INT_SWAP_HPP
+#define RANGES_V3_TEST_SAFE_INT_SWAP_HPP
+
+#include <range/v3/utility/safe_int.hpp>
+
+namespace ranges
+{
+
+RANGES_CXX14_CONSTEXPR
+void swap(safe_int<int>& a, safe_int<int>& b)
+{
+    safe_int<int> tmp = std::move(a);
+    a = std::move(b);
+    b = std::move(tmp);
+}
+
+}  // namespace ranges
+
+#endif

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -22,6 +22,7 @@
 #include "./test_iterators.hpp"
 
 template<typename Val, typename Rng>
+RANGES_CXX14_CONSTEXPR
 void check_equal(Rng && actual, std::initializer_list<Val> expected)
 {
     auto begin0 = ranges::begin(actual);
@@ -34,6 +35,7 @@ void check_equal(Rng && actual, std::initializer_list<Val> expected)
 }
 
 template<typename Rng, typename Rng2>
+RANGES_CXX14_CONSTEXPR
 void check_equal(Rng && actual, Rng2&& expected)
 {
     auto begin0 = ranges::begin(actual);
@@ -47,24 +49,28 @@ void check_equal(Rng && actual, Rng2&& expected)
 }
 
 template<typename Expected, typename Actual>
+RANGES_CXX14_CONSTEXPR
 void has_type(Actual &&)
 {
     static_assert(std::is_same<Expected, Actual>::value, "Not the same");
 }
 
 template<typename Concept, typename ...Types>
+RANGES_CXX14_CONSTEXPR
 void models(Types &&...)
 {
     CONCEPT_ASSERT(ranges::concepts::models<Concept, Types...>());
 }
 
 template<typename Concept, typename ...Types>
+RANGES_CXX14_CONSTEXPR
 void models_not(Types &&...)
 {
     CONCEPT_ASSERT(!ranges::concepts::models<Concept, Types...>());
 }
 
 template<typename T>
+RANGES_CXX14_CONSTEXPR
 T & as_lvalue(T && t)
 {
     return t;


### PR DESCRIPTION
add constexpr support to the following core facilities:
  - distance / enumerate
  - range / sized_range / make_range / range::get
  - range_iterface
add constexpr support to the following facilities in utility/functional:
  - as function
  - with_braced_init_args
  - operators
  - reference_wrapper
  - ref_fn / ref
  - add greater as a synonym for operator> (requires WeaklyOrdered and EqualityComparable)
add c++14 constexpr support to utility/move
add c++14 constexpr support to safe_int and add constexpr swap function to safe_int
bugfix: set_difference test

The following algorithms can be used within constexpr functions with minimal to no changes to the 
algorithm implementation: 
- adjacent_find
- all_of
- any_of
- binary_search
- copy
- copy_backward
- copy_if
- copy_n
- count
- count_if
- equal
- equal_range
- fill
- fill_n
- find
- find_end
- find_first_of
- find_if
- find_if_not
- for_each
- generate
- generate_n
- includes
- inplace_merge (unbuffered)
- is_heap
- is_heap_until
- is_partitioned
- is_sorted
- is_sorted_until
- lexicographical_compare
- lower_bound
- make_heap
- max_element
- merge
- merge_move
- min_element
- minmax_element
- mismatch
- move
- move_backward
- none_of
- partition
- partition_copy
- partition_move
- partition_point
- push_heap
- random_shuffle (for user-provided constexpr random number generators)
- remove
- remove_copy
- remove_copy_if
- remove_if
- replace
- replace_copy
- replace_copy_if
- replace_if
- reverse_copy
- rotate
- rotate_copy
- search
- search_n
- set_difference
- set_intersection
- set_symmetric_difference
- set_union
- shuffle* (for user-provided constexpr uniform random number generators)
- sort_heap
- stable_partition
- stable_sort
- swap_ranges
- transform
- unique
- unique_copy
- upper_bound

[*] shuffle: requires a constexpr uniform_int_distribution that has been adapted from 
libc++ (with minimal changes), but no real changes to the algorithm itself. For testing purposes, the linear_congruential_engine from libc++ has been adapted (with minimal changes).

The following algorithms haven’t been adapted yet because goto is not allowed within constexpr functions and as a consequence the algorithms would have to be rewritten: 
- nth_element
- is_permutation

This is doable, and I partially did so for stable_partition, but I would like to know what you think.

The following algorithms are constexpr but use iter_swap. Since iter_swap requires indirect_swap and thus swap to be constexpr, they won’t be constexpr for most types (e.g. int, they work for `safe_int<int>` because it has a constexpr swap): 
- sort_heap
- pop_heap
- inplace_merge
- next_permutation
- partial_sort
- partial_sort_copy
- partition
- prev_permutation
- random_shuffle
- reverse
- shuffle
- stable_partition
- swap_ranges

I’ve tested these with safe_int by adding a friend swap function to safe_int. It might be better to add this functions for testing only, and not in general to safe int, since it overrides the default swap for the underlying type and does not perform ADL. 

On the usage of temporary buffers (note this discussion is now taking place in [this issue](https://github.com/ericniebler/range-v3/issues/168)):

I think it is :
- wrong for algorithms to allocate memory by default,
- even wronger that users cannot opt out of this behavior,
- bad that users cannot pass these algorithms preallocated buffers.

In libstdc++ and libc++ get_temporary_buffer just calls new in a loop. 
So even tho I can understand the good intentions behind get_temporary_buffer, I think that the way this is handled by the STL right now is far from optimal. 

The algorithms that use it directly are:
- stable_partition
- inplace_merge

And the algorithms that use these algorithms are:
- stable_sort

I’ve provided these algorithms with a constexpr member function called `inplace` that uses no buffer.
It will be better to provide them with another member function called `with_buffer` that allows the user to specify a buffer (such a stack allocated buffer). 

I'd rather leave this as is (with inplace) and open an issue where we can discuss this on its own, since I think is one of the things that is worth to get right on an STL2 (and maybe try to unify get_temporary_buffer with Allocator).