### PR TITLE
Eliminate `view_adaptor_t`

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -209,7 +209,7 @@ Below in roughly 2 dozen lines of code is the `transform` view, which takes one 
     public:
         transform_view() = default;
         transform_view(Rng && rng, Fun fun)
-          : view_adaptor_t<transform_view>{std::forward<Rng>(rng)}
+          : transform_view::view_adaptor{std::forward<Rng>(rng)}
           , fun_(std::move(fun))
         {}
     };

--- a/example/calendar.cpp
+++ b/example/calendar.cpp
@@ -168,7 +168,7 @@ class chunk_view : public view_adaptor<chunk_view<Rng>, Rng> {
 public:
     chunk_view() = default;
     chunk_view(Rng rng, std::size_t n)
-      : view_adaptor_t<chunk_view>(std::move(rng)), n_(n)
+      : chunk_view::view_adaptor(std::move(rng)), n_(n)
     {}
 };
 

--- a/include/range/v3/range_access.hpp
+++ b/include/range/v3/range_access.hpp
@@ -350,8 +350,6 @@ namespace ranges
             static meta::id<typename RangeAdaptor::base_range_t> base_range_2_();
             template<typename RangeFacade>
             static meta::id<typename RangeFacade::view_facade_t> view_facade_2_();
-            template<typename RangeAdaptor>
-            static meta::id<typename RangeAdaptor::view_adaptor_t> view_adaptor_2_();
         public:
             template<typename RangeAdaptor>
             struct base_range
@@ -364,10 +362,6 @@ namespace ranges
             template<typename RangeFacade>
             struct view_facade
               : decltype(range_access::view_facade_2_<RangeFacade>())
-            {};
-            template<typename RangeAdaptor>
-            struct view_adaptor
-              : decltype(range_access::view_adaptor_2_<RangeAdaptor>())
             {};
             /// endcond
         };

--- a/include/range/v3/view/adjacent_filter.hpp
+++ b/include/range/v3/view/adjacent_filter.hpp
@@ -76,7 +76,7 @@ namespace ranges
         public:
             adjacent_filter_view() = default;
             adjacent_filter_view(Rng rng, Pred pred)
-              : view_adaptor_t<adjacent_filter_view>{std::move(rng)}
+              : adjacent_filter_view::view_adaptor{std::move(rng)}
               , pred_(as_function(std::move(pred)))
             {}
        };

--- a/include/range/v3/view/adjacent_remove_if.hpp
+++ b/include/range/v3/view/adjacent_remove_if.hpp
@@ -93,25 +93,25 @@ namespace ranges
         public:
             adjacent_remove_if_view() = default;
             adjacent_remove_if_view(adjacent_remove_if_view const &that)
-              : view_adaptor_t<adjacent_remove_if_view>(that)
+              : adjacent_remove_if_view::view_adaptor(that)
               , pred_(that.pred_)
               , begin_{}
             {}
             adjacent_remove_if_view(Rng rng, Pred pred)
