### PR TITLE
Mutable istream_range / getlines_range

### DIFF
--- a/include/range/v3/getlines.hpp
+++ b/include/range/v3/getlines.hpp
@@ -47,13 +47,17 @@ namespace ranges
                 {
                     rng_->next();
                 }
-                std::string const &get() const
+                std::string &get() const noexcept
                 {
                     return rng_->str_;
                 }
                 bool done() const
                 {
                     return !*rng_->sin_;
+                }
+                std::string && move() const noexcept
+                {
+                    return detail::move(rng_->str_);
                 }
             };
             void next()
@@ -71,7 +75,7 @@ namespace ranges
             {
                 this->next(); // prime the pump
             }
-            std::string & cached()
+            std::string & cached() noexcept
             {
                 return str_;
             }

--- a/include/range/v3/istream_range.hpp
+++ b/include/range/v3/istream_range.hpp
@@ -47,7 +47,7 @@ namespace ranges
                 {
                     rng_->next();
                 }
-                Val const &get() const
+                Val &get() const
                 {
                     return rng_->cached();
                 }
@@ -55,6 +55,11 @@ namespace ranges
                 {
                     return !*rng_->sin_;
                 }
+                Val && move() const noexcept
+                {
+                    return detail::move(rng_->cached());
+                }
+
             };
             void next()
             {
@@ -78,7 +83,7 @@ namespace ranges
             {
                 next(); // prime the pump
             }
-            Val & cached()
+            Val & cached() noexcept
             {
                 return obj_;
             }

--- a/include/range/v3/istream_range.hpp
+++ b/include/range/v3/istream_range.hpp
@@ -47,7 +47,7 @@ namespace ranges
                 {
                     rng_->next();
                 }
-                Val &get() const
+                Val &get() const noexcept
                 {
                     return rng_->cached();
                 }

--- a/test/getlines.cpp
+++ b/test/getlines.cpp
@@ -11,23 +11,28 @@
 
 #include <sstream>
 #include <range/v3/core.hpp>
+#include <range/v3/range_traits.hpp>
 #include "./simple_test.hpp"
 #include "./test_utils.hpp"
 
+using namespace ranges;
+
 int main()
 {
-    std::stringstream sin{
+    const char* text =
 R"(Now is
 the time
 for all
 good men
-)"};
+)";
 
-    ::check_equal(ranges::getlines(sin), {"Now is", "the time", "for all", "good men"});
+    std::stringstream sin{text};
+    ::check_equal(getlines(sin), {"Now is", "the time", "for all", "good men"});
 
-    using Rng = decltype(ranges::getlines(sin));
-    CONCEPT_ASSERT(ranges::InputView<Rng>());
-    CONCEPT_ASSERT(!ranges::ForwardView<Rng>());
+    using Rng = decltype(getlines(sin));
+    CONCEPT_ASSERT(InputView<Rng>());
+    CONCEPT_ASSERT(!ForwardView<Rng>());
+    CONCEPT_ASSERT(Same<range_rvalue_reference_t<Rng>, std::string &&>());
 
     return ::test_result();
 }

--- a/test/view/zip.cpp
+++ b/test/view/zip.cpp
@@ -49,10 +49,10 @@ int main()
             std::tuple<int, std::string, std::string>>());
         CONCEPT_ASSERT(Same<
             range_reference_t<Rng>,
-            common_tuple<int &, std::string const &, std::string const &>>());
+            common_tuple<int &, std::string const &, std::string &>>());
         CONCEPT_ASSERT(Same<
             range_rvalue_reference_t<Rng>,
-            common_tuple<int &&, std::string const &&, std::string const &&>>());
+            common_tuple<int &&, std::string const &&, std::string &&>>());
         CONCEPT_ASSERT(ConvertibleTo<range_value_t<Rng> &&,
             range_rvalue_reference_t<Rng>>());
         ::models<concepts::InputIterator>(begin(rng));


### PR DESCRIPTION
`istream` and `getlines` are poster children for mutable input ranges: Why copy elements/lines from the input range when we can move them out?