### PR TITLE
Correct critical error in is_permutation

### DIFF
--- a/include/range/v3/algorithm/permutation.hpp
+++ b/include/range/v3/algorithm/permutation.hpp
@@ -60,7 +60,7 @@ namespace ranges
                 auto &&pred = as_function(pred_);
                 auto &&proj1 = as_function(proj1_);
                 auto &&proj2 = as_function(proj2_);
-                // shorten sequences as much as possible by lopping of any equal parts
+                // shorten sequences as much as possible by lopping off any equal parts
                 for(; begin1 != end1 && begin2 != end2; ++begin1, ++begin2)
                     if(!pred(proj1(*begin1), proj2(*begin2)))
                         goto not_done;
@@ -111,7 +111,7 @@ namespace ranges
                 auto &&pred = as_function(pred_);
                 auto &&proj1 = as_function(proj1_);
                 auto &&proj2 = as_function(proj2_);
-                // shorten sequences as much as possible by lopping of any equal parts
+                // shorten sequences as much as possible by lopping off any equal parts
                 for(; begin1 != end1; ++begin1, ++begin2)
                     if(!pred(proj1(*begin1), proj2(*begin2)))
                         goto not_done;


### PR DESCRIPTION
I just found this terrible error in cmcstl2, and realizing that `is_permutation` came from range-v3 I figured it should be fixed here as well.