### PR TITLE
Update Concepts for decomposition design

### DIFF
--- a/include/range/v3/action/concepts.hpp
+++ b/include/range/v3/action/concepts.hpp
@@ -53,7 +53,7 @@ namespace ranges
                 template<typename T>
                 auto requires_(T&&) -> decltype(
                     concepts::valid_expr(
-                        concepts::model_of<DefaultConstructible, uncvref_t<T>>(),
+                        concepts::model_of<Constructible, uncvref_t<T>>(),
                         concepts::model_of<Movable, uncvref_t<T>>(),
                         concepts::is_false(is_view<T>())
                     ));

--- a/include/range/v3/numeric/accumulate.hpp
+++ b/include/range/v3/numeric/accumulate.hpp
@@ -34,7 +34,7 @@ namespace ranges
             InputIterator<I>,
             Callable<P, V>,
             Callable<Op, T, X>,
-            Assignable<T &, Y>>;
+            Assignable<T, Y>>;
 
         struct accumulate_fn
         {

--- a/include/range/v3/numeric/adjacent_difference.hpp
+++ b/include/range/v3/numeric/adjacent_difference.hpp
@@ -41,7 +41,7 @@ namespace ranges
             Callable<P, V>,
             Callable<BOp, X, X>,
             CopyConstructible<uncvref_t<X>>,
-            MoveAssignable<uncvref_t<X>>>;
+            Movable<uncvref_t<X>>>;
 
         struct adjacent_difference_fn
         {

--- a/include/range/v3/numeric/inner_product.hpp
+++ b/include/range/v3/numeric/inner_product.hpp
@@ -43,7 +43,7 @@ namespace ranges
             Callable<P2, V2>,
             Callable<BOp2, X1, X2>,
             Callable<BOp1, T, Y2>,
-            Assignable<T &, Y2>>;
+            Assignable<T, Y2>>;
 
         struct inner_product_fn
         {

--- a/include/range/v3/numeric/partial_sum.hpp
+++ b/include/range/v3/numeric/partial_sum.hpp
@@ -37,7 +37,7 @@ namespace ranges
             Callable<P, V>,
             CopyConstructible<uncvref_t<X>>,
             Callable<BOp, X, X>,
-            Assignable<uncvref_t<X> &, Y>>;
+            Assignable<uncvref_t<X>, Y>>;
 
         struct partial_sum_fn
         {

--- a/include/range/v3/range.hpp
+++ b/include/range/v3/range.hpp
@@ -182,7 +182,7 @@ namespace ranges
                 return *this;
             }
             template<typename X, typename Y,
-                CONCEPT_REQUIRES_(Assignable<I &, X &&>() && Assignable<S &, Y &&>())>
+                CONCEPT_REQUIRES_(Assignable<I, X &&>() && Assignable<S, Y &&>())>
             sized_range &operator=(sized_range<X, Y> rng)
             {
                 const_cast<I &>(first) = rng.move_first();

--- a/include/range/v3/utility/common_tuple.hpp
+++ b/include/range/v3/utility/common_tuple.hpp
@@ -64,31 +64,31 @@ namespace ranges
             };
         public:
             // Construction
-            CONCEPT_REQUIRES(meta::and_c<(bool) DefaultConstructible<Ts>()...>::value)
+            CONCEPT_REQUIRES(meta::and_c<(bool) Constructible<Ts>()...>::value)
             common_tuple()
                 noexcept(meta::and_c<std::is_nothrow_default_constructible<Ts>::value...>::value)
               : std::tuple<Ts...>{}
             {}
             template<typename...Us,
-                CONCEPT_REQUIRES_(meta::and_c<(bool) Constructible<Ts, Us &&>()...>::value)>
+                CONCEPT_REQUIRES_(meta::and_c<(bool) Initializable<Ts, Us &&>()...>::value)>
             explicit common_tuple(Us &&... us)
                 noexcept(meta::and_c<std::is_nothrow_constructible<Ts, Us &&>::value...>::value)
               : std::tuple<Ts...>{std::forward<Us>(us)...}
             {}
             template<typename...Us,
-                CONCEPT_REQUIRES_(meta::and_c<(bool) Constructible<Ts, Us &>()...>::value)>
+                CONCEPT_REQUIRES_(meta::and_c<(bool) Initializable<Ts, Us &>()...>::value)>
             common_tuple(std::tuple<Us...> &that)
                 noexcept(meta::and_c<std::is_nothrow_constructible<Ts, Us &>::value...>::value)
               : common_tuple(that, meta::make_index_sequence<sizeof...(Ts)>{})
             {}
             template<typename...Us,
-                CONCEPT_REQUIRES_(meta::and_c<(bool) Constructible<Ts, Us const &>()...>::value)>
+                CONCEPT_REQUIRES_(meta::and_c<(bool) Initializable<Ts, Us const &>()...>::value)>
             common_tuple(std::tuple<Us...> const &that)
                 noexcept(meta::and_c<std::is_nothrow_constructible<Ts, Us const &>::value...>::value)
               : common_tuple(that, meta::make_index_sequence<sizeof...(Ts)>{})
             {}
             template<typename...Us,
-                CONCEPT_REQUIRES_(meta::and_c<(bool) Constructible<Ts, Us &&>()...>::value)>
+                CONCEPT_REQUIRES_(meta::and_c<(bool) Initializable<Ts, Us &&>()...>::value)>
             common_tuple(std::tuple<Us...> &&that)
                 noexcept(meta::and_c<std::is_nothrow_constructible<Ts, Us &&>::value...>::value)
               : common_tuple(std::move(that), meta::make_index_sequence<sizeof...(Ts)>{})
@@ -96,15 +96,15 @@ namespace ranges
 
             // Assignment
             template<typename...Us,
-                CONCEPT_REQUIRES_(meta::and_c<(bool) Assignable<Ts &, Us &>()...>::value)>
+                CONCEPT_REQUIRES_(meta::and_c<(bool) Assignable<Ts, Us &>()...>::value)>
             common_tuple &operator=(std::tuple<Us...> &that)
-                noexcept(meta::and_c<std::is_nothrow_assignable<Ts &, Us &>::value...>::value)
+                noexcept(meta::and_c<std::is_nothrow_assignable<Ts, Us &>::value...>::value)
             {
                 (void)tuple_transform(base(), that, element_assign_{});
                 return *this;
             }
             template<typename...Us,
-                CONCEPT_REQUIRES_(meta::and_c<(bool) Assignable<Ts &, Us const &>()...>::value)>
+                CONCEPT_REQUIRES_(meta::and_c<(bool) Assignable<Ts, Us const &>()...>::value)>
             common_tuple &operator=(std::tuple<Us...> const & that)
                 noexcept(meta::and_c<std::is_nothrow_assignable<Ts &, Us const &>::value...>::value)
             {
@@ -112,7 +112,7 @@ namespace ranges
                 return *this;
             }
             template<typename...Us,
-                CONCEPT_REQUIRES_(meta::and_c<(bool) Assignable<Ts &, Us &&>()...>::value)>
+                CONCEPT_REQUIRES_(meta::and_c<(bool) Assignable<Ts, Us &&>()...>::value)>
             common_tuple &operator=(std::tuple<Us...> &&that)
                 noexcept(meta::and_c<std::is_nothrow_assignable<Ts &, Us &&>::value...>::value)
             {
@@ -122,21 +122,21 @@ namespace ranges
 
             // Conversion
             template<typename ...Us,
-                CONCEPT_REQUIRES_(meta::and_c<(bool) Constructible<Us, Ts &>()...>::value)>
+                CONCEPT_REQUIRES_(meta::and_c<(bool) Initializable<Us, Ts &>()...>::value)>
             operator std::tuple<Us...> () &
                 noexcept(meta::and_c<std::is_nothrow_constructible<Us, Ts &>::value...>::value)
             {
                 return detail::to_std_tuple<Us...>(*this, meta::make_index_sequence<sizeof...(Ts)>{});
             }
             template<typename ...Us,
-                CONCEPT_REQUIRES_(meta::and_c<(bool) Constructible<Us, Ts const &>()...>::value)>
+                CONCEPT_REQUIRES_(meta::and_c<(bool) Initializable<Us, Ts const &>()...>::value)>
             operator std::tuple<Us...> () const &
                 noexcept(meta::and_c<std::is_nothrow_constructible<Us, Ts const &>::value...>::value)
             {
                 return detail::to_std_tuple<Us...>(*this, meta::make_index_sequence<sizeof...(Ts)>{});
             }
             template<typename ...Us,
-                CONCEPT_REQUIRES_(meta::and_c<(bool) Constructible<Us, Ts &&>()...>::value)>
+                CONCEPT_REQUIRES_(meta::and_c<(bool) Initializable<Us, Ts &&>()...>::value)>
             operator std::tuple<Us...> () &&
                 noexcept(meta::and_c<std::is_nothrow_constructible<Us, Ts &&>::value...>::value)
             {
@@ -211,35 +211,35 @@ namespace ranges
             }
         public:
             // Construction
-            CONCEPT_REQUIRES(DefaultConstructible<F>() && DefaultConstructible<S>())
+            CONCEPT_REQUIRES(Constructible<F>() && Constructible<S>())
             common_pair()
                 noexcept(std::is_nothrow_default_constructible<F>::value &&
                     std::is_nothrow_default_constructible<S>::value)
               : std::pair<F, S>{}
             {}
             template<typename F2, typename S2,
-                CONCEPT_REQUIRES_(Constructible<F, F2 &&>() && Constructible<S, S2 &&>())>
+                CONCEPT_REQUIRES_(Initializable<F, F2 &&>() && Initializable<S, S2 &&>())>
             common_pair(F2 &&f2, S2 &&s2)
                 noexcept(std::is_nothrow_constructible<F, F2 &&>::value &&
                     std::is_nothrow_constructible<S, S2 &&>::value)
               : std::pair<F, S>{std::forward<F2>(f2), std::forward<S2>(s2)}
             {}
             template<typename F2, typename S2,
-                CONCEPT_REQUIRES_(Constructible<F, F2 &>() && Constructible<S, S2 &>())>
+                CONCEPT_REQUIRES_(Initializable<F, F2 &>() && Initializable<S, S2 &>())>
             common_pair(std::pair<F2, S2> &that)
                 noexcept(std::is_nothrow_constructible<F, F2 &>::value &&
                     std::is_nothrow_constructible<S, S2 &>::value)
               : std::pair<F, S>{that.first, that.second}
             {}
             template<typename F2, typename S2,
-                CONCEPT_REQUIRES_(Constructible<F, F2 const &>() && Constructible<S, S2 const &>())>
+                CONCEPT_REQUIRES_(Initializable<F, F2 const &>() && Initializable<S, S2 const &>())>
             common_pair(std::pair<F2, S2> const &that)
                 noexcept(std::is_nothrow_constructible<F, F2 const &>::value &&
                     std::is_nothrow_constructible<S, S2 const &>::value)
               : std::pair<F, S>{that.first, that.second}
             {}
             template<typename F2, typename S2,
-                CONCEPT_REQUIRES_(Constructible<F, F2 &&>() && Constructible<S, S2 &&>())>
+                CONCEPT_REQUIRES_(Initializable<F, F2 &&>() && Initializable<S, S2 &&>())>
             common_pair(std::pair<F2, S2> &&that)
                 noexcept(std::is_nothrow_constructible<F, F2 &&>::value &&
                     std::is_nothrow_constructible<S, S2 &&>::value)
@@ -248,7 +248,7 @@ namespace ranges
 
             // Conversion
             template<typename F2, typename S2,
-                CONCEPT_REQUIRES_(Constructible<F2, F &>() && Constructible<S2, S &>())>
+                CONCEPT_REQUIRES_(Initializable<F2, F &>() && Initializable<S2, S &>())>
             operator std::pair<F2, S2> () &
                 noexcept(std::is_nothrow_constructible<F2, F &>::value &&
                     std::is_nothrow_constructible<S2, S &>::value)
@@ -256,7 +256,7 @@ namespace ranges
                 return {this->first, this->second};
             }
             template<typename F2, typename S2,
-                CONCEPT_REQUIRES_(Constructible<F2, F const &>() && Constructible<S2, S const &>())>
+                CONCEPT_REQUIRES_(Initializable<F2, F const &>() && Initializable<S2, S const &>())>
             operator std::pair<F2, S2> () const &
                 noexcept(std::is_nothrow_constructible<F2, F const &>::value &&
                     std::is_nothrow_constructible<S2, S const &>::value)
@@ -264,7 +264,7 @@ namespace ranges
                 return {this->first, this->second};
             }
             template<typename F2, typename S2,
-                CONCEPT_REQUIRES_(Constructible<F2, F &&>() && Constructible<S2, S &&>())>
+                CONCEPT_REQUIRES_(Initializable<F2, F &&>() && Initializable<S2, S &&>())>
             operator std::pair<F2, S2> () &&
                 noexcept(std::is_nothrow_constructible<F2, F &&>::value &&
                     std::is_nothrow_constructible<S2, S &&>::value)
@@ -274,7 +274,7 @@ namespace ranges
 
             // Assignment
             template<typename F2, typename S2,
-                CONCEPT_REQUIRES_(Assignable<F &, F2 &>() && Assignable<S &, S2 &>())>
+                CONCEPT_REQUIRES_(Assignable<F, F2 &>() && Assignable<S, S2 &>())>
             common_pair &operator=(std::pair<F2, S2> &that)
                 noexcept(std::is_nothrow_assignable<F &, F2 &>::value &&
                          std::is_nothrow_assignable<S &, S2 &>::value)
@@ -284,7 +284,7 @@ namespace ranges
                 return *this;
             }
             template<typename F2, typename S2,
-                CONCEPT_REQUIRES_(Assignable<F &, F2 const &>() && Assignable<S &, S2 const &>())>
+                CONCEPT_REQUIRES_(Assignable<F, F2 const &>() && Assignable<S, S2 const &>())>
             common_pair &operator=(std::pair<F2, S2> const & that)
                 noexcept(std::is_nothrow_assignable<F &, F2 const &>::value &&
                          std::is_nothrow_assignable<S &, S2 const &>::value)
@@ -294,7 +294,7 @@ namespace ranges
                 return *this;
             }
             template<typename F2, typename S2,
