### PR TITLE
[bugfix] view::iota_minus overflow for UnsignedIntegral

### DIFF
--- a/include/range/v3/view/iota.hpp
+++ b/include/range/v3/view/iota.hpp
@@ -147,7 +147,7 @@ namespace ranges
             iota_difference_t<Val> iota_minus(Val const &v0, Val const &v1)
             {
                 using D = iota_difference_t<Val>;
-                return (D) (v0 - v1);
+                return v0 < v1? - static_cast<D>(v1 - v0) : static_cast<D>(v0 - v1);
             }
         }
         /// \endcond

--- a/test/view/iota.cpp
+++ b/test/view/iota.cpp
@@ -30,6 +30,24 @@ struct Int
     bool operator!=(Int j) const { return i != j.i; }
 };
 
+template <typename Integral>
+void test_iota_minus() {
+  using namespace ranges;
+  using D = detail::iota_difference_t<Integral>;
+  using I = Integral;
+  Integral max = std::numeric_limits<Integral>::max();
+
+  CHECK(detail::iota_minus(I(0), I(0)) == D(0));
+  CHECK(detail::iota_minus(I(0), I(1)) == D(-1));
+  CHECK(detail::iota_minus(I(1), I(0)) ==  D(1));
+  CHECK(detail::iota_minus(I(1), I(1)) == D(0));
+
+  CHECK(detail::iota_minus(I(max - I(1)), I(max - I(1))) == D(0));
+  CHECK(detail::iota_minus(I(max - I(1)), I(max)) == D(-1));
+  CHECK(detail::iota_minus(I(max), I(max - I(1))) == D(1));
+  CHECK(detail::iota_minus(I(max), I(max)) == D(0));
+}
+
 int main()
 {
     using namespace ranges;
@@ -75,6 +93,18 @@ int main()
         auto ints = view::closed_iota(Int{0}, Int{10});
         ::check_equal(ints, {Int{0},Int{1},Int{2},Int{3},Int{4},Int{5},Int{6},Int{7},Int{8},Int{9},Int{10}});
         models_not<concepts::BoundedView>(ints);
+    }
+
+    {  // iota minus tests
+      test_iota_minus<int8_t>();
+      test_iota_minus<int16_t>();
+      test_iota_minus<int32_t>();
+      test_iota_minus<int64_t>();
+
+      test_iota_minus<uint8_t>();
+      test_iota_minus<uint16_t>();
+      test_iota_minus<uint32_t>();
+      test_iota_minus<uint64_t>();
     }
 
     return ::test_result();


### PR DESCRIPTION
# The problem

iota_minus was implemented as `(D)(v0 - v1)`, where `D` is the
`iota_difference_t` of the `UnsignedIntegral` type of `v0` and `v1`.

Example: `v0 = 0`, and `v1 = 1` causes iota_minus to overflow.

Note: this overflow is perfectly defined behavior, but the result is
not what the users of iota_minus expect.

# The fix

`v0 < v1? - static_cast<D>(v1 - v0) : static_cast<D>(v0 - v1);`

That is, we check which integer is larger, we perform a non-overflowing
subtraction using the current type, and then we cast to the difference
type and correct the sign.

Pros: it maximizes the range for which iota_minus works correctly
without overflowing.
Cons: it introduces a branch and a signed bit change.

# Alternative solution (not pursued)


`static_cast<D>(v0) - static_cast<D>(v1)`

That is, we truncate the `UnsignedInteger`s into the different type and
then perform the subtraction.

Pros: simple and fast.
Cons: AFAIK this truncation is implementation defined.

Given:

`v0 = std::numeric_limits<UnsignedIntegral>::max()`
`v1 = std::numeric_limits<UnsignedIntegral>::max() - 1`

On x86 clang and gcc do the following

`static_cast<D>(v0) == -1`
`static_cast<D>(v1) == -2`

and thus `(-1) - (-2) == 1`, producing the correct result for `iota_minus`.

I pursued the other solution mainly because I'm not well versed on the standardese of unsigned to signed integer conversions. I hope somebody else can comment on this but AFAIK if:

-  the width of the types is the same (which is guaranteed by `iota_difference_t`),
- for 2's complement implementation (which is required by the standard for fixed width integer types), and
- the platform does not trap on overflow (most architectures I guess),

then this solution will work just fine. 

Since I am not sure and having architecture dependent behavior is messy I just prefer to do the safe thing here. 