### PR TITLE
Refactor compressed_pair and tagged:

### DIFF
--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -2,6 +2,7 @@
 // Range v3 library
 //
 //  Copyright Eric Niebler 2013-2014
+//  Copyright Casey Carter 2016
 //
 //  Use, modification and distribution is subject to the
 //  Boost Software License, Version 1.0. (See accompanying
@@ -41,6 +42,11 @@
     noexcept(noexcept(decltype(__VA_ARGS__)(__VA_ARGS__))) ->   \
     decltype(__VA_ARGS__)                                       \
     { return (__VA_ARGS__); }                                   \
+    /**/
+
+#define RANGES_DECLTYPE_NOEXCEPT(...)                           \
+    noexcept(noexcept(decltype(__VA_ARGS__)(__VA_ARGS__))) ->   \
+    decltype(__VA_ARGS__)                                       \
     /**/
 
 // Non-portable forward declarations of standard containers

--- a/include/range/v3/utility/basic_iterator.hpp
+++ b/include/range/v3/utility/basic_iterator.hpp
@@ -418,7 +418,6 @@ namespace ranges
         template<typename T>
         struct basic_mixin : private box<T>
         {
-        public:
             CONCEPT_REQUIRES(DefaultConstructible<T>())
             constexpr basic_mixin()
               : box<T>{}
@@ -432,17 +431,7 @@ namespace ranges
               : box<T>(t)
             {}
         protected:
-            RANGES_CXX14_CONSTEXPR
-            T &get() noexcept
-            {
-                return ranges::get<T>(*this);
-            }
-            /// \overload
-            RANGES_CXX14_CONSTEXPR
-            T const &get() const noexcept
-            {
-                return ranges::get<T>(*this);
-            }
+            using box<T>::get;
         };
 
         template<typename S>

--- a/include/range/v3/utility/box.hpp
+++ b/include/range/v3/utility/box.hpp
@@ -2,6 +2,7 @@
 // Range v3 library
 //
 //  Copyright Eric Niebler 2013-2014
+//  Copyright Casey Carter 2016
 //
 //  Use, modification and distribution is subject to the
 //  Boost Software License, Version 1.0. (See accompanying
@@ -129,21 +130,78 @@ namespace ranges
 
         static_assert(std::is_trivial<constant<int, 0>>::value, "Expected constant to be trivial");
 
-        template<typename Element, typename Tag = Element,
-            bool Empty = std::is_empty<Element>::value && !detail::is_final<Element>::value>
-        struct box
+        /// \cond
+        namespace detail
         {
-        private:
-            Element value;
+            // "box" has three different implementations that store a T differently:
+            enum class box_compress {
+                none,       // Nothing special: get() returns a reference to a T member subobject
+                ebo,        // Apply Empty Base Optimization: get() returns a reference to a T base subobject
+                coalesce    // Coalesce all Ts into one T: get() returns a reference to a static T singleton
+            };
 
+            // Per N4582, lambda closures are *not*:
+            // - aggregates             ([expr.prim.lambda]/4)
+            // - default constructible  ([expr.prim.lambda]/p21)
+            // - copy assignable        ([expr.prim.lambda]/p21)
+            template<typename Fn>
+            using could_be_lambda =
+                meta::bool_<
+                    !std::is_default_constructible<Fn>::value &&
+                    !std::is_copy_assignable<Fn>::value>;
+
+            template<typename>
+            constexpr box_compress box_compression_(...)
+            {
+                return box_compress::none;
+            }
+            template<typename T, typename = meta::if_<
+                meta::strict_and<std::is_empty<T>, meta::not_<detail::is_final<T>>
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 6
+                    // GCC 6 finds empty lambdas' implicit conversion to function pointer when doing
+                    // overload resolution for function calls. That causes hard errors.
+                    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71117
+                    , meta::not_<could_be_lambda<T>>
+#endif
+                >>>
+            constexpr box_compress box_compression_(long)
+            {
+                return box_compress::ebo;
+            }
+#ifndef _MSC_VER
+            // MSVC pukes passing non-constant-expression objects to constexpr
+            // functions, so do not coalesce.
+            template<typename T, typename = meta::if_<
+                meta::strict_and<std::is_empty<T>, std::is_trivial<T>, std::is_default_constructible<T>>>>
+            constexpr box_compress box_compression_(int)
+            {
+                return box_compress::coalesce;
+            }
+#endif
+            template<typename T>
+            constexpr box_compress box_compression()
+            {
+                return box_compression_<T>(0);
+            }
+        }
+        /// \endcond
+
+        template<typename Element, typename Tag = void, detail::box_compress = detail::box_compression<Element>()>
+        class box
+        {
+            Element value;
         public:
             CONCEPT_REQUIRES(std::is_default_constructible<Element>::value)
             constexpr box()
               : value{}
             {}
-
             template<typename E,
-                CONCEPT_REQUIRES_(std::is_constructible<Element, E &&>::value)>
+                CONCEPT_REQUIRES_(std::is_constructible<Element, E>::value && std::is_convertible<E, Element>::value)>
+            constexpr box(E && e)
+              : value(detail::forward<E>(e))
+            {}
+            template<typename E,
+                CONCEPT_REQUIRES_(std::is_constructible<Element, E>::value && !std::is_convertible<E, Element>::value)>
             constexpr explicit box(E && e)
               : value(detail::forward<E>(e))
             {}
@@ -163,16 +221,21 @@ namespace ranges
         };
 
         template<typename Element, typename Tag>
