### PR TITLE
transform: const correctness for size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,16 +26,14 @@ if(NOT RANGES_CXX_STD)
   set(RANGES_CXX_STD 11)
 endif()
 
-# Clang/C2 will blow up with various parts of the standard library
-# if compiling with -std less than c++14.
-if(("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") AND
-   ("x${CMAKE_CXX_SIMULATE_ID}x" STREQUAL "xMSVCx") AND
-   ("${RANGES_CXX_STD}" STREQUAL "11"))
-  set(CMAKE_CXX_STANDARD 14)
-  set(RANGES_CXX_STD 14)
-endif()
-
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+if("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xClang")
+  # Clang/C2 will blow up with various parts of the standard library
+  # if compiling with -std less than c++14.
+  if(("x${CMAKE_CXX_SIMULATE_ID}" STREQUAL "xMSVC") AND
+     ("${RANGES_CXX_STD}" STREQUAL "11"))
+    set(CMAKE_CXX_STANDARD 14)
+    set(RANGES_CXX_STD 14)
+  endif()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++${RANGES_CXX_STD} -ftemplate-backtrace-limit=0")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Weverything -Werror -pedantic-errors")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c++98-compat -Wno-c++98-compat-pedantic")

--- a/include/range/v3/action/insert.hpp
+++ b/include/range/v3/action/insert.hpp
@@ -119,7 +119,8 @@ namespace ranges
                     decltype(unwrap_reference(cont).insert(begin(unwrap_reference(cont)), C{begin(rng)}, C{end(rng)}))
                 {
                     auto const index = p - begin(unwrap_reference(cont));
-                    unwrap_reference(cont).reserve(unwrap_reference(cont).size() + size(rng));
+                    using size_type = decltype(unwrap_reference(cont).size());
+                    unwrap_reference(cont).reserve(unwrap_reference(cont).size() + static_cast<size_type>(size(rng)));
                     return unwrap_reference(cont).insert(begin(unwrap_reference(cont)) + index, C{begin(rng)}, C{end(rng)});
                 }
             }

--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -87,7 +87,7 @@
 #define RANGES_CXX_GENERIC_LAMBDAS_11 0
 #define RANGES_CXX_GENERIC_LAMBDAS_14 201304
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 #if _MSC_VER >= 1900
 #ifndef RANGES_CXX_STATIC_ASSERT
 #define RANGES_CXX_STATIC_ASSERT RANGES_CXX_STATIC_ASSERT_11
@@ -132,8 +132,7 @@
 
 #else // ^^^ defined(_MSC_VER) ^^^ / vvv !defined(_MSC_VER) vvv
 // Generic configuration using SD-6 feature test macros with fallback to __cplusplus
-#ifdef __GNUC__
-// GCC or clang
+#if defined(__GNUC__) || defined(__clang__)
 #define RANGES_PRAGMA(X) _Pragma(#X)
 #define RANGES_DIAGNOSTIC_PUSH RANGES_PRAGMA(GCC diagnostic push)
 #define RANGES_DIAGNOSTIC_POP RANGES_PRAGMA(GCC diagnostic pop)

--- a/include/range/v3/to_container.hpp
+++ b/include/range/v3/to_container.hpp
@@ -73,7 +73,8 @@ namespace ranges
                 Cont impl(Rng && rng, std::true_type) const
                 {
                     Cont c;
-                    c.reserve(size(rng));
+                    using size_type = decltype(c.size());
+                    c.reserve(static_cast<size_type>(size(rng)));
                     using I = range_common_iterator_t<Rng>;
                     c.assign(I{begin(rng)}, I{end(rng)});
                     return c;

--- a/include/range/v3/view/any_view.hpp
+++ b/include/range/v3/view/any_view.hpp
@@ -171,7 +171,7 @@ namespace ranges
                     any_cursor_impl const *pthat =
                         dynamic_cast<any_cursor_impl const *>(&that);
                     RANGES_ASSERT(pthat != nullptr);
-                    return pthat->it_.get() - it_.get();
+                    return static_cast<std::ptrdiff_t>(pthat->it_.get() - it_.get());
                 }
             };
 

--- a/test/algorithm/copy.cpp
+++ b/test/algorithm/copy.cpp
@@ -17,8 +17,6 @@
 #include <range/v3/view/delimit.hpp>
 #include "../simple_test.hpp"
 
-RANGES_DIAGNOSTIC_IGNORE_SIGN_CONVERSION
-
 int main()
 {
     using ranges::begin;
@@ -53,7 +51,7 @@ int main()
         auto str = delimit(sz, '\0');
         auto res3 = ranges::copy(str, buf);
         *res3.second = '\0';
-        CHECK(res3.first == std::next(begin(str), std::strlen(sz)));
+        CHECK(res3.first == std::next(begin(str), static_cast<std::ptrdiff_t>(std::strlen(sz))));
         CHECK(res3.second == buf + std::strlen(sz));
         CHECK(std::strcmp(sz, buf) == 0);
     }
@@ -64,7 +62,7 @@ int main()
         auto str = delimit(sz, '\0');
         auto res3 = ranges::copy(std::move(str), buf);
         *res3.second = '\0';
-        CHECK(res3.first.get_unsafe() == std::next(begin(str), std::strlen(sz)));
+        CHECK(res3.first.get_unsafe() == std::next(begin(str), static_cast<std::ptrdiff_t>(std::strlen(sz))));
         CHECK(res3.second == buf + std::strlen(sz));
         CHECK(std::strcmp(sz, buf) == 0);
     }

--- a/test/view/tokenize.cpp
+++ b/test/view/tokenize.cpp
@@ -8,7 +8,7 @@ int main()
     using namespace ranges;
 
     // GCC 4.8 doesn't do regex
-#if __GNUC__ != 4 || __GNUC_MINOR__ > 8
+#if !defined(__GNUC__) || defined(__clang__) || __GNUC__ > 4 || __GNUC_MINOR__ > 8
     std::string txt{"abc\ndef\tghi"};
     const std::regex rx{R"delim(([\w]+))delim"};
     auto&& rng = txt | view::tokenize(rx,1);


### PR DESCRIPTION
Details:
* CMakeLists.txt: Incorporate the Clang/C2 config block into the Clang config block.
* config.hpp:
  * Clang/C2 is emphatically *not* MSVC, even when it's silly enough to claim to be.
  * Clang/C2 doesn't define `__GNUC__`, so "gcc and/or clang" must be spelled `defined(__GNUC__) || defined(__clang__)`.
* to_container.hpp: Nitpicky warning fix.
* action/insert.hpp: Nitpicky warning fix.
* view/any_view.hpp: Nitpicky warning fix.
* view/transform.hpp: const correctness fixes for size members of `iter_transform_view` and `iter_transform2_view`.
* test/algorithm/copy.cpp: Nitpicky warning fix.
* test/view/tokenize.cpp: clang is *not* gcc 4.8, despite defining `__GNUC__ == 4 && __GNUC_MINOR__ == 2`