-              : view_adaptor_t<adjacent_remove_if_view>{std::move(rng)}
+              : adjacent_remove_if_view::view_adaptor{std::move(rng)}
               , pred_(as_function(std::move(pred)))
               , begin_{}
             {}
             adjacent_remove_if_view& operator=(adjacent_remove_if_view &&that)
             {
-                this->view_adaptor_t<adjacent_remove_if_view>::operator=(std::move(that));
+                this->adjacent_remove_if_view::view_adaptor::operator=(std::move(that));
                 pred_ = std::move(that).pred_;
                 begin_.reset();
                 return *this;
             }
             adjacent_remove_if_view& operator=(adjacent_remove_if_view const &that)
             {
-                this->view_adaptor_t<adjacent_remove_if_view>::operator=(that);
+                this->adjacent_remove_if_view::view_adaptor::operator=(that);
                 pred_ = that.pred_;
                 begin_.reset();
                 return *this;

--- a/include/range/v3/view/chunk.hpp
+++ b/include/range/v3/view/chunk.hpp
@@ -60,7 +60,7 @@ namespace ranges
         public:
             chunk_view() = default;
             chunk_view(Rng rng, range_difference_t<Rng> n)
-              : view_adaptor_t<chunk_view>(std::move(rng)), n_(n)
+              : chunk_view::view_adaptor(std::move(rng)), n_(n)
             {
                 RANGES_ASSERT(0 < n_);
             }

--- a/include/range/v3/view/const.hpp
+++ b/include/range/v3/view/const.hpp
@@ -69,7 +69,7 @@ namespace ranges
         public:
             const_view() = default;
             explicit const_view(Rng rng)
-              : view_adaptor_t<const_view>{std::move(rng)}
+              : const_view::view_adaptor{std::move(rng)}
             {}
             CONCEPT_REQUIRES(SizedRange<Rng>())
             range_size_t<Rng> size() const

--- a/include/range/v3/view/delimit.hpp
+++ b/include/range/v3/view/delimit.hpp
@@ -60,7 +60,7 @@ namespace ranges
         public:
             delimit_view() = default;
             delimit_view(Rng rng, Val value)
-              : view_adaptor_t<delimit_view>{std::move(rng)}
+              : delimit_view::view_adaptor{std::move(rng)}
               , value_(std::move(value))
             {}
         };

--- a/include/range/v3/view/drop_while.hpp
+++ b/include/range/v3/view/drop_while.hpp
@@ -38,10 +38,9 @@ namespace ranges
         template<typename Rng, typename Pred>
         struct drop_while_view
           : view_interface<drop_while_view<Rng, Pred>, is_finite<Rng>::value ? finite : unknown>
