### PR TITLE
Travis build fixes:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -134,29 +134,29 @@ matrix:
     #   addons: *clang36
 
     # Test clang-3.7: C++11/C++14, Build=Debug/Release, ASAN=On/Off
-    - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
-      os: linux
-      addons: &clang37
-        apt:
-          packages:
-            - util-linux
-            - clang-3.7
-            - valgrind
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
+    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: &clang37
+    #     apt:
+    #       packages:
+    #         - util-linux
+    #         - clang-3.7
+    #         - valgrind
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    #         - llvm-toolchain-precise-3.7
 
-    - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
-      os: linux
-      addons: *clang37
+    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang37
 
-    - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On
-      os: linux
-      addons: *clang37
+    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang37
 
-    - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On
-      os: linux
-      addons: *clang37
+    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang37
 
     # - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
     #   os: linux
@@ -175,49 +175,49 @@ matrix:
     #   addons: *clang37
 
     # Test clang-3.8: C++11/C++14, Build=Debug/Release, ASAN=On/Off
-    - env: CLANG_VERSION=3.8 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
-      os: linux
-      addons: &clang38
-        apt:
-          packages:
-            - util-linux
-            - clang-3.8
-            - valgrind
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.8
+    # - env: CLANG_VERSION=3.8 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
+    #   os: linux
+    #   addons: &clang38
+    #     apt:
+    #       packages:
+    #         - util-linux
+    #         - clang-3.8
+    #         - valgrind
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    #         - llvm-toolchain-precise-3.8
 
-    - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
-      os: linux
-      addons: *clang38
+    # - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
+    #   os: linux
+    #   addons: *clang38
 
-    - env: CLANG_VERSION=3.8 BUILD_TYPE=Debug CPP=14 ASAN=On LIBCXX=On
-      os: linux
-      addons: *clang38
+    # - env: CLANG_VERSION=3.8 BUILD_TYPE=Debug CPP=14 ASAN=On LIBCXX=On
+    #   os: linux
+    #   addons: *clang3# 8
 
-    - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On
-      os: linux
-      addons: *clang38
+    # - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On
+    #   os: linux
+    #   addons: *clang38
 
-    - env: CLANG_VERSION=3.8 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
-      os: linux
-      addons: *clang38
+    # - env: CLANG_VERSION=3.8 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang38
 
-    - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
-      os: linux
-      addons: *clang38
+    # - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang38
 
-    - env: CLANG_VERSION=3.8 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On
-      os: linux
-      addons: *clang38
+    # - env: CLANG_VERSION=3.8 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang38
 
-    - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On
-      os: linux
-      addons: *clang38
+    # - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang38
 
-    - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off
-      os: linux
-      addons: *clang38
+    # - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off
+    #   os: linux
+    #   addons: *clang38
 
     # Test gcc-4.8: C++11, Build=Debug/Release, ASAN=Off
     - env: GCC_VERSION=4.8 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=Off
@@ -258,7 +258,7 @@ matrix:
       addons: *gcc49
 
     # Test gcc-5: C++11/14, Build=Debug/Release, ASAN=On/Off
-    - env: GCC_VERSION=5 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=Off
+    - env: GCC_VERSION=5 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=Off
       os: linux
       addons: &gcc5
         apt:
@@ -268,17 +268,17 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    # - env: GCC_VERSION=5 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=Off
-    #   os: linux
-    #   addons: *gcc5
-
-    - env: GCC_VERSION=5 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=Off
-      os: linux
-      addons: *gcc5
-
     - env: GCC_VERSION=5 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off
       os: linux
       addons: *gcc5
+
+    # - env: GCC_VERSION=5 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=Off
+    #   os: linux
+    #   addons: *gcc5
+
+    # - env: GCC_VERSION=5 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=Off
+    #   os: linux
+    #   addons: *gcc5
 
     # - env: GCC_VERSION=5 BUILD_TYPE=Debug CPP=14 ASAN=On LIBCXX=Off
     #   os: linux


### PR DESCRIPTION
* Disable non-OSX clang builds; LLVM APT repo is broken.
* Disable GCC5 ASAN build - Ubuntu managed to break ASAN in gcc 5.4.