### PR TITLE
fix missing includes forever v2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,33 @@ if(BIICODE)
     return()
 endif()
 
+#   range_v3_list_remove_glob(<list> <GLOB|GLOB_RECURSE> [globbing expressions]...)
+#
+# Generates a list of files matching the given glob expressions, and remove
+# the matched elements from the given <list>.
+#
+# Adapted from Boost.Hana: https://github.com/ldionne/hana/
+#
+macro(range_v3_list_remove_glob list glob)
+    file(${glob} _bhlrg10321023_avoid_macro_clash_matches ${ARGN})
+    list(REMOVE_ITEM ${list} ${_bhlrg10321023_avoid_macro_clash_matches})
+endmacro()
+
+# Test all headers
+include(CheckIncludeFileCXX)
+file(GLOB_RECURSE RANGE_V3_PUBLIC_HEADERS "${CMAKE_SOURCE_DIR}/include/*.hpp")
+range_v3_list_remove_glob(RANGE_V3_PUBLIC_HEADERS GLOB_RECURSE
+  "${CMAKE_SOURCE_DIR}/include/range/v3/detail/re_enable_warnings.hpp"
+  )
+
+foreach(_header IN LISTS RANGE_V3_PUBLIC_HEADERS)
+  file(RELATIVE_PATH _relative "${CMAKE_SOURCE_DIR}/include" "${_header}")
+  check_include_file_cxx("${_relative}" ${_relative}_FOUND "-I${CMAKE_SOURCE_DIR}/include")
+  if(NOT ${_relative}_FOUND)
+    message(FATAL_ERROR "Compilation of header ${_relative} failed")
+  endif()
+endforeach()
+
 add_subdirectory(test)
 add_subdirectory(example)
 add_subdirectory(perf)


### PR DESCRIPTION
All kudos go to Louis Dione for writing the CMake scripts of Boost.Hana.

This just adapts his scripts for range-v3; all mistakes introduced are only mine.

- fix missing includes caught by the tests.

- replace # warning with `#pragma message` because `-Werror, -Wpedantic` complains that  `# warning` is a language extension (this prevents some new tests from compiling).

Thanks @tamaskenez for the fix described in #184 .