### PR TITLE
Update core concepts to spec as of the current Ranges proposal:

### DIFF
--- a/example/recursive_range.hpp
+++ b/example/recursive_range.hpp
@@ -110,7 +110,7 @@ namespace ranges
         public:
             template<typename Fun,
                 CONCEPT_REQUIRES_(Function<Fun>() &&
-                                  Convertible<
+                                  ConvertibleTo<
                                     concepts::Function::result_t<Fun>,
                                     any_input_range<Ref>
                                   >())>

--- a/include/range/v3/action/drop.hpp
+++ b/include/range/v3/action/drop.hpp
@@ -51,8 +51,8 @@ namespace ranges
                     auto requires_(Rng&&, T&&) -> decltype(
                         concepts::valid_expr(
                             concepts::model_of<concepts::ForwardRange, Rng>(),
-                            concepts::model_of<concepts::EraseableRange, Rng, I, I>(),
-                            concepts::model_of<concepts::Convertible, T, D>()
+                            concepts::model_of<concepts::ErasableRange, Rng, I, I>(),
+                            concepts::model_of<concepts::ConvertibleTo, T, D>()
                         ));
                 };
 
@@ -77,9 +77,9 @@ namespace ranges
                         "The object on which action::drop operates must be a model of the "
                         "ForwardRange concept.");
                     using I = range_iterator_t<Rng>;
-                    CONCEPT_ASSERT_MSG(EraseableRange<Rng, I, I>(),
+                    CONCEPT_ASSERT_MSG(ErasableRange<Rng, I, I>(),
                         "The object on which action::drop operates must allow element removal.");
-                    CONCEPT_ASSERT_MSG(Convertible<T, range_difference_t<Rng>>(),
+                    CONCEPT_ASSERT_MSG(ConvertibleTo<T, range_difference_t<Rng>>(),
                         "The count passed to action::drop must be an integral type.");
                 }
             #endif

--- a/include/range/v3/action/drop_while.hpp
+++ b/include/range/v3/action/drop_while.hpp
@@ -52,7 +52,7 @@ namespace ranges
                         concepts::valid_expr(
                             concepts::model_of<concepts::ForwardRange, Rng>(),
                             concepts::is_true(IndirectCallablePredicate<Fun, range_iterator_t<Rng>>{}),
-                            concepts::model_of<concepts::EraseableRange, Rng, I, I>()
+                            concepts::model_of<concepts::ErasableRange, Rng, I, I>()
                         ));
                 };
 
@@ -82,7 +82,7 @@ namespace ranges
                         "of the range's common reference type, and it must return something convertible to "
                         "bool.");
                     using I = range_iterator_t<Rng>;
-                    CONCEPT_ASSERT_MSG(EraseableRange<Rng, I, I>(),
+                    CONCEPT_ASSERT_MSG(ErasableRange<Rng, I, I>(),
                         "The object on which action::drop_while operates must allow element "
                         "removal.");
                 }

--- a/include/range/v3/action/erase.hpp
+++ b/include/range/v3/action/erase.hpp
@@ -81,7 +81,7 @@ namespace ranges
         /// @{
         namespace concepts
         {
-            struct EraseableRange
+            struct ErasableRange
               : refines<Range(_1)>
             {
                 template<typename Rng, typename...Rest>
@@ -90,13 +90,13 @@ namespace ranges
                 template<typename Rng, typename...Rest>
                 auto requires_(Rng&&, Rest&&...) -> decltype(
                     concepts::valid_expr(
-                        (ranges::erase(val<Rng>(), val<Rest>()...), 42)
+                        ((void)ranges::erase(val<Rng>(), val<Rest>()...), 42)
                     ));
             };
         }
 
         template<typename Rng, typename...Rest>
-        using EraseableRange = concepts::models<concepts::EraseableRange, Rng, Rest...>;
+        using ErasableRange = concepts::models<concepts::ErasableRange, Rng, Rest...>;
         /// @}
     }
 }

--- a/include/range/v3/action/remove_if.hpp
+++ b/include/range/v3/action/remove_if.hpp
@@ -52,7 +52,7 @@ namespace ranges
                     auto requires_(Rng&&, C&&, P&& = P{}) -> decltype(
                         concepts::valid_expr(
                             concepts::model_of<concepts::ForwardRange, Rng>(),
-                            concepts::model_of<concepts::EraseableRange, Rng, I, I>(),
+                            concepts::model_of<concepts::ErasableRange, Rng, I, I>(),
                             concepts::is_true(RemovableIf<I, C, P>())
                         ));
                 };
@@ -78,7 +78,7 @@ namespace ranges
                         "The object on which action::remove_if operates must be a model of the "
                         "ForwardRange concept.");
                     using I = range_iterator_t<Rng>;
