### PR TITLE
Reserve capacity before inserting a SizedRange into a std::vector.

### DIFF
--- a/include/range/v3/action/concepts.hpp
+++ b/include/range/v3/action/concepts.hpp
@@ -90,6 +90,13 @@ namespace ranges
                 );
             };
 
+            struct ReserveAndAssignable : refines<Reservable(_1)> {
+                template <class C, class I>
+                auto requires_(C&& c, I&& i) -> decltype(
+                    concepts::valid_expr((c.assign(i, i), 42))
+                );
+            };
+
             struct RandomAccessReservable : refines<Reservable> {
                 template <class C>
                 auto requires_(C&& c) -> decltype(
@@ -100,6 +107,9 @@ namespace ranges
 
         template <class C>
         using Reservable = concepts::models<concepts::Reservable, C>;
+
+        template <class C, class I>
+        using ReserveAndAssignable = concepts::models<concepts::ReserveAndAssignable, C, I>;
 
         template <class C>
         using RandomAccessReservable = concepts::models<concepts::RandomAccessReservable, C>;

--- a/include/range/v3/action/concepts.hpp
+++ b/include/range/v3/action/concepts.hpp
@@ -77,6 +77,33 @@ namespace ranges
         template<typename T>
         using Container = concepts::models<concepts::Container, T>;
 
+        namespace concepts
+        {
+            struct Reservable : refines<Container> {
+                template <class T>
+                using size_type = decltype(std::declval<const T&>().size());
+
+                template <class C>
+                auto requires_(C&& c) -> decltype(
+                    concepts::model_of<Integral, size_type<C>>(),
+                    concepts::valid_expr((c.reserve(c.size()), 42))
+                );
+            };
+
+            struct RandomAccessReservable : refines<Reservable> {
+                template <class C>
+                auto requires_(C&& c) -> decltype(
+                    concepts::model_of<RandomAccessIterator, decltype(begin(c))>()
+                );
+            };
+        }
+
+        template <class C>
+        using Reservable = concepts::models<concepts::Reservable, C>;
+
+        template <class C>
+        using RandomAccessReservable = concepts::models<concepts::RandomAccessReservable, C>;
+
         /// \cond
         namespace detail
         {
@@ -102,35 +129,10 @@ namespace ranges
                         detail::is_lvalue_container_like(std::forward<T>(t))
                     ));
             };
-
-            struct Reservable : refines<LvalueContainerLike> {
-                template <class T>
-                using size_type = decltype(std::declval<const T&>().size());
-
-                template <class C>
-                auto requires_(C&& c) -> decltype(
-                    concepts::model_of<Integral, size_type<C>>(),
-                    concepts::valid_expr((c.reserve(c.size()), 42))
-                );
-            };
-
-            struct RandomAccessReservable : refines<Reservable> {
-                template <class C>
-                auto requires_(C&& c) -> decltype(
-                    concepts::model_of<RandomAccessIterator, decltype(begin(c))>()
-                );
-            };
         }
 
         template<typename T>
         using LvalueContainerLike = concepts::models<concepts::LvalueContainerLike, T>;
-
-        template <class C>
-        using Reservable = concepts::models<concepts::Reservable, C>;
-
-        template <class C>
-        using RandomAccessReservable = concepts::models<concepts::RandomAccessReservable, C>;
-
         /// @}
     }
 }

--- a/include/range/v3/action/concepts.hpp
+++ b/include/range/v3/action/concepts.hpp
@@ -102,10 +102,35 @@ namespace ranges
                         detail::is_lvalue_container_like(std::forward<T>(t))
                     ));
             };
+
+            struct Reservable : refines<LvalueContainerLike> {
+                template <class T>
+                using size_type = decltype(std::declval<const T&>().size());
+
+                template <class C>
+                auto requires_(C&& c) -> decltype(
+                    concepts::model_of<Integral, size_type<C>>(),
+                    concepts::valid_expr((c.reserve(c.size()), 42))
+                );
+            };
+
+            struct RandomAccessReservable : refines<Reservable> {
+                template <class C>
+                auto requires_(C&& c) -> decltype(
+                    concepts::model_of<RandomAccessIterator, decltype(begin(c))>()
+                );
+            };
         }
 
         template<typename T>
         using LvalueContainerLike = concepts::models<concepts::LvalueContainerLike, T>;
