### PR TITLE
view::join rework

### DIFF
--- a/include/range/v3/view/generate_n.hpp
+++ b/include/range/v3/view/generate_n.hpp
@@ -14,18 +14,16 @@
 #ifndef RANGES_V3_VIEW_GENERATE_N_HPP
 #define RANGES_V3_VIEW_GENERATE_N_HPP
 
-#include <utility>
 #include <type_traits>
+#include <utility>
 #include <meta/meta.hpp>
 #include <range/v3/range_fwd.hpp>
-#include <range/v3/size.hpp>
-#include <range/v3/begin_end.hpp>
 #include <range/v3/range_traits.hpp>
+#include <range/v3/size.hpp>
 #include <range/v3/view_facade.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/semiregular.hpp>
 #include <range/v3/utility/static_const.hpp>
-#include <range/v3/utility/semiregular.hpp>
 
 namespace ranges
 {


### PR DESCRIPTION
* BUGFIX: Don't rely on value-initialized **input** iterators comparing equal.
* BUGFIX: Don't use accumulate() to calculate size() if the underlying range is not Forward.
* Use default_sentinel, avoid view_adaptor.