### PR TITLE
Minor cleanups to help Clang/C2 compiles:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,12 +27,21 @@ endif()
 
 include_directories(include)
 
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+# Clang/C2 will blow up with various parts of the standard library
+# if compiling with -std less than c++14.
+if(("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") AND
+   ("x${CMAKE_CXX_SIMULATE_ID}x" STREQUAL "xMSVCx") AND
+   ("${RANGES_CXX_STD}" STREQUAL "11"))
+  set(CMAKE_CXX_STANDARD 14)
+  set(RANGES_CXX_STD 14)
+endif()
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++${RANGES_CXX_STD} -ftemplate-backtrace-limit=0")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Weverything -Werror -pedantic-errors")                           
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=deprecated-declarations -Wno-error=deprecated")                  
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c++98-compat -Wno-c++98-compat-pedantic")        
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-return-stack-address")                  
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-return-stack-address -Wno-undef")                  
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable -Wno-unused-parameter")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-weak-vtables -Wno-padded")                       
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-global-constructors -Wno-exit-time-destructors") 

--- a/test/view/chunk.cpp
+++ b/test/view/chunk.cpp
@@ -37,7 +37,9 @@ int main()
     CHECK(it1 == ranges::end(rng1));
     ::check_equal(*ranges::next(it1, -3), {3,4,5});
     CHECK(size(rng1), 4u);
+#if !defined(_MSC_VER) // MS ABI has limited EBO
     static_assert(sizeof(rng1.begin()) == sizeof(v.begin())*2+sizeof(std::ptrdiff_t)*2, "");
+#endif
 
     std::forward_list<int> l = view::iota(0,11);
     auto rng2 = l | view::chunk(3);
@@ -50,7 +52,9 @@ int main()
     ::check_equal(*it2++, {6,7,8});
     ::check_equal(*it2++, {9,10});
     CHECK(it2 == ranges::end(rng2));
+#if !defined(_MSC_VER) // MS ABI has limited EBO
     static_assert(sizeof(rng2.begin()) == sizeof(l.begin())*2+sizeof(std::ptrdiff_t), "");
+#endif
 
     {
         // An infinite, cyclic range with cycle length == 1

--- a/test/view/stride.cpp
+++ b/test/view/stride.cpp
@@ -29,9 +29,11 @@ int main()
     std::vector<int> v(50);
     iota(v, 0);
 
+#if !defined(_MSC_VER) // MS ABI has limited EBO
     static_assert(
         sizeof((v|view::stride(3)).begin()) ==
         sizeof(void*)+sizeof(v.begin())+sizeof(std::ptrdiff_t),"");
+#endif
     ::check_equal(v | view::stride(3) | view::reverse,
                   {48, 45, 42, 39, 36, 33, 30, 27, 24, 21, 18, 15, 12, 9, 6, 3, 0});
 


### PR DESCRIPTION
* Force C++14. Parts of the standard library need C++14 to compile.
* Don't validate complete EBO for some range iterators, the MS ABI allows only limited EBO.
* Tell clang not to blow up the build simply because `__GNUC__` is undefined.