-                CONCEPT_REQUIRES_(Assignable<F &, F2 &&>() && Assignable<S &, S2 &&>())>
+                CONCEPT_REQUIRES_(Assignable<F, F2 &&>() && Assignable<S, S2 &&>())>
             common_pair &operator=(std::pair<F2, S2> &&that)
                 noexcept(std::is_nothrow_assignable<F &, F2 &&>::value &&
                          std::is_nothrow_assignable<S &, S2 &&>::value)

--- a/test/utility/concepts.cpp
+++ b/test/utility/concepts.cpp
@@ -37,28 +37,28 @@ struct nondefaultconstructible
     nondefaultconstructible(int) {}
 };
 
-static_assert(ranges::CopyAssignable<int>(), "");
-static_assert(!ranges::CopyAssignable<int const>(), "");
-static_assert(!ranges::CopyAssignable<moveonly>(), "");
-static_assert(!ranges::CopyAssignable<nonmovable>(), "");
+static_assert(ranges::MoveConstructible<int>(), "");
+static_assert(ranges::MoveConstructible<const int>(), "");
+static_assert(ranges::MoveConstructible<moveonly>(), "");
+static_assert(!ranges::MoveConstructible<nonmovable>(), "");
 
 static_assert(ranges::CopyConstructible<int>(), "");
 static_assert(ranges::CopyConstructible<const int>(), "");
 static_assert(!ranges::CopyConstructible<moveonly>(), "");
 static_assert(!ranges::CopyConstructible<nonmovable>(), "");
 