-        struct box<Element, Tag, true>
-          : private Element
+        class box<Element, Tag, detail::box_compress::ebo>
+          : Element
         {
+        public:
             CONCEPT_REQUIRES(std::is_default_constructible<Element>::value)
             constexpr box()
               : Element{}
             {}
-
             template<typename E,
-                CONCEPT_REQUIRES_(std::is_constructible<Element, E &&>::value)>
+                CONCEPT_REQUIRES_(std::is_constructible<Element, E>::value && std::is_convertible<E, Element>::value)>
+            constexpr box(E && e)
+              : Element(detail::forward<E>(e))
+            {}
+            template<typename E,
+                CONCEPT_REQUIRES_(std::is_constructible<Element, E>::value && !std::is_convertible<E, Element>::value)>
             constexpr explicit box(E && e)
               : Element(detail::forward<E>(e))
             {}
@@ -191,45 +254,73 @@ namespace ranges
             }
         };
 
-        template<typename Element, typename Tag = Element, bool Inherit = true>
-        using box_if =
-            box<Element, Tag, Inherit && std::is_empty<Element>::value &&
-                                         !detail::is_final<Element>::value>;
+        template<typename Element, typename Tag>
+        class box<Element, Tag, detail::box_compress::coalesce>
+        {
+            static Element value;
+        public:
+            constexpr box() noexcept
+            {}
+            template<typename E,
+                CONCEPT_REQUIRES_(std::is_constructible<Element, E>::value && std::is_convertible<E, Element>::value)>
+            constexpr box(E &&) noexcept
+            {}
+            template<typename E,
+                CONCEPT_REQUIRES_(std::is_constructible<Element, E>::value && !std::is_convertible<E, Element>::value)>
+            constexpr explicit box(E &&) noexcept
+            {}
+
+            RANGES_CXX14_CONSTEXPR Element &get() & noexcept
+            {
+                return value;
+            }
+            constexpr Element const &get() const & noexcept
+            {
+                return value;
+            }
+            RANGES_CXX14_CONSTEXPR Element &&get() && noexcept
+            {
+                return detail::move(value);
+            }
+        };
+
+        template<typename Element, typename Tag>
+        Element box<Element, Tag, detail::box_compress::coalesce>::value;
 
         // Get by tag type
-        template<typename Tag, typename Element, bool Empty>
-        RANGES_CXX14_CONSTEXPR Element & get(box<Element, Tag, Empty> & b) noexcept
+        template<typename Tag, typename Element, detail::box_compress BC>
+        RANGES_CXX14_CONSTEXPR Element & get(box<Element, Tag, BC> & b) noexcept
         {
             return b.get();
         }
 
-        template<typename Tag, typename Element, bool Empty>
-        constexpr Element const & get(box<Element, Tag, Empty> const & b) noexcept
+        template<typename Tag, typename Element, detail::box_compress BC>
+        constexpr Element const & get(box<Element, Tag, BC> const & b) noexcept
         {
             return b.get();
         }
 
-        template<typename Tag, typename Element, bool Empty>
-        RANGES_CXX14_CONSTEXPR Element && get(box<Element, Tag, Empty> && b) noexcept
+        template<typename Tag, typename Element, detail::box_compress BC>
+        RANGES_CXX14_CONSTEXPR Element && get(box<Element, Tag, BC> && b) noexcept
         {
             return detail::move(b).get();
         }
 
         // Get by index
-        template<std::size_t I, typename Element, bool Empty>
-        RANGES_CXX14_CONSTEXPR Element & get(box<Element, meta::size_t<I>, Empty> & b) noexcept
+        template<std::size_t I, typename Element, detail::box_compress BC>
+        RANGES_CXX14_CONSTEXPR Element & get(box<Element, meta::size_t<I>, BC> & b) noexcept
         {
             return b.get();
         }
 
-        template<std::size_t I, typename Element, bool Empty>
-        constexpr Element const & get(box<Element, meta::size_t<I>, Empty> const & b) noexcept
+        template<std::size_t I, typename Element, detail::box_compress BC>
+        constexpr Element const & get(box<Element, meta::size_t<I>, BC> const & b) noexcept
         {
             return b.get();
         }
 
-        template<std::size_t I, typename Element, bool Empty>
-        RANGES_CXX14_CONSTEXPR Element && get(box<Element, meta::size_t<I>, Empty> && b) noexcept
+        template<std::size_t I, typename Element, detail::box_compress BC>
+        RANGES_CXX14_CONSTEXPR Element && get(box<Element, meta::size_t<I>, BC> && b) noexcept
         {
             return detail::move(b).get();
         }

--- a/include/range/v3/utility/compressed_pair.hpp
+++ b/include/range/v3/utility/compressed_pair.hpp
@@ -2,6 +2,7 @@
 // Range v3 library
 //
 //  Copyright Eric Niebler 2013-2014
+//  Copyright Casey Carter 2016
 //
 //  Use, modification and distribution is subject to the
 //  Boost Software License, Version 1.0. (See accompanying
@@ -14,110 +15,118 @@
 #ifndef RANGES_V3_UTILITY_COMPRESSED_PAIR_HPP
 #define RANGES_V3_UTILITY_COMPRESSED_PAIR_HPP
 
-#include <utility>
 #include <type_traits>
+#include <utility>
 #include <meta/meta.hpp>
 #include <range/v3/range_fwd.hpp>
+#include <range/v3/utility/box.hpp>
 #include <range/v3/utility/concepts.hpp>