+
+        template <class C>
+        using Reservable = concepts::models<concepts::Reservable, C>;
+
+        template <class C>
+        using RandomAccessReservable = concepts::models<concepts::RandomAccessReservable, C>;
+
         /// @}
     }
 }

--- a/include/range/v3/action/insert.hpp
+++ b/include/range/v3/action/insert.hpp
@@ -85,6 +85,18 @@ namespace ranges
                 return unwrap_reference(cont).insert(p, C{i}, C{j});
             }
 
+            template<typename T, typename P, typename I, typename S,
+                typename C = common_iterator<I, S>,
+                typename CP = typename std::vector<T>::const_iterator,
+                CONCEPT_REQUIRES_(Convertible<P, CP>() && SizedIteratorRange<I, S>())>
+            auto insert(std::vector<T>& vec, P p, I i, S j) ->
+                decltype(vec.insert(begin(vec), C{i}, C{j}))
+            {
+                auto const index = CP(p) - vec.begin();
+                vec.reserve(vec.size() + (j - i));
+                return vec.insert(begin(vec) + index, C{i}, C{j});
+            }
+
             template<typename Cont, typename I, typename Rng,
                 typename C = range_common_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<I>() && Range<Rng>())>
@@ -92,6 +104,18 @@ namespace ranges
                 decltype(unwrap_reference(cont).insert(p, C{begin(rng)}, C{end(rng)}))
             {
                 return unwrap_reference(cont).insert(p, C{begin(rng)}, C{end(rng)});
+            }
+
+            template<typename T, typename I, typename Rng,
+                typename C = range_common_iterator_t<Rng>,
+                typename CI = typename std::vector<T>::const_iterator,
+                CONCEPT_REQUIRES_(Convertible<I, CI>() && SizedRange<Rng>())>
+            auto insert(std::vector<T>& vec, I p, Rng && rng) ->
+                decltype(vec.insert(begin(vec), C{begin(rng)}, C{end(rng)}))
+            {
+                auto const index = CI(p) - vec.begin();
+                vec.reserve(vec.size() + size(rng));
+                return vec.insert(begin(vec) + index, C{begin(rng)}, C{end(rng)});
             }
 
             struct insert_fn

--- a/include/range/v3/action/insert.hpp
+++ b/include/range/v3/action/insert.hpp
@@ -78,44 +78,44 @@ namespace ranges
 
             template<typename Cont, typename P, typename I, typename S,
                 typename C = common_iterator<I, S>,
-                CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<P>() && IteratorRange<I, S>())>
+                CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<P>() && IteratorRange<I, S>() &&
+                                  !(RandomAccessReservable<Cont>() && SizedIteratorRange<I, S>()))>
             auto insert(Cont && cont, P p, I i, S j) ->
                 decltype(unwrap_reference(cont).insert(p, C{i}, C{j}))
             {
                 return unwrap_reference(cont).insert(p, C{i}, C{j});
             }
 
-            template<typename T, typename A, typename P, typename I, typename S,
+            template<typename Cont, typename P, typename I, typename S,
                 typename C = common_iterator<I, S>,
-                typename CP = typename std::vector<T, A>::const_iterator,
-                CONCEPT_REQUIRES_(Convertible<P, CP>() && SizedIteratorRange<I, S>())>
-            auto insert(std::vector<T, A>& vec, P p, I i, S j) ->
-                decltype(vec.insert(begin(vec), C{i}, C{j}))
+                CONCEPT_REQUIRES_(RandomAccessReservable<Cont>() && Iterator<P>() && SizedIteratorRange<I, S>())>
+            auto insert(Cont && cont, P p, I i, S j) ->
+                decltype(unwrap_reference(cont).insert(begin(unwrap_reference(cont)), C{i}, C{j}))
             {
-                auto const index = CP(p) - vec.begin();
-                vec.reserve(vec.size() + (j - i));
-                return vec.insert(begin(vec) + index, C{i}, C{j});
+                auto const index = p - unwrap_reference(cont).begin();
+                unwrap_reference(cont).reserve(unwrap_reference(cont).size() + (j - i));
+                return unwrap_reference(cont).insert(begin(unwrap_reference(cont)) + index, C{i}, C{j});
             }
 
             template<typename Cont, typename I, typename Rng,
                 typename C = range_common_iterator_t<Rng>,
