### PR TITLE
(was #158) replace deprecated random_shuffle with shuffle

### DIFF
--- a/perf/counted_insertion_sort.cpp
+++ b/perf/counted_insertion_sort.cpp
@@ -12,6 +12,7 @@
 
 #include <chrono>
 #include <iostream>
+#include <random>
 #include <range/v3/all.hpp>
 
 class timer
@@ -121,10 +122,11 @@ std::unique_ptr<int> data(int i)
     return a;
 }
 
-void shuffle(int *a, int i)
+template<typename Gen>
+void shuffle(int *a, int i, Gen && rand)
 {
     auto rng = ranges::view::counted(a, i);
-    ranges::random_shuffle(rng);
+    rng |= ranges::action::shuffle(std::forward<Gen>(rand));
 }
 
 constexpr int cloops = 3;
@@ -132,11 +134,12 @@ constexpr int cloops = 3;
 template<typename I>
 void benchmark_n(int i)
 {
+    std::mt19937 gen;
     auto a = data(i);
     long ms = 0;
     for(int j = 0; j < cloops; ++j)
     {
-        ::shuffle(a.get(), i);
+        ::shuffle(a.get(), i, gen);
         timer t;
         insertion_sort_n(I{a.get()}, i);
         ms += t.elapsed().count();
@@ -147,11 +150,12 @@ void benchmark_n(int i)
 template<typename I>
 void benchmark_counted(int i)
 {
+    std::mt19937 gen;
     auto a = data(i);
     long ms = 0;
     for(int j = 0; j < cloops; ++j)
     {
-        ::shuffle(a.get(), i);
+        ::shuffle(a.get(), i, gen);
         timer t;
         insertion_sort(ranges::view::counted(I{a.get()}, i));
         ms += t.elapsed().count();

--- a/test/action/sort.cpp
+++ b/test/action/sort.cpp
@@ -8,16 +8,18 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 
 #include <array>
+#include <random>
 #include <vector>
 #include <range/v3/core.hpp>
 #include <range/v3/view/iota.hpp>
 #include <range/v3/view/stride.hpp>
 #include <range/v3/view/take.hpp>
-#include <range/v3/algorithm/random_shuffle.hpp>
+#include <range/v3/algorithm/shuffle.hpp>
 #include <range/v3/algorithm/copy.hpp>
 #include <range/v3/algorithm/move.hpp>
 #include <range/v3/algorithm/is_sorted.hpp>
 #include <range/v3/algorithm/equal.hpp>
+#include <range/v3/action/shuffle.hpp>
 #include <range/v3/action/sort.hpp>
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
@@ -25,9 +27,10 @@
 int main()
 {
     using namespace ranges;
+    std::mt19937 gen;
 
     std::vector<int> v = view::ints(0,100);
-    random_shuffle(v);
+    v |= action::shuffle(gen);
     CHECK(!is_sorted(v));
 
     auto v2 = v | copy | action::sort;
@@ -39,7 +42,7 @@ int main()
     v |= action::sort;
     CHECK(is_sorted(v));
 
-    random_shuffle(v);
+    v |= action::shuffle(gen);
     CHECK(!is_sorted(v));
 
     v = v | move | action::sort(std::less<int>());
@@ -48,7 +51,7 @@ int main()
 
     // Container algorithms can also be called directly
     // in which case they take and return by reference
-    random_shuffle(v);
+    shuffle(v, gen);
     CHECK(!is_sorted(v));
     auto & v3 = action::sort(v);
     CHECK(is_sorted(v));

--- a/test/action/unique.cpp
+++ b/test/action/unique.cpp
@@ -7,15 +7,17 @@
 //  file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 
+#include <random>
 #include <vector>
 #include <range/v3/core.hpp>
 #include <range/v3/view/iota.hpp>
 #include <range/v3/view/repeat_n.hpp>
 #include <range/v3/view/for_each.hpp>
 #include <range/v3/view/take.hpp>
-#include <range/v3/algorithm/random_shuffle.hpp>
+#include <range/v3/algorithm/shuffle.hpp>
 #include <range/v3/algorithm/equal.hpp>
 #include <range/v3/algorithm/is_sorted.hpp>
+#include <range/v3/action/shuffle.hpp>
 #include <range/v3/action/sort.hpp>
 #include <range/v3/action/unique.hpp>
 #include "../simple_test.hpp"
@@ -24,6 +26,7 @@
 int main()
 {
     using namespace ranges;
+    std::mt19937 gen;
 
     // [1,2,2,3,3,3,4,4,4,4,5,5,5,5,5,...]
     std::vector<int> v =
@@ -31,7 +34,7 @@ int main()
             return yield_from(view::repeat_n(i,i));
         });
     check_equal(view::take(v, 15), {1,2,2,3,3,3,4,4,4,4,5,5,5,5,5});
-    random_shuffle(v);
+    v |= action::shuffle(gen);
     CHECK(!is_sorted(v));
 
     v |= action::sort | action::unique;

--- a/test/algorithm/inplace_merge.cpp
+++ b/test/algorithm/inplace_merge.cpp
@@ -20,11 +20,14 @@
 
 #include <cassert>
 #include <algorithm>
+#include <random>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/inplace_merge.hpp>
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
+
+namespace { std::mt19937 gen; }
 
 template <class Iter, typename Sent = Iter>
 void
@@ -34,7 +37,7 @@ test_one_iter(unsigned N, unsigned M)
     int* ia = new int[N];
     for (unsigned i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::sort(ia, ia+M);
     std::sort(ia+M, ia+N);
     auto res = ranges::inplace_merge(Iter(ia), Iter(ia+M), Sent(ia+N));
@@ -56,7 +59,7 @@ test_one_rng(unsigned N, unsigned M)
     int* ia = new int[N];
     for (unsigned i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::sort(ia, ia+M);
     std::sort(ia+M, ia+N);
     auto res = ranges::inplace_merge(::as_lvalue(ranges::make_range(Iter(ia), Sent(ia+N))), Iter(ia+M));
@@ -68,7 +71,7 @@ test_one_rng(unsigned N, unsigned M)
         CHECK(std::is_sorted(ia, ia+N));
     }
 
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::sort(ia, ia+M);
     std::sort(ia+M, ia+N);
     auto res2 = ranges::inplace_merge(ranges::make_range(Iter(ia), Sent(ia+N)), Iter(ia+M));

--- a/test/algorithm/make_heap.cpp
+++ b/test/algorithm/make_heap.cpp
@@ -23,6 +23,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <memory>
+#include <random>
 #include <algorithm>
 #include <functional>
 #include <range/v3/core.hpp>
@@ -31,12 +32,14 @@
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
 
+namespace { std::mt19937 gen; }
+
 void test_1(int N)
 {
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     CHECK(ranges::make_heap(ia, ia+N) == ia+N);
     CHECK(std::is_heap(ia, ia+N));
     delete [] ia;
@@ -47,7 +50,7 @@ void test_2(int N)
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     CHECK(ranges::make_heap(ia, sentinel<int*>(ia+N)) == ia+N);
     CHECK(std::is_heap(ia, ia+N));
     delete [] ia;
@@ -58,11 +61,11 @@ void test_3(int N)
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     CHECK(ranges::make_heap(::as_lvalue(ranges::make_range(ia, ia+N))) == ia+N);
     CHECK(std::is_heap(ia, ia+N));
 
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     CHECK(ranges::make_heap(ranges::make_range(ia, ia+N)).get_unsafe() == ia+N);
     CHECK(std::is_heap(ia, ia+N));
 
@@ -74,11 +77,11 @@ void test_4(int N)
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     CHECK(ranges::make_heap(::as_lvalue(ranges::make_range(ia, sentinel<int*>(ia+N)))) == ia+N);
     CHECK(std::is_heap(ia, ia+N));
 
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     CHECK(ranges::make_heap(ranges::make_range(ia, sentinel<int*>(ia+N))).get_unsafe() == ia+N);
     CHECK(std::is_heap(ia, ia+N));
 
@@ -90,7 +93,7 @@ void test_5(int N)
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     CHECK(ranges::make_heap(ia, ia+N, std::greater<int>()) == ia+N);
     CHECK(std::is_heap(ia, ia+N, std::greater<int>()));
     delete [] ia;
@@ -101,7 +104,7 @@ void test_6(int N)
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     CHECK(ranges::make_heap(ia, sentinel<int*>(ia+N), std::greater<int>()) == ia+N);
     CHECK(std::is_heap(ia, ia+N, std::greater<int>()));
     delete [] ia;
@@ -112,11 +115,11 @@ void test_7(int N)
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     CHECK(ranges::make_heap(::as_lvalue(ranges::make_range(ia, ia+N)), std::greater<int>()) == ia+N);
     CHECK(std::is_heap(ia, ia+N, std::greater<int>()));
 
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     CHECK(ranges::make_heap(ranges::make_range(ia, ia+N), std::greater<int>()).get_unsafe() == ia+N);
     CHECK(std::is_heap(ia, ia+N, std::greater<int>()));
 
@@ -128,11 +131,11 @@ void test_8(int N)
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     CHECK(ranges::make_heap(::as_lvalue(ranges::make_range(ia, sentinel<int*>(ia+N))), std::greater<int>()) == ia+N);
     CHECK(std::is_heap(ia, ia+N, std::greater<int>()));
 
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     CHECK(ranges::make_heap(ranges::make_range(ia, sentinel<int*>(ia+N)), std::greater<int>()).get_unsafe() == ia+N);
     CHECK(std::is_heap(ia, ia+N, std::greater<int>()));
 
@@ -151,7 +154,7 @@ void test_9(int N)
     std::unique_ptr<int>* ia = new std::unique_ptr<int> [N];
     for (int i = 0; i < N; ++i)
         ia[i].reset(new int(i));
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     CHECK(ranges::make_heap(ia, ia+N, indirect_less()) == ia+N);
     CHECK(std::is_heap(ia, ia+N, indirect_less()));
     delete [] ia;
@@ -168,7 +171,7 @@ void test_10(int N)
     S* ib = new S [N];
     for (int i = 0; i < N; ++i)
         ib[i].i = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     CHECK(ranges::make_heap(ib, ib+N, std::less<int>(), &S::i) == ib+N);
     std::transform(ib, ib+N, ia, std::mem_fn(&S::i));
     CHECK(std::is_heap(ia, ia+N));

--- a/test/algorithm/max_element.cpp
+++ b/test/algorithm/max_element.cpp
@@ -20,12 +20,15 @@
 
 #include <memory>
 #include <numeric>
+#include <random>
 #include <algorithm>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/max_element.hpp>
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
+
+namespace { std::mt19937 gen; }
 
 template <class Iter, class Sent = Iter>
 void
@@ -66,7 +69,7 @@ test_iter(unsigned N)
 {
     std::unique_ptr<int[]> a{new int[N]};
     std::iota(a.get(), a.get()+N, 0);
-    std::random_shuffle(a.get(), a.get()+N);
+    std::shuffle(a.get(), a.get()+N, gen);
     test_iter(Iter(a.get()), Sent(a.get()+N));
 }
 
@@ -121,7 +124,7 @@ test_iter_comp(unsigned N)
 {
     std::unique_ptr<int[]> a{new int[N]};
     std::iota(a.get(), a.get()+N, 0);
-    std::random_shuffle(a.get(), a.get()+N);
+    std::shuffle(a.get(), a.get()+N, gen);
     test_iter_comp(Iter(a.get()), Sent(a.get()+N));
 }
 

--- a/test/algorithm/min_element.cpp
+++ b/test/algorithm/min_element.cpp
@@ -19,6 +19,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <memory>
+#include <random>
 #include <numeric>
 #include <algorithm>
 #include <range/v3/core.hpp>
@@ -26,6 +27,8 @@
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
+
+namespace { std::mt19937 gen; }
 
 template <class Iter, class Sent = Iter>
 void
@@ -66,7 +69,7 @@ test_iter(unsigned N)
 {
     std::unique_ptr<int[]> a{new int[N]};
     std::iota(a.get(), a.get()+N, 0);
-    std::random_shuffle(a.get(), a.get()+N);
+    std::shuffle(a.get(), a.get()+N, gen);
     test_iter(Iter(a.get()), Sent(a.get()+N));
 }
 
@@ -121,7 +124,7 @@ test_iter_comp(unsigned N)
 {
     std::unique_ptr<int[]> a{new int[N]};
     std::iota(a.get(), a.get()+N, 0);
-    std::random_shuffle(a.get(), a.get()+N);
+    std::shuffle(a.get(), a.get()+N, gen);
     test_iter_comp(Iter(a.get()), Sent(a.get()+N));
 }
 

--- a/test/algorithm/minmax_element.cpp
+++ b/test/algorithm/minmax_element.cpp
@@ -20,12 +20,15 @@
 
 #include <memory>
 #include <numeric>
+#include <random>
 #include <algorithm>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/minmax_element.hpp>
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
+
+namespace { std::mt19937 gen; }
 
 template <class Iter, class Sent = Iter>
 void
@@ -84,7 +87,7 @@ test_iter(unsigned N)
 {
     std::unique_ptr<int[]> a{new int[N]};
     std::iota(a.get(), a.get()+N, 0);
-    std::random_shuffle(a.get(), a.get()+N);
+    std::shuffle(a.get(), a.get()+N, gen);
     test_iter(Iter(a.get()), Sent(a.get()+N));
 }
 
@@ -102,7 +105,7 @@ test_iter()
         const unsigned N = 100;
         std::unique_ptr<int[]> a{new int[N]};
         std::fill_n(a.get(), N, 5);
-        std::random_shuffle(a.get(), a.get()+N);
+        std::shuffle(a.get(), a.get()+N, gen);
         std::pair<Iter, Iter> p = ranges::minmax_element(Iter(a.get()), Sent(a.get()+N));
         CHECK(base(p.first) == a.get());
         CHECK(base(p.second) == a.get()+N-1);
@@ -168,7 +171,7 @@ test_iter_comp(unsigned N)
 {
     std::unique_ptr<int[]> a{new int[N]};
     std::iota(a.get(), a.get()+N, 0);
-    std::random_shuffle(a.get(), a.get()+N);
+    std::shuffle(a.get(), a.get()+N, gen);
     test_iter_comp(Iter(a.get()), Sent(a.get()+N));
 }
 
@@ -186,7 +189,7 @@ test_iter_comp()
         const unsigned N = 100;
         std::unique_ptr<int[]> a{new int[N]};
         std::fill_n(a.get(), N, 5);
-        std::random_shuffle(a.get(), a.get()+N);
+        std::shuffle(a.get(), a.get()+N, gen);
         typedef std::greater<int> Compare;
         Compare comp;
         std::pair<Iter, Iter> p = ranges::minmax_element(Iter(a.get()), Sent(a.get()+N), comp);

--- a/test/algorithm/nth_element.cpp
+++ b/test/algorithm/nth_element.cpp
@@ -20,12 +20,15 @@
 
 #include <cassert>
 #include <memory>
+#include <random>
 #include <algorithm>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/nth_element.hpp>
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
+
+namespace { std::mt19937 gen; }
 
 void
 test_one(unsigned N, unsigned M)
@@ -35,13 +38,13 @@ test_one(unsigned N, unsigned M)
     std::unique_ptr<int[]> array{new int[N]};
     for (int i = 0; (unsigned)i < N; ++i)
         array[i] = i;
-    std::random_shuffle(array.get(), array.get()+N);
+    std::shuffle(array.get(), array.get()+N, gen);
     CHECK(ranges::nth_element(array.get(), array.get()+M, array.get()+N) == array.get()+N);
     CHECK((unsigned)array[M] == M);
-    std::random_shuffle(array.get(), array.get()+N);
+    std::shuffle(array.get(), array.get()+N, gen);
     CHECK(ranges::nth_element(::as_lvalue(ranges::make_range(array.get(), array.get()+N)), array.get()+M) == array.get()+N);
     CHECK((unsigned)array[M] == M);
-    std::random_shuffle(array.get(), array.get()+N);
+    std::shuffle(array.get(), array.get()+N, gen);
     CHECK(ranges::nth_element(ranges::make_range(array.get(), array.get()+N), array.get()+M).get_unsafe() == array.get()+N);
     CHECK((unsigned)array[M] == M);
     ranges::nth_element(array.get(), array.get()+N, array.get()+N); // begin, end, end
@@ -86,7 +89,7 @@ int main()
     S ia[N];
     for(int i = 0; i < N; ++i)
         ia[i].i = ia[i].j = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     ranges::nth_element(ia, ia+M, std::less<int>(), &S::i);
     CHECK(ia[M].i == M);
     CHECK(ia[M].j == M);

--- a/test/algorithm/partial_sort.cpp
+++ b/test/algorithm/partial_sort.cpp
@@ -20,6 +20,7 @@
 
 #include <cassert>
 #include <memory>
+#include <random>
 #include <algorithm>
 #include <vector>
 #include <range/v3/core.hpp>
@@ -27,6 +28,8 @@
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
+
+namespace { std::mt19937 gen; }
 
 struct indirect_less
 {
@@ -47,61 +50,61 @@ test_larger_sorts(int N, int M)
     using I = random_access_iterator<int*>;
     using S = sentinel<int*>;
 
-    std::random_shuffle(array, array+N);
+    std::shuffle(array, array+N, gen);
     int *res = ranges::partial_sort(array, array+M, array+N);
     CHECK(res == array+N);
     for(int i = 0; i < M; ++i)
         CHECK(array[i] == i);
 
-    std::random_shuffle(array, array+N);
+    std::shuffle(array, array+N, gen);
     I res2 = ranges::partial_sort(I{array}, I{array+M}, S{array+N});
     CHECK(res2.base() == array+N);
     for(int i = 0; i < M; ++i)
         CHECK(array[i] == i);
 
-    std::random_shuffle(array, array+N);
+    std::shuffle(array, array+N, gen);
     res = ranges::partial_sort(::as_lvalue(ranges::make_range(array, array+N)), array+M);
     CHECK(res == array+N);
     for(int i = 0; i < M; ++i)
         CHECK(array[i] == i);
 
-    std::random_shuffle(array, array+N);
+    std::shuffle(array, array+N, gen);
     res2 = ranges::partial_sort(::as_lvalue(ranges::make_range(I{array}, S{array+N})), I{array+M});
     CHECK(res2.base() == array+N);
     for(int i = 0; i < M; ++i)
         CHECK(array[i] == i);
 
-    std::random_shuffle(array, array+N);
+    std::shuffle(array, array+N, gen);
     auto res3 = ranges::partial_sort(ranges::make_range(array, array+N), array+M);
     CHECK(res3.get_unsafe() == array+N);
     for(int i = 0; i < M; ++i)
         CHECK(array[i] == i);
 
-    std::random_shuffle(array, array+N);
+    std::shuffle(array, array+N, gen);
     auto res4 = ranges::partial_sort(ranges::make_range(I{array}, S{array+N}), I{array+M});
     CHECK(res4.get_unsafe().base() == array+N);
     for(int i = 0; i < M; ++i)
         CHECK(array[i] == i);
 
-    std::random_shuffle(array, array+N);
+    std::shuffle(array, array+N, gen);
     res = ranges::partial_sort(array, array+M, array+N, std::greater<int>());
     CHECK(res == array+N);
     for(int i = 0; i < M; ++i)
         CHECK(array[i] == N-i-1);
 
-    std::random_shuffle(array, array+N);
+    std::shuffle(array, array+N, gen);
     res2 = ranges::partial_sort(I{array}, I{array+M}, S{array+N}, std::greater<int>());
     CHECK(res2.base() == array+N);
     for(int i = 0; i < M; ++i)
         CHECK(array[i] == N-i-1);
 
-    std::random_shuffle(array, array+N);
+    std::shuffle(array, array+N, gen);
     res = ranges::partial_sort(::as_lvalue(ranges::make_range(array, array+N)), array+M, std::greater<int>());
     CHECK(res == array+N);
     for(int i = 0; i < M; ++i)
         CHECK(array[i] == N-i-1);
 
-    std::random_shuffle(array, array+N);
+    std::shuffle(array, array+N, gen);
     res2 = ranges::partial_sort(::as_lvalue(ranges::make_range(I{array}, S{array+N})), I{array+M}, std::greater<int>());
     CHECK(res2.base() == array+N);
     for(int i = 0; i < M; ++i)

--- a/test/algorithm/partial_sort_copy.cpp
+++ b/test/algorithm/partial_sort_copy.cpp
@@ -20,6 +20,7 @@
 
 #include <cassert>
 #include <memory>
+#include <random>
 #include <vector>
 #include <algorithm>
 #include <range/v3/core.hpp>
@@ -27,6 +28,8 @@
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
+
+namespace { std::mt19937 gen; }
 
 template <class Iter>
 void
@@ -37,7 +40,7 @@ test_larger_sorts(int N, int M)
     int* output = new int[M];
     for (int i = 0; i < N; ++i)
         input[i] = i;
-    std::random_shuffle(input, input+N);
+    std::shuffle(input, input+N, gen);
     partial_sort_copy(Iter(input), Iter(input+N), output, output+M).check([&](int* r)
     {
         int* e = output + std::min(N, M);
@@ -45,7 +48,7 @@ test_larger_sorts(int N, int M)
         int i = 0;
         for (int* x = output; x < e; ++x, ++i)
             CHECK(*x == i);
-        std::random_shuffle(input, input+N);
+        std::shuffle(input, input+N, gen);
     });
     partial_sort_copy(Iter(input), Iter(input+N), output, output+M, std::greater<int>()).check([&](int* r)
     {
@@ -54,7 +57,7 @@ test_larger_sorts(int N, int M)
         int i = N-1;
         for (int* x = output; x < e; ++x, --i)
             CHECK(*x == i);
-        std::random_shuffle(input, input+N);
+        std::shuffle(input, input+N, gen);
     });
     delete [] output;
     delete [] input;
@@ -127,7 +130,7 @@ int main()
         U output[M];
         for (int i = 0; i < N; ++i)
             input[i].i = i;
-        std::random_shuffle(input, input+N);
+        std::shuffle(input, input+N, gen);
         U * r = ranges::partial_sort_copy(input, output, std::less<int>(), &S::i, &U::i);
         U* e = output + std::min(N, M);
         CHECK(r == e);
@@ -144,7 +147,7 @@ int main()
         U output[M];
         for (int i = 0; i < N; ++i)
             input[i].i = i;
-        std::random_shuffle(input, input+N);
+        std::shuffle(input, input+N, gen);
         auto r = ranges::partial_sort_copy(input, ranges::view::all(output), std::less<int>(), &S::i, &U::i);
         U* e = output + std::min(N, M);
         CHECK(r.get_unsafe() == e);

--- a/test/algorithm/pop_heap.cpp
+++ b/test/algorithm/pop_heap.cpp
@@ -23,6 +23,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <memory>
+#include <random>
 #include <algorithm>
 #include <functional>
 #include <range/v3/core.hpp>
@@ -31,12 +32,14 @@
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
 
+namespace { std::mt19937 gen; }
+
 void test_1(int N)
 {
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::make_heap(ia, ia+N);
     for (int i = N; i > 0; --i)
     {
@@ -52,7 +55,7 @@ void test_2(int N)
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::make_heap(ia, ia+N);
     for (int i = N; i > 0; --i)
     {
@@ -68,14 +71,14 @@ void test_3(int N)
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::make_heap(ia, ia+N);
     for (int i = N; i > 0; --i)
     {
         CHECK(ranges::pop_heap(::as_lvalue(ranges::make_range(ia, ia+i))) == ia+i);
         CHECK(std::is_heap(ia, ia+i-1));
     }
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::make_heap(ia, ia+N);
     for (int i = N; i > 0; --i)
     {
@@ -91,14 +94,14 @@ void test_4(int N)
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::make_heap(ia, ia+N);
     for (int i = N; i > 0; --i)
     {
         CHECK(ranges::pop_heap(::as_lvalue(ranges::make_range(ia, sentinel<int*>(ia+i)))) == ia+i);
         CHECK(std::is_heap(ia, ia+i-1));
     }
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::make_heap(ia, ia+N);
     for (int i = N; i > 0; --i)
     {
@@ -114,7 +117,7 @@ void test_5(int N)
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::make_heap(ia, ia+N, std::greater<int>());
     for (int i = N; i > 0; --i)
     {
@@ -130,7 +133,7 @@ void test_6(int N)
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::make_heap(ia, ia+N, std::greater<int>());
     for (int i = N; i > 0; --i)
     {
@@ -146,14 +149,14 @@ void test_7(int N)
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::make_heap(ia, ia+N, std::greater<int>());
     for (int i = N; i > 0; --i)
     {
         CHECK(ranges::pop_heap(::as_lvalue(ranges::make_range(ia, ia+i)), std::greater<int>()) == ia+i);
         CHECK(std::is_heap(ia, ia+i-1, std::greater<int>()));
     }
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::make_heap(ia, ia+N, std::greater<int>());
     for (int i = N; i > 0; --i)
     {
@@ -169,14 +172,14 @@ void test_8(int N)
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::make_heap(ia, ia+N, std::greater<int>());
     for (int i = N; i > 0; --i)
     {
         CHECK(ranges::pop_heap(::as_lvalue(ranges::make_range(ia, sentinel<int*>(ia+i))), std::greater<int>()) == ia+i);
         CHECK(std::is_heap(ia, ia+i-1, std::greater<int>()));
     }
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::make_heap(ia, ia+N, std::greater<int>());
     for (int i = N; i > 0; --i)
     {
@@ -199,7 +202,7 @@ void test_9(int N)
     std::unique_ptr<int>* ia = new std::unique_ptr<int> [N];
     for (int i = 0; i < N; ++i)
         ia[i].reset(new int(i));
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::make_heap(ia, ia+N, indirect_less());
     for (int i = N; i > 0; --i)
     {
@@ -230,7 +233,7 @@ void test_10(int N)
     S* ib = new S [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::make_heap(ia, ia+N);
     std::transform(ia, ia+N, ib, construct<S>());
     for (int i = N; i > 0; --i)

--- a/test/algorithm/push_heap.cpp
+++ b/test/algorithm/push_heap.cpp
@@ -31,6 +31,7 @@
 //   push_heap(Iter first, Iter last);
 
 #include <memory>
+#include <random>
 #include <algorithm>
 #include <functional>
 #include <range/v3/core.hpp>
@@ -39,6 +40,8 @@
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
 
+namespace { std::mt19937 gen; }
+
 void test(int N)
 {
     auto push_heap = make_testable_1(ranges::push_heap);
@@ -46,7 +49,7 @@ void test(int N)
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     for (int i = 0; i <= N; ++i)
     {
         push_heap(ia, ia+i).check([&](int *r){CHECK(r == ia + i);});
@@ -62,7 +65,7 @@ void test_comp(int N)
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     for (int i = 0; i <= N; ++i)
     {
         push_heap(ia, ia+i, std::greater<int>()).check([&](int *r){CHECK(r == ia+i);});
@@ -84,7 +87,7 @@ void test_proj(int N)
     int* ib = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i].i = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     for (int i = 0; i <= N; ++i)
     {
         push_heap(ia, ia+i, std::greater<int>(), &S::i).check([&](S *r){CHECK(r == ia+i);});
@@ -108,7 +111,7 @@ void test_move_only(int N)
     std::unique_ptr<int>* ia = new std::unique_ptr<int> [N];
     for (int i = 0; i < N; ++i)
         ia[i].reset(new int(i));
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     for (int i = 0; i <= N; ++i)
     {
         push_heap(ia, ia+i, indirect_less()).check([&](std::unique_ptr<int> *r){CHECK(r == ia+i);});
@@ -130,7 +133,7 @@ int main()
         int* ib = new int [N];
         for (int i = 0; i < N; ++i)
             ia[i].i = i;
-        std::random_shuffle(ia, ia+N);
+        std::shuffle(ia, ia+N, gen);
         for (int i = 0; i <= N; ++i)
         {
             CHECK(ranges::push_heap(ranges::make_range(ia, ia+i), std::greater<int>(), &S::i).get_unsafe() == ia+i);

--- a/test/algorithm/sort.cpp
+++ b/test/algorithm/sort.cpp
@@ -20,6 +20,7 @@
 
 #include <cassert>
 #include <memory>
+#include <random>
 #include <vector>
 #include <algorithm>
 #include <range/v3/core.hpp>
@@ -35,6 +36,8 @@
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
+
+namespace { std::mt19937 gen; }
 
 // BUGBUG
 namespace std
@@ -145,7 +148,7 @@ test_larger_sorts(int N, int M)
     CHECK(ranges::sort(array, array+N) == array+N);
     CHECK(std::is_sorted(array, array+N));
     // test random pattern
-    std::random_shuffle(array, array+N);
+    std::shuffle(array, array+N, gen);
     CHECK(ranges::sort(array, array+N) == array+N);
     CHECK(std::is_sorted(array, array+N));
     // test sorted pattern

--- a/test/algorithm/sort_heap.cpp
+++ b/test/algorithm/sort_heap.cpp
@@ -23,6 +23,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <memory>
+#include <random>
 #include <algorithm>
 #include <functional>
 #include <range/v3/core.hpp>
@@ -31,12 +32,14 @@
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
 
+namespace { std::mt19937 gen; }
+
 void test_1(int N)
 {
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::make_heap(ia, ia+N);
     CHECK(ranges::sort_heap(ia, ia+N) == ia+N);
     CHECK(std::is_sorted(ia, ia+N));
@@ -48,7 +51,7 @@ void test_2(int N)
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::make_heap(ia, ia+N);
     CHECK(ranges::sort_heap(ia, sentinel<int*>(ia+N)) == ia+N);
     CHECK(std::is_sorted(ia, ia+N));
@@ -60,7 +63,7 @@ void test_3(int N)
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::make_heap(ia, ia+N);
     CHECK(ranges::sort_heap(::as_lvalue(ranges::make_range(ia, ia+N))) == ia+N);
     CHECK(std::is_sorted(ia, ia+N));
@@ -72,7 +75,7 @@ void test_4(int N)
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::make_heap(ia, ia+N);
     CHECK(ranges::sort_heap(::as_lvalue(ranges::make_range(ia, sentinel<int*>(ia+N)))) == ia+N);
     CHECK(std::is_sorted(ia, ia+N));
@@ -84,7 +87,7 @@ void test_5(int N)
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::make_heap(ia, ia+N, std::greater<int>());
     CHECK(ranges::sort_heap(ia, ia+N, std::greater<int>()) == ia+N);
     CHECK(std::is_sorted(ia, ia+N, std::greater<int>()));
@@ -96,7 +99,7 @@ void test_6(int N)
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::make_heap(ia, ia+N, std::greater<int>());
     CHECK(ranges::sort_heap(ia, sentinel<int*>(ia+N), std::greater<int>()) == ia+N);
     CHECK(std::is_sorted(ia, ia+N, std::greater<int>()));
@@ -108,7 +111,7 @@ void test_7(int N)
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::make_heap(ia, ia+N, std::greater<int>());
     CHECK(ranges::sort_heap(::as_lvalue(ranges::make_range(ia, ia+N)), std::greater<int>()) == ia+N);
     CHECK(std::is_sorted(ia, ia+N, std::greater<int>()));
@@ -120,12 +123,12 @@ void test_8(int N)
     int* ia = new int [N];
     for (int i = 0; i < N; ++i)
         ia[i] = i;
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::make_heap(ia, ia+N, std::greater<int>());
     CHECK(ranges::sort_heap(::as_lvalue(ranges::make_range(ia, sentinel<int*>(ia+N))), std::greater<int>()) == ia+N);
     CHECK(std::is_sorted(ia, ia+N, std::greater<int>()));
 
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::make_heap(ia, ia+N, std::greater<int>());
     CHECK(ranges::sort_heap(ranges::make_range(ia, sentinel<int*>(ia+N)), std::greater<int>()).get_unsafe() == ia+N);
     CHECK(std::is_sorted(ia, ia+N, std::greater<int>()));
@@ -145,7 +148,7 @@ void test_9(int N)
     std::unique_ptr<int>* ia = new std::unique_ptr<int> [N];
     for (int i = 0; i < N; ++i)
         ia[i].reset(new int(i));
-    std::random_shuffle(ia, ia+N);
+    std::shuffle(ia, ia+N, gen);
     std::make_heap(ia, ia+N, indirect_less());
     CHECK(ranges::sort_heap(ia, ia+N, indirect_less()) == ia+N);
     CHECK(std::is_sorted(ia, ia+N, indirect_less()));
@@ -163,7 +166,7 @@ void test_10(int N)
     int* ib = new int [N];
     for (int i = 0; i < N; ++i)
         ib[i] = i;
-    std::random_shuffle(ib, ib+N);
+    std::shuffle(ib, ib+N, gen);
     std::make_heap(ib, ib+N);
     std::transform(ib, ib+N, ia, [](int i){return S{i};});
     CHECK(ranges::sort_heap(ia, ia+N, std::less<int>(), &S::i) == ia+N);

--- a/test/algorithm/stable_sort.cpp
+++ b/test/algorithm/stable_sort.cpp
@@ -20,6 +20,7 @@
 
 #include <cassert>
 #include <memory>
+#include <random>
 #include <vector>
 #include <algorithm>
 #include <range/v3/core.hpp>
@@ -27,6 +28,8 @@
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
+
+namespace { std::mt19937 gen; }
 
 struct indirect_less
 {
@@ -118,7 +121,7 @@ test_larger_sorts(int N, int M)
     CHECK(ranges::stable_sort(array, array+N) == array+N);
     CHECK(std::is_sorted(array, array+N));
     // test random pattern
-    std::random_shuffle(array, array+N);
+    std::shuffle(array, array+N, gen);
     CHECK(ranges::stable_sort(array, array+N) == array+N);
     CHECK(std::is_sorted(array, array+N));
     // test sorted pattern


### PR DESCRIPTION
including use of ranges::random_shuffle and std::random_shuffle
except for definition and unit tests for ranges::random_shuffle

include <random> in make_heap.cpp

include <random> in min_element.cpp