-#include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/static_const.hpp>
+#include <range/v3/utility/tagged_pair.hpp>
 
 namespace ranges
 {
     inline namespace v3
     {
         /// \cond
-        namespace detail
+        namespace compressed_tuple_detail
         {
-            template<typename T>
-            using is_ebo_able =
-                meta::and_<std::is_empty<T>, std::is_trivial<T>, std::is_default_constructible<T>>;
+            // tagging individual elements with the complete type list disambiguates
+            // base classes when composing compressed_tuples recursively.
+            template<typename T, std::size_t I, typename... Ts>
+            using storage = box<T, meta::list<meta::size_t<I>, Ts...>>;
 
-            template<typename T, bool EBOable = is_ebo_able<T>::value>
-            struct first_base
+            template<typename List, typename Indices> struct compressed_tuple_;
+            template<typename... Ts, std::size_t... Is>
+            struct compressed_tuple_<meta::list<Ts...>, meta::index_sequence<Is...>>
+              : storage<Ts, Is, Ts...>...
             {
-                T first;
-                first_base() = default;
-                template<typename U,
-                    meta::if_<std::is_constructible<T, U &&>, int> = 0>
-                constexpr explicit first_base(U && u)
-                  : first((U &&) u)
+                static_assert(Same<meta::index_sequence<Is...>,
+                    meta::make_index_sequence<sizeof...(Is)>>(), "What madness is this?!?");
+
+                compressed_tuple_() = default;
+
+                // TODO: EXPLICIT
+                template<typename... Args,
+                    meta::if_<meta::strict_and<std::is_constructible<Ts, Args>...>, int> = 0>
+                constexpr compressed_tuple_(Args &&... args)
+                  : storage<Ts, Is, Ts...>{detail::forward<Args>(args)}...
                 {}
+
+                template<typename... Us,
+                    meta::if_<meta::strict_and<std::is_constructible<Us, Ts const &>...>, int> = 0>
+                constexpr operator std::tuple<Us...> () const
+                {
+                    return std::tuple<Us...>{get<Is>(*this)...};
+                }
             };
 
-            template<typename T>
-            struct first_base<T, true>
+            template<typename... Ts>
+            using compressed_tuple =
+                compressed_tuple_<meta::list<Ts...>, meta::make_index_sequence<sizeof...(Ts)>>;
+
+            template<std::size_t I, typename... Ts, std::size_t... Is, typename T = meta::at_c<meta::list<Ts...>, I>>
+            RANGES_CXX14_CONSTEXPR T &get(compressed_tuple_<meta::list<Ts...>, meta::index_sequence<Is...>> &tuple) noexcept
             {
-                static T first;
-                first_base() = default;
-                template<typename U,
-                    meta::if_<std::is_constructible<T, U &&>, int> = 0>
-                constexpr explicit first_base(U &&)
-                {}
-            };
-
-            template<typename T>
-            T first_base<T, true>::first{};
-
-            template<typename T, bool EBOable = is_ebo_able<T>::value>
-            struct second_base
+                return static_cast<storage<T, I, Ts...> &>(tuple).get();
+            }
+            template<std::size_t I, typename... Ts, std::size_t... Is, typename T = meta::at_c<meta::list<Ts...>, I>>
+            constexpr T const &get(compressed_tuple_<meta::list<Ts...>, meta::index_sequence<Is...>> const &tuple) noexcept
             {
-                T second;
-                second_base() = default;
-                template<typename U,
-                    meta::if_<std::is_constructible<T, U &&>, int> = 0>
-                constexpr explicit second_base(U && u)
-                  : second((U &&) u)
-                {}
-            };
-
-            template<typename T>
-            struct second_base<T, true>
+                return static_cast<storage<T, I, Ts...> const &>(tuple).get();
+            }
+            template<std::size_t I, typename... Ts, std::size_t... Is, typename T = meta::at_c<meta::list<Ts...>, I>>
+            RANGES_CXX14_CONSTEXPR T && get(compressed_tuple_<meta::list<Ts...>, meta::index_sequence<Is...>> && tuple) noexcept
             {
-                static T second;
-                second_base() = default;
-                template<typename U,
-                    meta::if_<std::is_constructible<T, U &&>, int> = 0>
-                constexpr explicit second_base(U &&)
-                {}
-            };
-
-            template<typename T>
-            T second_base<T, true>::second{};
+                return static_cast<storage<T, I, Ts...> &&>(tuple).get();
+            }
         }
-        /// \endcond
+        using compressed_tuple_detail::compressed_tuple;
+
+        struct make_compressed_tuple_fn
+        {
+            template<typename... Args>
+            constexpr auto operator()(Args &&... args) const ->
+                compressed_tuple<bind_element_t<Args>...>
+            {
+                return {detail::forward<Args>(args)...};
+            }
+        };
+
+        /// \ingroup group-utility
+        /// \sa `make_compressed_tuple_fn`
+        namespace
+        {
+            constexpr auto&& make_compressed_tuple = static_const<make_compressed_tuple_fn>::value;
+        }
+
+        template<typename... Ts>
+        using tagged_compressed_tuple =
+            tagged<compressed_tuple<detail::tag_elem<Ts>...>, detail::tag_spec<Ts>...>;
+
+        RANGES_DEFINE_TAG_SPECIFIER(first)
+        RANGES_DEFINE_TAG_SPECIFIER(second)
 
         template<typename First, typename Second>
         struct compressed_pair
-          : private detail::first_base<First>
-          , private detail::second_base<Second>
+            : tagged_compressed_tuple<tag::first(First), tag::second(Second)>
         {
+            using base_t = tagged_compressed_tuple<tag::first(First), tag::second(Second)>;
             using first_type = First;
             using second_type = Second;
-            using detail::first_base<First>::first;
-            using detail::second_base<Second>::second;
+
+            using base_t::first;
+            using base_t::second;
 
             compressed_pair() = default;
-
-            constexpr compressed_pair(First f, Second s)
-              : detail::first_base<First>{(First &&) f}
-              , detail::second_base<Second>{(Second &&) s}
-            {}
+            using base_t::base_t;
 
             template<typename F, typename S,
-                meta::if_<meta::and_<std::is_constructible<First, F &&>,
-                                     std::is_constructible<Second, S &&>>, int> = 0>
-            constexpr compressed_pair(F && f, S && s)
-              : detail::first_base<First>{(F &&) f}
-              , detail::second_base<Second>{(S &&) s}
-            {}
-
-            template<typename F, typename S,
-                meta::if_<meta::and_<std::is_constructible<F, First const &>,
-                                     std::is_constructible<S, Second const &>>, int> = 0>
+                meta::if_<meta::strict_and<std::is_constructible<F, First const &>,
+                                           std::is_constructible<S, Second const &>>, int> = 0>
             constexpr operator std::pair<F, S> () const
             {
-                return std::pair<F, S>{first, second};
+                return std::pair<F, S>{first(), second()};
             }
         };
 
