### PR TITLE
Don't compare bool with 0 in set algorithm tests

### DIFF
--- a/test/algorithm/set_difference.hpp
+++ b/test/algorithm/set_difference.hpp
@@ -47,7 +47,7 @@ test_iter()
         {
             CHECK((base(res.first) - ia) == sa);
             CHECK((base(res.second) - ic) == sr);
-            CHECK(std::lexicographical_compare(ic, base(res.second), ir, ir+sr) == 0);
+            CHECK(std::lexicographical_compare(ic, base(res.second), ir, ir+sr) == false);
             ranges::fill(ic, 0);
         }
     );
@@ -58,7 +58,7 @@ test_iter()
         {
             CHECK((base(res.first) - ib) == sb);
             CHECK((base(res.second) - ic) == srr);
-            CHECK(std::lexicographical_compare(ic, base(res.second), irr, irr+srr) == 0);
+            CHECK(std::lexicographical_compare(ic, base(res.second), irr, irr+srr) == false);
             ranges::fill(ic, 0);
         }
     );
@@ -83,7 +83,7 @@ test_comp()
         {
             CHECK((base(res.first) - ia) == sa);
             CHECK((base(res.second) - ic) == sr);
-            CHECK(std::lexicographical_compare(ic, base(res.second), ir, ir+sr) == 0);
+            CHECK(std::lexicographical_compare(ic, base(res.second), ir, ir+sr) == false);
             ranges::fill(ic, 0);
         }
     );
@@ -94,7 +94,7 @@ test_comp()
         {
             CHECK((base(res.first) - ib) == sb);
             CHECK((base(res.second) - ic) == srr);
-            CHECK(std::lexicographical_compare(ic, base(res.second), irr, irr+srr) == 0);
+            CHECK(std::lexicographical_compare(ic, base(res.second), irr, irr+srr) == false);
             ranges::fill(ic, 0);
         }
     );
@@ -294,7 +294,7 @@ int main()
         std::pair<S *, U *> res = ranges::set_difference(ia, ib, ic, std::less<int>(), &S::i, &T::j);
         CHECK((res.first - ia) == sa);
         CHECK((res.second - ic) == sr);
-        CHECK(ranges::lexicographical_compare(ic, res.second, ir, ir+sr, std::less<int>(), &U::k) == 0);
+        CHECK(ranges::lexicographical_compare(ic, res.second, ir, ir+sr, std::less<int>(), &U::k) == false);
         ranges::fill(ic, U{0});
 
         int irr[] = {6};
@@ -302,7 +302,7 @@ int main()
         std::pair<T *, U *> res2 = ranges::set_difference(ib, ia, ic, std::less<int>(), &T::j, &S::i);
         CHECK((res2.first - ib) == sb);
         CHECK((res2.second - ic) == srr);
-        CHECK(ranges::lexicographical_compare(ic, res2.second, ir, irr+srr, std::less<int>(), &U::k) == 0);
+        CHECK(ranges::lexicographical_compare(ic, res2.second, ir, irr+srr, std::less<int>(), &U::k) == false);
     }
 
     // Test rvalue ranges
@@ -318,7 +318,7 @@ int main()
         auto res = ranges::set_difference(ranges::view::all(ia), ranges::view::all(ib), ic, std::less<int>(), &S::i, &T::j);
         CHECK((res.first.get_unsafe() - ia) == sa);
         CHECK((res.second - ic) == sr);
-        CHECK(ranges::lexicographical_compare(ic, res.second, ir, ir+sr, std::less<int>(), &U::k) == 0);
+        CHECK(ranges::lexicographical_compare(ic, res.second, ir, ir+sr, std::less<int>(), &U::k) == false);
         ranges::fill(ic, U{0});
 
         int irr[] = {6};
@@ -326,7 +326,7 @@ int main()
         auto res2 = ranges::set_difference(ranges::view::all(ib), ranges::view::all(ia), ic, std::less<int>(), &T::j, &S::i);
         CHECK((res2.first.get_unsafe() - ib) == sb);
         CHECK((res2.second - ic) == srr);
