### PR TITLE
Disable GCC5 Release+ASAN config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -256,9 +256,9 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: GCC_VERSION=5 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=Off
-      os: linux
-      addons: *gcc5
+    # - env: GCC_VERSION=5 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=Off
+    #   os: linux
+    #   addons: *gcc5
 
     - env: GCC_VERSION=5 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=Off
       os: linux
@@ -306,13 +306,12 @@ install:
   # Workaround for valgrind bug: https://bugs.kde.org/show_bug.cgi?id=326469.
   # It is fixed in valgrind 3.10 so this won't be necessary if someone
   # replaces the current valgrind (3.7) with valgrind-3.10
-  - sed -i 's/march=native/msse4.2/' CMakeLists.txt
+  - if [ "$BUILD_TYPE" == "Release" ] && [ "$ASAN" == "Off" ]; then sed -i 's/march=native/msse4.2/' CMakeLists.txt; fi
 
-  - if [ ! -d build ]; then mkdir build; fi
+  - mkdir -p build
   - cd build
   - export CXX_FLAGS=""
   - export CXX_LINKER_FLAGS=""
-  - if [ -z "$BUILD_TYPE" ]; then export BUILD_TYPE=Release; fi
   - if [ -n "$CLANG_VERSION" -a "$ASAN" == "On" ]; then export CXX_FLAGS="${CXX_FLAGS} -fsanitize=address,undefined,integer -fno-omit-frame-pointer -fno-sanitize=unsigned-integer-overflow"; fi
   - if [ -n "$GCC_VERSION" -a "$ASAN" == "On" ]; then export CXX_FLAGS="${CXX_FLAGS} -fsanitize=address,undefined -fno-omit-frame-pointer"; fi
   - if [ -n "$CLANG_VERSION" ]; then CXX_FLAGS="${CXX_FLAGS} -D__extern_always_inline=inline"; fi
@@ -322,11 +321,9 @@ install:
   - make VERBOSE=1
 
 script:
-  - ctest -VV
-  # Valgrind runs for clang release builds only,
-  # it fails when using gcc-4.9 + libstdc++-4.9.
-  # - if [ "$BUILD_TYPE" == "Release" ] && [ ! -n "$GCC_VERSION" ]; then ctest -VV -D ExperimentalMemCheck; fi
-  - if [ "$BUILD_TYPE" == "Release" ] && [ "$ASAN" == "Off" ]; then ctest -VV -D ExperimentalMemCheck; fi
+  # Only enable valgrind for non-ASAN Release builds (keep this in sync with line 309)
+  - if [ "$BUILD_TYPE" == "Release" ] && [ "$ASAN" == "Off" ]; then CTEST_FLAGS="-D ExperimentalMemCheck"; fi
+  - ctest -VV ${CTEST_FLAGS}
 
 notifications:
   email: false


### PR DESCRIPTION
It often runs over the Travis-mandated 50 minute per-job time limit.