@@ -137,61 +146,6 @@ namespace ranges
         {
             constexpr auto&& make_compressed_pair = static_const<make_compressed_pair_fn>::value;
         }
-
-        /// \brief Tuple-like access of `compressed_pair`
-        // TODO Switch to variable template when available
-        template<std::size_t I, typename First, typename Second,
-            CONCEPT_REQUIRES_(I == 0)>
-        constexpr auto get(compressed_pair<First, Second> & p) ->
-            decltype((p.first))
-        {
-            return p.first;
-        }
-
-        /// \overload
-        template<std::size_t I, typename First, typename Second,
-            CONCEPT_REQUIRES_(I == 0)>
-        constexpr auto get(compressed_pair<First, Second> const & p) ->
-            decltype((p.first))
-        {
-            return p.first;
-        }
-
-        /// \overload
-        template<std::size_t I, typename First, typename Second,
-            CONCEPT_REQUIRES_(I == 0)>
-        constexpr auto get(compressed_pair<First, Second> && p) ->
-            decltype((detail::move(p).first))
-        {
-            return detail::move(p).first;
-        }
-
-        /// \overload
-        template<std::size_t I, typename First, typename Second,
-            CONCEPT_REQUIRES_(I == 1)>
-        constexpr auto get(compressed_pair<First, Second> & p) ->
-            decltype((p.second))
-        {
-            return p.second;
-        }
-
-        /// \overload
-        template<std::size_t I, typename First, typename Second,
-            CONCEPT_REQUIRES_(I == 1)>
-        constexpr auto get(compressed_pair<First, Second> const & p) ->
-            decltype((p.second))
-        {
-            return p.second;
-        }
-
-        /// \overload
-        template<std::size_t I, typename First, typename Second,
-            CONCEPT_REQUIRES_(I == 1)>
-        constexpr auto get(compressed_pair<First, Second> && p) ->
-            decltype((detail::move(p).second))
-        {
-            return detail::move(p).second;
-        }
     }
 }
 
