### PR TITLE
basic_sentinel's constructors must be public.

### DIFF
--- a/include/range/v3/utility/basic_iterator.hpp
+++ b/include/range/v3/utility/basic_iterator.hpp
@@ -445,7 +445,7 @@ namespace ranges
         struct basic_sentinel : range_access::mixin_base_t<S>
         {
             // http://gcc.gnu.org/bugzilla/show_bug.cgi?id=60799
-            #ifndef __GNUC__
+            #if !defined(__GNUC__) || defined(__clang__)
         private:
             #endif
             friend range_access;
@@ -461,6 +461,7 @@ namespace ranges
             {
                 return this->range_access::mixin_base_t<S>::get();
             }
+        public:
             basic_sentinel() = default;
             RANGES_CXX14_CONSTEXPR basic_sentinel(S end)
               : range_access::mixin_base_t<S>(std::move(end))

--- a/include/range/v3/view/view.hpp
+++ b/include/range/v3/view/view.hpp
@@ -118,7 +118,7 @@ namespace ranges
                 view(View a)
                   : view_(std::move(a))
                 {}
-                // Calling directly requires range arguments or lvalue containers.
+                // Calling directly requires View arguments or lvalue containers.
                 template<typename Rng, typename...Rest,
                     CONCEPT_REQUIRES_(ViewConcept<Rng, Rest...>())>
                 auto operator()(Rng && rng, Rest &&... rest) const


### PR DESCRIPTION
Corrects a cause of major breakage when __GNUC__ is not defined, including DevDiv 191705. Changing the trigger for the GCC PR 60799 workaround from `#ifndef __GNUC__` to `#if !defined(__GNUC__) || defined(__clang__)` disables the workaround when compiling with clang, which should prevent this issue from reccurring. 