### PR TITLE
To container fix

### DIFF
--- a/include/range/v3/to_container.hpp
+++ b/include/range/v3/to_container.hpp
@@ -63,7 +63,7 @@ namespace ranges
                 Cont impl(Rng && rng, std::false_type) const
                 {
                     using I = range_common_iterator_t<Rng>;
-                    return Cont{I{begin(rng)}, I{end(rng)}};
+                    return Cont(I{begin(rng)}, I{end(rng)});
                 }
 
                 template<typename Rng,


### PR DESCRIPTION
Fixes #240 by not using uniform initialization in `to_container` when initializing a container from an iterator range.