### PR TITLE
fix iterator type in iter_transform2_view::cursor constructor

### DIFF
--- a/include/range/v3/view/transform.hpp
+++ b/include/range/v3/view/transform.hpp
@@ -182,7 +182,7 @@ namespace ranges
                         range_iterator_t<Rng2>{}))>;
 
                 cursor() = default;
-                cursor(fun_ref_ fun, range_iterator_t<Rng2> it1, range_iterator_t<Rng2> it2)
+                cursor(fun_ref_ fun, range_iterator_t<Rng1> it1, range_iterator_t<Rng2> it2)
                   : fun_(std::move(fun)), it1_(std::move(it1)), it2_(std::move(it2))
                 {}
                 auto get() const


### PR DESCRIPTION
Fix iter_transform2_view::cursor constructor to take range_iterator_t<Rng1> and range_iterator_t<Rng2> instead of twice range_iterator_t<Rng2>.