### PR TITLE
fix cmake install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,5 +114,5 @@ add_subdirectory(example)
 add_subdirectory(perf)
 add_subdirectory(scratch)
 
-install(DIRECTORY include/ DESTINATION install
+install(DIRECTORY include/ DESTINATION include
         FILES_MATCHING PATTERN "*.hpp")


### PR DESCRIPTION
Is this is what commit d85d1ad7b860e8175448378adc5a23327c6eadd7 meant?

Right now the library installs to `${CMAKE_INSTALL_PREFIX}/install`. I think it should install to `${CMAKE_INSTALL_PREFIX}/include`.