### PR TITLE
Fix reference type bugs in Function, AdjacentDifferentiable, and PartialSummable

### DIFF
--- a/include/range/v3/numeric/adjacent_difference.hpp
+++ b/include/range/v3/numeric/adjacent_difference.hpp
@@ -40,8 +40,8 @@ namespace ranges
             WeakOutputIterator<O, Y>,
             Callable<P, V>,
             Callable<BOp, X, X>,
-            CopyConstructible<X>,
-            MoveAssignable<X>>;
+            CopyConstructible<uncvref_t<X>>,
+            MoveAssignable<uncvref_t<X>>>;
 
         struct adjacent_difference_fn
         {

--- a/include/range/v3/numeric/partial_sum.hpp
+++ b/include/range/v3/numeric/partial_sum.hpp
@@ -35,9 +35,9 @@ namespace ranges
             InputIterator<I>,
             WeakOutputIterator<O, X>,
             Callable<P, V>,
-            CopyConstructible<X>,
+            CopyConstructible<uncvref_t<X>>,
             Callable<BOp, X, X>,
-            Assignable<X &, Y>>;
+            Assignable<uncvref_t<X> &, Y>>;
 
         struct partial_sum_fn
         {

--- a/include/range/v3/utility/concepts.hpp
+++ b/include/range/v3/utility/concepts.hpp
@@ -542,7 +542,6 @@ namespace ranges
             };
 
             struct Function
-              : refines<Destructible(_1), CopyConstructible(_1)>
             {
                 template<typename Fun, typename ...Args>
                 using result_t = decltype(val<Fun>()(val<Args>()...));
@@ -552,6 +551,8 @@ namespace ranges
                     typename UnCvRefFun = meta::eval<std::remove_cv<UnRefFun>>>
                 auto requires_(Fun&& fun, Args&&... args) -> decltype(
                     concepts::valid_expr(
+                        concepts::model_of<Destructible, UnCvRefFun>(),
+                        concepts::model_of<CopyConstructible, UnCvRefFun>(),
                         concepts::has_type<UnRefFun *>(&fun),
                         concepts::has_type<UnCvRefFun *>(new UnCvRefFun(fun)),
                         (delete new UnCvRefFun(fun), 42),


### PR DESCRIPTION
All three of these mis-apply a constraint to what may be an lvalue reference type which they actually intend to apply to the underlying value type.