### PR TITLE
intersperse_view::sentinel_adaptor::empty should be const

### DIFF
--- a/include/range/v3/view/intersperse.hpp
+++ b/include/range/v3/view/intersperse.hpp
@@ -105,7 +105,7 @@ namespace ranges
             struct sentinel_adaptor : adaptor_base
             {
                 bool empty(range_iterator_t<Rng> it, cursor_adaptor const &other,
-                    range_sentinel_t<Rng> sent)
+                    range_sentinel_t<Rng> sent) const
                 {
                     return it == sent;
                 }


### PR DESCRIPTION
...for obvious reasons, and so that the correctness of the view doesn't depend on `sentinel_adaptor` being empty & trivial to trigger the `compressed_pair` optimization.