@@ -200,9 +154,20 @@ RANGES_DIAGNOSTIC_IGNORE_PRAGMAS
 RANGES_DIAGNOSTIC_IGNORE_MISMATCHED_TAGS
 namespace std
 {
+    template<typename... Ts, size_t... Is>
+    struct tuple_size< ::ranges::v3::compressed_tuple_detail::compressed_tuple_<meta::list<Ts...>, meta::index_sequence<Is...>>>
+      : integral_constant<size_t, sizeof...(Ts)>
+    {};
+
+    template<size_t I, typename... Ts, size_t... Is>
+    struct tuple_element<I, ::ranges::v3::compressed_tuple_detail::compressed_tuple_<meta::list<Ts...>, meta::index_sequence<Is...>>>
+    {
+        using type = ::meta::at_c<meta::list<Ts...>, I>;
+    };
+
     template<typename First, typename Second>
     struct tuple_size< ::ranges::v3::compressed_pair<First, Second>>
-      : std::integral_constant<size_t, 2>
+      : integral_constant<size_t, 2>
     {};
 
     template<typename First, typename Second>

--- a/include/range/v3/utility/tagged_pair.hpp
+++ b/include/range/v3/utility/tagged_pair.hpp
@@ -2,6 +2,7 @@
 // Range v3 library
 //
 //  Copyright Eric Niebler 2013-2015
+//  Copyright Casey Carter 2016
 //
 //  Use, modification and distribution is subject to the
 //  Boost Software License, Version 1.0. (See accompanying
@@ -14,175 +15,196 @@
 #define RANGES_V3_UTILITY_TAGGED_PAIR_HPP
 
 #include <utility>
-#include <functional>
 #include <meta/meta.hpp>
 #include <range/v3/range_fwd.hpp>
+#include <range/v3/utility/concepts.hpp>
 #include <range/v3/utility/swap.hpp>
-#include <range/v3/utility/functional.hpp>
 
 namespace ranges
 {
     inline namespace v3
     {
-        template<typename Base, typename...Tags>
-        struct tagged;
-
         /// \cond
         namespace detail
         {
-            struct getters
-            {
-            private:
-                template<typename, typename...> friend struct ranges::tagged;
-                template<typename Type, typename Indices, typename...Tags>
-                struct collect_;
-                template<typename Type, std::size_t...Is, typename...Tags>
-                struct collect_<Type, meta::index_sequence<Is...>, Tags...>
-                  : Tags::template getter<Type, meta::_t<std::tuple_element<Is, Type>>, Is>...
-                {
-                    collect_() = default;
-                    collect_(const collect_&) = default;
-                    collect_ &operator=(const collect_&) = default;
-                private:
-                    template<typename, typename...> friend struct ranges::tagged;
-                    ~collect_() = default;
-                };
-                template<typename Type, typename...Tags>
-                using collect = collect_<Type, meta::make_index_sequence<sizeof...(Tags)>, Tags...>;
-            };
-
             template<typename T>
             using tag_spec = meta::front<meta::as_list<T>>;
 
             template<typename T>
             using tag_elem = meta::back<meta::as_list<T>>;
 
-        #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 6)
-            template<typename Base, typename...Tags>
-            meta::if_c<is_swappable<Base &>::value>
-            swap(tagged<Base, Tags...> &x, tagged<Base, Tags...> &y)
-                noexcept(is_nothrow_swappable<Base &>::value)
+            namespace adl_get_detail
             {
-                x.swap(y);
+                using std::get;
+
+                template<std::size_t I, typename T>
+                constexpr auto adl_get(T && t)
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                (
+                    get<I>((T &&) t)
+                )
             }
-        #endif
+            using adl_get_detail::adl_get;
         }
         /// \endcond
 
-        template<typename Base, typename...Tags>
-        struct tagged
-          : Base
-          , detail::getters::collect<tagged<Base, Tags...>, Tags...>
+        namespace tagged_detail
         {
-            tagged() = default;
-            tagged(tagged &&) = default;
-            tagged(tagged const &) = default;
-            using Base::Base;
-            CONCEPT_REQUIRES(MoveConstructible<Base>())
-            tagged(Base && that)
-              : Base(std::move(that))
-            {}
-            CONCEPT_REQUIRES(CopyConstructible<Base>())
-            tagged(Base const & that)
-              : Base(that)
-            {}
-            tagged &operator=(tagged &&) = default;
-            tagged &operator=(tagged const &) = default;
-            template<typename Other, typename = meta::if_<std::is_convertible<Other, Base>>>
-            tagged(tagged<Other, Tags...> &&that)
-                noexcept(noexcept(Base(static_cast<Other &&>(that))))
-              : Base(static_cast<Other &&>(that))
-            {}
-            template<typename Other, typename = meta::if_<std::is_convertible<Other, Base>>>
-            tagged(tagged<Other, Tags...> const &that)
-              : Base(static_cast<Other const &>(that))
-            {}
-            template<typename Other, typename = meta::if_<std::is_convertible<Other, Base>>>
-            tagged &operator=(tagged<Other, Tags...> &&that)
-                noexcept(noexcept(std::declval<Base &>() = static_cast<Other &&>(that)))
+            /// \cond
+            template<typename Base, std::size_t, typename...>
+            struct chain
             {
-                static_cast<Base &>(*this) = static_cast<Other &&>(that);
-                return *this;
-            }
-            template<typename Other, typename = meta::if_<std::is_convertible<Other, Base>>>
-            tagged &operator=(tagged<Other, Tags...> const &that)
+                using type = Base;
+            };
+            template<typename Base, std::size_t I, typename First, typename... Rest>
+            struct chain<Base, I, First, Rest...>
             {
-                static_cast<Base &>(*this) = static_cast<Other const &>(that);
-                return *this;
-            }
-            template<typename U,
-                typename = meta::if_c<!std::is_same<tagged, detail::decay_t<U>>::value>,
-                typename = decltype(std::declval<Base &>() = std::declval<U>())>
-            tagged &operator=(U && u)
-                noexcept(noexcept(std::declval<Base &>() = std::forward<U>(u)))
+                using type = typename First::template getter<
+                    Base, I, meta::_t<chain<Base, I + 1, Rest...>>>;
+            };
+            /// \endcond
+
+            template<typename Base, typename...Tags>
+            class tagged
+              : public meta::_t<chain<Base, 0, Tags...>>
             {
-                static_cast<Base &>(*this) = std::forward<U>(u);
-                return *this;
-            }
-            template<int tagged_dummy_ = 42>
-            meta::if_c<tagged_dummy_ == 43 || is_swappable<Base &>::value>
-            swap(tagged &that)
-                noexcept(is_nothrow_swappable<Base &>::value)
-            {
-                ranges::swap(static_cast<Base &>(*this), static_cast<Base &>(that));
-            }
-            // Workaround for GCC PR66957 https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66957
-        #if !defined(__GNUC__) || defined(__clang__) || !(__GNUC__ < 6)
-            template<int tagged_dummy_ = 42>
-            friend meta::if_c<tagged_dummy_ == 43 || is_swappable<Base &>::value>
-            swap(tagged &x, tagged &y)
-                noexcept(is_nothrow_swappable<Base &>::value)
-            {
-                x.swap(y);
-            }
-        #endif
-        };
+                CONCEPT_ASSERT(Same<Base, uncvref_t<Base>>());
+                using base_t = meta::_t<chain<Base, 0, Tags...>>;
+
+                template<typename Other>
+                using can_convert =
+                    meta::bool_<!std::is_same<Other, Base>::value &&
+                        std::is_convertible<Other, Base>::value>;
+            public:
+                tagged() = default;
+                using base_t::base_t;
+                CONCEPT_REQUIRES(MoveConstructible<Base>())
+                constexpr tagged(Base && that)
+                    noexcept(std::is_nothrow_move_constructible<Base>::value)
+                  : base_t(detail::move(that))
+                {}
+                CONCEPT_REQUIRES(CopyConstructible<Base>())
+                constexpr tagged(Base const &that)
+                    noexcept(std::is_nothrow_copy_constructible<Base>::value)
+                  : base_t(that)
+                {}
+                template<typename Other, typename = meta::if_<can_convert<Other>>>
+                constexpr tagged(tagged<Other, Tags...> && that)
+                    noexcept(std::is_nothrow_constructible<Base, Other>::value)
+                  : base_t(static_cast<Other &&>(that))
+                {}
+                template<typename Other, typename = meta::if_<can_convert<Other>>>
+                constexpr tagged(tagged<Other, Tags...> const &that)
+                    noexcept(std::is_nothrow_constructible<Base, Other const &>::value)
+                  : base_t(static_cast<Other const &>(that))
+                {}
+                template<typename Other, typename = meta::if_<can_convert<Other>>>
+                RANGES_CXX14_CONSTEXPR tagged &operator=(tagged<Other, Tags...> && that)
+                    noexcept(noexcept(std::declval<Base &>() = static_cast<Other &&>(that)))
+                {
+                    static_cast<Base &>(*this) = static_cast<Other &&>(that);
+                    return *this;
+                }
+                template<typename Other, typename = meta::if_<can_convert<Other>>>
+                RANGES_CXX14_CONSTEXPR tagged &operator=(tagged<Other, Tags...> const &that)
+                    noexcept(noexcept(std::declval<Base &>() = static_cast<Other const &>(that)))
+                {
+                    static_cast<Base &>(*this) = static_cast<Other const &>(that);
+                    return *this;
+                }
+                template<typename U,
+                    typename = meta::if_c<!std::is_same<tagged, detail::decay_t<U>>::value>,
+                    typename = decltype(std::declval<Base &>() = std::declval<U>())>
+                RANGES_CXX14_CONSTEXPR tagged &operator=(U && u)
+                    noexcept(noexcept(std::declval<Base &>() = std::forward<U>(u)))
+                {
+                    static_cast<Base &>(*this) = std::forward<U>(u);
+                    return *this;
+                }
+                template<int dummy_ = 42>
+                RANGES_CXX14_CONSTEXPR meta::if_c<dummy_ == 43 || is_swappable<Base &>::value>
+                swap(tagged &that)
+                    noexcept(is_nothrow_swappable<Base &>::value)
+                {
+                    ranges::swap(static_cast<Base &>(*this), static_cast<Base &>(that));
+                }
+                template<int dummy_ = 42>
+                friend RANGES_CXX14_CONSTEXPR meta::if_c<dummy_ == 43 || is_swappable<Base &>::value>
+                swap(tagged &x, tagged &y)
+                    noexcept(is_nothrow_swappable<Base &>::value)
+                {
+                    x.swap(y);
+                }
+            };
+        }
+        using tagged_detail::tagged;
 
         template<typename F, typename S>
         using tagged_pair =
             tagged<std::pair<detail::tag_elem<F>, detail::tag_elem<S>>,
                    detail::tag_spec<F>, detail::tag_spec<S>>;
 
