### PR TITLE
Remaining friend-to-cursor indirect_move changes

### DIFF
--- a/include/range/v3/utility/common_iterator.hpp
+++ b/include/range/v3/utility/common_iterator.hpp
@@ -101,15 +101,14 @@ namespace ranges
                              that.it() - this_.it());
                 }
                 CONCEPT_REQUIRES(Readable<I>())
-                friend iterator_rvalue_reference_t<I> indirect_move(common_iterator<I, S> const &it)
+                iterator_rvalue_reference_t<I> move() const
                     noexcept(noexcept(iter_move(std::declval<I const &>())))
                 {
-                    common_cursor const &cur = get_cursor(it);
-                    RANGES_ASSERT(!cur.is_sentinel());
-                    return iter_move(cur.it());
+                    RANGES_ASSERT(!is_sentinel());
+                    return iter_move(it());
                 }
                 CONCEPT_REQUIRES(Readable<I>())
-                auto get() const -> decltype(*std::declval<I const &>())
+                iterator_reference_t<I> get() const
                 {
                     return *it();
                 }

--- a/include/range/v3/utility/counted_iterator.hpp
+++ b/include/range/v3/utility/counted_iterator.hpp
@@ -111,10 +111,10 @@ namespace ranges
                     return {i, j.count() - n};
                 }
                 CONCEPT_REQUIRES(Readable<I>())
-                friend iterator_rvalue_reference_t<I> indirect_move(counted_iterator<I, D> const &it)
+                iterator_rvalue_reference_t<I> move() const
                     noexcept(noexcept(iter_move(std::declval<I const &>())))
                 {
-                    return iter_move(get_cursor(it).it_);
+                    return iter_move(it_);
                 }
                 CONCEPT_REQUIRES(Readable<I>())
                 auto get() const -> decltype(*it_)

--- a/include/range/v3/utility/iterator.hpp
+++ b/include/range/v3/utility/iterator.hpp
@@ -678,6 +678,7 @@ namespace ranges
             struct reverse_cursor
             {
             private:
+                CONCEPT_ASSERT(BidirectionalIterator<I>());
                 friend range_access;
                 template<typename OtherI>
                 friend struct reverse_cursor;
@@ -742,13 +743,12 @@ namespace ranges
                 {
                     return it_ - that.base();
                 }
-                CONCEPT_REQUIRES(Readable<I>())
                 RANGES_CXX14_CONSTEXPR
-                friend iterator_rvalue_reference_t<I> indirect_move(reverse_iterator<I> const &it)
-                    noexcept(noexcept(iter_move(std::declval<I const &>())))
-                {
-                    return iter_move(get_cursor(it).it_);
-                }
+                auto move() const
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                (
+                    iter_move(it_)
+                )
             public:
                 reverse_cursor() = default;
                 template<typename U,
@@ -829,11 +829,11 @@ namespace ranges
                 {
                     return that.it_ - it_;
                 }
-                friend iterator_rvalue_reference_t<I> indirect_move(move_iterator<I> const &it)
-                    noexcept(noexcept(iter_move(std::declval<I const &>())))
-                {
-                    return iter_move(get_cursor(it).it_);
-                }
+                auto move() const
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                (
+                    iter_move(it_)
+                )
             public:
                 constexpr move_cursor()
                   : it_{}
@@ -1017,10 +1017,10 @@ namespace ranges
                 }
                 CONCEPT_REQUIRES(Readable<I>())
                 RANGES_CXX14_CONSTEXPR
-                friend iterator_rvalue_reference_t<I> indirect_move(move_into_iterator<I> const &it)
-                    noexcept(noexcept(iter_move(std::declval<I const &>())))
+                iterator_rvalue_reference_t<I> move() const
+                    noexcept(noexcept(iter_move(it_)))
                 {
-                    return iter_move(get_cursor(it).it_);
+                    return iter_move(it_);
                 }
             public:
                 constexpr move_into_cursor()

--- a/include/range/v3/utility/move.hpp
+++ b/include/range/v3/utility/move.hpp
@@ -66,13 +66,14 @@ namespace ranges
         /// \cond
         namespace adl_move_detail
         {
+            // TODO: investigate the breakage when these are made constexpr.
+            // (Results in ODR-use of projected_readable::operator*)
+
             // Default indirect_move overload.
             template<typename I,
-                typename R = decltype(*std::declval<I const &>()),
-                typename U = meta::_t<std::remove_reference<R>>>
+                typename R = decltype(*std::declval<I const &>())>
             aux::move_t<R> indirect_move(I const &i)
-                noexcept(std::is_reference<R>::value ||
-                    std::is_nothrow_constructible<detail::decay_t<U>, U &&>::value)
+                noexcept(noexcept(static_cast<aux::move_t<R>>(aux::move(*i))))
             {
                 return aux::move(*i);
             }
@@ -81,11 +82,10 @@ namespace ranges
             {
                 template<typename I>
                 auto operator()(I const &i) const
-                    noexcept(noexcept(indirect_move(i))) ->
-                    decltype(indirect_move(i))
-                {
-                    return indirect_move(i);
-                }
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                (
+                    indirect_move(i)
+                )
             };
         }
         /// \endcond

--- a/include/range/v3/view/join.hpp
+++ b/include/range/v3/view/join.hpp
@@ -140,7 +140,7 @@ namespace ranges
                 (
                     *inner_it_
                 )
-                auto indirect_move() const
+                auto move() const
                 RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
                 (
                     iter_move(inner_it_)
@@ -276,7 +276,7 @@ namespace ranges
                         return *ranges::get<1>(cur_);
                     }
                 }
-                rvalue_reference indirect_move() const
+                rvalue_reference move() const
                 {
                     // return visit(cur_, [](auto& it) -> rvalue_reference { return iter_move(it); });
                     if (cur_.index() == 0)

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -288,12 +288,12 @@ namespace ranges
                 return static_cast<X &&>(second.get(first));
             }
             // Gives users a way to override the default indirect_move function in their adaptors.
-            template<typename Sent>
-            friend auto indirect_move(basic_iterator<adaptor_cursor, Sent> const &it)
-            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
-            (
-                get_cursor(it).indirect_move_(42)
-            )
+            auto move() const
+                noexcept(noexcept(std::declval<const adaptor_cursor &>().indirect_move_(42))) ->
+                decltype(std::declval<const adaptor_cursor &>().indirect_move_(42))
+            {
+                return indirect_move_(42);
+            }
         public:
             using compressed_pair<BaseIter, Adapt>::compressed_pair;
         };


### PR DESCRIPTION
* `common_iterator`, `counted_iterator`, `reverse_iterator`, `move_iterator`, `move_into_iterator`, `adaptor_cursor`.
* Simplify `indirect_move`
* Properly name `view::join`'s move member `move` instead of `indirect_move`