### PR TITLE
view::cycle

### DIFF
--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -421,6 +421,14 @@ namespace ranges
         using counted_sentinel =
             basic_sentinel<detail::counted_sentinel>;
 
+        template<typename Rng>
+        struct cycled_view;
+
+        namespace view
+        {
+            struct cycle_fn;
+        }
+
         namespace detail
         {
             template<typename I> struct reverse_cursor;

--- a/include/range/v3/view/cycle.hpp
+++ b/include/range/v3/view/cycle.hpp
@@ -1,0 +1,207 @@
+/// \file cycle.hpp
+// Range v3 library
+//
+//  Copyright Eric Niebler 2013-2015
+//  Copyright Gonzalo Brito Gadeschi 2015
+//  Copyright Casey Carter 2015
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#ifndef RANGES_V3_VIEW_CYCLE_HPP
+#define RANGES_V3_VIEW_CYCLE_HPP
+#include <utility>
+#include <type_traits>
+#include <meta/meta.hpp>
+#include <range/v3/range_fwd.hpp>
+#include <range/v3/size.hpp>
+#include <range/v3/distance.hpp>
+#include <range/v3/begin_end.hpp>
+#include <range/v3/range_traits.hpp>
+#include <range/v3/range_concepts.hpp>
+#include <range/v3/view_facade.hpp>
+#include <range/v3/view/all.hpp>
+#include <range/v3/view/view.hpp>
+#include <range/v3/utility/iterator.hpp>
+#include <range/v3/utility/static_const.hpp>
+
+namespace ranges
+{
+
+    inline namespace v3
+    {
+
+        /// \addtogroup group-views
+        ///@{
+        template <typename Rng>
+        struct cycled_view : view_facade<cycled_view<Rng>, infinite>
+        {
+
+        private:
+            CONCEPT_ASSERT(ForwardRange<Rng>());
+            friend range_access;
+            Rng rng_;
+
+        public:
+            cycled_view() = default;
+            explicit cycled_view(Rng rng) : rng_(std::move(rng))
+            {
+            }
+
+        private:
+            template <bool IsConst>
+            struct cursor
+            {
+            private:
+                template <typename T>
+                using constify_if = meta::apply<meta::add_const_if_c<IsConst>, T>;
+                using cycled_view_t = constify_if<cycled_view>;
+            public:
+                using difference_type = range_difference_t<Rng>;
+                using reference = range_reference_t<constify_if<Rng>>;
+
+            private:
+                cycled_view_t *rng_;
+                range_iterator_t<constify_if<Rng>> it_;
+
+            public:
+                cursor() = default;
+                explicit cursor(cycled_view_t &rng)
+                    : rng_(&rng), it_(ranges::begin(rng.rng_))
+                {
+                }
+
+                constexpr bool done() const
+                {
+                    return false;
+                }
+
+                reference current() const
+                {
+                    return *it_;
+                }
+
+                void next()
+                {
+                    const auto end = ranges::end(rng_->rng_);
+                    if (it_ != end)
+                    {
+                        ++it_;
+                    }
+                    if (it_ == end)
+                    {
+                        it_ = ranges::begin(rng_->rng_);
+                    }
+                }
+
+                bool equal(cursor const &pos) const
+                {
+                    RANGES_ASSERT(rng_ == pos.rng_);
+                    return it_ == pos.it_;
+                }
+
+                CONCEPT_REQUIRES(BidirectionalRange<Rng>{})
+                void prev()
+                {
+                    if (it_ == ranges::begin(rng_->rng_))
+                    {
+                        it_ = ranges::end(rng_->rng_);
+                    }
+                    --it_;
+                }
+
+                CONCEPT_REQUIRES(RandomAccessRange<Rng>())
+                void advance(difference_type n)
+                {
+                    if (n == difference_type{0})
+                    {
+                        return;
+                    }
+
+                    const auto begin = ranges::begin(rng_->rng_);
+                    const auto end = ranges::end(rng_->rng_);
+
+                    auto const N = end - begin;
+                    if (N == 0)
+                    {
+                        return;
+                    }
+
+                    auto pos = it_ - (begin + n);
+                    if (pos < 0 || pos >= N)
+                    {
+                      pos %= N;
+                      if (pos < 0)
+                      {
+                        pos += N;
+                      }
+                    }
+                    it_ = begin + pos;
+                }
+
+                CONCEPT_REQUIRES(RandomAccessRange<Rng>())
+                difference_type distance_to(cursor const &that) const
+                {
+                    RANGES_ASSERT(that.rng_ == rng_);
+                    return that.it_ - it_;
+                }
+            };
+
+            cursor<false> begin_cursor()
+            {
+                return cursor<false>{*this};
+            }
+            cursor<true> begin_cursor() const
+            {
+                return cursor<true>{*this};
+            }
+        };
+
+        namespace view
+        {
+
+            struct cycle_fn
+            {
+            private:
+                friend view_access;
+                template <class T>
+                using Concept = meta::and_<ForwardRange<T>, BoundedRange<T>>;
+
+            public:
+                template <typename Rng, CONCEPT_REQUIRES_(Concept<Rng>())>
+                cycled_view<all_t<Rng>> operator()(Rng &&rng) const
+                {
+                    return cycled_view<all_t<Rng>>{all(std::forward<Rng>(rng))};
+                }
+
+#ifndef RANGES_DOXYGEN_INVOKED
+                template <typename Rng, CONCEPT_REQUIRES_(!Concept<Rng>())>
+                void operator()(Rng &&) const
+                {
+                    CONCEPT_ASSERT_MSG(ForwardRange<Rng>(),
+                                       "The object on which view::cycle operates must be a "
+                                       "model of the ForwardRange concept.");
+                    CONCEPT_ASSERT_MSG(BoundedRange<Rng>(),
+                                       "To cycle a range object, its end iterator must be a "
+                                       "model of the ForwardIterator concept.");
+                }
+#endif
+            };
+
+            /// \relates cycle_fn
+            /// \ingroup group-views
+           namespace
+           {
+               constexpr auto &&cycle = static_const<view<cycle_fn>>::value;
+           }
+
+       } // namespace view
+       /// @}
+    } // namespace v3
+} // namespace ranges
+#endif

--- a/test/view/CMakeLists.txt
+++ b/test/view/CMakeLists.txt
@@ -23,6 +23,9 @@ add_test(test.view.const, view.const)
 add_executable(view.counted counted.cpp)
 add_test(test.view.counted, view.counted)
 
+add_executable(view.cycle cycle.cpp)
+add_test(test.view.cycle, view.cycle)
+
 add_executable(view.delimit delimit.cpp)
 add_test(test.view.delimit, view.delimit)
 

--- a/test/view/cycle.cpp
+++ b/test/view/cycle.cpp
@@ -1,0 +1,302 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2013-2015
+//  Copyright Gonzalo Brito Gadeschi 2015
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+
+#include <array>
+#include <list>
+#include <forward_list>
+#include <memory>
+#include <range/v3/range_for.hpp>
+#include <range/v3/algorithm/count_if.hpp>
+#include <range/v3/view/cycle.hpp>
+#include <range/v3/view/take.hpp>
+#include <range/v3/view/iota.hpp>
+#include <range/v3/view/reverse.hpp>
+#include "../simple_test.hpp"
+#include "../test_utils.hpp"
+
+using namespace ranges;
+
+template <typename Rng> void test_const_forward_range(Rng const &rng)
+{
+    auto r = rng | view::cycle;
+    static_assert(is_infinite<decltype(r)>{}, "");
+    static_assert(!BoundedRange<decltype(r)>{}, "");
+    CHECK(distance(r | view::take_exactly(0)) == 0);
+    CHECK(distance(r | view::take_exactly(1)) == 1);
+    CHECK(distance(r | view::take_exactly(2)) == 2);
+    CHECK(distance(r | view::take_exactly(3)) == 3);
+    CHECK(distance(r | view::take_exactly(4)) == 4);
+    CHECK(distance(r | view::take_exactly(6)) == 6);
+    CHECK(distance(r | view::take_exactly(7)) == 7);
+    CHECK(count_if(r | view::take_exactly(7), [](int) { return true; }) == 7);
+
+    ::check_equal(r | view::take_exactly(0), std::array<int, 0>{});
+    ::check_equal(r | view::take_exactly(1), {0});
+    ::check_equal(r | view::take_exactly(2), {0, 1});
+    ::check_equal(r | view::take_exactly(3), {0, 1, 2});
+    ::check_equal(r | view::take_exactly(4), {0, 1, 2, 0});
+    ::check_equal(r | view::take_exactly(6), {0, 1, 2, 0, 1, 2});
+    ::check_equal(r | view::take_exactly(7), {0, 1, 2, 0, 1, 2, 0});
+
+    CHECK(distance(r | view::take(0)) == 0);
+    CHECK(distance(r | view::take(1)) == 1);
+    CHECK(distance(r | view::take(2)) == 2);
+    CHECK(distance(r | view::take(3)) == 3);
+    CHECK(distance(r | view::take(4)) == 4);
+    CHECK(distance(r | view::take(6)) == 6);
+    CHECK(distance(r | view::take(7)) == 7);
+    CHECK(count_if(r | view::take(7), [](int) { return true; }) == 7);
+
+    ::check_equal(r | view::take(0), std::array<int, 0>{});
+    ::check_equal(r | view::take(1), {0});
+    ::check_equal(r | view::take(2), {0, 1});
+    ::check_equal(r | view::take(3), {0, 1, 2});
+    ::check_equal(r | view::take(4), {0, 1, 2, 0});
+    ::check_equal(r | view::take(6), {0, 1, 2, 0, 1, 2});
+    ::check_equal(r | view::take(7), {0, 1, 2, 0, 1, 2, 0});
+}
+
+template <typename Rng> void test_const_forward_reversed_range(Rng const &rng)
+{
+    test_const_forward_range(rng);
+
+    auto r = rng | view::reverse | view::cycle;
+    static_assert(is_infinite<decltype(r)>{}, "");
+    static_assert(!BoundedRange<decltype(r)>{}, "");
+
+    CHECK(distance(r | view::take_exactly(0)) == 0);
+    CHECK(distance(r | view::take_exactly(1)) == 1);
+    CHECK(distance(r | view::take_exactly(2)) == 2);
+    CHECK(distance(r | view::take_exactly(3)) == 3);
+    CHECK(distance(r | view::take_exactly(4)) == 4);
+    CHECK(distance(r | view::take_exactly(6)) == 6);
+    CHECK(distance(r | view::take_exactly(7)) == 7);
+    CHECK(count_if(r | view::take_exactly(7), [](int) { return true; }) == 7);
+
+    ::check_equal(r | view::take_exactly(0), std::array<int, 0>{});
+    ::check_equal(r | view::take_exactly(1), {2});
+    ::check_equal(r | view::take_exactly(2), {2, 1});
+    ::check_equal(r | view::take_exactly(3), {2, 1, 0});
+    ::check_equal(r | view::take_exactly(4), {2, 1, 0, 2});
+    ::check_equal(r | view::take_exactly(6), {2, 1, 0, 2, 1, 0});
+    ::check_equal(r | view::take_exactly(7), {2, 1, 0, 2, 1, 0, 2});
+
+    CHECK(distance(r | view::take(0)) == 0);
+    CHECK(distance(r | view::take(1)) == 1);
+    CHECK(distance(r | view::take(2)) == 2);
+    CHECK(distance(r | view::take(3)) == 3);
+    CHECK(distance(r | view::take(4)) == 4);
+    CHECK(distance(r | view::take(6)) == 6);
+    CHECK(distance(r | view::take(7)) == 7);
+    CHECK(count_if(r | view::take(7), [](int) { return true; }) == 7);
+
+    ::check_equal(r | view::take(0), std::array<int, 0>{});
+    ::check_equal(r | view::take(1), {2});
+    ::check_equal(r | view::take(2), {2, 1});
+    ::check_equal(r | view::take(3), {2, 1, 0});
+    ::check_equal(r | view::take(4), {2, 1, 0, 2});
+    ::check_equal(r | view::take(6), {2, 1, 0, 2, 1, 0});
+    ::check_equal(r | view::take(7), {2, 1, 0, 2, 1, 0, 2});
+}
+
+template <typename Rng> void test_mutable_forward_range_reversed(Rng &rng)
+{
+    test_const_forward_reversed_range(rng);
+    int count = 2;
+    RANGES_FOR(auto &&i, rng | view::cycle | view::take_exactly(6)) { i = ++count; }
+    ::check_equal(rng | view::take_exactly(3), {6, 7, 8});
+}
+
+template <typename Rng> void test_forward_it(Rng const &rng)
+{
+  auto r = rng | view::cycle;
+  static_assert(ForwardRange<decltype(r)>{}, "");
+  auto f = begin(r);
+  static_assert(ForwardIterator<decltype(f)>{}, "");
+
+  CHECK((*f) == 0);
+  auto n = next(f, 1);
+  CHECK((*n) == 1);
+}
+
+template <typename Rng> void test_bidirectional_it(Rng const &rng)
+{
+    test_forward_it(rng);
+    auto r = rng | view::cycle;
+    static_assert(BidirectionalRange<decltype(r)>{}, "");
+    auto f = begin(r);
+    static_assert(BidirectionalIterator<decltype(f)>{}, "");
+
+    CHECK((*f) == 0);
+    auto n = next(f, 1);
+    auto p = next(f, -1);
+    CHECK((*n) == 1);
+    CHECK((*p) == 2);
+    CHECK((++p) == f);
+    CHECK((--n) == f);
+}
+
+template <typename Rng> void test_random_access_it(Rng const &rng)
+{
+    test_bidirectional_it(rng);
+    auto r = rng | view::cycle;
+    static_assert(RandomAccessRange<decltype(r)>{}, "");
+    auto f = begin(r);
+    static_assert(RandomAccessIterator<decltype(f)>{}, "");
+    auto m = begin(r) + 1;
+    auto l = begin(r) + 2;
+    auto f1 = begin(r) + 3;
+    auto f2 = begin(r) + 6;
+
+    CHECK(r[0] == 0);
+    CHECK(r[1] == 1);
+    CHECK(r[2] == 2);
+    CHECK(r[3] == 0);
+    CHECK(r[4] == 1);
+    CHECK(r[5] == 2);
+    CHECK(r[-1] == 2);
+    CHECK(r[-2] == 1);
+    CHECK(r[-3] == 0);
+    CHECK(r[-4] == 2);
+    CHECK(r[-5] == 1);
+    CHECK(r[-6] == 0);
+
+    CHECK((f + 3) == f1);
+    CHECK((f + 6) == f2);
+    CHECK((f1 + 3) == f2);
+    CHECK((f2 - 3) == f1);
+    CHECK((f2 - 6) == f);
+
+    auto e = end(r);
+
+    CHECK(*f == 0);
+    CHECK(f[0] == 0);
+    CHECK(f[1] == 1);
+    CHECK(f[2] == 2);
+    CHECK(f[3] == 0);
+    CHECK(f[4] == 1);
+    CHECK(f[5] == 2);
+    CHECK(f[-1] == 2);
+    CHECK(f[-2] == 1);
+    CHECK(f[-3] == 0);
+    CHECK(f[-4] == 2);
+    CHECK(f[-5] == 1);
+    CHECK(f[-6] == 0);
+
+    CHECK(*m == 1);
+    CHECK(m[0] == 1);
+    CHECK(m[1] == 2);
+    CHECK(m[2] == 0);
+    CHECK(m[3] == 1);
+    CHECK(m[4] == 2);
+    CHECK(m[5] == 0);
+
+    CHECK(m[-1] == 0);
+    CHECK(m[-2] == 2);
+    CHECK(m[-3] == 1);
+    CHECK(m[-4] == 0);
+    CHECK(m[-5] == 2);
+    CHECK(m[-6] == 1);
+
+    CHECK(*l == 2);
+    CHECK(l[0] == 2);
+    CHECK(l[1] == 0);
+    CHECK(l[2] == 1);
+    CHECK(l[3] == 2);
+    CHECK(l[4] == 0);
+    CHECK(l[5] == 1);
+
+    CHECK(l[-1] == 1);
+    CHECK(l[-2] == 0);
+    CHECK(l[-3] == 2);
+    CHECK(l[-4] == 1);
+    CHECK(l[-5] == 0);
+    CHECK(l[-6] == 2);
+
+    CHECK(f != e);
+}
+
+int main()
+{
+
+    // initializer list
+    {
+        auto il = {0, 1, 2};
+        test_random_access_it(il);
+        test_const_forward_reversed_range(il);
+
+        const auto cil = {0, 1, 2};
+        test_random_access_it(cil);
+        test_const_forward_reversed_range(cil);
+    }
+
+    // array
+    {
+        std::array<int, 3> a = {{0, 1, 2}};
+        test_random_access_it(a);
+        test_mutable_forward_range_reversed(a);
+
+        const std::array<int, 3> ca = {{0, 1, 2}};
+        test_random_access_it(ca);
+        test_const_forward_reversed_range(ca);
+    }
+
+    // list
+    {
+        std::list<int> l = {0, 1, 2};
+        test_bidirectional_it(l);
+        test_mutable_forward_range_reversed(l);
+
+        const std::list<int> cl = {0, 1, 2};
+        test_bidirectional_it(cl);
+        test_const_forward_reversed_range(cl);
+    }
+
+    // forward list
+    {
+      std::forward_list<int> l = {0, 1, 2};
+      test_forward_it(l);
+      test_const_forward_range(l);
+
+      const std::forward_list<int> cl = {0, 1, 2};
+      test_forward_it(cl);
+      test_const_forward_range(cl);
+    }
+
+    // move-only types
+    {
+        std::array<std::unique_ptr<int>, 3> a = {{
+            std::unique_ptr<int>(new int(0)),
+            std::unique_ptr<int>(new int(1)),
+            std::unique_ptr<int>(new int(2))
+        }};
+        auto r = a | view::cycle;
+        auto b = iter_move(r.begin() + 4);
+        CHECK((*(b)) == 1);
+    }
+
+    // infinite
+    {
+      int count = 0;
+      auto il = {0, 1, 2};
+      auto v = 10;
+      RANGES_FOR(auto&& i, il | view::cycle) {
+        if (count == 42) { break; }
+        v = i;
+        ++count;
+      }
+      CHECK(count == 42);
+      CHECK(v == 2);
+    }
+
+    return test_result();
+}


### PR DESCRIPTION
Turns a finite `ForwardRange` into an infinite range that cycles on itself. 

### Example

```c++
auto il = {0, 1, 2};
RANGES_FOR(auto i, il | view::cycle) { std::cout << i << " "; }
```

prints "0 1 2 0 1 2 0 1 2 0 1 2...". 

### Notes on the design 

This designs chooses to make two iterators compare equal only if they point to the same element of the sequence within the same cycle. Example: in the sequence above both iterators `begin` and `begin  + 3` point to the same element (`0`); since they are "in different cycles" they are not equal. 

The rationale is that this allows iterating from `[begin, begin + M)` where `M` is larger than the number of elements in the sequence.

### TODO

- The implementation of `cycled_view<Rng>::cursor<IsConst>::advance` is pretty ugly.

- The implementation of `cycled_view<Rng>::cursor` can be optimized for `RandomAccessRange`s where the iterator can be obtained from the position in `O(1)`. 