-        template<typename Tag1, typename Tag2, typename T1, typename T2>
-        constexpr tagged_pair<Tag1(bind_element_t<T1>), Tag2(bind_element_t<T2>)>
-        make_tagged_pair(T1 && t1, T2 && t2)
+        template<typename Tag1, typename Tag2, typename T1, typename T2,
+            typename R = tagged_pair<Tag1(bind_element_t<T1>), Tag2(bind_element_t<T2>)>>
+        constexpr R make_tagged_pair(T1 && t1, T2 && t2)
+            noexcept(std::is_nothrow_constructible<R, T1, T2>::value)
         {
             return {detail::forward<T1>(t1), detail::forward<T2>(t2)};
         }
     }
 }
 
-#define RANGES_DEFINE_TAG_SPECIFIER(NAME)                                       \
-    namespace tag                                                               \
-    {                                                                           \
-        struct NAME                                                             \
-        {                                                                       \
-        private:                                                                \
-            friend struct ranges::detail::getters;                              \
-            template<typename Derived, typename Type, std::size_t I>            \
-            struct getter                                                       \
-            {                                                                   \
-                getter() = default;                                             \
-                getter(getter const &) = default;                               \
-                getter &operator=(getter const &) = default;                    \
-                RANGES_CXX14_CONSTEXPR Type &NAME() &                           \
-                {                                                               \
-                    return std::get<I>(static_cast<Derived &>(*this));          \
-                }                                                               \
-                RANGES_CXX14_CONSTEXPR Type &&NAME() &&                         \
-                {                                                               \
-                    return std::get<I>(static_cast<Derived &&>(*this));         \
-                }                                                               \
-                constexpr Type const &NAME() const &                            \
-                {                                                               \
-                    return std::get<I>(static_cast<Derived const &>(*this));    \
-                }                                                               \
-            private:                                                            \
-                friend struct ranges::detail::getters;                          \
-                ~getter() = default;                                            \
-            };                                                                  \
-        };                                                                      \
-    }                                                                           \
+#define RANGES_DEFINE_TAG_SPECIFIER(NAME)                                            \
+    namespace tag                                                                    \
+    {                                                                                \
+        struct NAME                                                                  \
+        {                                                                            \
+            template<typename Untagged, std::size_t I, typename Next>                \
+            class getter : public Next                                               \
+            {                                                                        \
+            protected:                                                               \
+                ~getter() = default;                                                 \
+            public:                                                                  \
+                getter() = default;                                                  \
+                getter(getter &&) = default;                                         \
+                getter(getter const &) = default;                                    \
+                using Next::Next;                                                    \
+                CONCEPT_REQUIRES(MoveConstructible<Untagged>())                      \
+                constexpr getter(Untagged && that)                                   \
+                    noexcept(std::is_nothrow_move_constructible<Untagged>::value)    \
+                  : Next(detail::move(that))                                         \
+                {}                                                                   \
+                CONCEPT_REQUIRES(CopyConstructible<Untagged>())                      \
+                constexpr getter(Untagged const &that)                               \
+                    noexcept(std::is_nothrow_copy_constructible<Untagged>::value)    \
+                  : Next(that)                                                       \
+                {}                                                                   \
+                getter &operator=(getter &&) = default;                              \
+                getter &operator=(getter const &) = default;                         \
+                RANGES_CXX14_CONSTEXPR                                               \
+                meta::_t<std::tuple_element<I, Untagged>> &NAME() &                  \
+                    noexcept(noexcept(                                               \
+                        detail::adl_get<I>(std::declval<Untagged &>())))             \
+                {                                                                    \
+                    return detail::adl_get<I>(static_cast<Untagged &>(*this));       \
+                }                                                                    \
+                RANGES_CXX14_CONSTEXPR                                               \
+                meta::_t<std::tuple_element<I, Untagged>> &&NAME() &&                \
+                    noexcept(noexcept(                                               \
+                        detail::adl_get<I>(std::declval<Untagged>())))               \
+                {                                                                    \
+                    return detail::adl_get<I>(static_cast<Untagged &&>(*this));      \
+                }                                                                    \
+                constexpr                                                            \
+                meta::_t<std::tuple_element<I, Untagged>> const &NAME() const &      \
+                    noexcept(noexcept(                                               \
+                        detail::adl_get<I>(std::declval<Untagged const &>())))       \
+                {                                                                    \
+                    return detail::adl_get<I>(static_cast<Untagged const &>(*this)); \
+                }                                                                    \
+            };                                                                       \
+        };                                                                           \
+    }                                                                                \
     /**/
 
 RANGES_DIAGNOSTIC_PUSH
