### PR TITLE
Disable deprecation warnings for test.alg.random_shuffle.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -318,6 +318,7 @@ install:
   - if [ -n "$CLANG_VERSION" ]; then CXX_FLAGS="${CXX_FLAGS} -D__extern_always_inline=inline"; fi
   - if [ "$LIBCXX" == "On" ]; then CXX_FLAGS="${CXX_FLAGS} -stdlib=libc++ -I/usr/include/c++/v1/"; fi
   - if [ "$LIBCXX" == "On" ]; then CXX_LINKER_FLAGS="${CXX_FLAGS} -L/usr/lib/ -lc++"; fi
+  - cmake --version
   - cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" -DCMAKE_EXE_LINKER_FLAGS="${CXX_LINKER_FLAGS}" -DRANGES_CXX_STD=$CPP -DRANGE_V3_NO_HEADER_CHECK=1
   - make VERBOSE=1
 

--- a/test/algorithm/CMakeLists.txt
+++ b/test/algorithm/CMakeLists.txt
@@ -169,6 +169,7 @@ add_executable(alg.push_heap push_heap.cpp)
 add_test(test.alg.push_heap alg.push_heap)
 
 add_executable(alg.random_shuffle random_shuffle.cpp)
+set_target_properties(alg.random_shuffle PROPERTIES COMPILE_DEFINITIONS RANGES_DISABLE_DEPRECATED_WARNINGS)
 add_test(test.alg.random_shuffle, alg.random_shuffle)
 
 add_executable(alg.remove remove.cpp)


### PR DESCRIPTION
...when cmake supports `target_compile_options`. While we're at it, let's get the cmake version recorded in the Travis build log as well.