-                CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<I>() && Range<Rng>())>
+                CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<I>() && Range<Rng>() &&
+                                  !(RandomAccessReservable<Cont>() && SizedRange<Rng>()))>
             auto insert(Cont && cont, I p, Rng && rng) ->
                 decltype(unwrap_reference(cont).insert(p, C{begin(rng)}, C{end(rng)}))
             {
                 return unwrap_reference(cont).insert(p, C{begin(rng)}, C{end(rng)});
             }
 
-            template<typename T, typename A, typename I, typename Rng,
+            template<typename Cont, typename I, typename Rng,
                 typename C = range_common_iterator_t<Rng>,
-                typename CI = typename std::vector<T, A>::const_iterator,
-                CONCEPT_REQUIRES_(Convertible<I, CI>() && SizedRange<Rng>())>
-            auto insert(std::vector<T, A>& vec, I p, Rng && rng) ->
-                decltype(vec.insert(begin(vec), C{begin(rng)}, C{end(rng)}))
+                CONCEPT_REQUIRES_(RandomAccessReservable<Cont>() && SizedRange<Rng>())>
+            auto insert(Cont && cont, I p, Rng && rng) ->
+                decltype(unwrap_reference(cont).insert(begin(unwrap_reference(cont)), C{begin(rng)}, C{end(rng)}))
             {
-                auto const index = CI(p) - vec.begin();
-                vec.reserve(vec.size() + size(rng));
-                return vec.insert(begin(vec) + index, C{begin(rng)}, C{end(rng)});
+                auto const index = p - begin(unwrap_reference(cont));
+                unwrap_reference(cont).reserve(unwrap_reference(cont).size() + size(rng));
+                return unwrap_reference(cont).insert(begin(unwrap_reference(cont)) + index, C{begin(rng)}, C{end(rng)});
             }
 
             struct insert_fn

--- a/include/range/v3/action/insert.hpp
+++ b/include/range/v3/action/insert.hpp
@@ -85,11 +85,11 @@ namespace ranges
                 return unwrap_reference(cont).insert(p, C{i}, C{j});
             }
 
-            template<typename T, typename P, typename I, typename S,
+            template<typename T, typename A, typename P, typename I, typename S,
                 typename C = common_iterator<I, S>,
-                typename CP = typename std::vector<T>::const_iterator,
+                typename CP = typename std::vector<T, A>::const_iterator,
                 CONCEPT_REQUIRES_(Convertible<P, CP>() && SizedIteratorRange<I, S>())>
-            auto insert(std::vector<T>& vec, P p, I i, S j) ->
+            auto insert(std::vector<T, A>& vec, P p, I i, S j) ->
                 decltype(vec.insert(begin(vec), C{i}, C{j}))
             {
                 auto const index = CP(p) - vec.begin();
@@ -106,11 +106,11 @@ namespace ranges
                 return unwrap_reference(cont).insert(p, C{begin(rng)}, C{end(rng)});
             }
 
-            template<typename T, typename I, typename Rng,
+            template<typename T, typename A, typename I, typename Rng,
                 typename C = range_common_iterator_t<Rng>,
-                typename CI = typename std::vector<T>::const_iterator,
+                typename CI = typename std::vector<T, A>::const_iterator,
                 CONCEPT_REQUIRES_(Convertible<I, CI>() && SizedRange<Rng>())>
