### PR TITLE
Update to current meta; update compiler support matrix in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Supported Compilers
 The code is known to work on the following compilers:
 
 - clang 3.4.0 (C++14 support requires at least clang 3.5.0)
-- GCC 4.9.0
+- GCC 4.9.0 (C++14 support requires GCC 5.2. Complex `constexpr` usage may be unreliable due to bugs in GCC, e.g. [PR67813](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67813), as witnessed by the failure of the constexpr-core test.)
 
 **Development Status:** This code is fairly stable, well-tested, and suitable for casual use, although currently lacking documentation. No promise is made about support or long-term stability. This code *will* evolve without regard to backwards compatibility.
 

--- a/include/meta/meta_fwd.hpp
+++ b/include/meta/meta_fwd.hpp
@@ -15,6 +15,8 @@
 #ifndef META_FWD_HPP
 #define META_FWD_HPP
 
+#include <utility>
+
 #ifndef META_DISABLE_DEPRECATED_WARNINGS
 #ifdef __cpp_attribute_deprecated
 #define META_DEPRECATED(MSG) [[deprecated(MSG)]]
@@ -35,8 +37,12 @@ namespace meta
 {
     inline namespace v1
     {
+#ifdef __cpp_lib_integer_sequence
+        using std::integer_sequence;
+#else
         template <typename T, T...>
         struct integer_sequence;
+#endif
 
         template <typename... Ts>
         struct list;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Strange, need to use static linking here or tests fail.
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
-endif()
+#if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
+#  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
+#endif()
 
-set(CMAKE_CXX_COMPILER_FLAGS "${CMAKE_CXX_COMPILER_FLAGS} -g")
+#set(CMAKE_CXX_COMPILER_FLAGS "${CMAKE_CXX_COMPILER_FLAGS} -g")
 
 add_subdirectory(action)
 add_subdirectory(algorithm)

--- a/test/constexpr_core.cpp
+++ b/test/constexpr_core.cpp
@@ -181,10 +181,13 @@ RANGES_CXX14_CONSTEXPR auto test_array() -> bool {
 
     auto beg = ranges::begin(a);
     auto three = ranges::next(beg, 2);
-    // ranges::iter_swap(beg, three);
-    // if (*beg != 3) { return false; }
-    // if (*three != 1) { return false; }
-    // ranges::iter_swap(beg, three);
+
+    if ((false)) {
+      ranges::iter_swap(beg, three);
+      if (*beg != 3) { return false; }
+      if (*three != 1) { return false; }
+      ranges::iter_swap(beg, three);
+    }
 
     if (!test_its(a)) { return false; }
     if (!test_cits(a)) { return false; }


### PR DESCRIPTION
Disable constexpr_core since it's ill-formed. E.g., `ranges::begin` isn't `constexpr`, this test cannot possibly complete with -std=c++14. I assume the test is abandoned.

Also disables the flags in test/CMakeLists.txt to force static linking and debug info.

Fixes #210.