### PR TITLE
add meta::integer_range

### DIFF
--- a/include/meta/meta.hpp
+++ b/include/meta/meta.hpp
@@ -2868,6 +2868,28 @@ namespace meta
             return {};
         }
 
+        ///////////////////////////////////////////////////////////////////////////////////////////////
+        // integer_range
+        /// \cond
+        namespace detail
+        {
+            template <class T, T offset, class U> struct offset_integer_sequence_ {};
+
+            template <class T, T offset, T... Ts>
+            struct offset_integer_sequence_<T, offset, meta::integer_sequence<T, Ts...>>
+            {
+                using type = meta::integer_sequence<T, (Ts + offset)...>;
+            };
+        }  // namespace detail
+        /// \endcond
+
+        /// Makes the integer sequence [from, to).
+        /// \ingroup integral
+        template <class T, T from, T to>
+        using integer_range = meta::eval<
+            detail::offset_integer_sequence_<T, from,
+                                             meta::make_integer_sequence<T, to - from>>>;
+
         /// \cond
     } // namespace v1
     /// \endcond

--- a/test/utility/meta.cpp
+++ b/test/utility/meta.cpp
@@ -388,6 +388,24 @@ int main()
     // Check the _z user-defined literal:
     static_assert(42_z == 42, "");
 
+    // Check integer_range
+    {
+      constexpr std::size_t a
+          = meta::fold<meta::as_list<meta::integer_range<std::size_t, 0, 5>>,
+                       meta::size_t<0>, meta::quote<meta::plus>>{};
+
+        static_assert(a == 10, "");
+
+        constexpr std::size_t b
+          = meta::fold<meta::as_list<meta::integer_range<std::size_t, 5, 10>>,
+                       meta::size_t<0>, meta::quote<meta::plus>>{};
+
+        static_assert(b == 35, "");
+
+        using c = meta::integer_range<std::size_t, 5, 10>;
+        static_assert(std::is_same<c, meta::integer_sequence<std::size_t, 5, 6, 7, 8, 9>>{}, "");
+    }
+
     test_tuple_cat();
     return ::test_result();
 }


### PR DESCRIPTION
`meta::make_integer_sequence<T, N>` creates a `meta::integer_sequence<T, 0, ..., N-1>`.

- add `meta::integer_range<T, from, to>` that creates a `meta::integer_sequence<T, from, ..., to - 1>` similar in spirit to `boost::mpl::range_c`.