-                    CONCEPT_ASSERT_MSG(EraseableRange<Rng, I, I>(),
+                    CONCEPT_ASSERT_MSG(ErasableRange<Rng, I, I>(),
                         "The object on which action::remove_if operates must allow element "
                         "removal.");
                     CONCEPT_ASSERT_MSG(Projectable<I, P>(),

--- a/include/range/v3/action/shuffle.hpp
+++ b/include/range/v3/action/shuffle.hpp
@@ -52,9 +52,9 @@ namespace ranges
                             concepts::model_of<concepts::RandomAccessRange, Rng>(),
                             concepts::is_true(Permutable<I>()),
                             concepts::is_true(UniformRandomNumberGenerator<Gen>()),
-                            concepts::is_true(Convertible<
+                            concepts::is_true(ConvertibleTo<
                                 concepts::UniformRandomNumberGenerator::result_t<Gen>,
-                                concepts::WeaklyIncrementable::difference_t<I>>())
+                                iterator_difference_t<I>>())
                         ));
                 };
 
@@ -85,9 +85,9 @@ namespace ranges
                     CONCEPT_ASSERT_MSG(UniformRandomNumberGenerator<Gen>(),
                         "The generator passed to action::shuffle must fulfill the "
                         "UniformRandomNumberGenerator concept.");
-                    CONCEPT_ASSERT_MSG(Convertible<
+                    CONCEPT_ASSERT_MSG(ConvertibleTo<
                         concepts::UniformRandomNumberGenerator::result_t<Gen>,
-                        concepts::WeaklyIncrementable::difference_t<I>>(),
+                        iterator_difference_t<I>>(),
                         "The random generator passed to action::shuffle has to have a return type "
                         "convertible to the container iterator difference type.");
                 }

--- a/include/range/v3/action/slice.hpp
+++ b/include/range/v3/action/slice.hpp
@@ -51,9 +51,9 @@ namespace ranges
                     auto requires_(Rng&&, T&&, U&&) -> decltype(
                         concepts::valid_expr(
                             concepts::model_of<concepts::ForwardRange, Rng>(),
-                            concepts::model_of<concepts::EraseableRange, Rng, I, I>(),
-                            concepts::model_of<concepts::Convertible, T, D>(),
-                            concepts::model_of<concepts::Convertible, U, D>()
+                            concepts::model_of<concepts::ErasableRange, Rng, I, I>(),
+                            concepts::model_of<concepts::ConvertibleTo, T, D>(),
+                            concepts::model_of<concepts::ConvertibleTo, U, D>()
                         ));
                 };
 
@@ -83,11 +83,11 @@ namespace ranges
                         "The object on which action::slice operates must be a model of the "
                         "ForwardRange concept.");
                     using I = range_iterator_t<Rng>;
