### PR TITLE
Give up on preprocessor macros: actually test for broken EBO.

### DIFF
--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -116,4 +116,17 @@
 #define RANGES_GCC_BROKEN_CUSTPOINT
 #endif
 
+namespace ranges {
+    inline namespace v3 {
+        namespace detail {
+            namespace ebo_test {
+                struct empty1 {};
+                struct empty2 {};
+                struct refines : empty1, empty2 {};
+            }
+            constexpr bool broken_ebo = sizeof(ebo_test::refines) > sizeof(ebo_test::empty1);
+        }
+    }
+}
+
 #endif

--- a/test/view/chunk.cpp
+++ b/test/view/chunk.cpp
@@ -37,9 +37,8 @@ int main()
     CHECK(it1 == ranges::end(rng1));
     ::check_equal(*ranges::next(it1, -3), {3,4,5});
     CHECK(size(rng1), 4u);
-#if !defined(_WIN32) // MS ABI has limited EBO
-    static_assert(sizeof(rng1.begin()) == sizeof(v.begin())*2+sizeof(std::ptrdiff_t)*2, "");
-#endif
+    if (!ranges::v3::detail::broken_ebo)
+        CHECK(sizeof(rng1.begin()) == sizeof(v.begin()) * 2 + sizeof(std::ptrdiff_t) * 2);
 
     std::forward_list<int> l = view::iota(0,11);
     auto rng2 = l | view::chunk(3);
@@ -52,9 +51,8 @@ int main()
     ::check_equal(*it2++, {6,7,8});
     ::check_equal(*it2++, {9,10});
     CHECK(it2 == ranges::end(rng2));
-#if !defined(_WIN32) // MS ABI has limited EBO
-    static_assert(sizeof(rng2.begin()) == sizeof(l.begin())*2+sizeof(std::ptrdiff_t), "");
-#endif
+    if (!ranges::v3::detail::broken_ebo)
+        CHECK(sizeof(rng2.begin()) == sizeof(l.begin()) * 2 + sizeof(std::ptrdiff_t));
 
     {
         // An infinite, cyclic range with cycle length == 1

--- a/test/view/stride.cpp
+++ b/test/view/stride.cpp
@@ -29,11 +29,10 @@ int main()
     std::vector<int> v(50);
     iota(v, 0);
 
-#if !defined(_WIN32) // MS ABI has limited EBO
-    static_assert(
-        sizeof((v|view::stride(3)).begin()) ==
-        sizeof(void*)+sizeof(v.begin())+sizeof(std::ptrdiff_t),"");
-#endif
+    if (!ranges::v3::detail::broken_ebo)
+        CHECK(
+            sizeof((v | view::stride(3)).begin()) ==
+            sizeof(void*) + sizeof(v.begin()) + sizeof(std::ptrdiff_t));
     ::check_equal(v | view::stride(3) | view::reverse,
                   {48, 45, 42, 39, 36, 33, 30, 27, 24, 21, 18, 15, 12, 9, 6, 3, 0});
 


### PR DESCRIPTION
Instead of trying to determine from the preprocessor if we're on a platform with broken EBO, detect directly if EBO is broken.