### PR TITLE
Workaround warnings when using RANGES_DEPRECATED with -std=c++11

### DIFF
--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -228,7 +228,9 @@
 #endif // MSVC/Generic configuration switch
 
 #ifndef RANGES_DISABLE_DEPRECATED_WARNINGS
-#if RANGES_CXX_ATTRIBUTE_DEPRECATED
+#if RANGES_CXX_ATTRIBUTE_DEPRECATED && \
+   !((defined(__clang__) || defined(__GNUC__)) && \
+     RANGES_CXX_STD < RANGES_CXX_STD_14)
 #define RANGES_DEPRECATED(MSG) [[deprecated(MSG)]]
 #elif defined(__clang__) || defined(__GNUC__)
 #define RANGES_DEPRECATED(MSG) __attribute__((deprecated(MSG)))

--- a/range-v3.vcxproj
+++ b/range-v3.vcxproj
@@ -654,6 +654,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="test\config.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="test\constexpr_core.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>

--- a/range-v3.vcxproj.filters
+++ b/range-v3.vcxproj.filters
@@ -81,6 +81,9 @@
     <ClCompile Include="example\fibonacci.cpp">
       <Filter>Example Files</Filter>
     </ClCompile>
+    <ClCompile Include="test\config.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
     <ClCompile Include="test\constexpr_core.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,9 @@ add_subdirectory(numeric)
 add_subdirectory(utility)
 add_subdirectory(view)
 
+add_executable(config config.cpp)
+add_test(test.config config)
+
 add_executable(container_conversion container_conversion.cpp)
 add_test(test.container_conversion container_conversion)
 

--- a/test/config.cpp
+++ b/test/config.cpp
@@ -1,0 +1,19 @@
+// Range v3 library
+//
+//  Copyright Casey Carter 2016
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+
+#include <range/v3/detail/config.hpp>
+
+RANGES_DEPRECATED("compile test for \"RANGES_DEPRECATED\"") void foo() {}
+
+int main()
+{
+    return 0;
+}


### PR DESCRIPTION
...which went unnoticed because `RANGES_DEPRECATED` is currently unused. Added a test to avoid regression.

Alternatively, we could simply get rid of `RANGES_DEPRECATED`. I chose not to do so in the expectation that we'll need it again in the not-so-distant future.