### PR TITLE
make meta::for_each constexpr

### DIFF
--- a/include/meta/meta.hpp
+++ b/include/meta/meta.hpp
@@ -1998,7 +1998,7 @@ namespace meta
                 template <class UnaryFunction, class... Args>
                 constexpr auto operator()(list<Args...>, UnaryFunction f) const -> UnaryFunction
                 {
-                    return (void)std::initializer_list<int>{(f(Args{}), void(), 0)...}, f;
+                    return (void)std::initializer_list<int>{(f(Args{}), 0)...}, f;
                 }
             };
         } // namespace detail

--- a/test/utility/meta.cpp
+++ b/test/utility/meta.cpp
@@ -150,10 +150,12 @@ static_assert(std::is_same<reverse_find<L, int>, list<int, float>>::value, "");
 
 struct check_integral
 {
+    constexpr check_integral() {}
     template <class T>
-    void operator()(T &&)
+    constexpr T operator()(T && i) const
     {
         static_assert(std::is_integral<T>{}, "");
+        return i;
     }
 };
 
@@ -256,7 +258,9 @@ int main()
     // meta::for_each
     {
         using l = meta::list<int, long, short>;
-        meta::for_each(l{}, check_integral());
+        constexpr auto r = meta::for_each(l{}, check_integral());
+        static_assert(std::is_same<meta::eval<std::remove_cv<decltype(r)>>,
+                      check_integral>::value, "");
     }
 
     // meta::all_of with trivial lambda


### PR DESCRIPTION
`meta::for_each` was not constexpr because:

range-v3/include/meta/meta.hpp:2001:73: note: subexpression not valid in a constant expression
                    return (void)std::initializer_list<int>{(f(Args{}), void(), 0)...}, f;
                                                                        ^
range-v3/test/utility/meta.cpp:261:28: note: in call to '&value->operator()({}, {})'
        constexpr auto r = meta::for_each(l{}, check_integral());
                           ^

This PR has a solution. It is not a perfect solution: it removes the safeguard against an overloaded comma operator. 