### PR TITLE
View fixes

### DIFF
--- a/example/calendar.cpp
+++ b/example/calendar.cpp
@@ -199,7 +199,7 @@ auto chunk(std::size_t n) {
 // Flattens a range of ranges by iterating the inner
 // ranges in round-robin fashion.
 template<class Rngs>
-class interleave_view : public range_facade<interleave_view<Rngs>> {
+class interleave_view : public view_facade<interleave_view<Rngs>> {
     friend range_access;
     std::vector<range_value_t<Rngs>> rngs_;
     struct cursor;

--- a/example/calendar.cpp
+++ b/example/calendar.cpp
@@ -152,7 +152,7 @@ auto layout_months() {
 // Out: Range<Range<T>>, where each inner range has $n$ elements.
 //                       The last range may have fewer.
 template<class Rng>
-class chunk_view : public range_adaptor<chunk_view<Rng>, Rng> {
+class chunk_view : public view_adaptor<chunk_view<Rng>, Rng> {
     CONCEPT_ASSERT(ForwardRange<Rng>());
     std::size_t n_;
     friend range_access;
@@ -163,7 +163,7 @@ class chunk_view : public range_adaptor<chunk_view<Rng>, Rng> {
 public:
     chunk_view() = default;
     chunk_view(Rng rng, std::size_t n)
-      : range_adaptor_t<chunk_view>(std::move(rng)), n_(n)
+      : view_adaptor_t<chunk_view>(std::move(rng)), n_(n)
     {}
 };
 

--- a/example/recursive_range.hpp
+++ b/example/recursive_range.hpp
@@ -29,7 +29,7 @@
 #include <range/v3/size.hpp>
 #include <range/v3/range.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/range_interface.hpp>
+#include <range/v3/view_interface.hpp>
 #include <range/v3/utility/concepts.hpp>
 #include <range/v3/utility/optional.hpp>
 #include <range/v3/view/any_range.hpp>
@@ -50,7 +50,7 @@ namespace ranges
             std::function<any_input_range<int>()> fun_;
 
             struct impl
-              : range_interface<impl>
+              : view_interface<impl>
             {
             private:
                 friend recursive_range_fn;

--- a/include/range/v3/core.hpp
+++ b/include/range/v3/core.hpp
@@ -18,7 +18,7 @@
 #include <range/v3/distance.hpp>
 #include <range/v3/empty.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/range_facade.hpp>
+#include <range/v3/view_facade.hpp>
 #include <range/v3/range_adaptor.hpp>
 #include <range/v3/range_access.hpp>
 #include <range/v3/view_interface.hpp>

--- a/include/range/v3/core.hpp
+++ b/include/range/v3/core.hpp
@@ -21,7 +21,7 @@
 #include <range/v3/range_facade.hpp>
 #include <range/v3/range_adaptor.hpp>
 #include <range/v3/range_access.hpp>
-#include <range/v3/range_interface.hpp>
+#include <range/v3/view_interface.hpp>
 #include <range/v3/range_for.hpp>
 #include <range/v3/at.hpp>
 #include <range/v3/back.hpp>

--- a/include/range/v3/core.hpp
+++ b/include/range/v3/core.hpp
@@ -19,7 +19,7 @@
 #include <range/v3/empty.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/view_facade.hpp>
-#include <range/v3/range_adaptor.hpp>
+#include <range/v3/view_adaptor.hpp>
 #include <range/v3/range_access.hpp>
 #include <range/v3/view_interface.hpp>
 #include <range/v3/range_for.hpp>

--- a/include/range/v3/getlines.hpp
+++ b/include/range/v3/getlines.hpp
@@ -17,7 +17,7 @@
 #include <string>
 #include <istream>
 #include <range/v3/range_fwd.hpp>
-#include <range/v3/range_facade.hpp>
+#include <range/v3/view_facade.hpp>
 #include <range/v3/utility/static_const.hpp>
 
 namespace ranges
@@ -27,7 +27,7 @@ namespace ranges
         /// \addtogroup group-core
         /// @{
         struct getlines_range
-          : range_facade<getlines_range, unknown>
+          : view_facade<getlines_range, unknown>
         {
         private:
             friend range_access;

--- a/include/range/v3/istream_range.hpp
+++ b/include/range/v3/istream_range.hpp
@@ -16,7 +16,7 @@
 
 #include <istream>
 #include <range/v3/range_fwd.hpp>
-#include <range/v3/range_facade.hpp>
+#include <range/v3/view_facade.hpp>
 #include <range/v3/utility/semiregular.hpp>
 
 namespace ranges
@@ -27,7 +27,7 @@ namespace ranges
         /// @{
         template<typename Val>
         struct istream_range
-          : range_facade<istream_range<Val>, unknown>
+          : view_facade<istream_range<Val>, unknown>
         {
         private:
             friend range_access;

--- a/include/range/v3/range.hpp
+++ b/include/range/v3/range.hpp
@@ -18,7 +18,7 @@
 #include <type_traits>
 #include <meta/meta.hpp>
 #include <range/v3/range_fwd.hpp>
-#include <range/v3/range_interface.hpp>
+#include <range/v3/view_interface.hpp>
 #include <range/v3/utility/concepts.hpp>
 #include <range/v3/utility/iterator.hpp>
 #include <range/v3/utility/compressed_pair.hpp>
@@ -45,7 +45,7 @@ namespace ranges
         template<typename I, typename S /*= I*/>
         struct range
           : private compressed_pair<I, S>
-          , range_interface<range<I, S>>
+          , view_interface<range<I, S>>
         {
             using iterator = I;
             using sentinel = S;
@@ -105,7 +105,7 @@ namespace ranges
         template<typename I, typename S /* = I */>
         struct sized_range
           : private compressed_pair<I const, S const>
-          , range_interface<sized_range<I, S>>
+          , view_interface<sized_range<I, S>>
         {
         private:
             template<typename X, typename Y>

--- a/include/range/v3/range_access.hpp
+++ b/include/range/v3/range_access.hpp
@@ -269,9 +269,9 @@ namespace ranges
                 using type = typename RangeFacade::view_facade_t;
             };
             template<typename RangeAdaptor>
-            struct range_adaptor
+            struct view_adaptor
             {
-                using type = typename RangeAdaptor::range_adaptor_t;
+                using type = typename RangeAdaptor::view_adaptor_t;
             };
             /// endcond
         };

--- a/include/range/v3/range_access.hpp
+++ b/include/range/v3/range_access.hpp
@@ -264,9 +264,9 @@ namespace ranges
                 using type = typename RangeAdaptor::base_range_t const;
             };
             template<typename RangeFacade>
-            struct range_facade
+            struct view_facade
             {
-                using type = typename RangeFacade::range_facade_t;
+                using type = typename RangeFacade::view_facade_t;
             };
             template<typename RangeAdaptor>
             struct range_adaptor

--- a/include/range/v3/range_adaptor.hpp
+++ b/include/range/v3/range_adaptor.hpp
@@ -17,7 +17,7 @@
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/size.hpp>
 #include <range/v3/distance.hpp>
-#include <range/v3/range_facade.hpp>
+#include <range/v3/view_facade.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/utility/concepts.hpp>
 #include <range/v3/utility/iterator_concepts.hpp>
@@ -356,7 +356,7 @@ namespace ranges
 
         template<typename Derived, typename BaseRng, cardinality Cardinality /*= range_cardinality<BaseRng>::value*/>
         struct range_adaptor
-          : range_facade<Derived, Cardinality>
+          : view_facade<Derived, Cardinality>
         {
         private:
             friend Derived;
@@ -364,7 +364,7 @@ namespace ranges
             friend adaptor_base;
             using range_adaptor_t = range_adaptor;
             using base_range_t = view::all_t<BaseRng>;
-            using range_facade<Derived, Cardinality>::derived;
+            using view_facade<Derived, Cardinality>::derived;
             // Mutable here. Const-correctness is enforced below by disabling
             // begin_cursor/end_cursor if "BaseRng const" does not model
             // the View concept.
@@ -399,7 +399,7 @@ namespace ranges
             }
             // Const-correctness is enforced here by only allowing these if the base range
             // has const begin/end accessors. That disables the const begin()/end() accessors
-            // in range_facade, meaning the derived range type only has mutable iterators.
+            // in view_facade, meaning the derived range type only has mutable iterators.
             template<typename D = Derived,
                 CONCEPT_REQUIRES_(Same<D, Derived>() && View<base_range_t const>())>
             adaptor_cursor_t<D const> begin_cursor() const

--- a/include/range/v3/range_facade.hpp
+++ b/include/range/v3/range_facade.hpp
@@ -18,7 +18,7 @@
 #include <meta/meta.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_access.hpp>
-#include <range/v3/range_interface.hpp>
+#include <range/v3/view_interface.hpp>
 #include <range/v3/utility/concepts.hpp>
 #include <range/v3/utility/iterator_traits.hpp>
 #include <range/v3/utility/basic_iterator.hpp>
@@ -64,12 +64,12 @@ namespace ranges
 
         template<typename Derived, cardinality Cardinality>
         struct range_facade
-          : range_interface<Derived, Cardinality>
+          : view_interface<Derived, Cardinality>
         {
         protected:
             friend range_access;
             using range_facade_t = range_facade;
-            using range_interface<Derived, Cardinality>::derived;
+            using view_interface<Derived, Cardinality>::derived;
             // Default implementations
             Derived begin_cursor() const
             {

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -340,7 +340,7 @@ namespace ranges
         template<typename Derived,
                  typename BaseRng,
                  cardinality C = range_cardinality<BaseRng>::value>
-        struct range_adaptor;
+        struct view_adaptor;
 
         template<typename I, typename S>
         using common_iterator =

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -335,7 +335,7 @@ namespace ranges
         {};
 
         template<typename Derived, cardinality C = finite>
-        struct range_facade;
+        struct view_facade;
 
         template<typename Derived,
                  typename BaseRng,

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -355,7 +355,7 @@ namespace ranges
         struct as_function_fn;
 
         template<typename Derived, cardinality = finite>
-        struct range_interface;
+        struct view_interface;
 
         template<typename T>
         struct istream_range;

--- a/include/range/v3/utility/common_iterator.hpp
+++ b/include/range/v3/utility/common_iterator.hpp
@@ -16,7 +16,7 @@
 #include <type_traits>
 #include <meta/meta.hpp>
 #include <range/v3/range_fwd.hpp>
-#include <range/v3/range_facade.hpp>
+#include <range/v3/view_facade.hpp>
 #include <range/v3/utility/concepts.hpp>
 #include <range/v3/utility/variant.hpp>
 

--- a/include/range/v3/view/adjacent_remove_if.hpp
+++ b/include/range/v3/view/adjacent_remove_if.hpp
@@ -18,7 +18,7 @@
 #include <meta/meta.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
-#include <range/v3/range_adaptor.hpp>
+#include <range/v3/view_adaptor.hpp>
 #include <range/v3/utility/iterator.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/semiregular.hpp>
@@ -34,7 +34,7 @@ namespace ranges
         /// @{
         template<typename Rng, typename F>
         struct adjacent_remove_if_view
-          : range_adaptor<
+          : view_adaptor<
                 adjacent_remove_if_view<Rng, F>,
                 Rng,
                 is_finite<Rng>::value ? finite : range_cardinality<Rng>::value>
@@ -72,7 +72,7 @@ namespace ranges
         public:
             adjacent_remove_if_view() = default;
             adjacent_remove_if_view(Rng rng, F pred)
-              : range_adaptor_t<adjacent_remove_if_view>{std::move(rng)}
+              : view_adaptor_t<adjacent_remove_if_view>{std::move(rng)}
               , pred_(as_function(std::move(pred)))
             {}
         };

--- a/include/range/v3/view/any_range.hpp
+++ b/include/range/v3/view/any_range.hpp
@@ -21,7 +21,7 @@
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/range_facade.hpp>
+#include <range/v3/view_facade.hpp>
 #include <range/v3/view/all.hpp>
 
 namespace ranges
@@ -229,7 +229,7 @@ namespace ranges
         /// \ingroup group-views
         template<typename Ref>
         struct any_input_range
-          : range_facade<any_input_range<Ref>, unknown>
+          : view_facade<any_input_range<Ref>, unknown>
         {
         private:
             friend range_access;

--- a/include/range/v3/view/any_range.hpp
+++ b/include/range/v3/view/any_range.hpp
@@ -190,17 +190,17 @@ namespace ranges
             };
 
             template<typename Ref>
-            struct any_input_range_interface
+            struct any_input_view_interface
             {
-                virtual ~any_input_range_interface() {}
+                virtual ~any_input_view_interface() {}
                 virtual any_input_cursor<Ref> begin_cursor() const = 0;
                 virtual any_input_sentinel<Ref> end_cursor() const = 0;
-                virtual any_input_range_interface *clone() const = 0;
+                virtual any_input_view_interface *clone() const = 0;
             };
 
             template<typename Rng>
             struct any_input_range_impl
-              : any_input_range_interface<range_reference_t<Rng>>
+              : any_input_view_interface<range_reference_t<Rng>>
             {
             private:
                 Rng rng_;
@@ -217,7 +217,7 @@ namespace ranges
                 {
                     return {rng_, end_tag{}};
                 }
-                any_input_range_interface<range_reference_t<Rng>> *clone() const override
+                any_input_view_interface<range_reference_t<Rng>> *clone() const override
                 {
                     return new any_input_range_impl<Rng>{rng_};
                 }
@@ -233,7 +233,7 @@ namespace ranges
         {
         private:
             friend range_access;
-            std::unique_ptr<detail::any_input_range_interface<Ref>> ptr_;
+            std::unique_ptr<detail::any_input_view_interface<Ref>> ptr_;
             detail::any_input_cursor<Ref> begin_cursor() const
             {
                 return ptr_->begin_cursor();

--- a/include/range/v3/view/bounded.hpp
+++ b/include/range/v3/view/bounded.hpp
@@ -19,7 +19,7 @@
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/range_interface.hpp>
+#include <range/v3/view_interface.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/iterator_concepts.hpp>
 #include <range/v3/utility/common_iterator.hpp>
@@ -36,7 +36,7 @@ namespace ranges
 
         template<typename Rng>
         struct bounded_view
-          : range_interface<bounded_view<Rng>, range_cardinality<Rng>::value>
+          : view_interface<bounded_view<Rng>, range_cardinality<Rng>::value>
         {
         private:
             friend range_access;

--- a/include/range/v3/view/chunk.hpp
+++ b/include/range/v3/view/chunk.hpp
@@ -23,7 +23,7 @@
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/range_adaptor.hpp>
+#include <range/v3/view_adaptor.hpp>
 #include <range/v3/view/all.hpp>
 #include <range/v3/view/view.hpp>
 #include <range/v3/view/take.hpp>
@@ -38,7 +38,7 @@ namespace ranges
         /// @{
         template<typename Rng>
         struct chunk_view
-          : range_adaptor<
+          : view_adaptor<
                 chunk_view<Rng>,
                 Rng,
                 is_finite<Rng>::value ? finite : range_cardinality<Rng>::value>
@@ -60,7 +60,7 @@ namespace ranges
         public:
             chunk_view() = default;
             chunk_view(Rng rng, range_difference_t<Rng> n)
-              : range_adaptor_t<chunk_view>(std::move(rng)), n_(n)
+              : view_adaptor_t<chunk_view>(std::move(rng)), n_(n)
             {
                 RANGES_ASSERT(0 < n_);
             }

--- a/include/range/v3/view/concat.hpp
+++ b/include/range/v3/view/concat.hpp
@@ -23,7 +23,7 @@
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/range_facade.hpp>
+#include <range/v3/view_facade.hpp>
 #include <range/v3/utility/variant.hpp>
 #include <range/v3/utility/iterator.hpp>
 #include <range/v3/utility/functional.hpp>
@@ -66,7 +66,7 @@ namespace ranges
         /// @{
         template<typename...Rngs>
         struct concat_view
-          : range_facade<concat_view<Rngs...>,
+          : view_facade<concat_view<Rngs...>,
                 meta::fold<
                     meta::list<range_cardinality<Rngs>...>,
                     std::integral_constant<cardinality, static_cast<cardinality>(0)>,

--- a/include/range/v3/view/const.hpp
+++ b/include/range/v3/view/const.hpp
@@ -20,7 +20,7 @@
 #include <range/v3/size.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/range_adaptor.hpp>
+#include <range/v3/view_adaptor.hpp>
 #include <range/v3/utility/move.hpp>
 #include <range/v3/utility/common_type.hpp>
 #include <range/v3/utility/functional.hpp>
@@ -36,7 +36,7 @@ namespace ranges
         /// @{
         template<typename Rng>
         struct const_view
-          : range_adaptor<const_view<Rng>, Rng>
+          : view_adaptor<const_view<Rng>, Rng>
         {
         private:
             friend range_access;
@@ -69,7 +69,7 @@ namespace ranges
         public:
             const_view() = default;
             explicit const_view(Rng rng)
-              : range_adaptor_t<const_view>{std::move(rng)}
+              : view_adaptor_t<const_view>{std::move(rng)}
             {}
             CONCEPT_REQUIRES(SizedRange<Rng>())
             range_size_t<Rng> size() const

--- a/include/range/v3/view/counted.hpp
+++ b/include/range/v3/view/counted.hpp
@@ -15,7 +15,7 @@
 
 #include <utility>
 #include <range/v3/range_fwd.hpp>
-#include <range/v3/range_facade.hpp>
+#include <range/v3/view_facade.hpp>
 #include <range/v3/range.hpp>
 #include <range/v3/utility/iterator.hpp>
 #include <range/v3/utility/iterator_traits.hpp>
@@ -31,7 +31,7 @@ namespace ranges
         /// @{
         template<typename I, typename D /* = iterator_difference_t<I>*/>
         struct counted_view
-          : range_facade<counted_view<I, D>, finite>
+          : view_facade<counted_view<I, D>, finite>
         {
         private:
             friend range_access;

--- a/include/range/v3/view/delimit.hpp
+++ b/include/range/v3/view/delimit.hpp
@@ -17,7 +17,7 @@
 #include <meta/meta.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/range_adaptor.hpp>
+#include <range/v3/view_adaptor.hpp>
 #include <range/v3/range.hpp>
 #include <range/v3/utility/unreachable.hpp>
 #include <range/v3/utility/iterator_concepts.hpp>
@@ -34,7 +34,7 @@ namespace ranges
         /// @{
         template<typename Rng, typename Val>
         struct delimit_view
-          : range_adaptor<delimit_view<Rng, Val>, Rng, is_finite<Rng>::value ? finite : unknown>
+          : view_adaptor<delimit_view<Rng, Val>, Rng, is_finite<Rng>::value ? finite : unknown>
         {
         private:
             friend range_access;
@@ -60,7 +60,7 @@ namespace ranges
         public:
             delimit_view() = default;
             delimit_view(Rng rng, Val value)
-              : range_adaptor_t<delimit_view>{std::move(rng)}
+              : view_adaptor_t<delimit_view>{std::move(rng)}
               , value_(std::move(value))
             {}
         };

--- a/include/range/v3/view/drop.hpp
+++ b/include/range/v3/view/drop.hpp
@@ -19,7 +19,7 @@
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/range_interface.hpp>
+#include <range/v3/view_interface.hpp>
 #include <range/v3/range.hpp>
 #include <range/v3/utility/box.hpp>
 #include <range/v3/utility/optional.hpp>
@@ -37,7 +37,7 @@ namespace ranges
         /// @{
         template<typename Rng>
         struct drop_view
-          : range_interface<drop_view<Rng>, is_finite<Rng>::value ? finite : range_cardinality<Rng>::value>
+          : view_interface<drop_view<Rng>, is_finite<Rng>::value ? finite : range_cardinality<Rng>::value>
           , private meta::if_<
                 RandomAccessRange<Rng>,
                 meta::nil_,

--- a/include/range/v3/view/drop_while.hpp
+++ b/include/range/v3/view/drop_while.hpp
@@ -20,7 +20,7 @@
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/range_interface.hpp>
+#include <range/v3/view_interface.hpp>
 #include <range/v3/utility/optional.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/semiregular.hpp>
@@ -37,7 +37,7 @@ namespace ranges
         /// @{
         template<typename Rng, typename Pred>
         struct drop_while_view
-          : range_interface<drop_while_view<Rng, Pred>, is_finite<Rng>::value ? finite : unknown>
+          : view_interface<drop_while_view<Rng, Pred>, is_finite<Rng>::value ? finite : unknown>
        {
         private:
             friend range_access;

--- a/include/range/v3/view/empty.hpp
+++ b/include/range/v3/view/empty.hpp
@@ -15,7 +15,7 @@
 #define RANGES_V3_VIEW_EMPTY_HPP
 
 #include <range/v3/range_fwd.hpp>
-#include <range/v3/range_facade.hpp>
+#include <range/v3/view_facade.hpp>
 
 namespace ranges
 {
@@ -23,7 +23,7 @@ namespace ranges
     {
         template<typename T>
         struct empty_view
-          : range_facade<empty_view<T>, (cardinality)0>
+          : view_facade<empty_view<T>, (cardinality)0>
         {
         private:
             friend range_access;

--- a/include/range/v3/view/generate.hpp
+++ b/include/range/v3/view/generate.hpp
@@ -21,7 +21,7 @@
 #include <range/v3/size.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_traits.hpp>
-#include <range/v3/range_facade.hpp>
+#include <range/v3/view_facade.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/optional.hpp>
 #include <range/v3/utility/semiregular.hpp>
@@ -35,7 +35,7 @@ namespace ranges
         /// @{
         template<typename G>
         struct generate_view
-          : range_facade<generate_view<G>, infinite>
+          : view_facade<generate_view<G>, infinite>
         {
         private:
             friend struct range_access;

--- a/include/range/v3/view/generate_n.hpp
+++ b/include/range/v3/view/generate_n.hpp
@@ -21,7 +21,7 @@
 #include <range/v3/size.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_traits.hpp>
-#include <range/v3/range_facade.hpp>
+#include <range/v3/view_facade.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/optional.hpp>
 #include <range/v3/utility/static_const.hpp>
@@ -34,7 +34,7 @@ namespace ranges
         /// @{
         template<typename G>
         struct generate_n_view
-          : range_facade<generate_n_view<G>, finite>
+          : view_facade<generate_n_view<G>, finite>
         {
         private:
             friend struct range_access;

--- a/include/range/v3/view/group_by.hpp
+++ b/include/range/v3/view/group_by.hpp
@@ -22,7 +22,7 @@
 #include <range/v3/range.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/range_facade.hpp>
+#include <range/v3/view_facade.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/semiregular.hpp>
 #include <range/v3/utility/static_const.hpp>
@@ -38,7 +38,7 @@ namespace ranges
         /// @{
         template<typename Rng, typename Fun>
         struct group_by_view
-          : range_facade<
+          : view_facade<
                 group_by_view<Rng, Fun>,
                 is_finite<Rng>::value ? finite : range_cardinality<Rng>::value>
         {

--- a/include/range/v3/view/indirect.hpp
+++ b/include/range/v3/view/indirect.hpp
@@ -21,7 +21,7 @@
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/begin_end.hpp>
-#include <range/v3/range_adaptor.hpp>
+#include <range/v3/view_adaptor.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/static_const.hpp>
 #include <range/v3/view/view.hpp>
@@ -34,7 +34,7 @@ namespace ranges
         /// @{
         template<typename Rng>
         struct indirect_view
-          : range_adaptor<indirect_view<Rng>, Rng>
+          : view_adaptor<indirect_view<Rng>, Rng>
         {
         private:
             friend range_access;
@@ -63,7 +63,7 @@ namespace ranges
         public:
             indirect_view() = default;
             explicit indirect_view(Rng rng)
-              : range_adaptor_t<indirect_view>{std::move(rng)}
+              : view_adaptor_t<indirect_view>{std::move(rng)}
             {}
             CONCEPT_REQUIRES(SizedRange<Rng>())
             range_size_t<Rng> size() const

--- a/include/range/v3/view/intersperse.hpp
+++ b/include/range/v3/view/intersperse.hpp
@@ -24,7 +24,7 @@
 #include <range/v3/size.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/range_adaptor.hpp>
+#include <range/v3/view_adaptor.hpp>
 #include <range/v3/utility/iterator.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/static_const.hpp>
@@ -38,7 +38,7 @@ namespace ranges
         /// @{
         template<typename Rng>
         struct intersperse_view
-          : range_adaptor<
+          : view_adaptor<
                 intersperse_view<Rng>,
                 Rng,
                 (range_cardinality<Rng>::value > 0) ?
@@ -126,7 +126,7 @@ namespace ranges
         public:
             intersperse_view() = default;
             intersperse_view(Rng rng, range_value_t<Rng> val)
-              : range_adaptor_t<intersperse_view>{std::move(rng)}, val_(std::move(val))
+              : view_adaptor_t<intersperse_view>{std::move(rng)}, val_(std::move(val))
             {}
             CONCEPT_REQUIRES(SizedRange<Rng>())
             range_size_t<Rng> size() const

--- a/include/range/v3/view/iota.hpp
+++ b/include/range/v3/view/iota.hpp
@@ -21,7 +21,7 @@
 #include <meta/meta.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/range_facade.hpp>
+#include <range/v3/view_facade.hpp>
 #include <range/v3/utility/concepts.hpp>
 #include <range/v3/utility/static_const.hpp>
 #include <range/v3/view/take_exactly.hpp>
@@ -158,7 +158,7 @@ namespace ranges
         /// An iota view in a closed range with non-random access iota value type
         template<typename From, typename To /* = From */>
         struct closed_iota_view
-          : range_facade<closed_iota_view<From, To>, finite>
+          : view_facade<closed_iota_view<From, To>, finite>
         {
         private:
             friend range_access;
@@ -213,7 +213,7 @@ namespace ranges
 
         template<typename From, typename To /* = void*/>
         struct iota_view
-          : range_facade<iota_view<From, To>, finite>
+          : view_facade<iota_view<From, To>, finite>
         {
         private:
             friend range_access;
@@ -264,7 +264,7 @@ namespace ranges
 
         template<typename From>
         struct iota_view<From, void>
-          : range_facade<iota_view<From, void>, infinite>
+          : view_facade<iota_view<From, void>, infinite>
         {
         private:
             using incrementable_concept_t = ranges::incrementable_concept<From>;

--- a/include/range/v3/view/join.hpp
+++ b/include/range/v3/view/join.hpp
@@ -23,7 +23,7 @@
 #include <range/v3/begin_end.hpp>
 #include <range/v3/empty.hpp>
 #include <range/v3/range_traits.hpp>
-#include <range/v3/range_adaptor.hpp>
+#include <range/v3/view_adaptor.hpp>
 #include <range/v3/view/transform.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/static_const.hpp>
@@ -58,7 +58,7 @@ namespace ranges
         // Join a range of ranges
         template<typename Rng>
         struct join_view<Rng, void>
-          : range_adaptor<join_view<Rng, void>, Rng,
+          : view_adaptor<join_view<Rng, void>, Rng,
                 detail::join_cardinality<
                     range_cardinality<Rng>,
                     range_cardinality<range_value_t<Rng>>>::value>
@@ -156,7 +156,7 @@ namespace ranges
         public:
             join_view() = default;
             explicit join_view(Rng rng)
-              : range_adaptor_t<join_view>{std::move(rng)}, cur_{}
+              : view_adaptor_t<join_view>{std::move(rng)}, cur_{}
             {}
             CONCEPT_REQUIRES(range_cardinality<Rng>::value >= 0 && SizedRange<range_value_t<Rng>>())
             constexpr size_t_ size() const
@@ -170,7 +170,7 @@ namespace ranges
         // Join a range of ranges, inserting a range of values between them.
         template<typename Rng, typename ValRng>
         struct join_view
-          : range_adaptor<join_view<Rng, ValRng>, Rng,
+          : view_adaptor<join_view<Rng, ValRng>, Rng,
                 detail::join_cardinality<
                     range_cardinality<Rng>,
                     range_cardinality<range_value_t<Rng>>,
@@ -297,7 +297,7 @@ namespace ranges
         public:
             join_view() = default;
             join_view(Rng rng, ValRng val)
-              : range_adaptor_t<join_view>{std::move(rng)}
+              : view_adaptor_t<join_view>{std::move(rng)}
               , cur_{}, val_(std::move(val))
             {}
             CONCEPT_REQUIRES(range_cardinality<Rng>::value >= 0 &&

--- a/include/range/v3/view/move.hpp
+++ b/include/range/v3/view/move.hpp
@@ -20,7 +20,7 @@
 #include <range/v3/size.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_traits.hpp>
-#include <range/v3/range_adaptor.hpp>
+#include <range/v3/view_adaptor.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/static_const.hpp>
@@ -35,7 +35,7 @@ namespace ranges
         /// @{
         template<typename Rng>
         struct move_view
-          : range_adaptor<move_view<Rng>, Rng>
+          : view_adaptor<move_view<Rng>, Rng>
         {
         private:
             friend range_access;
@@ -62,7 +62,7 @@ namespace ranges
         public:
             move_view() = default;
             explicit move_view(Rng rng)
-              : range_adaptor_t<move_view>{std::move(rng)}
+              : view_adaptor_t<move_view>{std::move(rng)}
             {}
             CONCEPT_REQUIRES(SizedRange<Rng>())
             range_size_t<Rng> size() const

--- a/include/range/v3/view/partial_sum.hpp
+++ b/include/range/v3/view/partial_sum.hpp
@@ -25,7 +25,7 @@
 #include <range/v3/front.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_traits.hpp>
-#include <range/v3/range_adaptor.hpp>
+#include <range/v3/view_adaptor.hpp>
 #include <range/v3/utility/optional.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/semiregular.hpp>
@@ -41,7 +41,7 @@ namespace ranges
         /// @{
         template<typename Rng, typename Fun>
         struct partial_sum_view
-          : range_adaptor<partial_sum_view<Rng, Fun>, Rng>
+          : view_adaptor<partial_sum_view<Rng, Fun>, Rng>
         {
         private:
             friend range_access;
@@ -109,7 +109,7 @@ namespace ranges
         public:
             partial_sum_view() = default;
             partial_sum_view(Rng rng, Fun fun)
-              : range_adaptor_t<partial_sum_view>{std::move(rng)}
+              : view_adaptor_t<partial_sum_view>{std::move(rng)}
               , fun_(as_function(std::move(fun)))
             {}
             CONCEPT_REQUIRES(SizedRange<Rng>())

--- a/include/range/v3/view/remove_if.hpp
+++ b/include/range/v3/view/remove_if.hpp
@@ -20,7 +20,7 @@
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_traits.hpp>
-#include <range/v3/range_adaptor.hpp>
+#include <range/v3/view_adaptor.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/utility/optional.hpp>
 #include <range/v3/utility/functional.hpp>
@@ -37,7 +37,7 @@ namespace ranges
         /// @{
         template<typename Rng, typename Pred>
         struct remove_if_view
-          : range_adaptor<
+          : view_adaptor<
                 remove_if_view<Rng, Pred>,
                 Rng,
                 is_finite<Rng>::value ? finite : range_cardinality<Rng>::value>
@@ -97,30 +97,30 @@ namespace ranges
         public:
             remove_if_view() = default;
             remove_if_view(remove_if_view &&that)
-              : range_adaptor_t<remove_if_view>(std::move(that))
+              : view_adaptor_t<remove_if_view>(std::move(that))
               , pred_(std::move(that).pred_)
               , begin_{}
             {}
             remove_if_view(remove_if_view const &that)
-              : range_adaptor_t<remove_if_view>(that)
+              : view_adaptor_t<remove_if_view>(that)
               , pred_(that.pred_)
               , begin_{}
             {}
             remove_if_view(Rng rng, Pred pred)
-              : range_adaptor_t<remove_if_view>{std::move(rng)}
+              : view_adaptor_t<remove_if_view>{std::move(rng)}
               , pred_(as_function(std::move(pred)))
               , begin_{}
             {}
             remove_if_view& operator=(remove_if_view &&that)
             {
-                this->range_adaptor_t<remove_if_view>::operator=(std::move(that));
+                this->view_adaptor_t<remove_if_view>::operator=(std::move(that));
                 pred_ = std::move(that).pred_;
                 begin_.reset();
                 return *this;
             }
             remove_if_view& operator=(remove_if_view const &that)
             {
-                this->range_adaptor_t<remove_if_view>::operator=(that);
+                this->view_adaptor_t<remove_if_view>::operator=(that);
                 pred_ = that.pred_;
                 begin_.reset();
                 return *this;

--- a/include/range/v3/view/repeat.hpp
+++ b/include/range/v3/view/repeat.hpp
@@ -16,7 +16,7 @@
 
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/range_facade.hpp>
+#include <range/v3/view_facade.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/static_const.hpp>
 
@@ -36,7 +36,7 @@ namespace ranges
         //    semantics.
         template<typename Val>
         struct repeat_view
-          : range_facade<repeat_view<Val>, infinite>
+          : view_facade<repeat_view<Val>, infinite>
         {
         private:
             Val value_;

--- a/include/range/v3/view/repeat_n.hpp
+++ b/include/range/v3/view/repeat_n.hpp
@@ -16,7 +16,7 @@
 
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/range_facade.hpp>
+#include <range/v3/view_facade.hpp>
 #include <range/v3/utility/static_const.hpp>
 
 namespace ranges
@@ -35,7 +35,7 @@ namespace ranges
         //    semantics.
         template<typename Val>
         struct repeat_n_view
-          : range_facade<repeat_n_view<Val>, finite>
+          : view_facade<repeat_n_view<Val>, finite>
         {
         private:
             friend range_access;

--- a/include/range/v3/view/reverse.hpp
+++ b/include/range/v3/view/reverse.hpp
@@ -21,7 +21,7 @@
 #include <range/v3/size.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_traits.hpp>
-#include <range/v3/range_adaptor.hpp>
+#include <range/v3/view_adaptor.hpp>
 #include <range/v3/utility/static_const.hpp>
 #include <range/v3/view/view.hpp>
 
@@ -33,7 +33,7 @@ namespace ranges
         /// @{
         template<typename Rng>
         struct reverse_view
-          : range_adaptor<reverse_view<Rng>, Rng>
+          : view_adaptor<reverse_view<Rng>, Rng>
         {
         private:
             CONCEPT_ASSERT(BidirectionalRange<Rng>());
@@ -100,7 +100,7 @@ namespace ranges
         public:
             reverse_view() = default;
             reverse_view(Rng rng)
-              : range_adaptor_t<reverse_view>{std::move(rng)}
+              : view_adaptor_t<reverse_view>{std::move(rng)}
             {}
             CONCEPT_REQUIRES(SizedRange<Rng>())
             range_size_t<Rng> size() const

--- a/include/range/v3/view/single.hpp
+++ b/include/range/v3/view/single.hpp
@@ -20,7 +20,7 @@
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/range_traits.hpp>
-#include <range/v3/range_facade.hpp>
+#include <range/v3/view_facade.hpp>
 #include <range/v3/utility/iterator_concepts.hpp>
 #include <range/v3/utility/iterator_traits.hpp>
 #include <range/v3/utility/static_const.hpp>
@@ -33,7 +33,7 @@ namespace ranges
         /// @{
         template<typename Val>
         struct single_view
-          : range_facade<single_view<Val>, (cardinality)1>
+          : view_facade<single_view<Val>, (cardinality)1>
         {
         private:
             friend struct range_access;

--- a/include/range/v3/view/slice.hpp
+++ b/include/range/v3/view/slice.hpp
@@ -19,7 +19,7 @@
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/range_interface.hpp>
+#include <range/v3/view_interface.hpp>
 #include <range/v3/range.hpp>
 #include <range/v3/utility/optional.hpp>
 #include <range/v3/utility/functional.hpp>
@@ -140,7 +140,7 @@ namespace ranges
 
             template<typename Rng>
             struct slice_view_<Rng, true>
-              : range_interface<slice_view<Rng>, finite>
+              : view_interface<slice_view<Rng>, finite>
             {
             private:
                 using difference_type_ = range_difference_t<Rng>;

--- a/include/range/v3/view/slice.hpp
+++ b/include/range/v3/view/slice.hpp
@@ -73,7 +73,7 @@ namespace ranges
 
             template<typename Rng, bool IsRandomAccess = RandomAccessRange<Rng>()>
             struct slice_view_
-              : range_facade<slice_view<Rng>, finite>
+              : view_facade<slice_view<Rng>, finite>
             {
             private:
                 friend range_access;

--- a/include/range/v3/view/split.hpp
+++ b/include/range/v3/view/split.hpp
@@ -22,7 +22,7 @@
 #include <range/v3/range.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/range_facade.hpp>
+#include <range/v3/view_facade.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/semiregular.hpp>
 #include <range/v3/utility/static_const.hpp>
@@ -41,7 +41,7 @@ namespace ranges
         /// @{
         template<typename Rng, typename Fun>
         struct split_view
-          : range_facade<
+          : view_facade<
                 split_view<Rng, Fun>,
                 is_finite<Rng>::value ? finite : range_cardinality<Rng>::value>
         {

--- a/include/range/v3/view/stride.hpp
+++ b/include/range/v3/view/stride.hpp
@@ -24,7 +24,7 @@
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/range_adaptor.hpp>
+#include <range/v3/view_adaptor.hpp>
 #include <range/v3/utility/box.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/iterator.hpp>
@@ -40,7 +40,7 @@ namespace ranges
         /// @{
         template<typename Rng>
         struct stride_view
-          : range_adaptor<
+          : view_adaptor<
                 stride_view<Rng>,
                 Rng,
                 is_finite<Rng>::value ? finite : range_cardinality<Rng>::value>
@@ -155,7 +155,7 @@ namespace ranges
         public:
             stride_view() = default;
             stride_view(Rng rng, difference_type_ stride)
-              : range_adaptor_t<stride_view>{std::move(rng)}
+              : view_adaptor_t<stride_view>{std::move(rng)}
               , stride_(stride)
             {
                 RANGES_ASSERT(0 < stride_);

--- a/include/range/v3/view/tail.hpp
+++ b/include/range/v3/view/tail.hpp
@@ -22,7 +22,7 @@
 #include <range/v3/size.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/range_interface.hpp>
+#include <range/v3/view_interface.hpp>
 #include <range/v3/utility/iterator.hpp>
 #include <range/v3/utility/static_const.hpp>
 #include <range/v3/view/all.hpp>
@@ -36,7 +36,7 @@ namespace ranges
         /// @{
         template<typename Rng>
         struct tail_view
-          : range_interface<
+          : view_interface<
                 tail_view<Rng>,
                 (range_cardinality<Rng>::value > 0) ?
                     (cardinality)(range_cardinality<Rng>::value - 1) :

--- a/include/range/v3/view/take.hpp
+++ b/include/range/v3/view/take.hpp
@@ -18,7 +18,7 @@
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/range_interface.hpp>
+#include <range/v3/view_interface.hpp>
 #include <range/v3/utility/static_const.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/view/take_exactly.hpp>

--- a/include/range/v3/view/take.hpp
+++ b/include/range/v3/view/take.hpp
@@ -30,7 +30,7 @@ namespace ranges
     {
         template<typename Rng>
         struct take_view
-          : range_facade<take_view<Rng>, finite>
+          : view_facade<take_view<Rng>, finite>
         {
         private:
             friend range_access;

--- a/include/range/v3/view/take_exactly.hpp
+++ b/include/range/v3/view/take_exactly.hpp
@@ -18,7 +18,7 @@
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/range_interface.hpp>
+#include <range/v3/view_interface.hpp>
 #include <range/v3/range.hpp>
 #include <range/v3/utility/iterator_traits.hpp>
 #include <range/v3/utility/counted_iterator.hpp>
@@ -81,7 +81,7 @@ namespace ranges
 
             template<typename Rng>
             struct take_exactly_view_<Rng, true>
-              : range_interface<take_exactly_view<Rng>, finite>
+              : view_interface<take_exactly_view<Rng>, finite>
             {
             private:
                 using difference_type_ = range_difference_t<Rng>;

--- a/include/range/v3/view/take_exactly.hpp
+++ b/include/range/v3/view/take_exactly.hpp
@@ -36,7 +36,7 @@ namespace ranges
         {
             template<typename Rng, bool IsRandomAccess = RandomAccessRange<Rng>()>
             struct take_exactly_view_
-              : range_facade<take_exactly_view<Rng>, finite>
+              : view_facade<take_exactly_view<Rng>, finite>
             {
             private:
                 friend range_access;

--- a/include/range/v3/view/take_while.hpp
+++ b/include/range/v3/view/take_while.hpp
@@ -20,7 +20,7 @@
 #include <meta/meta.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/range_adaptor.hpp>
+#include <range/v3/view_adaptor.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/semiregular.hpp>
 #include <range/v3/utility/iterator_concepts.hpp>
@@ -35,7 +35,7 @@ namespace ranges
         /// @{
         template<typename Rng, typename Pred>
         struct iter_take_while_view
-          : range_adaptor<
+          : view_adaptor<
                 iter_take_while_view<Rng, Pred>,
                 Rng,
                 is_finite<Rng>::value ? finite : unknown>
@@ -72,7 +72,7 @@ namespace ranges
         public:
             iter_take_while_view() = default;
             iter_take_while_view(Rng rng, Pred pred)
-              : range_adaptor_t<iter_take_while_view>{std::move(rng)}
+              : view_adaptor_t<iter_take_while_view>{std::move(rng)}
               , pred_(as_function(std::move(pred)))
             {}
         };

--- a/include/range/v3/view/tokenize.hpp
+++ b/include/range/v3/view/tokenize.hpp
@@ -20,7 +20,7 @@
 #include <type_traits>
 #include <initializer_list>
 #include <range/v3/range_fwd.hpp>
-#include <range/v3/range_interface.hpp>
+#include <range/v3/view_interface.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/utility/functional.hpp>
@@ -35,7 +35,7 @@ namespace ranges
         /// @{
         template<typename Rng, typename Regex, typename SubMatchRange>
         struct tokenize_view
-          : range_interface<
+          : view_interface<
                 tokenize_view<Rng, Regex, SubMatchRange>,
                 is_finite<Rng>::value ? finite : range_cardinality<Rng>::value>
         {

--- a/include/range/v3/view/transform.hpp
+++ b/include/range/v3/view/transform.hpp
@@ -23,7 +23,7 @@
 #include <range/v3/size.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_traits.hpp>
-#include <range/v3/range_adaptor.hpp>
+#include <range/v3/view_adaptor.hpp>
 #include <range/v3/utility/move.hpp>
 #include <range/v3/utility/semiregular.hpp>
 #include <range/v3/utility/optional.hpp>
@@ -41,7 +41,7 @@ namespace ranges
         /// @{
         template<typename Rng, typename Fun>
         struct iter_transform_view
-          : range_adaptor<iter_transform_view<Rng, Fun>, Rng>
+          : view_adaptor<iter_transform_view<Rng, Fun>, Rng>
         {
         private:
             friend range_access;
@@ -95,7 +95,7 @@ namespace ranges
         public:
             iter_transform_view() = default;
             iter_transform_view(Rng rng, Fun fun)
-              : range_adaptor_t<iter_transform_view>{std::move(rng)}
+              : view_adaptor_t<iter_transform_view>{std::move(rng)}
               , fun_(as_function(std::move(fun)))
             {}
             CONCEPT_REQUIRES(SizedRange<Rng>())

--- a/include/range/v3/view/unbounded.hpp
+++ b/include/range/v3/view/unbounded.hpp
@@ -13,7 +13,7 @@
 #define RANGES_V3_VIEW_UNBOUNDED_HPP
 
 #include <range/v3/range_fwd.hpp>
-#include <range/v3/range_interface.hpp>
+#include <range/v3/view_interface.hpp>
 #include <range/v3/utility/unreachable.hpp>
 #include <range/v3/utility/static_const.hpp>
 
@@ -25,7 +25,7 @@ namespace ranges
         /// @{
         template<typename I>
         struct unbounded_view
-          : range_interface<unbounded_view<I>, infinite>
+          : view_interface<unbounded_view<I>, infinite>
         {
         private:
             I it_;

--- a/include/range/v3/view/zip_with.hpp
+++ b/include/range/v3/view/zip_with.hpp
@@ -24,7 +24,7 @@
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/range_facade.hpp>
+#include <range/v3/view_facade.hpp>
 #include <range/v3/utility/iterator.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/semiregular.hpp>
@@ -123,7 +123,7 @@ namespace ranges
         /// @{
         template<typename Fun, typename...Rngs>
         struct iter_zip_with_view
-          : range_facade<
+          : view_facade<
                 iter_zip_with_view<Fun, Rngs...>,
                 meta::fold<
                     meta::list<range_cardinality<Rngs>...>,

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -10,8 +10,8 @@
 //
 // Project home: https://github.com/ericniebler/range-v3
 //
-#ifndef RANGES_V3_RANGE_ADAPTOR_HPP
-#define RANGES_V3_RANGE_ADAPTOR_HPP
+#ifndef RANGES_V3_VIEW_ADAPTOR_HPP
+#define RANGES_V3_VIEW_ADAPTOR_HPP
 
 #include <meta/meta.hpp>
 #include <range/v3/range_fwd.hpp>
@@ -82,7 +82,7 @@ namespace ranges
         using base_range_t = meta::eval<range_access::base_range<Derived>>;
 
         template<typename Derived>
-        using range_adaptor_t = meta::eval<range_access::range_adaptor<Derived>>;
+        using view_adaptor_t = meta::eval<range_access::view_adaptor<Derived>>;
 
         template<typename BaseIt, typename Adapt>
         struct adaptor_cursor;
@@ -355,14 +355,14 @@ namespace ranges
                 adaptor_sentinel<detail::adapted_sentinel_t<D>, detail::end_adaptor_t<D>>>;
 
         template<typename Derived, typename BaseRng, cardinality Cardinality /*= range_cardinality<BaseRng>::value*/>
-        struct range_adaptor
+        struct view_adaptor
           : view_facade<Derived, Cardinality>
         {
         private:
             friend Derived;
             friend range_access;
             friend adaptor_base;
-            using range_adaptor_t = range_adaptor;
+            using view_adaptor_t = view_adaptor;
             using base_range_t = view::all_t<BaseRng>;
             using view_facade<Derived, Cardinality>::derived;
             // Mutable here. Const-correctness is enforced below by disabling
@@ -417,8 +417,8 @@ namespace ranges
                 return {std::move(pos), std::move(adapt)};
             }
         public:
-            range_adaptor() = default;
-            constexpr range_adaptor(BaseRng && rng)
+            view_adaptor() = default;
+            constexpr view_adaptor(BaseRng && rng)
               : rng_(view::all(detail::forward<BaseRng>(rng)))
             {}
             base_range_t & base()

--- a/include/range/v3/view_facade.hpp
+++ b/include/range/v3/view_facade.hpp
@@ -10,8 +10,8 @@
 //
 // Project home: https://github.com/ericniebler/range-v3
 //
-#ifndef RANGES_V3_RANGE_FACADE_HPP
-#define RANGES_V3_RANGE_FACADE_HPP
+#ifndef RANGES_V3_VIEW_FACADE_HPP
+#define RANGES_V3_VIEW_FACADE_HPP
 
 #include <utility>
 #include <type_traits>
@@ -63,12 +63,12 @@ namespace ranges
         };
 
         template<typename Derived, cardinality Cardinality>
-        struct range_facade
+        struct view_facade
           : view_interface<Derived, Cardinality>
         {
         protected:
             friend range_access;
-            using range_facade_t = range_facade;
+            using view_facade_t = view_facade;
             using view_interface<Derived, Cardinality>::derived;
             // Default implementations
             Derived begin_cursor() const
@@ -105,7 +105,7 @@ namespace ranges
         };
 
         template<typename RangeFacade>
-        using range_facade_t = meta::eval<range_access::range_facade<RangeFacade>>;
+        using view_facade_t = meta::eval<range_access::view_facade<RangeFacade>>;
 
         /// @}
     }

--- a/include/range/v3/view_interface.hpp
+++ b/include/range/v3/view_interface.hpp
@@ -10,8 +10,8 @@
 //
 // Project home: https://github.com/ericniebler/range-v3
 //
-#ifndef RANGES_V3_RANGE_INTERFACE_HPP
-#define RANGES_V3_RANGE_INTERFACE_HPP
+#ifndef RANGES_V3_VIEW_INTERFACE_HPP
+#define RANGES_V3_VIEW_INTERFACE_HPP
 
 #include <iosfwd>
 #include <meta/meta.hpp>
@@ -61,7 +61,7 @@ namespace ranges
         /// \addtogroup group-core
         /// @{
         template<typename Derived, cardinality Cardinality /* = finite*/>
-        struct range_interface
+        struct view_interface
           : basic_view<Cardinality>
         {
         protected:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,8 +17,8 @@ add_test(test.container_conversion container_conversion)
 add_executable(constexpr_core constexpr_core.cpp)
 add_test(test.constexpr_core constexpr_core)
 
-add_executable(range_facade range_facade.cpp)
-add_test(test.range_facade range_facade)
+add_executable(view_facade view_facade.cpp)
+add_test(test.view_facade view_facade)
 
 add_executable(range_adaptor range_adaptor.cpp)
 add_test(test.range_adaptor range_adaptor)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,8 +20,8 @@ add_test(test.constexpr_core constexpr_core)
 add_executable(view_facade view_facade.cpp)
 add_test(test.view_facade view_facade)
 
-add_executable(range_adaptor range_adaptor.cpp)
-add_test(test.range_adaptor range_adaptor)
+add_executable(view_adaptor view_adaptor.cpp)
+add_test(test.view_adaptor view_adaptor)
 
 add_executable(range range.cpp)
 add_test(test.range range)

--- a/test/view/zip.cpp
+++ b/test/view/zip.cpp
@@ -216,7 +216,7 @@ int main()
         CONCEPT_ASSERT(Same<range_reference_t<Zipped>, common_tuple<int &&> >());
     }
 
-    // This is actually a test of the logic of range_adaptor. Since the stride view
+    // This is actually a test of the logic of view_adaptor. Since the stride view
     // does not redefine the current member function, the base range's indirect_move
     // function gets picked up automatically.
     {

--- a/test/view_adaptor.cpp
+++ b/test/view_adaptor.cpp
@@ -19,7 +19,7 @@
 
 template<typename BidiRange>
 struct my_reverse_view
-  : ranges::range_adaptor<my_reverse_view<BidiRange>, BidiRange>
+  : ranges::view_adaptor<my_reverse_view<BidiRange>, BidiRange>
 {
 private:
     CONCEPT_ASSERT(ranges::BidirectionalRange<BidiRange>());
@@ -71,15 +71,15 @@ private:
         return {};
     }
 public:
-    using ranges::range_adaptor_t<my_reverse_view>::range_adaptor_t;
+    using ranges::view_adaptor_t<my_reverse_view>::view_adaptor_t;
 };
 
 struct my_delimited_range
-  : ranges::range_adaptor<
+  : ranges::view_adaptor<
         my_delimited_range,
         ranges::delimit_view<ranges::istream_range<int>, int>>
 {
-    using range_adaptor_t::range_adaptor_t;
+    using view_adaptor_t::view_adaptor_t;
 };
 
 int main()

--- a/test/view_facade.cpp
+++ b/test/view_facade.cpp
@@ -15,7 +15,7 @@
 #include "./test_utils.hpp"
 
 struct MyRange
-  : ranges::range_facade<MyRange>
+  : ranges::view_facade<MyRange>
 {
 private:
     friend struct ranges::range_access;


### PR DESCRIPTION
Partially addresses #164 - future work will (hopefully) separate the view-specific functionality from the generic range functionality. range-v3 doesn't contain any containers - see what I did there? - but it would be nice to have generic range functionality that makes it easy to write containers that integrate well with the library.

Note that I added range_interface into the renaming since it inherits basic_view.