### PR TITLE
Travis updates:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,18 @@ script: cmake
 # - clang 3.5, 3.6, trunk
 #   - Note: trunk is tested with/without ASAN,
 #     the rest are only tested with ASAN=On.
-# - gcc 4.9, 5.0
+# - gcc 4.9, 5
 #
 matrix:
   include:
-    - env: BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
+    - env: BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
       os: osx
       compiler: clang
 
-    # Test clang-3.4: C++11, Buidd=Debug/Release, ASAN=On/Off
+    # ASAN disabled for clang builds pending resolution of
+    #  https://llvm.org/bugs/show_bug.cgi?id=22757
+
+    # Test clang-3.4: C++11, Build=Debug/Release, ASAN=On/Off
     # - env: CLANG_VERSION=3.4 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
     #   os: linux
     #   compiler: clang34
@@ -54,7 +57,7 @@ matrix:
     #   compiler: clang
     #   addons: *clang34
 
-    # Test clang-3.5: C++11/C++14, Buidd=Debug/Release, ASAN=On/Off
+    # Test clang-3.5: C++11/C++14, Build=Debug/Release, ASAN=On/Off
     # - env: CLANG_VERSION=3.5 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
     #   os: linux
     #   addons: &clang35
@@ -92,7 +95,7 @@ matrix:
     #   os: linux
     #   addons: *clang35
 
-    # Test clang-3.6: C++11/C++14, Buidd=Debug/Release, ASAN=On/Off
+    # Test clang-3.6: C++11/C++14, Build=Debug/Release, ASAN=On/Off
     # - env: CLANG_VERSION=3.6 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
     #   os: linux
     #   addons: &clang36
@@ -130,8 +133,8 @@ matrix:
     #   os: linux
     #   addons: *clang36
 
-    # Test clang-3.7: C++11/C++14, Buidd=Debug/Release, ASAN=On/Off
-    - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
+    # Test clang-3.7: C++11/C++14, Build=Debug/Release, ASAN=On/Off
+    - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
       os: linux
       addons: &clang37
         apt:
@@ -143,31 +146,31 @@ matrix:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.7
 
-    - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
+    - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
       os: linux
       addons: *clang37
 
-    - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=14 ASAN=On LIBCXX=On
+    - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On
       os: linux
       addons: *clang37
 
-    - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On
+    - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On
       os: linux
       addons: *clang37
 
-    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
+    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
     #   os: linux
     #   addons: *clang37
 
-    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
+    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
     #   os: linux
     #   addons: *clang37
 
-    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On
+    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=14 ASAN=On LIBCXX=On
     #   os: linux
     #   addons: *clang37
 
-    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On
+    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On
     #   os: linux
     #   addons: *clang37
 
@@ -201,18 +204,34 @@ matrix:
       os: linux
       addons: *gcc49
 
-    # Test gcc-5.0: C++11/14, Build=Debug/Release, ASAN=Off
+    # Test gcc-5: C++11/14, Build=Debug/Release, ASAN=On/Off
+    - env: GCC_VERSION=5 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=Off
+      os: linux
+      addons: &gcc5
+        apt:
+          packages:
+            - g++-5
+            - valgrind
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - env: GCC_VERSION=5 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=Off
+      os: linux
+      addons: *gcc5
+
     # - env: GCC_VERSION=5 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=Off
     #   os: linux
-    #   addons: &gcc5
-    #     apt:
-    #       packages:
-    #         - gcc-5
-    #         - valgrind
-    #       sources:
-    #         - ubuntu-toolchain-r-test
+    #   addons: *gcc5
 
     # - env: GCC_VERSION=5 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off
+    #   os: linux
+    #   addons: *gcc5
+
+    # - env: GCC_VERSION=5 BUILD_TYPE=Debug CPP=14 ASAN=On LIBCXX=Off
+    #   os: linux
+    #   addons: *gcc5
+
+    # - env: GCC_VERSION=5 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=Off
     #   os: linux
     #   addons: *gcc5
 
@@ -253,7 +272,8 @@ install:
   - export CXX_FLAGS=""
   - export CXX_LINKER_FLAGS=""
   - if [ -z "$BUILD_TYPE" ]; then export BUILD_TYPE=Release; fi
-  - if [ "$ASAN" == "On"]; then export CXX_FLAGS="${CXX_FLAGS} -fsanitize=address,undefined,integer -fno-omit-frame-pointer -fno-sanitize=unsigned-integer-overflow"; fi
+  - if [ -n "$CLANG_VERSION" -a "$ASAN" == "On" ]; then export CXX_FLAGS="${CXX_FLAGS} -fsanitize=address,undefined,integer -fno-omit-frame-pointer -fno-sanitize=unsigned-integer-overflow"; fi
+  - if [ -n "$GCC_VERSION" -a "$ASAN" == "On" ]; then export CXX_FLAGS="${CXX_FLAGS} -fsanitize=address,undefined -fno-omit-frame-pointer"; fi
   - if [ -n "$CLANG_VERSION" ]; then CXX_FLAGS="${CXX_FLAGS} -D__extern_always_inline=inline"; fi
   - if [ "$LIBCXX" == "On" ]; then CXX_FLAGS="${CXX_FLAGS} -stdlib=libc++ -I/usr/include/c++/v1/"; fi
   - if [ "$LIBCXX" == "On" ]; then CXX_LINKER_FLAGS="${CXX_FLAGS} -L/usr/lib/ -lc++"; fi


### PR DESCRIPTION
* Enable GCC5 C++11 ASAN in the test matrix. (GCC doesn't support
  -fsanitize=integer)
* Fix typo in .travis.yaml that was effectively disabling sanitzers
  for ASAN builds
* **Intentionally** disable ASAN for clang; it's broken on Travis pending resolution
  of https://llvm.org/bugs/show_bug.cgi?id=22757.

Relates to #206.