### PR TITLE
Protect basic_mixin::get to avoid inadvertent access

### DIFF
--- a/include/range/v3/utility/basic_iterator.hpp
+++ b/include/range/v3/utility/basic_iterator.hpp
@@ -434,6 +434,7 @@ namespace ranges
             basic_mixin(T t)
               : t_(std::move(t))
             {}
+        protected:
             RANGES_CXX14_CONSTEXPR
             T &get() noexcept
             {
@@ -490,6 +491,7 @@ namespace ranges
         private:
             friend range_access;
             friend range_access::mixin_base_t<Cur>;
+            friend struct get_cursor_fn;
             template<typename OtherCur, typename OtherS>
             friend struct basic_iterator;
             CONCEPT_ASSERT(detail::WeakCursor<Cur>());
@@ -767,23 +769,20 @@ namespace ranges
             RANGES_CXX14_CONSTEXPR
             Cur &operator()(basic_iterator<Cur, Sent> &it) const noexcept
             {
-                range_access::mixin_base_t<Cur> &mix = it;
-                return mix.get();
+                return it.pos();
             }
             template<typename Cur, typename Sent>
             RANGES_CXX14_CONSTEXPR
             Cur const &operator()(basic_iterator<Cur, Sent> const &it) const noexcept
             {
-                range_access::mixin_base_t<Cur> const &mix = it;
-                return mix.get();
+                return it.pos();
             }
             template<typename Cur, typename Sent>
             RANGES_CXX14_CONSTEXPR
             Cur operator()(basic_iterator<Cur, Sent> &&it) const
                 noexcept(std::is_nothrow_copy_constructible<Cur>::value)
             {
-                range_access::mixin_base_t<Cur> &mix = it;
-                return std::move(mix.get());
+                return std::move(it.pos());
             }
         };
 

--- a/include/range/v3/utility/common_iterator.hpp
+++ b/include/range/v3/utility/common_iterator.hpp
@@ -17,6 +17,7 @@
 #include <meta/meta.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/view_facade.hpp>
+#include <range/v3/utility/basic_iterator.hpp>
 #include <range/v3/utility/concepts.hpp>
 #include <range/v3/utility/variant.hpp>
 
@@ -79,7 +80,7 @@ namespace ranges
                 friend iterator_difference_t<I>
                 operator-(common_iterator<I, S> const &end, common_iterator<I, S> const &begin)
                 {
-                    common_cursor const &this_ = begin.mixin::get(), &that = end.mixin::get();
+                    common_cursor const &this_ = get_cursor(begin), &that = get_cursor(end);
                     return that.is_sentinel() ?
                         (this_.is_sentinel() ? 0 : that.se() - this_.it()) :
                         (this_.is_sentinel() ?


### PR DESCRIPTION
`basic_iterator` currently exposes its cursor though the public member function `get` in `basic_mixin`. Given that `get` is an incredibly common function name, there is a fair likelihood that someone will mistakenly use `i.get()` when they meant `i->get()` or `(*i).get()`. This patch makes `basic_mixin::get` a `protected` member, and officially blesses `get_cursor` as the approved way to break encapsulation and retrieve a cursor from a `basic_iterator`.