-static_assert(ranges::MoveAssignable<int>(), "");
-static_assert(!ranges::MoveAssignable<int const>(), "");
-static_assert(ranges::MoveAssignable<moveonly>(), "");
-static_assert(!ranges::MoveAssignable<nonmovable>(), "");
+static_assert(ranges::Movable<int>(), "");
+static_assert(!ranges::Movable<int const>(), "");
+static_assert(ranges::Movable<moveonly>(), "");
+static_assert(!ranges::Movable<nonmovable>(), "");
 
-static_assert(ranges::MoveConstructible<int>(), "");
-static_assert(ranges::MoveConstructible<const int>(), "");
-static_assert(ranges::MoveConstructible<moveonly>(), "");
-static_assert(!ranges::MoveConstructible<nonmovable>(), "");
+static_assert(ranges::Copyable<int>(), "");
+static_assert(!ranges::Copyable<int const>(), "");
+static_assert(!ranges::Copyable<moveonly>(), "");
+static_assert(!ranges::Copyable<nonmovable>(), "");
 
-static_assert(ranges::DefaultConstructible<int>(), "");
-static_assert(!ranges::DefaultConstructible<nondefaultconstructible>(), "");
+static_assert(ranges::Constructible<int>(), "");
+static_assert(!ranges::Constructible<nondefaultconstructible>(), "");
 
 static_assert(ranges::InputIterator<int*>(), "");
 static_assert(!ranges::InputIterator<int>(), "");
