### PR TITLE
fix missing includes forever

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,8 @@
+# Copyright Eric Niebler 2013-2015
+# Copyright Louis Dione 2015
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
 cmake_minimum_required(VERSION 2.8)
 set(CMAKE_LEGACY_CYGWIN_WIN32 0)
 
@@ -55,7 +60,6 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
 #   message(FATAL_ERROR "Unknown compiler.")
 endif()
 
-
 add_subdirectory(doc)
 
 if(BIICODE)
@@ -71,6 +75,33 @@ if(BIICODE)
 
     return()
 endif()
+
+#   range_v3_list_remove_glob(<list> <GLOB|GLOB_RECURSE> [globbing expressions]...)
+#
+# Generates a list of files matching the given glob expressions, and remove
+# the matched elements from the given <list>.
+#
+# Adapted from Boost.Hana: https://github.com/ldionne/hana/
+#
+macro(range_v3_list_remove_glob list glob)
+    file(${glob} _bhlrg10321023_avoid_macro_clash_matches ${ARGN})
+    list(REMOVE_ITEM ${list} ${_bhlrg10321023_avoid_macro_clash_matches})
+endmacro()
+
+# Test all headers
+include(CheckIncludeFileCXX)
+file(GLOB_RECURSE RANGE_V3_PUBLIC_HEADERS "${CMAKE_SOURCE_DIR}/include/*.hpp")
+range_v3_list_remove_glob(RANGE_V3_PUBLIC_HEADERS GLOB_RECURSE
+  "${CMAKE_SOURCE_DIR}/include/range/v3/detail/re_enable_warnings.hpp"
+  )
+
+foreach(_header IN LISTS RANGE_V3_PUBLIC_HEADERS)
+  file(RELATIVE_PATH _relative "${CMAKE_SOURCE_DIR}/include" "${_header}")
+  check_include_file_cxx("${_relative}" ${_relative}_FOUND "-I/${CMAKE_SOURCE_DIR}/include")
+  if(NOT ${_relative}_FOUND)
+    message(FATAL_ERROR "Compilation of header ${_relative} failed")
+  endif()
+endforeach()
 
 add_subdirectory(test)
 add_subdirectory(example)

--- a/include/range/v3/action/join.hpp
+++ b/include/range/v3/action/join.hpp
@@ -15,6 +15,7 @@
 #define RANGES_V3_ACTION_JOIN_HPP
 
 #include <functional>
+#include <vector>
 #include <meta/meta.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/action/action.hpp>

--- a/include/range/v3/action/split.hpp
+++ b/include/range/v3/action/split.hpp
@@ -14,6 +14,7 @@
 #ifndef RANGES_V3_ACTION_SPLIT_HPP
 #define RANGES_V3_ACTION_SPLIT_HPP
 
+#include <vector>
 #include <functional>
 #include <meta/meta.hpp>
 #include <range/v3/range_fwd.hpp>

--- a/include/range/v3/at.hpp
+++ b/include/range/v3/at.hpp
@@ -17,6 +17,7 @@
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_concepts.hpp>
+#include <range/v3/range_traits.hpp>
 #include <range/v3/utility/iterator.hpp>
 #include <range/v3/utility/static_const.hpp>
 

--- a/include/range/v3/to_container.hpp
+++ b/include/range/v3/to_container.hpp
@@ -18,7 +18,6 @@
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/range_traits.hpp>
-#include <range/v3/utility/common_iterator.hpp>
 #include <range/v3/utility/static_const.hpp>
 #include <range/v3/action/concepts.hpp>
 

--- a/include/range/v3/utility/compressed_tuple.hpp
+++ b/include/range/v3/utility/compressed_tuple.hpp
@@ -33,7 +33,7 @@ namespace ranges
             struct compressed_tuple_data;
 
             template<std::size_t...Is, typename...Ts>
-            struct compressed_tuple_data<index_sequence<Is...>, Ts...>
+            struct compressed_tuple_data<meta::index_sequence<Is...>, Ts...>
               : box<Ts, std::integral_constant<std::size_t, Is>>...
             {
                 constexpr compressed_tuple_data() = default;

--- a/include/range/v3/utility/get.hpp
+++ b/include/range/v3/utility/get.hpp
@@ -14,6 +14,7 @@
 #ifndef RANGES_V3_UTILITY_GET_HPP
 #define RANGES_V3_UTILITY_GET_HPP
 
+#include <utility>
 #include <meta/meta.hpp>
 
 namespace ranges

--- a/include/range/v3/utility/integer_sequence.hpp
+++ b/include/range/v3/utility/integer_sequence.hpp
@@ -15,7 +15,7 @@
 #define RANGES_V3_UTILITY_INTEGER_SEQUENCE_HPP
 
 #if defined(__GNUC__) || defined(__clang__)
-#  warning "This header is deprecated. Please use: meta/meta.hpp"
+#  pragma message "This header is deprecated. Please use: meta/meta.hpp"
 #endif
 
 #include <range/v3/range_fwd.hpp>

--- a/include/range/v3/utility/meta.hpp
+++ b/include/range/v3/utility/meta.hpp
@@ -15,7 +15,7 @@
 #define RANGES_V3_UTILITY_META_HPP
 
 #if defined(__GNUC__) || defined(__clang__)
-#  warning "This header is deprecated. Please use: meta/meta.hpp"
+#  pragma message "This header is deprecated. Please use: meta/meta.hpp"
 #endif
 
 #include <range/v3/range_fwd.hpp>

--- a/include/range/v3/view/generate_n.hpp
+++ b/include/range/v3/view/generate_n.hpp
@@ -25,6 +25,7 @@
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/optional.hpp>
 #include <range/v3/utility/static_const.hpp>
+#include <range/v3/utility/semiregular.hpp>
 
 namespace ranges
 {

--- a/include/range/v3/view/take.hpp
+++ b/include/range/v3/view/take.hpp
@@ -14,6 +14,7 @@
 #ifndef RANGES_V3_VIEW_TAKE_HPP
 #define RANGES_V3_VIEW_TAKE_HPP
 
+#include <algorithm>
 #include <type_traits>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_traits.hpp>

--- a/include/range/v3/view/transform.hpp
+++ b/include/range/v3/view/transform.hpp
@@ -14,6 +14,7 @@
 #ifndef RANGES_V3_VIEW_TRANSFORM_HPP
 #define RANGES_V3_VIEW_TRANSFORM_HPP
 
+#include <algorithm>
 #include <utility>
 #include <iterator>
 #include <functional>

--- a/include/range/v3/view_interface.hpp
+++ b/include/range/v3/view_interface.hpp
@@ -19,6 +19,7 @@
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/begin_end.hpp>
+#include <range/v3/to_container.hpp>
 #include <range/v3/utility/concepts.hpp>
 #include <range/v3/utility/iterator.hpp>
 #include <range/v3/utility/common_iterator.hpp>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Copyright Eric Niebler 2013-2015
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
 # Strange, need to use static linking here or tests fail.
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")


### PR DESCRIPTION
All kudos go to Louis Dione for writing the CMake scripts of Boost.Hana. 

This just adapts his scripts for range-v3; all mistakes introduced are only mine.

- fix missing includes caught by the tests.

- replace `# warning` with `#pragma message` because `-Werror, -Wpedantic` complains that 
  `# warning` is a language extension (this prevents some new tests from compiling).

Closes #182  .