### PR TITLE
In is_swappable, don't require swap to return void

### DIFF
--- a/include/range/v3/utility/swap.hpp
+++ b/include/range/v3/utility/swap.hpp
@@ -80,9 +80,9 @@ namespace ranges
             {};
 
             template<typename T, typename U>
-            struct is_swappable_<T, U, meta::if_c<
-                std::is_void<decltype(swap(std::declval<T>(), std::declval<U>()))>::value &&
-                std::is_void<decltype(swap(std::declval<U>(), std::declval<T>()))>::value>>
+            struct is_swappable_<T, U, meta::void_<
+                decltype(swap(std::declval<T>(), std::declval<U>())),
+                decltype(swap(std::declval<U>(), std::declval<T>()))>>
               : std::true_type
             {};
 


### PR DESCRIPTION
`Swappable` doesn't care about the return type of `swap`. Hmmm.... the ranges proposal requires `swap(...)` to be equality preserving. That needs to be `(void)swap(...)` since we don't care about the return value.