@@ -95,6 +95,14 @@ struct NotDestructible
 
 static_assert(ranges::Destructible<int>(), "");
 static_assert(ranges::Destructible<const int>(), "");
+static_assert(!ranges::Destructible<void>(), "");
+static_assert(!ranges::Destructible<int&>(), "");
+static_assert(!ranges::Destructible<void()>(), "");
+static_assert(ranges::Destructible<void(*)()>(), "");
+static_assert(!ranges::Destructible<void(&)()>(), "");
+static_assert(!ranges::Destructible<int[2]>(), "");
+static_assert(ranges::Destructible<int(*)[2]>(), "");
+static_assert(!ranges::Destructible<int(&)[2]>(), "");
 static_assert(ranges::Destructible<moveonly>(), "");
 static_assert(ranges::Destructible<nonmovable>(), "");
 static_assert(!ranges::Destructible<NotDestructible>(), "");


### PR DESCRIPTION
As discussed in ericniebler/stl2#10.

Note that `ConstructibleRef` is a positively terrible name for "Constructible object or reference type."

Also, I'm not convinced that `CopyConstructible<Foo> && Movable<Foo>` is a meaningful constraint for algorithms that want to memoize the return value of a projection a la adjacent_difference. I can't imagine there are many useful types that are copy constructible and move assignable but not copy assignable - I don't think there would be anything lost by simply requiring `Copyable`.