### PR TITLE
value-initialized view::concat iterators must compare equal.

### DIFF
--- a/include/range/v3/view/concat.hpp
+++ b/include/range/v3/view/concat.hpp
@@ -238,7 +238,8 @@ namespace ranges
                 }
                 bool equal(cursor const &pos) const
                 {
-                    return its_ == pos.its_;
+                    return its_.is_valid() == pos.its_.is_valid() &&
+                        (!its_.is_valid() || its_ == pos.its_);
                 }
                 CONCEPT_REQUIRES(meta::and_c<(bool)BidirectionalRange<Rngs>()...>::value)
                 void prev()


### PR DESCRIPTION
ForwardIterator requires that value-initialized iterators compare equal, but value-initialized `tagged_variant`s are incomparable.