@@ -191,14 +213,14 @@ RANGES_DIAGNOSTIC_IGNORE_MISMATCHED_TAGS
 
 namespace std
 {
-    template<typename Base, typename...Tags>
-    struct tuple_size<ranges::tagged<Base, Tags...>>
-      : tuple_size<Base>
+    template<typename Untagged, typename...Tags>
+    struct tuple_size< ::ranges::v3::tagged<Untagged, Tags...>>
+      : tuple_size<Untagged>
     {};
 
-    template<size_t N, typename Base, typename...Tags>
-    struct tuple_element<N, ranges::tagged<Base, Tags...>>
-      : tuple_element<N, Base>
+    template<size_t N, typename Untagged, typename...Tags>
+    struct tuple_element<N, ::ranges::v3::tagged<Untagged, Tags...>>
+      : tuple_element<N, Untagged>
     {};
 }
 

--- a/include/range/v3/utility/tagged_tuple.hpp
+++ b/include/range/v3/utility/tagged_tuple.hpp
@@ -14,9 +14,6 @@
 #define RANGES_V3_UTILITY_TAGGED_TUPLE_HPP
 
 #include <tuple>
-#include <utility>
-#include <functional>
-#include <meta/meta.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/utility/tagged_pair.hpp>
 

--- a/include/range/v3/view/chunk.hpp
+++ b/include/range/v3/view/chunk.hpp
@@ -79,8 +79,8 @@ namespace ranges
         private:
             range_difference_t<Rng> n_;
             range_sentinel_t<Rng> end_;
-            offset_t & offset() {return ranges::get<offset_t>(*this);}
-            offset_t const & offset() const {return ranges::get<offset_t>(*this);}
+            offset_t & offset() {return this->box<offset_t>::get();}
+            offset_t const & offset() const {return this->box<offset_t>::get();}
         public:
             adaptor() = default;
             adaptor(range_difference_t<Rng> n, range_sentinel_t<Rng> end)

--- a/include/range/v3/view/replace_if.hpp
+++ b/include/range/v3/view/replace_if.hpp
@@ -19,6 +19,7 @@
 #include <meta/meta.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/view/transform.hpp>
+#include <range/v3/utility/compressed_pair.hpp>
 #include <range/v3/utility/concepts.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/semiregular.hpp>
@@ -37,14 +38,17 @@ namespace ranges
         {
             template<typename Pred, typename Val>
             struct replacer_if_fn
+              : compressed_pair<semiregular_t<function_type<Pred>>, Val>
             {
             private:
-                compressed_pair<semiregular_t<function_type<Pred>>, Val> fun_and_new_value_;
+                using base_t = compressed_pair<semiregular_t<function_type<Pred>>, Val>;
+                using base_t::first;
+                using base_t::second;
 
             public:
                 replacer_if_fn() = default;
                 replacer_if_fn(Pred pred, Val new_value)
-                  : fun_and_new_value_{as_function(std::move(pred)), std::move(new_value)}
+                  : base_t{as_function(std::move(pred)), std::move(new_value)}
                 {}
 
                 template<typename I>
@@ -61,8 +65,8 @@ namespace ranges
                 operator()(I const &i)
                 {
                     auto &&x = *i;
-                    if(fun_and_new_value_.first((decltype(x) &&) x))
-                        return unwrap_reference(fun_and_new_value_.second);
+                    if(first()((decltype(x) &&) x))
+                        return unwrap_reference(second());
                     return (decltype(x) &&) x;
                 }
                 template<typename I,
@@ -71,8 +75,8 @@ namespace ranges
                 operator()(I const &i) const
                 {
                     auto &&x = *i;
-                    if(fun_and_new_value_.first((decltype(x) &&) x))
-                        return unwrap_reference(fun_and_new_value_.second);
+                    if(first()((decltype(x) &&) x))
+                        return unwrap_reference(second());
                     return (decltype(x) &&) x;
                 }
 
@@ -82,8 +86,8 @@ namespace ranges
                 operator()(move_tag, I const &i)
                 {
                     auto &&x = iter_move(i);
-                    if(fun_and_new_value_.first((decltype(x) &&) x))
-                        return unwrap_reference(fun_and_new_value_.second);
+                    if(first()((decltype(x) &&) x))
+                        return unwrap_reference(second());
                     return (decltype(x) &&) x;
                 }
                 template<typename I,
@@ -92,8 +96,8 @@ namespace ranges
                 operator()(move_tag, I const &i) const
                 {
                     auto &&x = iter_move(i);
-                    if(fun_and_new_value_.first((decltype(x) &&) x))
-                        return unwrap_reference(fun_and_new_value_.second);
+                    if(first()((decltype(x) &&) x))
+                        return unwrap_reference(second());
                     return (decltype(x) &&) x;
                 }
             };

--- a/include/range/v3/view/stride.hpp
+++ b/include/range/v3/view/stride.hpp
@@ -25,7 +25,6 @@
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/view_adaptor.hpp>
-#include <range/v3/utility/box.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/iterator.hpp>
 #include <range/v3/utility/static_const.hpp>

--- a/test/iterator_range.cpp
+++ b/test/iterator_range.cpp
@@ -28,9 +28,9 @@ int main()
     iterator_range<std::vector<int>::iterator> r0 {vi.begin(), vi.end()};
     ::models<concepts::SizedView>(r0);
     CHECK(r0.size() == 4u);
-    CHECK(r0.first == vi.begin());
-    CHECK(r0.second == vi.end());
-    ++r0.first;
+    CHECK(r0.begin() == vi.begin());
+    CHECK(r0.end() == vi.end());
+    ++r0.begin();
     CHECK(r0.size() == 3u);
 
     std::pair<std::vector<int>::iterator, std::vector<int>::iterator> p0 = r0;
@@ -40,13 +40,13 @@ int main()
     iterator_range<std::vector<int>::iterator, unreachable> r1 { r0.begin(), {} };
     ::models<concepts::View>(r1);
     ::models_not<concepts::SizedView>(r1);
-    CHECK(r1.first == vi.begin()+1);
-    r1.second = unreachable{};
+    CHECK(r1.begin() == vi.begin()+1);
+    r1.end() = unreachable{};
 
-    ++r0.first;
+    ++r0.begin();
     CHECK(r0.begin() == vi.begin()+2);
     CHECK(r0.size() == 2u);
-    --r0.second;
+    --r0.end();
     CHECK(r0.end() == vi.end()-1);
     CHECK(r0.size() == 1u);
     CHECK(r0.front() == 3);
@@ -56,7 +56,7 @@ int main()
     CHECK(p1.first == vi.begin()+1);
 
     iterator_range<std::vector<int>::iterator, unreachable> r2 { p1 };
-    CHECK(r1.first == vi.begin()+1);
+    CHECK(r1.begin() == vi.begin()+1);
 
     std::list<int> li{1,2,3,4};
     sized_iterator_range<std::list<int>::iterator> l0 {li.begin(), li.end(), li.size()};
@@ -68,8 +68,8 @@ int main()
     l0 = view::all(li);
 
     iterator_range<std::list<int>::iterator> l1 = l0;
-    CHECK(l1.first == li.begin());
-    CHECK(l1.second == li.end());
+    CHECK(l1.begin() == li.begin());
+    CHECK(l1.end() == li.end());
 
     return ::test_result();
 }