-            auto insert(std::vector<T>& vec, I p, Rng && rng) ->
+            auto insert(std::vector<T, A>& vec, I p, Rng && rng) ->
                 decltype(vec.insert(begin(vec), C{begin(rng)}, C{end(rng)}))
             {
                 auto const index = CI(p) - vec.begin();

--- a/include/range/v3/to_container.hpp
+++ b/include/range/v3/to_container.hpp
@@ -54,7 +54,8 @@ namespace ranges
                 template<typename Rng,
                     typename Cont = meta::apply<ContainerMetafunctionClass, range_value_t<Rng>>,
                     CONCEPT_REQUIRES_(Range<Rng>() && detail::ConvertibleToContainer<Rng, Cont>() &&
-                                      !(Reservable<Cont>() && SizedRange<Rng>()))>
+                                      !(ReserveAndAssignable<Cont, range_common_iterator_t<Rng>>() &&
+                                        SizedRange<Rng>()))>
                 Cont operator()(Rng && rng) const
                 {
                     static_assert(!is_infinite<Rng>::value,
@@ -66,7 +67,8 @@ namespace ranges
                 template<typename Rng,
                     typename Cont = meta::apply<ContainerMetafunctionClass, range_value_t<Rng>>,
                     CONCEPT_REQUIRES_(Range<Rng>() && detail::ConvertibleToContainer<Rng, Cont>() &&
-                                      Reservable<Cont>() && SizedRange<Rng>())>
+                                      ReserveAndAssignable<Cont, range_common_iterator_t<Rng>>() &&
+                                      SizedRange<Rng>())>
                 Cont operator()(Rng && rng) const
                 {
                     static_assert(!is_infinite<Rng>::value,
@@ -75,7 +77,7 @@ namespace ranges
 
                     Cont c;
                     c.reserve(size(rng));
-                    c.assign(I{begin(rng)}, I{end(rng)}); // FIXME: require assign
+                    c.assign(I{begin(rng)}, I{end(rng)});
                     return c;
                 }
             };

--- a/include/range/v3/to_container.hpp
+++ b/include/range/v3/to_container.hpp
@@ -20,6 +20,7 @@
 #include <range/v3/range_traits.hpp>
 #include <range/v3/utility/common_iterator.hpp>
 #include <range/v3/utility/static_const.hpp>
+#include <range/v3/action/concepts.hpp>
 
 #ifndef RANGES_NO_STD_FORWARD_DECLARATIONS
 // Non-portable forward declarations of standard containers
@@ -52,14 +53,30 @@ namespace ranges
             {
                 template<typename Rng,
                     typename Cont = meta::apply<ContainerMetafunctionClass, range_value_t<Rng>>,
-                    CONCEPT_REQUIRES_(Range<Rng>() && detail::ConvertibleToContainer<Rng, Cont>())>
+                    CONCEPT_REQUIRES_(Range<Rng>() && detail::ConvertibleToContainer<Rng, Cont>() &&
+                                      !(Reservable<Cont>() && SizedRange<Rng>()))>
                 Cont operator()(Rng && rng) const
                 {
                     static_assert(!is_infinite<Rng>::value,
                         "Attempt to convert an infinite range to a container.");
                     using I = range_common_iterator_t<Rng>;
-                    // BUGBUG size may be known here, even though I may be an InputIterator
                     return Cont{I{begin(rng)}, I{end(rng)}};
+                }
+
+                template<typename Rng,
+                    typename Cont = meta::apply<ContainerMetafunctionClass, range_value_t<Rng>>,
+                    CONCEPT_REQUIRES_(Range<Rng>() && detail::ConvertibleToContainer<Rng, Cont>() &&
+                                      Reservable<Cont>() && SizedRange<Rng>())>
+                Cont operator()(Rng && rng) const
+                {
+                    static_assert(!is_infinite<Rng>::value,
+                        "Attempt to convert an infinite range to a container.");
+                    using I = range_common_iterator_t<Rng>;
+
+                    Cont c;
+                    c.reserve(size(rng));
+                    c.assign(I{begin(rng)}, I{end(rng)}); // FIXME: require assign
+                    return c;
                 }
             };
         }


### PR DESCRIPTION
It's a special case and not a generic optimization, but `std::vector` is worth special-casing. (In response to [this SO question](http://stackoverflow.com/questions/30425417/how-to-write-a-range-v3-action-for-random-shuffle).)