-        CHECK(ranges::lexicographical_compare(ic, res2.second, ir, irr+srr, std::less<int>(), &U::k) == 0);
+        CHECK(ranges::lexicographical_compare(ic, res2.second, ir, irr+srr, std::less<int>(), &U::k) == false);
     }
 
     // Test initializer list
@@ -346,7 +346,7 @@ int main()
             std::less<int>(), &S::i, &T::j);
         CHECK((res.first - ia) == sa);
         CHECK((res.second - ic) == sr);
-        CHECK(ranges::lexicographical_compare(ic, res.second, ir, ir+sr, std::less<int>(), &U::k) == 0);
+        CHECK(ranges::lexicographical_compare(ic, res.second, ir, ir+sr, std::less<int>(), &U::k) == false);
         ranges::fill(ic, U{0});
 
         int irr[] = {6};
@@ -358,7 +358,7 @@ int main()
             std::less<int>(), &T::j, &S::i);
         CHECK((res2.first - ib) == sb);
         CHECK((res2.second - ic) == srr);
-        CHECK(ranges::lexicographical_compare(ic, res2.second, ir, irr+srr, std::less<int>(), &U::k) == 0);
+        CHECK(ranges::lexicographical_compare(ic, res2.second, ir, irr+srr, std::less<int>(), &U::k) == false);
     }
 #endif
 

--- a/test/algorithm/set_intersection.hpp
+++ b/test/algorithm/set_intersection.hpp
@@ -46,14 +46,14 @@ test()
                      Iter2(ib), Iter2(ib+sb), OutIter(ic)).check([&](OutIter ce)
         {
             CHECK((base(ce) - ic) == sr);
-            CHECK(std::lexicographical_compare(ic, base(ce), ir, ir+sr) == 0);
+            CHECK(std::lexicographical_compare(ic, base(ce), ir, ir+sr) == false);
             ranges::fill(ic, 0);
         });
     set_intersection(Iter1(ib), Iter1(ib+sb),
                      Iter2(ia), Iter2(ia+sa), OutIter(ic)).check([&](OutIter ce)
         {
             CHECK((base(ce) - ic) == sr);
-            CHECK(std::lexicographical_compare(ic, base(ce), ir, ir+sr) == 0);
+            CHECK(std::lexicographical_compare(ic, base(ce), ir, ir+sr) == false);
             ranges::fill(ic, 0);
         });
 
@@ -62,14 +62,14 @@ test()
                      Iter2(ib), Iter2(ib+sb), OutIter(ic), std::less<int>()).check([&](OutIter ce)
         {
             CHECK((base(ce) - ic) == sr);
-            CHECK(std::lexicographical_compare(ic, base(ce), ir, ir+sr) == 0);
+            CHECK(std::lexicographical_compare(ic, base(ce), ir, ir+sr) == false);
             ranges::fill(ic, 0);
         });
     set_intersection(Iter1(ib), Iter1(ib+sb),
                      Iter2(ia), Iter2(ia+sa), OutIter(ic), std::less<int>()).check([&](OutIter ce)
         {
             CHECK((base(ce) - ic) == sr);
-            CHECK(std::lexicographical_compare(ic, base(ce), ir, ir+sr) == 0);
+            CHECK(std::lexicographical_compare(ic, base(ce), ir, ir+sr) == false);
             ranges::fill(ic, 0);
         });
 }
@@ -259,7 +259,7 @@ int main()
 
         U * res = ranges::set_intersection(ranges::view::all(ia), ranges::view::all(ib), ic, std::less<int>(), &S::i, &T::j);
         CHECK((res - ic) == sr);
-        CHECK(ranges::lexicographical_compare(ic, res, ir, ir+sr, std::less<int>(), &U::k) == 0);
+        CHECK(ranges::lexicographical_compare(ic, res, ir, ir+sr, std::less<int>(), &U::k) == false);
     }
 
     // Test initializer lists
