### PR TITLE
counted_iterator-related changes:

### DIFF
--- a/include/range/v3/algorithm/search.hpp
+++ b/include/range/v3/algorithm/search.hpp
@@ -51,44 +51,6 @@ namespace ranges
         struct search_fn
         {
         private:
-            template<typename I1, typename D1, typename I2, typename S2, typename D2,
-                typename C, typename P1, typename P2,
-                CONCEPT_REQUIRES_(RandomAccessIterator<I1>())>
-            static I1 sized_impl(I1 const begin1_, I1 end1, D1 d1, I2 begin2, S2 end2, D2 d2,
-                C &pred, P1 &proj1, P2 &proj2)
-            {
-                if(d1 < d2)
-                    return end1;
-                auto begin1 = uncounted(begin1_);
-                auto const s = uncounted(end1 - (d2 - 1)); // Start of pattern match can't go beyond here
-                while(true)
-                {
-                    // Find begin element in sequence 1 that matches *begin2, with a mininum of loop checks
-                    while(true)
-                    {
-                        if(begin1 == s)  // return the end if we've run out of room
-                            return end1;
-                        if(pred(proj1(*begin1), proj2(*begin2)))
-                            break;
-                        ++begin1;
-                    }
-                    // *begin1 matches *begin2, now match elements after here
-                    auto m1 = begin1;
-                    I2 m2 = begin2;
-                    while(true)
-                    {
-                        if(++m2 == end2)  // If pattern exhausted, begin1 is the answer (works for 1 element pattern)
-                            return recounted(begin1_, std::move(begin1));
-                        ++m1;  // No need to check, we know we have room to match successfully
-                        if(!pred(proj1(*m1), proj2(*m2)))  // if there is a mismatch, restart with a new begin1
-                        {
-                            ++begin1;
-                            break;
-                        }  // else there is a match, check next elements
-                    }
-                }
-            }
-
             template<typename I1, typename S1, typename D1, typename I2, typename S2, typename D2,
                 typename C, typename P1, typename P2>
             static I1 sized_impl(I1 const begin1_, S1 end1, D1 const d1_, I2 begin2, S2 end2, D2 d2,

--- a/include/range/v3/algorithm/search_n.hpp
+++ b/include/range/v3/algorithm/search_n.hpp
@@ -49,43 +49,6 @@ namespace ranges
         struct search_n_fn
         {
         private:
-            template<typename I, typename D, typename V, typename C, typename P,
-                CONCEPT_REQUIRES_(RandomAccessIterator<I>())>
-            static I sized_impl(I const begin_, I end, D d, D count, V const &val,
-                C &pred, P &proj)
-            {
-                if(d < count)
-                    return end;
-                auto begin = uncounted(begin_);
-                auto const s = uncounted(end - (count - 1)); // Start of pattern match can't go beyond here
-                while(true)
-                {
-                    // Find first element in sequence that matches val, with a mininum of loop checks
-                    while(true)
-                    {
-                        if(begin >= s)  // return the end if we've run out of room
-                            return end;
-                        if(pred(proj(*begin), val))
-                            break;
-                        ++begin;
-                    }
-                    // *begin matches val, now match elements after here
-                    auto m = begin;
-                    D c = 0;
-                    while(true)
-                    {
-                        if(++c == count)  // If pattern exhausted, begin is the answer (works for 1 element pattern)
-                            return recounted(begin_, std::move(begin));
-                        ++m;  // No need to check, we know we have room to match successfully
-                        if(!pred(proj(*m), val))  // if there is a mismatch, restart with a new begin
-                        {
-                            begin = next(std::move(m));
-                            break;
-                        }  // else there is a match, check next elements
-                    }
-                }
-            }
-
             template<typename I, typename S, typename D, typename V, typename C, typename P>
             static I sized_impl(I const begin_, S end, D const d_, D count,
                 V const &val, C &pred, P &proj)

--- a/include/range/v3/utility/counted_iterator.hpp
+++ b/include/range/v3/utility/counted_iterator.hpp
@@ -196,6 +196,12 @@ namespace ranges
         {
             return 0;
         }
+
+        template<typename I, CONCEPT_REQUIRES_(WeakInputIterator<I>())>
+        counted_iterator<I> make_counted_iterator(I i, iterator_difference_t<I> n)
+        {
+            return counted_iterator<I>{std::move(i), n};
+        }
         /// @}
     }
 }

--- a/include/range/v3/utility/iterator.hpp
+++ b/include/range/v3/utility/iterator.hpp
@@ -641,12 +641,6 @@ namespace ranges
                 return i;
             }
 
-            template<typename I>
-            constexpr I recounted(I const &, I i)
-            {
-                return i;
-            }
-
             struct uncounted_fn
             {
                 template<typename I>
@@ -666,14 +660,6 @@ namespace ranges
                     decltype(recounted((I&&)i, (J&&)j, n))
                 {
                     return recounted((I&&)i, (J&&)j, n);
-                }
-
-                template<typename I, typename J>
-                constexpr
-                auto operator()(I i, J j) const ->
-                    decltype(recounted((I&&)i, (J&&)j))
-                {
-                    return recounted((I&&)i, (J&&)j);
                 }
             };
         }


### PR DESCRIPTION
* Implement `make_counted_iterator` from the ranges proposal
* Remove the remaining vestiges of `recounted(Iterator, Iterator)` that was removed from `counted_iterator` to support cyclic iterators in ce2d726e.
* Remove the `search` and `search_n` implementations for sized ranges of `RandomAccessIterator`. Without `recounted(I, I)`, they are no more efficient than the general sized range implementation.