-       {
+        {
         private:
             friend range_access;
-            using difference_type_ = range_difference_t<Rng>;
             Rng rng_;
             semiregular_t<function_type<Pred>> pred_;
             optional<range_iterator_t<Rng>> begin_;
@@ -55,10 +54,12 @@ namespace ranges
         public:
             drop_while_view() = default;
             drop_while_view(drop_while_view &&that)
-              : rng_(std::move(that).rng_), pred_(std::move(that).pred_), begin_{}
+              : drop_while_view::view_interface(std::move(that))
+              , rng_(std::move(that).rng_), pred_(std::move(that).pred_), begin_{}
             {}
             drop_while_view(drop_while_view const &that)
-              : rng_(that.rng_), pred_(that.pred_), begin_{}
+              : drop_while_view::view_interface(that)
+              , rng_(that.rng_), pred_(that.pred_), begin_{}
             {}
             drop_while_view(Rng rng, Pred pred)
               : rng_(std::move(rng)), pred_(as_function(std::move(pred))), begin_{}

--- a/include/range/v3/view/indirect.hpp
+++ b/include/range/v3/view/indirect.hpp
@@ -64,7 +64,7 @@ namespace ranges
         public:
             indirect_view() = default;
             explicit indirect_view(Rng rng)
-              : view_adaptor_t<indirect_view>{std::move(rng)}
+              : indirect_view::view_adaptor{std::move(rng)}
             {}
             CONCEPT_REQUIRES(SizedRange<Rng>())
             range_size_t<Rng> size() const

--- a/include/range/v3/view/intersperse.hpp
+++ b/include/range/v3/view/intersperse.hpp
@@ -127,7 +127,7 @@ namespace ranges
         public:
             intersperse_view() = default;
             intersperse_view(Rng rng, range_value_t<Rng> val)
-              : view_adaptor_t<intersperse_view>{std::move(rng)}, val_(std::move(val))
+              : intersperse_view::view_adaptor{std::move(rng)}, val_(std::move(val))
             {}
             CONCEPT_REQUIRES(SizedRange<Rng>())
             range_size_t<Rng> size() const

--- a/include/range/v3/view/move.hpp
+++ b/include/range/v3/view/move.hpp
@@ -62,7 +62,7 @@ namespace ranges
         public:
             move_view() = default;
             explicit move_view(Rng rng)
-              : view_adaptor_t<move_view>{std::move(rng)}
+              : move_view::view_adaptor{std::move(rng)}
             {}
             CONCEPT_REQUIRES(SizedRange<Rng>())
             range_size_t<Rng> size() const

--- a/include/range/v3/view/partial_sum.hpp
+++ b/include/range/v3/view/partial_sum.hpp
@@ -109,7 +109,7 @@ namespace ranges
         public:
             partial_sum_view() = default;
             partial_sum_view(Rng rng, Fun fun)
-              : view_adaptor_t<partial_sum_view>{std::move(rng)}
+              : partial_sum_view::view_adaptor{std::move(rng)}
               , fun_(as_function(std::move(fun)))
             {}
             CONCEPT_REQUIRES(SizedRange<Rng>())

--- a/include/range/v3/view/remove_if.hpp
+++ b/include/range/v3/view/remove_if.hpp
@@ -100,30 +100,30 @@ namespace ranges
         public:
             remove_if_view() = default;
             remove_if_view(remove_if_view &&that)
-              : view_adaptor_t<remove_if_view>(std::move(that))
+              : remove_if_view::view_adaptor(std::move(that))
               , pred_(std::move(that).pred_)
               , begin_{}
             {}
             remove_if_view(remove_if_view const &that)
-              : view_adaptor_t<remove_if_view>(that)
+              : remove_if_view::view_adaptor(that)
               , pred_(that.pred_)
               , begin_{}
             {}
             remove_if_view(Rng rng, Pred pred)
-              : view_adaptor_t<remove_if_view>{std::move(rng)}
+              : remove_if_view::view_adaptor{std::move(rng)}
               , pred_(as_function(std::move(pred)))
               , begin_{}
             {}
             remove_if_view& operator=(remove_if_view &&that)
             {
-                this->view_adaptor_t<remove_if_view>::operator=(std::move(that));
+                this->remove_if_view::view_adaptor::operator=(std::move(that));
                 pred_ = std::move(that).pred_;
                 begin_.reset();
                 return *this;
             }
             remove_if_view& operator=(remove_if_view const &that)
             {
-                this->view_adaptor_t<remove_if_view>::operator=(that);
+                this->remove_if_view::view_adaptor::operator=(that);
                 pred_ = that.pred_;
                 begin_.reset();
                 return *this;

--- a/include/range/v3/view/reverse.hpp
+++ b/include/range/v3/view/reverse.hpp
@@ -165,26 +165,26 @@ namespace ranges
         public:
             reverse_view() = default;
             reverse_view(reverse_view &&that)
-              : view_adaptor_t<reverse_view>{std::move(that)}
+              : reverse_view::view_adaptor{std::move(that)}
               , detail::reverse_end_<Rng>{}
             {}
             reverse_view(reverse_view const &that)
-              : view_adaptor_t<reverse_view>{that}
+              : reverse_view::view_adaptor{that}
               , detail::reverse_end_<Rng>{}
             {}
             explicit reverse_view(Rng rng)
-              : view_adaptor_t<reverse_view>{std::move(rng)}
+              : reverse_view::view_adaptor{std::move(rng)}
               , detail::reverse_end_<Rng>{}
             {}
             reverse_view& operator=(reverse_view &&that)
             {
-                this->view_adaptor_t<reverse_view>::operator=(std::move(that));
+                this->reverse_view::view_adaptor::operator=(std::move(that));
                 this->dirty_(BoundedRange<Rng>{});
                 return *this;
             }
             reverse_view& operator=(reverse_view const &that)
             {
-                this->view_adaptor_t<reverse_view>::operator=(that);
+                this->reverse_view::view_adaptor::operator=(that);
                 this->dirty_(BoundedRange<Rng>{});
                 return *this;
             }

--- a/include/range/v3/view/stride.hpp
+++ b/include/range/v3/view/stride.hpp
@@ -171,7 +171,7 @@ namespace ranges
         public:
             stride_view() = default;
             stride_view(Rng rng, difference_type_ stride)
-              : view_adaptor_t<stride_view>{std::move(rng)}
+              : stride_view::view_adaptor{std::move(rng)}
               , stride_(stride)
             {
                 RANGES_ASSERT(0 < stride_);

--- a/include/range/v3/view/take_while.hpp
+++ b/include/range/v3/view/take_while.hpp
@@ -72,7 +72,7 @@ namespace ranges
         public:
             iter_take_while_view() = default;
             iter_take_while_view(Rng rng, Pred pred)
-              : view_adaptor_t<iter_take_while_view>{std::move(rng)}
+              : iter_take_while_view::view_adaptor{std::move(rng)}
               , pred_(as_function(std::move(pred)))
             {}
         };

--- a/include/range/v3/view/transform.hpp
+++ b/include/range/v3/view/transform.hpp
@@ -111,7 +111,7 @@ namespace ranges
         public:
             iter_transform_view() = default;
             iter_transform_view(Rng rng, Fun fun)
-              : view_adaptor_t<iter_transform_view>{std::move(rng)}
+              : iter_transform_view::view_adaptor{std::move(rng)}
               , fun_(as_function(std::move(fun)))
             {}
             CONCEPT_REQUIRES(SizedRange<Rng>())

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -81,9 +81,6 @@ namespace ranges
         template<typename Derived>
         using base_range_t = meta::_t<range_access::base_range<Derived>>;
 
-        template<typename Derived>
-        using view_adaptor_t = meta::_t<range_access::view_adaptor<Derived>>;
-
         template<typename BaseIt, typename Adapt>
         struct adaptor_cursor;
 
@@ -369,7 +366,6 @@ namespace ranges
             friend Derived;
             friend range_access;
             friend adaptor_base;
-            using view_adaptor_t = view_adaptor;
             using base_range_t = view::all_t<BaseRng>;
             using view_facade<Derived, Cardinality>::derived;
             // Mutable here. Const-correctness is enforced below by disabling

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -419,8 +419,14 @@ namespace ranges
                 auto pos = adapt.end(derived());
                 return {std::move(pos), std::move(adapt)};
             }
+        protected:
+            ~view_adaptor() = default;
         public:
             view_adaptor() = default;
+            view_adaptor(view_adaptor &&) = default;
+            view_adaptor(view_adaptor const &) = default;
+            view_adaptor &operator=(view_adaptor &&) = default;
+            view_adaptor &operator=(view_adaptor const &) = default;
             constexpr view_adaptor(BaseRng && rng)
               : rng_(view::all(detail::forward<BaseRng>(rng)))
             {}

--- a/include/range/v3/view_interface.hpp
+++ b/include/range/v3/view_interface.hpp
@@ -74,7 +74,13 @@ namespace ranges
             {
                 return static_cast<Derived const &>(*this);
             }
+            ~view_interface() = default;
         public:
+            view_interface() = default;
+            view_interface(view_interface &&) = default;
+            view_interface(view_interface const &) = default;
+            view_interface &operator=(view_interface &&) = default;
+            view_interface &operator=(view_interface const &) = default;
             // A few ways of testing whether a range can be empty:
             constexpr bool empty() const
             {

--- a/test/view_adaptor.cpp
+++ b/test/view_adaptor.cpp
@@ -71,7 +71,7 @@ private:
         return {};
     }
 public:
-    using ranges::view_adaptor_t<my_reverse_view>::view_adaptor_t;
+    using my_reverse_view::view_adaptor::view_adaptor;
 };
 
 struct my_delimited_range
@@ -79,7 +79,7 @@ struct my_delimited_range
         my_delimited_range,
         ranges::delimit_view<ranges::istream_range<int>, int>>
 {
-    using view_adaptor_t::view_adaptor_t;
+    using view_adaptor::view_adaptor;
 };
 
 int main()


### PR DESCRIPTION
Both the alias template and the `view_adaptor` member of the same name.

While doing so, I noticed that `view_interface` and `view_facade` have public destructors which could be made private to reduce the danger of polymorphically deleting a class derived from either/both.

The compiler then complained about `drop_while_view`'s copy constructor failing to copy its `view_interface` base, causing me to notice that `drop_while_view` has mutually exclusive predicate and iterator members that should be stored in a variant.