--- a/test/utility/basic_iterator.cpp
+++ b/test/utility/basic_iterator.cpp
@@ -16,8 +16,6 @@
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 
-#include <range/v3/utility/counted_iterator.hpp>
-
 namespace test_weak_input
 {
     template<typename I>
@@ -359,6 +357,23 @@ namespace test_forward_sized
     }
 }
 
+void test_box()
+{
+    struct A : ranges::box<int> {};
+    CHECK(sizeof(A) == sizeof(int));
+    struct empty {};
+    struct B : ranges::box<empty> { int i; };
+    CHECK(sizeof(B) == sizeof(int));
+    B b1, b2;
+    if (ranges::detail::box_compression<empty>() == ranges::detail::box_compress::coalesce)
+        CHECK((&b1.get() == &b2.get()));
+    struct nontrivial { nontrivial() {} };
+    struct C : ranges::box<nontrivial> { int i; };
+    CHECK(sizeof(C) == sizeof(int));
+    C c1, c2;
+    CHECK((&c1.get() != &c2.get()));
+}
+
 int main()
 {
     using namespace ranges;
@@ -370,6 +385,7 @@ int main()
     ::test_output::test();
     ::test_move_only::test();
     ::test_forward_sized::test();
+    ::test_box();
 
     return ::test_result();
 }

--- a/test/view_adaptor.cpp
+++ b/test/view_adaptor.cpp
@@ -38,11 +38,11 @@ private:
         {
             return ranges::begin(rng.base());
         }
-        void next(base_iterator_t &it)
+        void next(base_iterator_t &it) const
         {
             --it;
         }
-        void prev(base_iterator_t &it)
+        void prev(base_iterator_t &it) const
         {
             ++it;
         }
@@ -51,13 +51,13 @@ private:
             return *ranges::prev(it);
         }
         CONCEPT_REQUIRES(ranges::RandomAccessRange<BidiRange>())
-        void advance(base_iterator_t &it, ranges::range_difference_t<BidiRange> n)
+        void advance(base_iterator_t &it, ranges::range_difference_t<BidiRange> n) const
         {
             it -= n;
         }
         CONCEPT_REQUIRES(ranges::SizedIteratorRange<base_iterator_t, base_iterator_t>())
         ranges::range_difference_t<BidiRange>
-        distance_to(base_iterator_t const &here, base_iterator_t const &there)
+        distance_to(base_iterator_t const &here, base_iterator_t const &there) const
         {
             return here - there;
         }
@@ -86,7 +86,7 @@ int main()
 {
     using namespace ranges;
     std::vector<int> v{1, 2, 3, 4};
-    my_reverse_view<std::vector<int>& > retro{v};
+    my_reverse_view<std::vector<int>&> retro{v};
     ::models<concepts::BoundedView>(retro);
     ::models<concepts::RandomAccessIterator>(retro.begin());
     ::check_equal(retro, {4, 3, 2, 1});


### PR DESCRIPTION
`compressed_pair`:
* Implement `compressed_pair`'s notion that multiple empty+trivial objects can be coalesced into a single object in `box`. Guard `box`'s EBO specialization against types that could be lambda closures when the compiler is GCC 6+.
* Implement `compressed_tuple` as a simple aggregation of `box`es.
* `compressed_pair` becomes essentially `tagged<compressed_tuple<tag::first(First), tag::second(Second)>`; all `.first` and `.second` member references become `.first()` and `.second()`.
* Replace `iterator_range`'s `tagged_pair` base with `tagged_compressed_tuple`.
* Replace `replacer_if_fn`'s `compressed_pair` member with a base.

`tagged` refactoring:
* Ensure that `tagged's conversions are only used for conversion.
* Construct by getter chain inheritance instead of fan inheritance, so that getters hide members of the same name in the base type.
* Use ADL to find `get` in tagged getters.
* Convert `tagged` to base before calling `get`.

Fixes #386.