### PR TITLE
Update range_iterator/sentinel_t to the Ranges proposal.

### DIFF
--- a/include/range/v3/range_concepts.hpp
+++ b/include/range/v3/range_concepts.hpp
@@ -60,10 +60,10 @@ namespace ranges
             {
                 // Associated types
                 template<typename T>
-                using iterator_t = decltype(begin(val<T>()));
+                using iterator_t = decltype(begin(std::declval<T&>()));
 
                 template<typename T>
-                using sentinel_t = decltype(end(val<T>()));
+                using sentinel_t = decltype(end(std::declval<T&>()));
 
                 template<typename T>
                 using difference_t = concepts::WeaklyIncrementable::difference_t<iterator_t<T>>;


### PR DESCRIPTION
i.e., `range_iterator_t` is `decltype(begin(declval<T&>()))` and `range_sentinel_t` is `decltype(end(declval<T&>()))`. This fixes a compile error in test/view/transform.cpp with clang-3.4 that happens only on my Ubuntu install, and not on Travis for whatever reason:
```c++
auto && rng2 = rgp | view::transform(&std::pair<int,int>::first);
has_type<int &>(*begin(rng2));
CONCEPT_ASSERT(Same<range_value_t<decltype(rng2)>, int>());
```
clang refuses to resolve `decltype(begin(val<decltype(rng2)>()))` inside `range_value_t` here, as it should since `begin` on rvalues is a terrible idea ;)