### PR TITLE
fix equal() for set_union_cursor and set_symmetric_difference_cursor

### DIFF
--- a/include/range/v3/view/set_algorithm.hpp
+++ b/include/range/v3/view/set_algorithm.hpp
@@ -555,7 +555,7 @@ namespace ranges
                 }
                 bool equal(set_union_cursor const &that) const
                 {
-                    return it1_ == that.it1_; // does not support comparing iterators from different ranges
+                    return (it1_ == that.it1_) && (it2_ == that.it2_); // does not support comparing iterators from different ranges
                 }
                 bool done() const
                 {
@@ -784,7 +784,7 @@ namespace ranges
                 }
                 bool equal(set_symmetric_difference_cursor const &that) const
                 {
-                    return it1_ == that.it1_; // does not support comparing iterators from different ranges
+                    return (it1_ == that.it1_) && (it2_ == that.it2_); // does not support comparing iterators from different ranges
                 }
                 bool done() const
                 {

--- a/test/view/set_symmetric_difference.cpp
+++ b/test/view/set_symmetric_difference.cpp
@@ -297,6 +297,28 @@ int main()
     //     begin(empty_range); // infinite loop!
     // }
     
-
+    // iterator (in)equality
+    {
+        int r1[] = {1, 2, 3};
+        int r2[] = {   2, 3, 4, 5};
+        auto res = view::set_symmetric_difference(r1, r2); // 1, 4, 5
+        
+        auto it1 = ranges::next(res.begin()); // *it1 == 4, member iterator into r1 points to r1.end()
+        auto it2 = ranges::next(it1);         // *it2 == 5, member iterator into r1 also points to r1.end()
+        auto sentinel = res.end();
+        
+        CHECK(*it1 == 4);
+        CHECK(*it2 == 5);
+        
+        CHECK(it1 != it2); // should be different even though member iterators into r1 are the same
+        
+        CHECK(it1 != sentinel);
+        CHECK(ranges::next(it1, 2) == sentinel);
+        
+        CHECK(it2 != sentinel);
+        CHECK(ranges::next(it2, 1) == sentinel);
+    }
+    
+    
     return test_result();
 }

--- a/test/view/set_union.cpp
+++ b/test/view/set_union.cpp
@@ -287,7 +287,29 @@ int main()
         CONCEPT_ASSERT(Same<range_reference_t<R>, MoveOnlyString &>());
         CONCEPT_ASSERT(Same<range_rvalue_reference_t<R>, MoveOnlyString &&>());
     }
-
+    
+    // iterator (in)equality
+    {
+        int r1[] = {1, 2, 3};
+        int r2[] = {   2, 3, 4, 5};
+        auto res = view::set_union(r1, r2); // 1, 2, 3, 4, 5
+        
+        auto it1 = ranges::next(res.begin(), 3); // *it1 == 4, member iterator into r1 points to r1.end()
+        auto it2 = ranges::next(it1);            // *it2 == 5, member iterator into r1 also points to r1.end()
+        auto sentinel = res.end();
+        
+        CHECK(*it1 == 4);
+        CHECK(*it2 == 5);
+        
+        CHECK(it1 != it2); // should be different even though member iterators into r1 are the same
+        
+        CHECK(it1 != sentinel);
+        CHECK(ranges::next(it1, 2) == sentinel);
+        
+        CHECK(it2 != sentinel);
+        CHECK(ranges::next(it2, 1) == sentinel);
+    }
+    
 
     return test_result();
 }


### PR DESCRIPTION
In case of lazy set union and symmetric difference views, comparing iterators for equality must involve subiterators of both operand ranges. Fixes bug where it1_ has already reached the end (and is therefore not incremented anymore) but it2_ still provides new elements.