### PR TITLE
fix libstdcxx4.9 support and test clang+libstdc++ on travis (C++11 only)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -215,6 +215,10 @@ matrix:
       os: linux
       addons: *clang38
 
+    - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off
+      os: linux
+      addons: *clang38
+
     # Test gcc-4.8: C++11, Build=Debug/Release, ASAN=Off
     - env: GCC_VERSION=4.8 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=Off
       os: linux

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -254,23 +254,37 @@ namespace ranges
             void ignore_unused(Ts &&...)
             {}
 
-#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 5)
-            template<typename T>
-            struct is_trivially_copy_assignable
-              : std::is_trivial<T>
-            {};
+            #if defined(__clang__) && !defined(_LIBCPP_VERSION)
+                template <class T, class Arg = T>
+                struct is_trivially_copy_assignable
+                  : meta::bool_<__is_trivially_assignable(T &, Arg const&)>
+                {};
+                template <class T, class Arg = T>
+                struct is_trivially_move_assignable
+                  : meta::bool_<__is_trivially_assignable(T &, Arg &&)>
+                {};  
+             #elif defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5
+                template<typename T>
+                using is_trivially_copy_assignable = std::is_trivial<T>;
 
-            template<typename T>
-            struct is_trivially_move_assignable
-              : std::is_trivial<T>
-            {};
-#else
-            template<typename T>
-            using is_trivially_copy_assignable = std::is_trivially_copy_assignable<T>;
+                template<typename T>
+                using is_trivially_move_assignable = std::is_trivial<T>;
+            #else
+                using std::is_trivially_copy_assignable;
+                using std::is_trivially_move_assignable;
+            #endif
 
-            template<typename T>
-            using is_trivially_move_assignable = std::is_trivially_move_assignable<T>;
-#endif
+            #if RANGES_CXX_LIB_IS_FINAL > 0
+                #if defined(__clang__) && !defined(_LIBCPP_VERSION)
+                    template<typename T>
+                    using is_final = meta::bool_<__is_final(T)>;
+                #else
+                    using std::is_final;          
+                #endif
+            #else 
+                template<typename T>
+                using is_final = std::false_type;
+            #endif 
 
             template<typename T>
             struct remove_rvalue_reference

--- a/include/range/v3/utility/box.hpp
+++ b/include/range/v3/utility/box.hpp
@@ -129,12 +129,7 @@ namespace ranges
         static_assert(std::is_trivial<constant<int, 0>>::value, "Expected constant to be trivial");
 
         template<typename Element, typename Tag = Element,
-            bool Empty = std::is_empty<Element>::value &&
-#if RANGES_CXX_LIB_IS_FINAL
-                         !std::is_final<Element>::value>
-#else
-                         true>
-#endif
+            bool Empty = std::is_empty<Element>::value && !detail::is_final<Element>::value>
         struct box
         {
             Element value;


### PR DESCRIPTION
Instead of checking for clang this checks for libc++. 
