### PR TITLE
disable sort_patterns in cxx11

### DIFF
--- a/perf/CMakeLists.txt
+++ b/perf/CMakeLists.txt
@@ -1,4 +1,3 @@
 add_executable(counted_insertion_sort counted_insertion_sort.cpp)
 
 add_executable(sort_patterns sort_patterns.cpp)
-set_target_properties(sort_patterns PROPERTIES COMPILE_FLAGS "-std=gnu++1y")

--- a/perf/sort_patterns.cpp
+++ b/perf/sort_patterns.cpp
@@ -22,6 +22,8 @@
 #include <algorithm>
 #include <range/v3/all.hpp>
 
+#ifdef RANGES_CXX_GREATER_THAN_11
+
 /// Creates an geometric infinite sequence starting at 1 where the
 /// successor is multiplied by \p V
 auto geometric_sequence(std::size_t V) {
@@ -244,3 +246,12 @@ int main() {
 
   return 0;
 }
+
+
+#else
+
+#pragma message("sort_patterns requires C++ 14 or greater")
+
+int main() { return 0; }
+
+#endif


### PR DESCRIPTION
problem: perf/sort_patterns requires c++14 and breaks in travis under C++11.
solution: disable sort_patterns in C++11 

I'll clean sort_patterns and backport it to C++11 later on. 