-                    CONCEPT_ASSERT_MSG(EraseableRange<Rng, I, I>(),
+                    CONCEPT_ASSERT_MSG(ErasableRange<Rng, I, I>(),
                         "The object on which action::slice operates must allow element "
                         "removal.");
-                    CONCEPT_ASSERT_MSG(meta::and_<Convertible<T, range_difference_t<Rng>>,
-                            Convertible<U, range_difference_t<Rng>>>(),
+                    CONCEPT_ASSERT_MSG(meta::and_<ConvertibleTo<T, range_difference_t<Rng>>,
+                            ConvertibleTo<U, range_difference_t<Rng>>>(),
                         "The bounds passed to action::slice must be convertible to the range's "
                         "difference type. TODO slicing from the end with 'end-2' syntax is not "
                         "supported yet, sorry!");

--- a/include/range/v3/action/split.hpp
+++ b/include/range/v3/action/split.hpp
@@ -72,13 +72,13 @@ namespace ranges
 
             #ifndef RANGES_DOXYGEN_INVOKED
                 template<typename Rng, typename T,
-                    CONCEPT_REQUIRES_(!Convertible<T, range_value_t<Rng>>())>
+                    CONCEPT_REQUIRES_(!ConvertibleTo<T, range_value_t<Rng>>())>
                 void operator()(Rng &&, T &&) const volatile
                 {
                     CONCEPT_ASSERT_MSG(ForwardRange<Rng>(),
                         "The object on which action::split operates must be a model of the "
                         "ForwardRange concept.");
-                    CONCEPT_ASSERT_MSG(Convertible<T, range_value_t<Rng>>(),
+                    CONCEPT_ASSERT_MSG(ConvertibleTo<T, range_value_t<Rng>>(),
                         "The delimiter argument to action::split must be one of the following: "
                         "(1) A single element of the range's value type, where the value type is a "
                         "model of the Regular concept, "

--- a/include/range/v3/action/stride.hpp
+++ b/include/range/v3/action/stride.hpp
@@ -51,8 +51,8 @@ namespace ranges
                     auto requires_(Rng&&, T&&) -> decltype(
                         concepts::valid_expr(
                             concepts::model_of<concepts::ForwardRange, Rng>(),
-                            concepts::model_of<concepts::EraseableRange, Rng, I, S>(),
-                            concepts::model_of<concepts::Convertible, T, D>(),
+                            concepts::model_of<concepts::ErasableRange, Rng, I, S>(),
+                            concepts::model_of<concepts::ConvertibleTo, T, D>(),
                             concepts::is_true(Permutable<I>())
                         ));
                 };
@@ -94,9 +94,9 @@ namespace ranges
                         "ForwardRange concept.");
                     using I = range_iterator_t<Rng>;
                     using S = range_sentinel_t<Rng>;
-                    CONCEPT_ASSERT_MSG(EraseableRange<Rng, I, S>(),
+                    CONCEPT_ASSERT_MSG(ErasableRange<Rng, I, S>(),
                         "The object on which action::stride operates must allow element removal.");
-                    CONCEPT_ASSERT_MSG(Convertible<T, range_difference_t<Rng>>(),
+                    CONCEPT_ASSERT_MSG(ConvertibleTo<T, range_difference_t<Rng>>(),
                         "The stride argument to action::stride must be convertible to the range's "
                         "difference type.");
                     CONCEPT_ASSERT_MSG(Permutable<I>(),

--- a/include/range/v3/action/take.hpp
+++ b/include/range/v3/action/take.hpp
@@ -52,8 +52,8 @@ namespace ranges
                     auto requires_(Rng&&, T&&) -> decltype(
                         concepts::valid_expr(
                             concepts::model_of<concepts::ForwardRange, Rng>(),
-                            concepts::model_of<concepts::EraseableRange, Rng, I, S>(),
-                            concepts::model_of<concepts::Convertible, T, D>()
+                            concepts::model_of<concepts::ErasableRange, Rng, I, S>(),
+                            concepts::model_of<concepts::ConvertibleTo, T, D>()
                         ));
                 };
 
@@ -79,9 +79,9 @@ namespace ranges
                         "ForwardRange concept.");
                     using I = range_iterator_t<Rng>;
                     using S = range_sentinel_t<Rng>;
-                    CONCEPT_ASSERT_MSG(EraseableRange<Rng, I, S>(),
+                    CONCEPT_ASSERT_MSG(ErasableRange<Rng, I, S>(),
                         "The object on which action::take operates must allow element removal.");
-                    CONCEPT_ASSERT_MSG(Convertible<T, range_difference_t<Rng>>(),
+                    CONCEPT_ASSERT_MSG(ConvertibleTo<T, range_difference_t<Rng>>(),
                         "The stride argument to action::take must be convertible to the range's "
                         "difference type.");
                 }

--- a/include/range/v3/action/take_while.hpp
+++ b/include/range/v3/action/take_while.hpp
@@ -52,7 +52,7 @@ namespace ranges
                     auto requires_(Rng&&, Fun&&) -> decltype(
                         concepts::valid_expr(
                             concepts::model_of<concepts::ForwardRange, Rng>(),
-                            concepts::model_of<concepts::EraseableRange, Rng, I, S>(),
+                            concepts::model_of<concepts::ErasableRange, Rng, I, S>(),
                             concepts::is_true(IndirectCallablePredicate<Fun, I>{})
                         ));
                 };
@@ -79,7 +79,7 @@ namespace ranges
                         "ForwardRange concept.");
                     using I = range_iterator_t<Rng>;
                     using S = range_sentinel_t<Rng>;
-                    CONCEPT_ASSERT_MSG(EraseableRange<Rng, I, S>(),
+                    CONCEPT_ASSERT_MSG(ErasableRange<Rng, I, S>(),
                         "The object on which action::take_while operates must allow element "
                         "removal.");
                     CONCEPT_ASSERT_MSG(IndirectCallablePredicate<Fun, I>(),

--- a/include/range/v3/action/unique.hpp
+++ b/include/range/v3/action/unique.hpp
@@ -50,7 +50,7 @@ namespace ranges
                         auto requires_(Rng&&, C&& = C{}, P&& = P{}) -> decltype(
                         concepts::valid_expr(
                             concepts::model_of<concepts::ForwardRange, Rng>(),
-                            concepts::model_of<concepts::EraseableRange, Rng, I, S>(),
+                            concepts::model_of<concepts::ErasableRange, Rng, I, S>(),
                             concepts::is_true(Sortable<I, C, P>())
                         ));
                 };
@@ -78,7 +78,7 @@ namespace ranges
                         "ForwardRange concept.");
                     using I = range_iterator_t<Rng>;
                     using S = range_sentinel_t<Rng>;
-                    CONCEPT_ASSERT_MSG(EraseableRange<Rng, I, S>(),
+                    CONCEPT_ASSERT_MSG(ErasableRange<Rng, I, S>(),
                         "The object on which action::unique operates must allow element "
                         "removal.");
                     CONCEPT_ASSERT_MSG(Projectable<I, P>(),

--- a/include/range/v3/algorithm/shuffle.hpp
+++ b/include/range/v3/algorithm/shuffle.hpp
@@ -55,9 +55,9 @@ namespace ranges
             template<typename I, typename S, typename Gen,
                 CONCEPT_REQUIRES_(RandomAccessIterator<I>() && IteratorRange<I, S>() &&
                     Permutable<I>() && UniformRandomNumberGenerator<Gen>() &&
-                    Convertible<
+                    ConvertibleTo<
                         concepts::UniformRandomNumberGenerator::result_t<Gen>,
-                        concepts::WeaklyIncrementable::difference_t<I>>())>
+                        iterator_difference_t<I>>())>
             I operator()(I begin, S end_, Gen && gen) const
             {
                 I end = ranges::next(begin, end_), orig = end;
@@ -79,9 +79,9 @@ namespace ranges
             template<typename Rng, typename Gen,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(RandomAccessRange<Rng>() && Permutable<I>() &&
-                    UniformRandomNumberGenerator<Gen>() && Convertible<
+                    UniformRandomNumberGenerator<Gen>() && ConvertibleTo<
                         concepts::UniformRandomNumberGenerator::result_t<Gen>,
-                        concepts::WeaklyIncrementable::difference_t<I>>())>
+                        iterator_difference_t<I>>())>
             range_safe_iterator_t<Rng> operator()(Rng &&rng, Gen && rand) const
             {
                 return (*this)(begin(rng), end(rng), std::forward<Gen>(rand));

--- a/include/range/v3/range.hpp
+++ b/include/range/v3/range.hpp
@@ -60,12 +60,12 @@ namespace ranges
               : compressed_pair<I, S>{detail::move(begin), detail::move(end)}
             {}
             template<typename X, typename Y,
-                CONCEPT_REQUIRES_(Convertible<X, iterator>() && Convertible<Y, sentinel>())>
+                CONCEPT_REQUIRES_(ConvertibleTo<X, iterator>() && ConvertibleTo<Y, sentinel>())>
             constexpr range(range<X, Y> rng)
               : compressed_pair<I, S>{detail::move(rng.first), detail::move(rng.second)}
             {}
             template<typename X, typename Y,
-                CONCEPT_REQUIRES_(Convertible<X, iterator>() && Convertible<Y, sentinel>())>
+                CONCEPT_REQUIRES_(ConvertibleTo<X, iterator>() && ConvertibleTo<Y, sentinel>())>
             constexpr range(std::pair<X, Y> rng)
               : compressed_pair<I, S>{detail::move(rng.first), detail::move(rng.second)}
             {}
@@ -78,7 +78,7 @@ namespace ranges
                 return second;
             }
             template<typename X, typename Y,
-                CONCEPT_REQUIRES_(Convertible<I, X>() && Convertible<S, Y>())>
+                CONCEPT_REQUIRES_(ConvertibleTo<I, X>() && ConvertibleTo<S, Y>())>
             constexpr operator std::pair<X, Y>() const
             {
                 return {first, second};
@@ -153,17 +153,17 @@ namespace ranges
               : compressed_pair<I const, S const>{rng.move_first(), rng.move_second()}, third(rng.third)
             {}
             template<typename X, typename Y,
-                CONCEPT_REQUIRES_(Convertible<X, I>() && Convertible<Y, S>())>
+                CONCEPT_REQUIRES_(ConvertibleTo<X, I>() && ConvertibleTo<Y, S>())>
             sized_range(std::pair<X, Y> rng, iterator_size_t<I> size)
               : sized_range{std::move(rng).first, std::move(rng).second, size}
             {}
             template<typename X, typename Y,
-                CONCEPT_REQUIRES_(Convertible<X, I>() && Convertible<Y, S>())>
+                CONCEPT_REQUIRES_(ConvertibleTo<X, I>() && ConvertibleTo<Y, S>())>
             sized_range(range<X, Y> rng, iterator_size_t<I> size)
               : sized_range{std::move(rng).first, std::move(rng).second, size}
             {}
             template<typename X, typename Y,
-                CONCEPT_REQUIRES_(Convertible<X, I>() && Convertible<Y, S>())>
+                CONCEPT_REQUIRES_(ConvertibleTo<X, I>() && ConvertibleTo<Y, S>())>
             sized_range(sized_range<X, Y> rng)
               : sized_range{rng.move_first(), rng.move_second(), rng.third}
             {}
@@ -203,13 +203,13 @@ namespace ranges
                 return third;
             }
             template<typename X, typename Y,
-                CONCEPT_REQUIRES_(Convertible<I, X>() && Convertible<S, Y>())>
+                CONCEPT_REQUIRES_(ConvertibleTo<I, X>() && ConvertibleTo<S, Y>())>
             constexpr operator std::pair<X, Y>() const
             {
                 return {first, second};
             }
             template<typename X, typename Y,
-                CONCEPT_REQUIRES_(Convertible<I, X>() && Convertible<S, Y>())>
+                CONCEPT_REQUIRES_(ConvertibleTo<I, X>() && ConvertibleTo<S, Y>())>
             constexpr operator range<X, Y>() const
             {
                 return {first, second};

--- a/include/range/v3/range_concepts.hpp
+++ b/include/range/v3/range_concepts.hpp
@@ -384,7 +384,7 @@ namespace ranges
             struct is_view_impl_
               : std::integral_constant<
                     bool,
-                    Range<T>() && (!ContainerLike_<T>() || Derived<T, view_base>())
+                    Range<T>() && (!ContainerLike_<T>() || DerivedFrom<T, view_base>())
                 >
             {};
 

--- a/include/range/v3/to_container.hpp
+++ b/include/range/v3/to_container.hpp
@@ -43,7 +43,7 @@ namespace ranges
                 Range<Cont>,
                 meta::not_<View<Cont>>,
                 Movable<Cont>,
-                Convertible<range_value_t<Rng>, range_value_t<Cont>>,
+                ConvertibleTo<range_value_t<Rng>, range_value_t<Cont>>,
                 Constructible<Cont, I, I>>;
 
             template<typename ContainerMetafunctionClass>

--- a/include/range/v3/utility/basic_iterator.hpp
+++ b/include/range/v3/utility/basic_iterator.hpp
@@ -107,7 +107,7 @@ namespace ranges
                     {
                         return *it_;
                     }
-                    CONCEPT_REQUIRES(Convertible<Ref, value_t>())
+                    CONCEPT_REQUIRES(ImplicitlyConvertibleTo<Ref, value_t>())
                     RANGES_CXX14_CONSTEXPR operator value_t() const
                     {
                         return *it_;
@@ -146,7 +146,7 @@ namespace ranges
                     {
                         return *it_;
                     }
-                    CONCEPT_REQUIRES(Convertible<Ref, value_t>())
+                    CONCEPT_REQUIRES(ImplicitlyConvertibleTo<Ref, value_t>())
                     RANGES_CXX14_CONSTEXPR operator value_t() const
                     {
                         return *it_;
@@ -314,7 +314,7 @@ namespace ranges
                         std::is_convertible<Ref, Val const &>,
                         // No forward iterator can have values that disappear
                         // before positions can be re-visited
-                        ranges::Derived<ranges::input_iterator_tag, Cat>>,
+                        meta::not_<DerivedFrom<Cat, ranges::forward_iterator_tag>>>,
                     meta::if_<
                         is_non_proxy_reference<Ref, Val>,
                         postfix_increment_proxy<I>,
@@ -487,7 +487,7 @@ namespace ranges
               : detail::mixin_base<Cur>{std::move(pos)}
             {}
             template<typename OtherCur, typename OtherS,
-                CONCEPT_REQUIRES_(Convertible<OtherCur, Cur>())>
+                CONCEPT_REQUIRES_(ConvertibleTo<OtherCur, Cur>())>
             basic_iterator(basic_iterator<OtherCur, OtherS> that)
               : detail::mixin_base<Cur>{std::move(that.pos())}
             {}

--- a/include/range/v3/utility/common_iterator.hpp
+++ b/include/range/v3/utility/common_iterator.hpp
@@ -96,8 +96,8 @@ namespace ranges
                   : data_(meta::size_t<1>{}, std::move(se))
                 {}
                 template<typename I2, typename S2,
-                    CONCEPT_REQUIRES_(Convertible<I, I2>() &&
-                                      Convertible<S, S2>())>
+                    CONCEPT_REQUIRES_(ExplicitlyConvertibleTo<I, I2>() &&
+                                      ExplicitlyConvertibleTo<S, S2>())>
                 operator common_cursor<I2, S2>() const
                 {
                     return is_sentinel() ?

--- a/include/range/v3/utility/counted_iterator.hpp
+++ b/include/range/v3/utility/counted_iterator.hpp
@@ -32,8 +32,7 @@ namespace ranges
             using UnambiguouslyConvertible =
                 meta::or_c<
                     (bool)Same<A, B>(),
-                    Convertible<A, B>() && !Convertible<B, A>(),
-                    Convertible<B, A>() && !Convertible<A, B>()>;
+                    ConvertibleTo<A, B>() == !ConvertibleTo<B, A>()>;
 
             template<typename A, typename B>
             using UnambiguouslyConvertibleType =
@@ -42,10 +41,10 @@ namespace ranges
                         (bool)Same<A, B>(),
                         meta::id<A>,
                         meta::if_c<
-                            Convertible<A, B>() && !Convertible<B, A>(),
+                            ConvertibleTo<A, B>() && !ConvertibleTo<B, A>(),
                             meta::id<A>,
                             meta::if_c<
-                                Convertible<B, A>() && !Convertible<A, B>(),
+                                ConvertibleTo<B, A>() && !ConvertibleTo<A, B>(),
                                 meta::id<B>,
                                 meta::nil_>>>>;
 
@@ -110,7 +109,7 @@ namespace ranges
                   : it_(std::move(it)), n_(n)
                 {}
                 template<typename OtherI, typename OtherD,
-                    CONCEPT_REQUIRES_(Convertible<OtherI, I>() && Convertible<OtherD, D>())>
+                    CONCEPT_REQUIRES_(ConvertibleTo<OtherI, I>() && ConvertibleTo<OtherD, D>())>
                 counted_cursor(counted_cursor<OtherI, OtherD> that)
                   : it_(std::move(that.it_)), n_(std::move(that.n_))
                 {}

--- a/include/range/v3/utility/iterator.hpp
+++ b/include/range/v3/utility/iterator.hpp
@@ -569,7 +569,7 @@ namespace ranges
                   : it_(std::move(it))
                 {}
                 template<typename U,
-                    CONCEPT_REQUIRES_(Convertible<U, I>())>
+                    CONCEPT_REQUIRES_(ConvertibleTo<U, I>())>
                 RANGES_CXX14_CONSTEXPR
                 reverse_cursor(reverse_cursor<U> const &u)
                   : it_(u.base())

--- a/include/range/v3/utility/iterator_concepts.hpp
+++ b/include/range/v3/utility/iterator_concepts.hpp
@@ -303,7 +303,7 @@ namespace ranges
                 template<typename I>
                 auto requires_(I&& i) -> decltype(
                     concepts::valid_expr(
-                        concepts::model_of<Derived, category_t<I>, ranges::weak_input_iterator_tag>(),
+                        concepts::model_of<DerivedFrom, category_t<I>, ranges::weak_input_iterator_tag>(),
                         concepts::model_of<Readable>(i++)
                     ));
             };
@@ -314,7 +314,7 @@ namespace ranges
                 template<typename I>
                 auto requires_(I&&) -> decltype(
                     concepts::valid_expr(
-                        concepts::model_of<Derived, category_t<I>, ranges::input_iterator_tag>()
+                        concepts::model_of<DerivedFrom, category_t<I>, ranges::input_iterator_tag>()
                     ));
             };
 
@@ -324,7 +324,7 @@ namespace ranges
                 template<typename I>
                 auto requires_(I&&) -> decltype(
                     concepts::valid_expr(
-                        concepts::model_of<Derived, category_t<I>, ranges::forward_iterator_tag>()
+                        concepts::model_of<DerivedFrom, category_t<I>, ranges::forward_iterator_tag>()
                     ));
             };
 
@@ -334,7 +334,7 @@ namespace ranges
                 template<typename I>
                 auto requires_(I&& i) -> decltype(
                     concepts::valid_expr(
-                        concepts::model_of<Derived, category_t<I>, ranges::bidirectional_iterator_tag>(),
+                        concepts::model_of<DerivedFrom, category_t<I>, ranges::bidirectional_iterator_tag>(),
                         concepts::has_type<I &>(--i),
                         concepts::has_type<I>(i--),
                         concepts::same_type(*i, *i--)
@@ -347,7 +347,7 @@ namespace ranges
                 template<typename I, typename V = common_reference_t<I>>
                 auto requires_(I&& i) -> decltype(
                     concepts::valid_expr(
-                        concepts::model_of<Derived, category_t<I>, ranges::random_access_iterator_tag>(),
+                        concepts::model_of<DerivedFrom, category_t<I>, ranges::random_access_iterator_tag>(),
                         concepts::model_of<SignedIntegral>(i - i),
                         concepts::has_type<difference_t<I>>(i - i),
                         concepts::has_type<I>(i + (i - i)),

--- a/include/range/v3/view/intersperse.hpp
+++ b/include/range/v3/view/intersperse.hpp
@@ -152,8 +152,8 @@ namespace ranges
                 template<typename Rng, typename T = range_value_t<Rng>>
                 using Concept = meta::and_<
                     InputRange<Rng>,
-                    Convertible<T, range_value_t<Rng>>,
-                    Convertible<range_reference_t<Rng>, range_value_t<Rng>>,
+                    ConvertibleTo<T, range_value_t<Rng>>,
+                    ConvertibleTo<range_reference_t<Rng>, range_value_t<Rng>>,
                     SemiRegular<range_value_t<Rng>>>;
 
                 template<typename Rng,
@@ -171,10 +171,10 @@ namespace ranges
                     CONCEPT_ASSERT_MSG(InputRange<Rng>(),
                         "The object on which view::intersperse operates must be a model of the "
                         "InputRange concept.");
-                    CONCEPT_ASSERT_MSG(Convertible<T, range_value_t<Rng>>(),
+                    CONCEPT_ASSERT_MSG(ConvertibleTo<T, range_value_t<Rng>>(),
                         "The value to intersperse in the range must be convertible to the range's "
                         "value type.");
-                    CONCEPT_ASSERT_MSG(Convertible<range_reference_t<Rng>, range_value_t<Rng>>(),
+                    CONCEPT_ASSERT_MSG(ConvertibleTo<range_reference_t<Rng>, range_value_t<Rng>>(),
                         "The range's reference type must be convertible to the range's "
                         "value type.");
                     CONCEPT_ASSERT_MSG(SemiRegular<range_value_t<Rng>>(),

--- a/include/range/v3/view/partial_sum.hpp
+++ b/include/range/v3/view/partial_sum.hpp
@@ -137,7 +137,7 @@ namespace ranges
                 using Concept = meta::and_<
                     InputRange<Rng>,
                     IndirectCallable<Fun, range_iterator_t<Rng>, range_iterator_t<Rng>>,
-                    Convertible<
+                    ConvertibleTo<
                         concepts::Callable::result_t<Fun, range_common_reference_t<Rng>,
                             range_common_reference_t<Rng>>,
                         range_value_t<Rng>>>;
@@ -160,7 +160,7 @@ namespace ranges
                         range_iterator_t<Rng>>(),
                         "The second argument passed to view::partial_sum must be callable with "
                         "two values from the range passed as the first argument.");
-                    CONCEPT_ASSERT_MSG(Convertible<
+                    CONCEPT_ASSERT_MSG(ConvertibleTo<
                         concepts::Callable::result_t<Fun, range_common_reference_t<Rng>,
                         range_common_reference_t<Rng>>, range_value_t<Rng>>(),
                         "The return type of the function passed to view::partial_sum must be "

--- a/include/range/v3/view/split.hpp
+++ b/include/range/v3/view/split.hpp
@@ -188,7 +188,7 @@ namespace ranges
                 using FunctionConcept = meta::and_<
                     ForwardRange<Rng>,
                     Function<Fun, range_iterator_t<Rng>, range_sentinel_t<Rng>>,
-                    Convertible<
+                    ConvertibleTo<
                         concepts::Function::result_t<Fun, range_iterator_t<Rng>, range_sentinel_t<Rng>>,
                         std::pair<bool, range_difference_t<Rng>>>>;
 
@@ -224,13 +224,13 @@ namespace ranges
 
             #ifndef RANGES_DOXYGEN_INVOKED
                 template<typename Rng, typename T,
-                    CONCEPT_REQUIRES_(!Convertible<T, range_value_t<Rng>>())>
+                    CONCEPT_REQUIRES_(!ConvertibleTo<T, range_value_t<Rng>>())>
                 void operator()(Rng &&, T &&) const volatile
                 {
                     CONCEPT_ASSERT_MSG(ForwardRange<Rng>(),
                         "The object on which view::split operates must be a model of the "
                         "ForwardRange concept.");
-                    CONCEPT_ASSERT_MSG(Convertible<T, range_value_t<Rng>>(),
+                    CONCEPT_ASSERT_MSG(ConvertibleTo<T, range_value_t<Rng>>(),
                         "The delimiter argument to view::split must be one of the following: "
                         "(1) A single element of the range's value type, where the value type is a "
                         "model of the Regular concept, "

--- a/include/range/v3/view/transform.hpp
+++ b/include/range/v3/view/transform.hpp
@@ -167,8 +167,8 @@ namespace ranges
             public:
                 using difference_type = difference_type_;
                 using single_pass = meta::or_c<
-                    (bool) Derived<ranges::input_iterator_tag, range_category_t<Rng1>>(),
-                    (bool) Derived<ranges::input_iterator_tag, range_category_t<Rng2>>()>;
+                    (bool) SinglePass<range_iterator_t<Rng1>>(),
+                    (bool) SinglePass<range_iterator_t<Rng2>>()>;
                 using value_type =
                     detail::decay_t<decltype(fun_(copy_tag{}, range_iterator_t<Rng1>{},
                         range_iterator_t<Rng2>{}))>;

--- a/include/range/v3/view/transform.hpp
+++ b/include/range/v3/view/transform.hpp
@@ -238,7 +238,8 @@ namespace ranges
             using end_cursor_t =
                 meta::if_c<
                     BoundedRange<Rng1>() && BoundedRange<Rng2>() &&
-                        !SinglePass<Rng1>() && !SinglePass<Rng2>(),
+                        !SinglePass<range_iterator_t<Rng1>>() &&
+                        !SinglePass<range_iterator_t<Rng2>>(),
                     cursor,
                     sentinel>;
 

--- a/include/range/v3/view/zip_with.hpp
+++ b/include/range/v3/view/zip_with.hpp
@@ -162,7 +162,7 @@ namespace ranges
                 using difference_type =
                     common_type_t<range_difference_t<Rngs>...>;
                 using single_pass =
-                    meta::or_c<(bool) SinglePass<range_iterator_t<Rngs>>()...>;
+                    meta::fast_or<SinglePass<range_iterator_t<Rngs>>...>;
                 using value_type =
                     detail::decay_t<decltype(fun_(copy_tag{}, range_iterator_t<Rngs>{}...))>;
 
@@ -241,7 +241,9 @@ namespace ranges
 
             using end_cursor_t =
                 meta::if_<
-                    meta::and_c<!!BoundedRange<Rngs>()..., !SinglePass<Rngs>()...>,
+                    meta::and_c<
+                        (bool) BoundedRange<Rngs>()...,
+                        !SinglePass<range_iterator_t<Rngs>>()...>,
                     cursor,
                     sentinel>;
 

--- a/include/range/v3/view/zip_with.hpp
+++ b/include/range/v3/view/zip_with.hpp
@@ -162,7 +162,7 @@ namespace ranges
                 using difference_type =
                     common_type_t<range_difference_t<Rngs>...>;
                 using single_pass =
-                    meta::fast_or<SinglePass<range_iterator_t<Rngs>>...>;
+                    meta::or_c<(bool) SinglePass<range_iterator_t<Rngs>>()...>;
                 using value_type =
                     detail::decay_t<decltype(fun_(copy_tag{}, range_iterator_t<Rngs>{}...))>;
 

--- a/include/range/v3/view/zip_with.hpp
+++ b/include/range/v3/view/zip_with.hpp
@@ -162,8 +162,7 @@ namespace ranges
                 using difference_type =
                     common_type_t<range_difference_t<Rngs>...>;
                 using single_pass =
-                    meta::or_c<(bool) Derived<ranges::input_iterator_tag,
-                        range_category_t<Rngs>>()...>;
+                    meta::or_c<(bool) SinglePass<range_iterator_t<Rngs>>()...>;
                 using value_type =
                     detail::decay_t<decltype(fun_(copy_tag{}, range_iterator_t<Rngs>{}...))>;
 

--- a/include/range/v3/view_interface.hpp
+++ b/include/range/v3/view_interface.hpp
@@ -37,7 +37,7 @@ namespace ranges
                 From from;
                 To to;
                 template<typename F, typename T,
-                    CONCEPT_REQUIRES_(Convertible<F, From>() && Convertible<T, To>())>
+                    CONCEPT_REQUIRES_(ConvertibleTo<F, From>() && ConvertibleTo<T, To>())>
                 slice_bounds(F from, T to)
                   : from(from), to(to)
                 {}
@@ -49,7 +49,7 @@ namespace ranges
                 Int dist_;
 
                 template<typename Other,
-                    CONCEPT_REQUIRES_(Integral<Other>() && Convertible<Other, Int>())>
+                    CONCEPT_REQUIRES_(Integral<Other>() && ExplicitlyConvertibleTo<Other, Int>())>
                 operator from_end_<Other> () const
                 {
                     return {static_cast<Other>(dist_)};

--- a/test/utility/basic_iterator.cpp
+++ b/test/utility/basic_iterator.cpp
@@ -28,7 +28,7 @@ struct cursor
     };
     cursor() = default;
     explicit cursor(I i) : it_(i) {}
-    template<class J, CONCEPT_REQUIRES_(ranges::Convertible<J, I>())>
+    template<class J, CONCEPT_REQUIRES_(ranges::ConvertibleTo<J, I>())>
     cursor(cursor<J> that) : it_(std::move(that.it_)) {}
 
     auto current() const -> decltype(*it_) { return *it_; }

--- a/test/view/zip.cpp
+++ b/test/view/zip.cpp
@@ -86,7 +86,7 @@ int main()
         CONCEPT_ASSERT(Same<
             range_rvalue_reference_t<Rng>,
             common_tuple<int &&, std::string const &&, std::string const &&>>());
-        CONCEPT_ASSERT(Convertible<range_value_t<Rng> &&,
+        CONCEPT_ASSERT(ConvertibleTo<range_value_t<Rng> &&,
             range_rvalue_reference_t<Rng>>());
         ::models<concepts::InputIterator>(begin(rng));
         ::models_not<concepts::ForwardIterator>(begin(rng));

--- a/test/view/zip.cpp
+++ b/test/view/zip.cpp
@@ -69,13 +69,13 @@ int main()
     std::vector<int> vi{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
     std::vector<std::string> const vs{"hello", "goodbye", "hello", "goodbye"};
 
-    // All ranges
+    // All bounded ranges, but one single-pass
     {
         std::stringstream str{"john paul george ringo"};
         using V = std::tuple<int, std::string, std::string>;
         auto && rng = view::zip(vi, vs, istream<std::string>(str) | view::bounded);
         using Rng = decltype((rng));
-        ::models<concepts::BoundedView>(rng);
+        ::models_not<concepts::BoundedView>(rng);
         ::models_not<concepts::SizedView>(rng);
         CONCEPT_ASSERT(Same<
             range_value_t<Rng>,
@@ -90,7 +90,7 @@ int main()
             range_rvalue_reference_t<Rng>>());
         ::models<concepts::InputIterator>(begin(rng));
         ::models_not<concepts::ForwardIterator>(begin(rng));
-        std::vector<V> expected(begin(rng), end(rng));
+        auto expected = to_vector(rng);
         ::check_equal(expected, {V{0, "hello", "john"},
                                  V{1, "goodbye", "paul"},
                                  V{2, "hello", "george"},


### PR DESCRIPTION
* Use `std::declval` instead of `ranges::concepts::val` in `Swappable`.
* Variadic `Same` (This is an extension; I'm sure we'll put it in the spec eventually.)
* Rename `Derived` to `DerivedFrom`.

  Drive-by: Replace several instances of tests for "single pass"-ness:
  ```
Derived<input_iterator_tag, Foo>
```
  with uses of `SinglePass` so that an input iterator tagged with
 ```
struct my_input_iterator_tag : input_iterator_tag {}
```
  is appropriately single-pass.

* `Convertible` changes:
  * Rename `Convertible` to `ImplicitlyConvertibleTo`
  * Add `ExplicitlyConvertibleTo`
  * Add `ConvertibleTo` that subsumes both `ImplicitlyConvertibleTo` and `ExplicitlyConvertibleTo`.
  This is half extension as well, but almost certainly required to specify the library. I don't think generic code should have to jump through hoops to require explicit & implicit conversion with equivalent semantics. (Most occurrences of `Convertible` in range-v3 actually mis-constrain explicit conversions.)

* Drive-by: Rename `Eraseable` to `Erasable`.

* Drive-by: Correct uses of `SinglePass<Range>` to `SinglePass<range_iterator_t<Range>>` (the second commit)

* Drive-by: Replace occurrences of `BoundedRange<Range> && !SinglePass<range_iterator_t<Range>>` with `BoundedRange<Range>` alone (the third commit). This one needs review to ensure I am not crazy.