### PR TITLE
libstdc++<5.1 doesn't provide std::is_final

### DIFF
--- a/include/range/v3/utility/box.hpp
+++ b/include/range/v3/utility/box.hpp
@@ -130,7 +130,7 @@ namespace ranges
 
         template<typename Element, typename Tag = Element,
             bool Empty = std::is_empty<Element>::value &&
-#ifdef RANGES_CXX_GREATER_THAN_11
+#ifdef __cpp_lib_is_final
                          !std::is_final<Element>::value>
 #else
                          true>


### PR DESCRIPTION
Commit 6bddf650d9b53197bb82a504e8038a160b56174c uses `std::is_final` if C++>11, which breaks e.g. when clang is used with libstdc++-4.9 in C++14 mode.

This commit also checks if the std library implementation is libstdc++, and in that case, if its version is >= 5.1, which implements std::is_final according to their docs (haven't tested this though).