### PR TITLE
Update iterator concepts per ericniebler/stl2#153:

### DIFF
--- a/include/range/v3/algorithm/copy_n.hpp
+++ b/include/range/v3/algorithm/copy_n.hpp
@@ -38,7 +38,7 @@ namespace ranges
         {
             template<typename I, typename O, typename P = ident,
                 CONCEPT_REQUIRES_(
-                    WeakInputIterator<I>() &&
+                    InputIterator<I>() &&
                     WeaklyIncrementable<O>() &&
                     IndirectlyCopyable<I, O>()
                 )>

--- a/include/range/v3/algorithm/equal.hpp
+++ b/include/range/v3/algorithm/equal.hpp
@@ -52,7 +52,7 @@ namespace ranges
                 typename C = equal_to, typename P0 = ident, typename P1 = ident,
                 CONCEPT_REQUIRES_(
                     IteratorRange<I0, S0>() &&
-                    WeaklyComparable<I0, I1, C, P0, P1>()
+                    Comparable<I0, I1, C, P0, P1>()
                 )>
             bool operator()(I0 begin0, S0 end0, I1 begin1, C pred_ = C{},
                 P0 proj0_ = P0{}, P1 proj1_ = P1{}) const
@@ -88,7 +88,7 @@ namespace ranges
                 typename I1 = uncvref_t<I1Ref>,
                 CONCEPT_REQUIRES_(
                     Range<Rng0>() && Iterator<I1>() &&
-                    WeaklyComparable<I0, I1, C, P0, P1>()
+                    Comparable<I0, I1, C, P0, P1>()
                 )>
             bool operator()(Rng0 && rng0, I1Ref && begin1, C pred_ = C{}, P0 proj0_ = P0{},
                 P1 proj1_ = P1{}) const

--- a/include/range/v3/algorithm/fill_n.hpp
+++ b/include/range/v3/algorithm/fill_n.hpp
@@ -31,7 +31,7 @@ namespace ranges
         struct fill_n_fn
         {
             template<typename O, typename V,
-                CONCEPT_REQUIRES_(WeakOutputIterator<O, V>())>
+                CONCEPT_REQUIRES_(OutputIterator<O, V>())>
             O operator()(O begin, iterator_difference_t<O> n, V const & val) const
             {
                 RANGES_ASSERT(n >= 0);

--- a/include/range/v3/algorithm/generate_n.hpp
+++ b/include/range/v3/algorithm/generate_n.hpp
@@ -35,7 +35,7 @@ namespace ranges
         {
             template<typename O, typename F,
                 CONCEPT_REQUIRES_(Function<F>() &&
-                    WeakOutputIterator<O, concepts::Function::result_t<F>>())>
+                    OutputIterator<O, concepts::Function::result_t<F>>())>
             tagged_pair<tag::out(O), tag::fun(F)>
             operator()(O begin, iterator_difference_t<O> n, F fun) const
             {

--- a/include/range/v3/algorithm/merge_move.hpp
+++ b/include/range/v3/algorithm/merge_move.hpp
@@ -53,7 +53,7 @@ namespace ranges
                 CONCEPT_REQUIRES_(
                     IteratorRange<I0, S0>() &&
                     IteratorRange<I1, S1>() &&
-                    MergeMovable<I0, I1, O, C, P0, P1>()
+                    MoveMergeable<I0, I1, O, C, P0, P1>()
                 )>
             tagged_tuple<tag::in1(I0), tag::in2(I1), tag::out(O)>
             operator()(I0 begin0, S0 end0, I1 begin1, S1 end1, O out, C pred_ = C{},
@@ -87,7 +87,7 @@ namespace ranges
                 CONCEPT_REQUIRES_(
                     Range<Rng0>() &&
                     Range<Rng1>() &&
-                    MergeMovable<I0, I1, O, C, P0, P1>()
+                    MoveMergeable<I0, I1, O, C, P0, P1>()
                 )>
             tagged_tuple<tag::in1(range_safe_iterator_t<Rng0>), tag::in2(range_safe_iterator_t<Rng1>), tag::out(O)>
             operator()(Rng0 &&rng0, Rng1 &&rng1, O out, C pred = C{}, P0 proj0 = P0{},

--- a/include/range/v3/algorithm/mismatch.hpp
+++ b/include/range/v3/algorithm/mismatch.hpp
@@ -30,21 +30,13 @@ namespace ranges
 {
     inline namespace v3
     {
-        // TODO Would be nice to use WeaklyComparable here, but that uses Relation instead
+        // TODO Would be nice to use Comparable here, but that uses Relation instead
         // of Predicate. Relation requires symmetry: is_valid(pred(a,b)) => is_valid(pred(b,a))
 
         /// \ingroup group-concepts
         template<typename I1, typename I2, typename C = equal_to, typename P1 = ident,
             typename P2 = ident>
-        using Mismatchable1 = meta::fast_and<
-            InputIterator<I1>,
-            WeakInputIterator<I2>,
-            IndirectCallablePredicate<C, Projected<I1, P1>, Projected<I2, P2>>>;
-
-        /// \ingroup group-concepts
-        template<typename I1, typename I2, typename C = equal_to, typename P1 = ident,
-            typename P2 = ident>
-        using Mismatchable2 = meta::fast_and<
+        using Mismatchable = meta::fast_and<
             InputIterator<I1>,
             InputIterator<I2>,
             IndirectCallablePredicate<C, Projected<I1, P1>, Projected<I2, P2>>>;
@@ -55,7 +47,7 @@ namespace ranges
         {
             template<typename I1, typename S1, typename I2, typename C = equal_to,
                 typename P1 = ident, typename P2 = ident,
-                CONCEPT_REQUIRES_(Mismatchable1<I1, I2, C, P1, P2>() && IteratorRange<I1, S1>())>
+                CONCEPT_REQUIRES_(Mismatchable<I1, I2, C, P1, P2>() && IteratorRange<I1, S1>())>
             tagged_pair<tag::in1(I1), tag::in2(I2)>
             operator()(I1 begin1, S1 end1, I2 begin2, C pred_ = C{}, P1 proj1_ = P1{},
                 P2 proj2_ = P2{}) const
@@ -71,7 +63,7 @@ namespace ranges
 
             template<typename I1, typename S1, typename I2, typename S2, typename C = equal_to,
                 typename P1 = ident, typename P2 = ident,
-                CONCEPT_REQUIRES_(Mismatchable2<I1, I2, C, P1, P2>() && IteratorRange<I1, S1>() &&
+                CONCEPT_REQUIRES_(Mismatchable<I1, I2, C, P1, P2>() && IteratorRange<I1, S1>() &&
                     IteratorRange<I2, S2>())>
             tagged_pair<tag::in1(I1), tag::in2(I2)>
             operator()(I1 begin1, S1 end1, I2 begin2, S2 end2, C pred_ = C{}, P1 proj1_ = P1{},
@@ -91,7 +83,7 @@ namespace ranges
                 typename I1 = range_iterator_t<Rng1>,
                 typename I2 = uncvref_t<I2Ref>, // [*] See below
                 CONCEPT_REQUIRES_(InputRange<Rng1>() && Iterator<I2>() &&
-                    Mismatchable1<I1, I2, C, P1, P2>())>
+                    Mismatchable<I1, I2, C, P1, P2>())>
             tagged_pair<tag::in1(range_safe_iterator_t<Rng1>), tag::in2(I2)>
             operator()(Rng1 &&rng1, I2Ref &&begin2, C pred = C{}, P1 proj1 = P1{},
                 P2 proj2 = P2{}) const
@@ -105,7 +97,7 @@ namespace ranges
                 typename I1 = range_iterator_t<Rng1>,
                 typename I2 = range_iterator_t<Rng2>,
                 CONCEPT_REQUIRES_(InputRange<Rng1>() && InputRange<Rng2>() &&
-                    Mismatchable2<I1, I2, C, P1, P2>())>
+                    Mismatchable<I1, I2, C, P1, P2>())>
             tagged_pair<tag::in1(range_safe_iterator_t<Rng1>), tag::in2(range_safe_iterator_t<Rng2>)>
             operator()(Rng1 &&rng1, Rng2 &&rng2, C pred = C{}, P1 proj1 = P1{}, P2 proj2 = P2{}) const
             {

--- a/include/range/v3/algorithm/replace_copy.hpp
+++ b/include/range/v3/algorithm/replace_copy.hpp
@@ -33,7 +33,7 @@ namespace ranges
         template<typename I, typename O, typename T0, typename T1, typename P = ident>
         using ReplaceCopyable = meta::fast_and<
             InputIterator<I>,
-            WeakOutputIterator<O, T1>,
+            OutputIterator<O, T1>,
             IndirectlyCopyable<I, O>,
             IndirectCallableRelation<equal_to, Projected<I, P>, T0 const *>>;
 

--- a/include/range/v3/algorithm/replace_copy_if.hpp
+++ b/include/range/v3/algorithm/replace_copy_if.hpp
@@ -33,7 +33,7 @@ namespace ranges
         template<typename I, typename O, typename C, typename T, typename P = ident>
         using ReplaceCopyIfable = meta::fast_and<
             InputIterator<I>,
-            WeakOutputIterator<O, T>,
+            OutputIterator<O, T>,
             IndirectlyCopyable<I, O>,
             IndirectCallablePredicate<C, Projected<I, P>>>;
 

--- a/include/range/v3/algorithm/swap_ranges.hpp
+++ b/include/range/v3/algorithm/swap_ranges.hpp
@@ -34,7 +34,7 @@ namespace ranges
             template<typename I1Ref, typename S1, typename I2,
                 typename I1 = uncvref_t<I1Ref>,
                 CONCEPT_REQUIRES_(InputIterator<I1>() && IteratorRange<I1, S1>() &&
-                                  WeakInputIterator<I2>() &&
+                                  InputIterator<I2>() &&
                                   IndirectlySwappable<I1, I2>())>
             tagged_pair<tag::in1(I1), tag::in2(I2)> operator()(I1Ref&& begin1, S1 end1, I2 begin2) const
             {
@@ -57,7 +57,7 @@ namespace ranges
             template<typename Rng1, typename I2,
                 typename I1 = range_iterator_t<Rng1>,
                 CONCEPT_REQUIRES_(InputRange<Rng1>() &&
-                                  WeakInputIterator<I2>() &&
+                                  InputIterator<I2>() &&
                                   IndirectlySwappable<I1, I2>())>
             tagged_pair<tag::in1(I1), tag::in2(I2)> operator()(Rng1 & rng1, I2 begin2) const
             {

--- a/include/range/v3/algorithm/transform.hpp
+++ b/include/range/v3/algorithm/transform.hpp
@@ -54,7 +54,7 @@ namespace ranges
             typename Y = concepts::Callable::result_t<F, X0, X1>>
         using Transformable2 = meta::fast_and<
             InputIterator<I0>,
-            WeakInputIterator<I1>,
+            InputIterator<I1>,
             WeaklyIncrementable<O>,
             IndirectCallable<F, Projected<I0, P0>, Projected<I1, P1>>,
             Writable<O, Y>>;

--- a/include/range/v3/numeric/adjacent_difference.hpp
+++ b/include/range/v3/numeric/adjacent_difference.hpp
@@ -36,8 +36,8 @@ namespace ranges
                   typename Y = concepts::Callable::result_t<BOp, X, X>>
         using AdjacentDifferentiable = meta::fast_and<
             InputIterator<I>,
-            WeakOutputIterator<O, X>,
-            WeakOutputIterator<O, Y>,
+            OutputIterator<O, X>,
+            OutputIterator<O, Y>,
             Callable<P, V>,
             Callable<BOp, X, X>,
             CopyConstructible<uncvref_t<X>>,

--- a/include/range/v3/numeric/partial_sum.hpp
+++ b/include/range/v3/numeric/partial_sum.hpp
@@ -33,7 +33,7 @@ namespace ranges
                   typename Y = concepts::Callable::result_t<BOp, X, X>>
         using PartialSummable = meta::fast_and<
             InputIterator<I>,
-            WeakOutputIterator<O, X>,
+            OutputIterator<O, X>,
             Callable<P, V>,
             CopyConstructible<uncvref_t<X>>,
             Callable<BOp, X, X>,

--- a/include/range/v3/range_access.hpp
+++ b/include/range/v3/range_access.hpp
@@ -65,24 +65,6 @@ namespace ranges
               : mixin_base_2_<Cur>
             {};
 
-            struct HasDoneCursor_
-            {
-                template<typename T>
-                auto requires_(T&& t) -> decltype(
-                    concepts::valid_expr(
-                        concepts::convertible_to<bool>(t.done())
-                    ));
-            };
-
-            struct HasEqualCursor_
-            {
-                template<typename T>
-                auto requires_(T&& t) -> decltype(
-                    concepts::valid_expr(
-                        concepts::convertible_to<bool>(t.equal(t))
-                    ));
-            };
-
         public:
             template<typename Cur>
             using single_pass_t = meta::_t<single_pass_<Cur>>;
@@ -93,7 +75,7 @@ namespace ranges
             //
             // Concepts that the range cursor must model
             //
-            struct WeakCursor
+            struct Cursor
             {
                 template<typename T>
                 auto requires_(T&& t) -> decltype(
@@ -101,16 +83,12 @@ namespace ranges
                         (t.next(), concepts::void_)
                     ));
             };
-            struct Cursor
-              : concepts::refines<WeakCursor>
+            struct HasEqualCursor
             {
                 template<typename T>
                 auto requires_(T&& t) -> decltype(
                     concepts::valid_expr(
-                        concepts::is_true(
-                            meta::or_<
-                                concepts::models<HasDoneCursor_, T>,
-                                concepts::models<HasEqualCursor_, T> >())
+                        concepts::convertible_to<bool>(t.equal(t))
                     ));
             };
             struct ReadableCursor
@@ -145,20 +123,14 @@ namespace ranges
                         concepts::model_of<concepts::SignedIntegral>(s.distance_from(c))
                     ));
             };
-            struct WeakOutputCursor
-              : concepts::refines<WritableCursor, WeakCursor(concepts::_1)>
-            {};
             struct OutputCursor
-              : concepts::refines<WeakOutputCursor, Cursor(concepts::_1)>
-            {};
-            struct WeakInputCursor
-              : concepts::refines<WeakCursor, ReadableCursor>
+              : concepts::refines<WritableCursor, Cursor(concepts::_1)>
             {};
             struct InputCursor
-              : concepts::refines<WeakInputCursor, Cursor>
+              : concepts::refines<ReadableCursor, Cursor>
             {};
             struct ForwardCursor
-              : concepts::refines<WeakInputCursor, HasEqualCursor_>
+              : concepts::refines<InputCursor, HasEqualCursor>
             {
                 template<typename T>
                 auto requires_(T&& t) -> decltype(
@@ -404,20 +376,20 @@ namespace ranges
         namespace detail
         {
             template<typename T>
+            using Cursor =
+                concepts::models<range_access::Cursor, T>;
+
+            template<typename T>
+            using HasEqualCursor =
+                concepts::models<range_access::HasEqualCursor, T>;
+
+            template<typename T>
             using ReadableCursor =
                 concepts::models<range_access::ReadableCursor, T>;
 
             template<typename T, typename U>
             using WritableCursor =
                 concepts::models<range_access::WritableCursor, T, U>;
-
-            template<typename T>
-            using WeakCursor =
-                concepts::models<range_access::WeakCursor, T>;
-
-            template<typename T>
-            using Cursor =
-                concepts::models<range_access::Cursor, T>;
 
             template<typename T>
             using SizedCursor =
@@ -428,16 +400,8 @@ namespace ranges
               concepts::models<range_access::SizedCursorRange, T, U>;
 
             template<typename T, typename U>
-            using WeakOutputCursor =
-                concepts::models<range_access::WeakOutputCursor, T, U>;
-
-            template<typename T, typename U>
             using OutputCursor =
                 concepts::models<range_access::OutputCursor, T, U>;
-
-            template<typename T>
-            using WeakInputCursor =
-                concepts::models<range_access::WeakInputCursor, T>;
 
             template<typename T>
             using InputCursor =
@@ -467,9 +431,7 @@ namespace ranges
                         range_access::BidirectionalCursor,
                         range_access::ForwardCursor,
                         range_access::InputCursor,
-                        range_access::WeakInputCursor,
-                        range_access::Cursor,
-                        range_access::WeakCursor>, T>;
+                        range_access::Cursor>, T>;
 
             template<typename T>
             using cursor_concept_t = meta::_t<cursor_concept<T>>;

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -323,8 +323,11 @@ namespace ranges
         template<typename T, typename Enable = void>
         struct is_view;
 
-        template<typename T, typename Enable = void>
-        struct is_sized_range;
+        template<typename R>
+        struct disable_sized_range;
+
+        template<typename I, typename S>
+        struct disable_sized_iterator_range;
 
         template<typename Cur>
         struct basic_mixin;

--- a/include/range/v3/utility/associated_types.hpp
+++ b/include/range/v3/utility/associated_types.hpp
@@ -19,7 +19,6 @@
 #include <utility>
 #include <type_traits>
 #include <meta/meta.hpp>
-#include <range/v3/utility/common_type.hpp>
 
 namespace ranges
 {
@@ -135,6 +134,9 @@ namespace ranges
         {
             using type = typename T::char_type;
         };
+
+        template<typename I, typename S>
+        struct disable_sized_iterator_range : std::false_type {};
         /// @}
     }
 }

--- a/include/range/v3/utility/concepts.hpp
+++ b/include/range/v3/utility/concepts.hpp
@@ -410,6 +410,17 @@ namespace ranges
             ////////////////////////////////////////////////////////////////////////////////////////////
             // Comparison concepts
             ////////////////////////////////////////////////////////////////////////////////////////////
+            struct WeaklyEqualityComparable
+            {
+                template<typename T, typename U>
+                auto requires_(T && t, U && u) -> decltype(
+                    concepts::valid_expr(
+                        concepts::convertible_to<bool>(t == u),
+                        concepts::convertible_to<bool>(t != u),
+                        concepts::convertible_to<bool>(u == t),
+                        concepts::convertible_to<bool>(u != t)
+                    ));
+            };
 
             struct EqualityComparable
             {
@@ -422,10 +433,9 @@ namespace ranges
 
                 template<typename T, typename U,
                     meta::if_<std::is_same<T, U>, int> = 0>
-                auto requires_(T && t, U && u) -> decltype(
+                auto requires_(T &&, U &&) -> decltype(
                     concepts::valid_expr(
-                        concepts::convertible_to<bool>(t == u),
-                        concepts::convertible_to<bool>(t != u)
+                        concepts::model_of<EqualityComparable, T>()
                     ));
 
                 // Cross-type equality comparison from N3351:
@@ -433,16 +443,13 @@ namespace ranges
                 template<typename T, typename U,
                     meta::if_c<!std::is_same<T, U>::value, int> = 0,
                     typename C = CommonReference::reference_t<T const &, U const &>>
-                auto requires_(T && t, U && u) -> decltype(
+                auto requires_(T &&, U &&) -> decltype(
                     concepts::valid_expr(
                         concepts::model_of<EqualityComparable, T>(),
                         concepts::model_of<EqualityComparable, U>(),
+                        concepts::model_of<WeaklyEqualityComparable, T, U>(),
                         concepts::model_of<CommonReference, T const &, U const &>(),
-                        concepts::model_of<EqualityComparable, C>(),
-                        concepts::convertible_to<bool>(t == u),
-                        concepts::convertible_to<bool>(u == t),
-                        concepts::convertible_to<bool>(t != u),
-                        concepts::convertible_to<bool>(u != t)
+                        concepts::model_of<EqualityComparable, C>()
                     ));
             };
 
@@ -812,6 +819,9 @@ namespace ranges
 
         template<typename T>
         using Copyable = concepts::models<concepts::Copyable, T>;
+
+        template<typename T, typename U>
+        using WeaklyEqualityComparable = concepts::models<concepts::WeaklyEqualityComparable, T, U>;
 
         template<typename T, typename U = T>
         using EqualityComparable = concepts::models<concepts::EqualityComparable, T, U>;

--- a/include/range/v3/utility/counted_iterator.hpp
+++ b/include/range/v3/utility/counted_iterator.hpp
@@ -74,8 +74,6 @@ namespace ranges
             private:
                 template<typename OtherI, typename OtherD>
                 friend struct counted_cursor;
-                using iterator_concept_ =
-                    concepts::most_refined<meta::list<concepts::Iterator, concepts::WeakIterator>, I>;
                 I it_;
                 D n_;
 
@@ -165,7 +163,7 @@ namespace ranges
         /// \addtogroup group-utility
         /// @{
 
-        template<typename I, CONCEPT_REQUIRES_(WeakInputIterator<I>())>
+        template<typename I, CONCEPT_REQUIRES_(Iterator<I>())>
         counted_iterator<I> make_counted_iterator(I i, iterator_difference_t<I> n)
         {
             return counted_iterator<I>{std::move(i), n};

--- a/include/range/v3/utility/iterator_traits.hpp
+++ b/include/range/v3/utility/iterator_traits.hpp
@@ -40,7 +40,7 @@ namespace ranges
         using iterator_common_reference_t = concepts::Readable::common_reference_t<I>;
 
         template<typename I>
-        using iterator_category_t = concepts::WeakInputIterator::category_t<I>;
+        using iterator_category_t = concepts::InputIterator::category_t<I>;
 
         template<typename I>
         using iterator_difference_t = concepts::WeaklyIncrementable::difference_t<I>;

--- a/include/range/v3/utility/unreachable.hpp
+++ b/include/range/v3/utility/unreachable.hpp
@@ -45,49 +45,6 @@ namespace ranges
             {
                 return true;
             }
-            constexpr bool operator==(unreachable) const
-            {
-                return true;
-            }
-            constexpr bool operator!=(unreachable) const
-            {
-                return false;
-            }
-        };
-
-        // Specializations of common_type for concept checking, needed because
-        // std::common_type is not SFINAE-friendly.
-        template<typename T>
-        struct common_type<T, unreachable>
-        {
-            using type = common_iterator<T, unreachable>;
-        };
-        template<typename T>
-        struct common_type<unreachable, T>
-        {
-            using type = common_iterator<T, unreachable>;
-        };
-        template<>
-        struct common_type<unreachable, unreachable>
-        {
-            using type = unreachable;
-        };
-
-        template<typename T, typename TQual, typename UQual>
-        struct basic_common_reference<T, unreachable, TQual, UQual>
-        {
-            using type = common_iterator<T, unreachable>;
-        };
-        template<typename T, typename TQual, typename UQual>
-        struct basic_common_reference<unreachable, T, TQual, UQual>
-        {
-            using type = common_iterator<T, unreachable>;
-        };
-        template<typename TQual, typename UQual>
-        struct basic_common_reference<unreachable, unreachable, TQual, UQual>
-        {
-            using type = decltype(true ? std::declval<meta::apply<TQual, unreachable>>()
-                                       : std::declval<meta::apply<UQual, unreachable>>());
         };
         /// @}
     }

--- a/include/range/v3/view/any_view.hpp
+++ b/include/range/v3/view/any_view.hpp
@@ -41,7 +41,7 @@ namespace ranges
         {
             struct any_object
             {
-                virtual ~any_object() {}
+                virtual ~any_object() = default;
             };
 
             template<class T>
@@ -59,7 +59,7 @@ namespace ranges
             template<typename Ref, category Cat = category::input>
             struct any_cursor_interface
             {
-                virtual ~any_cursor_interface() {}
+                virtual ~any_cursor_interface() = default;
                 virtual any_object const &iter() const = 0;
                 virtual Ref get() const = 0;
                 virtual bool equal(any_cursor_interface const &) const = 0;
@@ -115,7 +115,23 @@ namespace ranges
                 template<typename S, typename II>
                 friend struct any_sentinel_impl;
                 using Ref = iterator_reference_t<I>;
+                using Input = any_cursor_interface<Ref, category::input>;
                 object<I> it_;
+
+                CONCEPT_REQUIRES(EqualityComparable<I>())
+                bool equal_(Input const &that) const
+                {
+                    any_cursor_impl const *pthat =
+                        dynamic_cast<any_cursor_impl const *>(&that);
+                    RANGES_ASSERT(pthat != nullptr);
+                    return pthat->it_.get() == it_.get();
+                }
+                CONCEPT_REQUIRES(!EqualityComparable<I>())
+                bool equal_(Input const &) const
+                {
+                    return true;
+                }
+
             public:
                 any_cursor_impl() = default;
                 any_cursor_impl(I it)
@@ -129,12 +145,9 @@ namespace ranges
                 {
                     return *it_.get();
                 }
-                bool equal(any_cursor_interface<Ref, category::input> const &that) const
+                bool equal(Input const &that) const
                 {
-                    any_cursor_impl const *pthat =
-                        dynamic_cast<any_cursor_impl const *>(&that);
-                    RANGES_ASSERT(pthat != nullptr);
-                    return pthat->it_.get() == it_.get();
+                    return equal_(that);
                 }
                 void next()
                 {
@@ -164,7 +177,7 @@ namespace ranges
 
             struct any_sentinel_interface
             {
-                virtual ~any_sentinel_interface() {}
+                virtual ~any_sentinel_interface() = default;
                 virtual bool equal(any_object const &) const = 0;
                 virtual any_sentinel_interface *clone() const = 0;
             };
@@ -289,7 +302,7 @@ namespace ranges
             template<typename Ref, category Cat>
             struct any_view_interface
             {
-                virtual ~any_view_interface() {}
+                virtual ~any_view_interface() = default;
                 virtual any_cursor<Ref, Cat> begin_cursor() = 0;
                 virtual any_sentinel end_cursor() = 0;
                 virtual any_view_interface *clone() const = 0;

--- a/include/range/v3/view/counted.hpp
+++ b/include/range/v3/view/counted.hpp
@@ -61,7 +61,7 @@ namespace ranges
             struct counted_fn
             {
                 template<typename I,
-                    CONCEPT_REQUIRES_(WeakIterator<I>())>
+                    CONCEPT_REQUIRES_(Iterator<I>())>
                 counted_view<I> operator()(I it, iterator_difference_t<I> n) const
                 {
                     return {std::move(it), n};

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -110,19 +110,19 @@ namespace ranges
             {
                 return ranges::end(rng.base());
             }
-            template<typename I, CONCEPT_REQUIRES_(Iterator<I>())>
+            template<typename I, CONCEPT_REQUIRES_(EqualityComparable<I>())>
             static bool equal(I const &it0, I const &it1)
             {
                 return it0 == it1;
             }
-            template<typename I, CONCEPT_REQUIRES_(WeakIterator<I>())>
+            template<typename I, CONCEPT_REQUIRES_(Iterator<I>())>
             static iterator_reference_t<I> get(I const &it,
                 detail::adaptor_base_current_mem_fn = {})
                 noexcept(noexcept(iterator_reference_t<I>(*it)))
             {
                 return *it;
             }
-            template<typename I, CONCEPT_REQUIRES_(WeakIterator<I>())>
+            template<typename I, CONCEPT_REQUIRES_(Iterator<I>())>
             static void next(I &it)
             {
                 ++it;

--- a/test/constexpr_core.cpp
+++ b/test/constexpr_core.cpp
@@ -38,6 +38,21 @@ void advance(input_iterator<T> & i, ranges::iterator_difference_t<I> n) {
 
 // Test sequence 1,2,3,4
 template<typename It>
+RANGES_CXX14_CONSTEXPR auto test_it_back(It beg, It end,
+    ranges::concepts::BidirectionalIterator*) -> bool
+{
+    auto end_m1_2 = It{ranges::prev(end, 1)};
+    if (*end_m1_2 != 4) { return false; }
+    return true;
+}
+
+template<typename It, typename Concept>
+RANGES_CXX14_CONSTEXPR auto test_it_back(It, It, Concept) -> bool
+{
+    return true;
+}
+
+template<typename It>
 RANGES_CXX14_CONSTEXPR auto test_it_(It beg, It end) -> bool {
     if (*beg != 1) { return false; }
     if (ranges::distance(beg, end) != 4) { return false; }
@@ -45,11 +60,7 @@ RANGES_CXX14_CONSTEXPR auto test_it_(It beg, It end) -> bool {
     auto end_m1 = It{ranges::next(beg, 3)};
     if (*end_m1 != 4) { return false; }
 
-    if (std::is_convertible<ranges::iterator_concept<It>,
-                            ranges::concepts::BidirectionalIterator*>{}) {
-        auto end_m1_2 = It{ranges::prev(end, 1)};
-        if (*end_m1_2 != 4) { return false; }
-    }
+    if (!test_it_back(beg, end, ranges::iterator_concept<It>{})) { return false; }
     auto end2 = beg;
     ranges::advance(end2, end);
     if (end2 != end) { return false; }

--- a/test/range.cpp
+++ b/test/range.cpp
@@ -58,7 +58,6 @@ int main()
     ::models<ranges::concepts::View>(r1);
     ::models_not<ranges::concepts::SizedView>(r1);
     CHECK(r1.first == vi.begin()+1);
-    CHECK(r1.second == ranges::unreachable{});
     r1.second = ranges::unreachable{};
 
     r0.pop_front();
@@ -72,12 +71,10 @@ int main()
 
     std::pair<std::vector<int>::iterator, ranges::unreachable> p1 = r1;
     CHECK(p1.first == vi.begin()+1);
-    CHECK(p1.second == ranges::unreachable{});
     static_assert(sizeof(p1) > sizeof(r1), "");
 
     ranges::range<std::vector<int>::iterator, ranges::unreachable> r2 { p1 };
     CHECK(r1.first == vi.begin()+1);
-    CHECK(r1.second == ranges::unreachable{});
 
     std::list<int> li{1,2,3,4};
     ranges::sized_range<std::list<int>::iterator> l0 {li.begin(), li.end(), li.size()};

--- a/test/test_iterators.hpp
+++ b/test/test_iterators.hpp
@@ -405,23 +405,4 @@ struct sentinel_type<I<It>, Sized>
     using type = sentinel<It, Sized>;
 };
 
-namespace ranges
-{
-    template<typename I0, bool B, typename I1>
-    struct common_type<sentinel<I0, B>, I1>
-    {
-        using type = common_iterator<I1, sentinel<I0, B>>;
-    };
-    template<typename I0, typename I1, bool B>
-    struct common_type<I0, sentinel<I1, B>>
-    {
-        using type = common_iterator<I0, sentinel<I1, B>>;
-    };
-    template<typename I, bool B>
-    struct common_type<sentinel<I, B>, sentinel<I, B>>
-    {
-        using type = sentinel<I, B>;
-    };
-}
-
 #endif  // RANGES_TEST_ITERATORS_HPP

--- a/test/utility/basic_iterator.cpp
+++ b/test/utility/basic_iterator.cpp
@@ -39,7 +39,8 @@ namespace test_weak_input
         void next() { ++it_; }
     };
 
-    CONCEPT_ASSERT(ranges::detail::WeakInputCursor<cursor<char*>>());
+    CONCEPT_ASSERT(ranges::detail::InputCursor<cursor<char*>>());
+    CONCEPT_ASSERT(!ranges::detail::HasEqualCursor<cursor<char*>>());
 
     template<class I>
     using iterator = ranges::basic_iterator<cursor<I>>;
@@ -47,7 +48,10 @@ namespace test_weak_input
     static_assert(
         std::is_same<
             iterator<char*>::iterator_category,
-            ranges::weak_input_iterator_tag>::value,
+            ranges::input_iterator_tag>::value,
+        "");
+    static_assert(
+        !ranges::EqualityComparable<iterator<char*>>(),
         "");
 
     void test()
@@ -149,12 +153,14 @@ namespace test_weak_output
         explicit cursor(I i) : it_(i) {}
     };
 
-    CONCEPT_ASSERT(ranges::detail::WeakOutputCursor<cursor<char*>, char>());
+    CONCEPT_ASSERT(ranges::detail::OutputCursor<cursor<char*>, char>());
+    CONCEPT_ASSERT(!ranges::detail::HasEqualCursor<cursor<char*>>());
 
     template<class I>
     using iterator = ranges::basic_iterator<cursor<I>>;
 
-    CONCEPT_ASSERT(ranges::WeakOutputIterator<iterator<char*>, char>());
+    CONCEPT_ASSERT(ranges::OutputIterator<iterator<char*>, char>());
+    CONCEPT_ASSERT(!ranges::EqualityComparable<iterator<char*>>());
 
     void test()
     {

--- a/test/utility/iterator.cpp
+++ b/test/utility/iterator.cpp
@@ -19,7 +19,8 @@ using namespace ranges;
 
 void test_insert_iterator()
 {
-    CONCEPT_ASSERT(WeakOutputIterator<insert_iterator<std::vector<int>>, int&&>());
+    CONCEPT_ASSERT(OutputIterator<insert_iterator<std::vector<int>>, int&&>());
+    CONCEPT_ASSERT(!EqualityComparable<insert_iterator<std::vector<int>>>());
     std::vector<int> vi{5,6,7,8};
     copy({1,2,3,4}, inserter(vi, vi.begin()+2));
     ::check_equal(vi, {5,6,1,2,3,4,7,8});

--- a/test/view/adjacent_remove_if.cpp
+++ b/test/view/adjacent_remove_if.cpp
@@ -34,7 +34,8 @@ int main()
     models_not<concepts::SizedView>(rng);
     models<concepts::ForwardIterator>(begin(rng));
     models_not<concepts::BidirectionalIterator>(begin(rng));
-    CONCEPT_ASSERT(WeakOutputIterator<decltype(ranges::back_inserter(out)), int>());
+    CONCEPT_ASSERT(OutputIterator<decltype(ranges::back_inserter(out)), int>());
+    CONCEPT_ASSERT(!EqualityComparable<decltype(ranges::back_inserter(out))>());
     copy(rng, ranges::back_inserter(out));
     ::check_equal(out, {1, 2, 3, 4});
 


### PR DESCRIPTION
* Rename `MergeMovable` to `MoveMergeable`.
* Implement `WeaklyEqualityComparable`.
* Relax `IteratorRange` to agree with the Ranges TS `Sentinel` concept.
* `SinglePass` is now true for `OutputIterator`s.
* Coalesce:
  *  `{Input,Output,""}Iterator` with `Weak{Input,Output,""}Iterator`
  * `WeaklyComparable` with `Comparable`
  * `Mismatchable1` with `Mismatchable2`
  * `AsymmetricallyComparable` with `WeaklyAsymmetricallyComparable`

* Replace `is_sized_range`/`SizedRangeLike_` with `disable_sized_range`, which is a
  boolean UnaryTypeTrait instead of a variable template as in the TS.
* Implement `disable_sized_iterator_range<I, S>`, also a boolean UnaryTypeTrait,
  to serve the function of the TS's `disable_sized_sentinel<S, I>`. Closes #231.

* Update cursor concepts in `range_access`, and usages in `basic_iterator`.
* Remove relational operators from `basic_sentinel`, and the cross-type relational
  operators from `basic_iterator`.

* Bring `advance` and `distance` into spec, adjust `enumerate` to agree.
* Constrain `prev`.
* Don't use `sized_iterator_range_concept_t<I, I>` in `iter_enumerate`: `<I, I>` may
  not satisfy `IteratorRange`, let alone `SizedIteratorRange`.

* Implement `common_cursor::equal` overload for non-EC wrapped iterators.

* Remove `unreachable`'s same-type `==`/`!=` and cross-type `<`, etc.
* Remove all Iterator/Sentinel `common_type` specializations.

* `any_cursor` treats all non-equality-comparable (weak) iterators as equal.