@@ -273,7 +273,7 @@ int main()
             {T{2}, T{4}, T{4}, T{6}},
             ic, std::less<int>(), &S::i, &T::j);
         CHECK((res - ic) == sr);
-        CHECK(ranges::lexicographical_compare(ic, res, ir, ir+sr, std::less<int>(), &U::k) == 0);
+        CHECK(ranges::lexicographical_compare(ic, res, ir, ir+sr, std::less<int>(), &U::k) == false);
     }
 #endif
 

--- a/test/algorithm/set_symmetric_difference.hpp
+++ b/test/algorithm/set_symmetric_difference.hpp
@@ -46,7 +46,7 @@ test_iter()
         check([&](std::tuple<Iter1, Iter2, OutIter> res)
         {
             CHECK((base(std::get<2>(res)) - ic) == sr);
-            CHECK(std::lexicographical_compare(ic, base(std::get<2>(res)), ir, ir+sr) == 0);
+            CHECK(std::lexicographical_compare(ic, base(std::get<2>(res)), ir, ir+sr) == false);
             ranges::fill(ic, 0);
         }
     );
@@ -55,7 +55,7 @@ test_iter()
         check([&](std::tuple<Iter1, Iter2, OutIter> res)
         {
             CHECK((base(std::get<2>(res)) - ic) == sr);
-            CHECK(std::lexicographical_compare(ic, base(std::get<2>(res)), ir, ir+sr) == 0);
+            CHECK(std::lexicographical_compare(ic, base(std::get<2>(res)), ir, ir+sr) == false);
             ranges::fill(ic, 0);
         }
     );
@@ -79,7 +79,7 @@ test_comp()
         check([&](std::tuple<Iter1, Iter2, OutIter> res)
         {
             CHECK((base(std::get<2>(res)) - ic) == sr);
-            CHECK(std::lexicographical_compare(ic, base(std::get<2>(res)), ir, ir+sr) == 0);
+            CHECK(std::lexicographical_compare(ic, base(std::get<2>(res)), ir, ir+sr) == false);
             ranges::fill(ic, 0);
         }
     );
@@ -88,7 +88,7 @@ test_comp()
         check([&](std::tuple<Iter1, Iter2, OutIter> res)
         {
             CHECK((base(std::get<2>(res)) - ic) == sr);
-            CHECK(std::lexicographical_compare(ic, base(std::get<2>(res)), ir, ir+sr) == 0);
+            CHECK(std::lexicographical_compare(ic, base(std::get<2>(res)), ir, ir+sr) == false);
             ranges::fill(ic, 0);
         }
     );
@@ -287,13 +287,13 @@ int main()
         std::tuple<S *, T *, U *> res1 =
             ranges::set_symmetric_difference(ia, ib, ic, std::less<int>(), &S::i, &T::j);
         CHECK((std::get<2>(res1) - ic) == sr);
-        CHECK(ranges::lexicographical_compare(ic, std::get<2>(res1), ir, ir+sr, std::less<int>(), &U::k) == 0);
+        CHECK(ranges::lexicographical_compare(ic, std::get<2>(res1), ir, ir+sr, std::less<int>(), &U::k) == false);
         ranges::fill(ic, U{0});
 
         std::tuple<T *, S *, U *> res2 =
             ranges::set_symmetric_difference(ib, ia, ic, std::less<int>(), &T::j, &S::i);
         CHECK((std::get<2>(res2) - ic) == sr);
-        CHECK(ranges::lexicographical_compare(ic, std::get<2>(res2), ir, ir+sr, std::less<int>(), &U::k) == 0);
+        CHECK(ranges::lexicographical_compare(ic, std::get<2>(res2), ir, ir+sr, std::less<int>(), &U::k) == false);
     }
 
     // Test rvalue ranges
@@ -309,7 +309,7 @@ int main()
         CHECK(std::get<0>(res1).get_unsafe() == ranges::end(ia));
         CHECK(std::get<1>(res1).get_unsafe() == ranges::end(ib));
         CHECK((std::get<2>(res1) - ic) == sr);
