### PR TITLE
bugfix: group_by and split broken for mutable views

### DIFF
--- a/include/range/v3/view/group_by.hpp
+++ b/include/range/v3/view/group_by.hpp
@@ -94,7 +94,7 @@ namespace ranges
                 return {fun_, ranges::begin(rng_), ranges::end(rng_)};
             }
             CONCEPT_REQUIRES(Callable<Fun const, range_common_reference_t<Rng>,
-                range_common_reference_t<Rng>>())
+                range_common_reference_t<Rng>>() && Range<Rng const>())
             cursor<true> begin_cursor() const
             {
                 return {fun_, ranges::begin(rng_), ranges::end(rng_)};

--- a/include/range/v3/view/split.hpp
+++ b/include/range/v3/view/split.hpp
@@ -118,7 +118,8 @@ namespace ranges
             {
                 return {fun_, ranges::begin(rng_), ranges::end(rng_)};
             }
-            CONCEPT_REQUIRES(Callable<Fun const, range_iterator_t<Rng>, range_sentinel_t<Rng>>())
+            CONCEPT_REQUIRES(Callable<Fun const, range_iterator_t<Rng>,
+                range_sentinel_t<Rng>>() && Range<Rng const>())
             cursor<true> begin_cursor() const
             {
                 return {fun_, ranges::begin(rng_), ranges::end(rng_)};

--- a/test/view/group_by.cpp
+++ b/test/view/group_by.cpp
@@ -14,6 +14,7 @@
 #include <range/v3/core.hpp>
 #include <range/v3/view/counted.hpp>
 #include <range/v3/view/group_by.hpp>
+#include <range/v3/view/remove_if.hpp>
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
@@ -74,6 +75,13 @@ int main()
         CHECK(distance(rng1) == 2);
         check_equal(*rng1.begin(), {P{1,1},P{1,1},P{1,2},P{1,2},P{1,2},P{1,2}});
         check_equal(*next(rng1.begin()), {P{2,2},P{2,2},P{2,3},P{2,3},P{2,3},P{2,3}});
+    }
+
+    {
+        int a[] = {0, 1, 2, 3, 4, 5};
+        auto rng = a | view::remove_if([](int n) { return n % 2 == 0; })
+          | view::group_by([](int, int) { return true; });
+        check_equal(*rng.begin(), {1, 3, 5});
     }
 
     return test_result();

--- a/test/view/split.cpp
+++ b/test/view/split.cpp
@@ -14,6 +14,7 @@
 #include <range/v3/view/counted.hpp>
 #include <range/v3/view/split.hpp>
 #include <range/v3/view/empty.hpp>
+#include <range/v3/view/remove_if.hpp>
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
@@ -125,6 +126,16 @@ int main()
             check_equal(*(next(begin(rng),2)), c_str("o"));
             check_equal(*(next(begin(rng),3)), c_str("w"));
         }
+    }
+
+    {
+      int a[] = {0, 2, 3, 1, 4, 5, 1, 6, 7};
+      auto rng = a | view::remove_if([](int i) { return i % 2 == 0; });
+      auto srng = view::split(rng, 1);
+      CHECK(distance(srng) == 3);
+      check_equal(*begin(srng), {3});
+      check_equal(*next(begin(srng), 1), {5});
+      check_equal(*next(begin(srng), 2), {7});
     }
 
     return test_result();


### PR DESCRIPTION
Some views mutate its state on begin/end (e.g. `view::remove_if` on begin).  
This patch constrains `view::group_by` and `view::split` `begin_cursor` on `Range<const Rng>()`
to disable the const overload for these kinds of ranges (such that the non-const overload
is picked up instead). 