-        CHECK(ranges::lexicographical_compare(ic, std::get<2>(res1), ir, ir+sr, std::less<int>(), &U::k) == 0);
+        CHECK(ranges::lexicographical_compare(ic, std::get<2>(res1), ir, ir+sr, std::less<int>(), &U::k) == false);
         ranges::fill(ic, U{0});
 
         auto res2 =
@@ -317,7 +317,7 @@ int main()
         CHECK(std::get<0>(res2).get_unsafe() == ranges::end(ib));
         CHECK(std::get<1>(res2).get_unsafe() == ranges::end(ia));
         CHECK((std::get<2>(res2) - ic) == sr);
-        CHECK(ranges::lexicographical_compare(ic, std::get<2>(res2), ir, ir+sr, std::less<int>(), &U::k) == 0);
+        CHECK(ranges::lexicographical_compare(ic, std::get<2>(res2), ir, ir+sr, std::less<int>(), &U::k) == false);
     }
 #endif
 

--- a/test/algorithm/set_union.hpp
+++ b/test/algorithm/set_union.hpp
@@ -46,7 +46,7 @@ test()
     auto checker = [&](R res)
     {
         CHECK((base(std::get<2>(res)) - ic) == sr);
-        CHECK(std::lexicographical_compare(ic, base(std::get<2>(res)), ir, ir+sr) == 0);
+        CHECK(std::lexicographical_compare(ic, base(std::get<2>(res)), ir, ir+sr) == false);
         ranges::fill(ic, 0);
     };
 
@@ -247,13 +247,13 @@ int main()
         using R = std::tuple<S *, T*, U*>;
         R res = ranges::set_union(ia, ib, ic, std::less<int>(), &S::i, &T::j);
         CHECK((std::get<2>(res) - ic) == sr);
-        CHECK(ranges::lexicographical_compare(ic, std::get<2>(res), ir, ir+sr, std::less<int>(), &U::k) == 0);
+        CHECK(ranges::lexicographical_compare(ic, std::get<2>(res), ir, ir+sr, std::less<int>(), &U::k) == false);
         ranges::fill(ic, U{0});
 
         using R2 = std::tuple<T *, S*, U*>;
         R2 res2 = ranges::set_union(ib, ia, ic, std::less<int>(), &T::j, &S::i);
         CHECK((std::get<2>(res2) - ic) == sr);
-        CHECK(ranges::lexicographical_compare(ic, std::get<2>(res2), ir, ir+sr, std::less<int>(), &U::k) == 0);
+        CHECK(ranges::lexicographical_compare(ic, std::get<2>(res2), ir, ir+sr, std::less<int>(), &U::k) == false);
     }
 
     // Test projections
@@ -268,14 +268,14 @@ int main()
         CHECK(std::get<0>(res).get_unsafe() == ranges::end(ia));
         CHECK(std::get<1>(res).get_unsafe() == ranges::end(ib));
         CHECK((std::get<2>(res) - ic) == sr);
-        CHECK(ranges::lexicographical_compare(ic, std::get<2>(res), ir, ir+sr, std::less<int>(), &U::k) == 0);
+        CHECK(ranges::lexicographical_compare(ic, std::get<2>(res), ir, ir+sr, std::less<int>(), &U::k) == false);
         ranges::fill(ic, U{0});
 
         auto res2 = ranges::set_union(ranges::view::all(ib), ranges::view::all(ia), ic, std::less<int>(), &T::j, &S::i);
         CHECK(std::get<0>(res2).get_unsafe() == ranges::end(ib));
         CHECK(std::get<1>(res2).get_unsafe() == ranges::end(ia));
         CHECK((std::get<2>(res2) - ic) == sr);
-        CHECK(ranges::lexicographical_compare(ic, std::get<2>(res2), ir, ir+sr, std::less<int>(), &U::k) == 0);
+        CHECK(ranges::lexicographical_compare(ic, std::get<2>(res2), ir, ir+sr, std::less<int>(), &U::k) == false);
     }
 #endif
 


### PR DESCRIPTION
A certain compiler warns about comparing `bool` with literal `0`.