### PR TITLE
Implement a few random things.

### DIFF
--- a/include/range/v3/algorithm/sample.hpp
+++ b/include/range/v3/algorithm/sample.hpp
@@ -19,6 +19,7 @@
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/range_traits.hpp>
+#include <range/v3/algorithm/min.hpp>
 #include <range/v3/utility/random.hpp>
 #include <range/v3/utility/swap.hpp>
 #include <range/v3/utility/iterator.hpp>
@@ -36,7 +37,7 @@ namespace ranges
         {
             template<typename I, typename S, typename O, typename Gen>
             using Constraint = meta::strict_and<
-                InputIterator<I>, IteratorRange<I, S>, WeaklyIncrementable<O>,
+                InputIterator<I>, Sentinel<S, I>, WeaklyIncrementable<O>,
                 IndirectlyCopyable<I, O>, UniformRandomNumberGenerator<Gen>,
                 ConvertibleTo<concepts::UniformRandomNumberGenerator::result_t<Gen>,
                     iterator_difference_t<I>>>;
@@ -49,7 +50,7 @@ namespace ranges
             {
                 std::uniform_int_distribution<iterator_difference_t<I>> dist;
                 using param_t = typename decltype(dist)::param_type;
-                n = std::min(pop_size, n);
+                n = ranges::min(pop_size, n);
                 for (; n > 0 && first != last; ++first)
                 {
                     if (dist(gen, param_t{0, --pop_size}) < n)
@@ -65,7 +66,7 @@ namespace ranges
             template<typename I, typename S, typename O,
                 typename Gen = detail::default_random_engine&,
                 CONCEPT_REQUIRES_(
-                    (ForwardIterator<I>() || SizedIteratorRange<I, S>()) &&
+                    (ForwardIterator<I>() || SizedSentinel<S, I>()) &&
                     Constraint<I, S, O, Gen>())>
             O operator()(I first, S last, O out, iterator_difference_t<I> n,
                 Gen && gen = detail::get_random_engine()) const
@@ -77,7 +78,7 @@ namespace ranges
             template<typename I, typename S, typename O,
                 typename Gen = detail::default_random_engine&,
                 CONCEPT_REQUIRES_(RandomAccessIterator<O>() &&
-                    !(ForwardIterator<I>() || SizedIteratorRange<I, S>()) &&
+                    !(ForwardIterator<I>() || SizedSentinel<S, I>()) &&
                     Constraint<I, S, O, Gen>())>
             O operator()(I first, S last, O out, iterator_difference_t<I> n,
                 Gen && gen = detail::get_random_engine()) const
@@ -103,7 +104,7 @@ namespace ranges
             template<typename I, typename S, typename ORng,
                 typename Gen = detail::default_random_engine&,
                 CONCEPT_REQUIRES_(
-                    (ForwardIterator<I>() || SizedIteratorRange<I, S>()) &&
+                    (ForwardIterator<I>() || SizedSentinel<S, I>()) &&
                     (ForwardRange<ORng>() || SizedRange<ORng>()) &&
                     Constraint<I, S, range_iterator_t<ORng>, Gen>())>
             range_safe_iterator_t<ORng> operator()(I first, S last, ORng && out,
@@ -116,7 +117,7 @@ namespace ranges
             template<typename I, typename S, typename ORng,
                 typename Gen = detail::default_random_engine&,
                 CONCEPT_REQUIRES_(RandomAccessIterator<range_iterator_t<ORng>>() &&
-                    !(ForwardIterator<I>() || SizedIteratorRange<I, S>()) &&
+                    !(ForwardIterator<I>() || SizedSentinel<S, I>()) &&
                     (ForwardRange<ORng>() || SizedRange<ORng>()) &&
                     Constraint<I, S, range_iterator_t<ORng>, Gen>())>
             range_safe_iterator_t<ORng> operator()(I first, S last, ORng && out,

--- a/include/range/v3/algorithm/sample.hpp
+++ b/include/range/v3/algorithm/sample.hpp
@@ -1,0 +1,188 @@
+/// \file
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//  Copyright Casey Carter 2016
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+#ifndef RANGES_V3_ALGORITHM_SAMPLE_HPP
+#define RANGES_V3_ALGORITHM_SAMPLE_HPP
+
+#include <utility>
+#include <range/v3/range_fwd.hpp>
+#include <range/v3/begin_end.hpp>
+#include <range/v3/range_concepts.hpp>
+#include <range/v3/range_traits.hpp>
+#include <range/v3/utility/random.hpp>
+#include <range/v3/utility/swap.hpp>
+#include <range/v3/utility/iterator.hpp>
+#include <range/v3/utility/iterator_concepts.hpp>
+#include <range/v3/utility/iterator_traits.hpp>
+#include <range/v3/utility/static_const.hpp>
+
+namespace ranges
+{
+    inline namespace v3
+    {
+        /// \addtogroup group-algorithms
+        /// @{
+        class sample_fn
+        {
+            template<typename I, typename S, typename O, typename Gen>
+            using Constraint = meta::strict_and<
+                InputIterator<I>, IteratorRange<I, S>, WeaklyIncrementable<O>,
+                IndirectlyCopyable<I, O>, UniformRandomNumberGenerator<Gen>,
+                ConvertibleTo<concepts::UniformRandomNumberGenerator::result_t<Gen>,
+                    iterator_difference_t<I>>>;
+
+            template<typename I, typename S, typename O,
+                typename Gen = detail::default_random_engine&,
+                CONCEPT_REQUIRES_(Constraint<I, S, O, Gen>())>
+            static O sized_impl(I first, S last, iterator_difference_t<I> pop_size,
+                O out, iterator_difference_t<I> n, Gen && gen)
+            {
+                std::uniform_int_distribution<iterator_difference_t<I>> dist;
+                using param_t = typename decltype(dist)::param_type;
+                n = std::min(pop_size, n);
+                for (; n > 0 && first != last; ++first)
+                {
+                    if (dist(gen, param_t{0, --pop_size}) < n)
+                    {
+                        --n;
+                        *out = *first;
+                        ++out;
+                    }
+                }
+                return out;
+            }
+        public:
+            template<typename I, typename S, typename O,
+                typename Gen = detail::default_random_engine&,
+                CONCEPT_REQUIRES_(
+                    (ForwardIterator<I>() || SizedIteratorRange<I, S>()) &&
+                    Constraint<I, S, O, Gen>())>
+            O operator()(I first, S last, O out, iterator_difference_t<I> n,
+                Gen && gen = detail::get_random_engine()) const
+            {
+                auto k = distance(first, last);
+                return sample_fn::sized_impl(std::move(first), std::move(last),
+                    k, out, n, std::forward<Gen>(gen));
+            }
+            template<typename I, typename S, typename O,
+                typename Gen = detail::default_random_engine&,
+                CONCEPT_REQUIRES_(RandomAccessIterator<O>() &&
+                    !(ForwardIterator<I>() || SizedIteratorRange<I, S>()) &&
+                    Constraint<I, S, O, Gen>())>
+            O operator()(I first, S last, O out, iterator_difference_t<I> n,
+                Gen && gen = detail::get_random_engine()) const
+            {
+                if (n > 0)
+                {
+                    for (auto i = n - n; i < n && first != last; (void)++i, ++first)
+                    {
+                        out[i] = *first;
+                    }
+                    std::uniform_int_distribution<iterator_difference_t<I>> dist;
+                    using param_t = typename decltype(dist)::param_type;
+                    for (auto pop_size = n; first != last; (void)++first, ++pop_size)
+                    {
+                        auto const i = dist(gen, param_t{0, pop_size});
+                        if (i < n)
+                            out[i] = *first;
+                    }
+                    out += n;
+                }
+                return out;
+            }
+            template<typename I, typename S, typename ORng,
+                typename Gen = detail::default_random_engine&,
+                CONCEPT_REQUIRES_(
+                    (ForwardIterator<I>() || SizedIteratorRange<I, S>()) &&
+                    (ForwardRange<ORng>() || SizedRange<ORng>()) &&
+                    Constraint<I, S, range_iterator_t<ORng>, Gen>())>
+            range_safe_iterator_t<ORng> operator()(I first, S last, ORng && out,
+                Gen && gen = detail::get_random_engine()) const
+            {
+                auto k = distance(first, last);
+                return sample_fn::sized_impl(std::move(first), std::move(last),
+                    k, begin(out), distance(out), std::forward<Gen>(gen));
+            }
+            template<typename I, typename S, typename ORng,
+                typename Gen = detail::default_random_engine&,
+                CONCEPT_REQUIRES_(RandomAccessIterator<range_iterator_t<ORng>>() &&
+                    !(ForwardIterator<I>() || SizedIteratorRange<I, S>()) &&
+                    (ForwardRange<ORng>() || SizedRange<ORng>()) &&
+                    Constraint<I, S, range_iterator_t<ORng>, Gen>())>
+            range_safe_iterator_t<ORng> operator()(I first, S last, ORng && out,
+                Gen && gen = detail::get_random_engine()) const
+            {
+                return (*this)(std::move(first), std::move(last), begin(out),
+                    distance(out), std::forward<Gen>(gen));
+            }
+            template<typename Rng, typename O,
+                typename Gen = detail::default_random_engine&,
+                CONCEPT_REQUIRES_(RandomAccessIterator<O>() &&
+                    !(ForwardRange<Rng>() || SizedRange<Rng>()) &&
+                    Constraint<range_iterator_t<Rng>, range_sentinel_t<Rng>, O, Gen>())>
+            O operator()(Rng && rng, O out, range_difference_t<Rng> n,
+                Gen && gen = detail::get_random_engine()) const
+            {
+                return (*this)(begin(rng), end(rng),
+                    std::move(out), n, std::forward<Gen>(gen));
+            }
+            template<typename Rng, typename O,
+                typename Gen = detail::default_random_engine&,
+                CONCEPT_REQUIRES_(
+                    (ForwardRange<Rng>() || SizedRange<Rng>()) &&
+                    Constraint<range_iterator_t<Rng>, range_sentinel_t<Rng>, O, Gen>())>
+            O operator()(Rng && rng, O out, range_difference_t<Rng> n,
+                Gen && gen = detail::get_random_engine()) const
+            {
+                return sample_fn::sized_impl(begin(rng), end(rng), distance(rng),
+                    std::move(out), n, std::forward<Gen>(gen));
+            }
+            template<typename IRng, typename ORng,
+                typename Gen = detail::default_random_engine&,
+                CONCEPT_REQUIRES_(RandomAccessIterator<range_iterator_t<ORng>>() &&
+                    !(ForwardRange<IRng>() || SizedRange<IRng>()) &&
+                    (ForwardRange<ORng>() || SizedRange<ORng>()) &&
+                    Constraint<range_iterator_t<IRng>, range_sentinel_t<IRng>,
+                        range_iterator_t<ORng>, Gen>())>
+            range_safe_iterator_t<ORng> operator()(IRng && rng, ORng && out,
+                Gen && gen = detail::get_random_engine()) const
+            {
+                return (*this)(begin(rng), end(rng),
+                    begin(out), distance(out), std::forward<Gen>(gen));
+            }
+            template<typename IRng, typename ORng,
+                typename Gen = detail::default_random_engine&,
+                CONCEPT_REQUIRES_(
+                    (ForwardRange<IRng>() || SizedRange<IRng>()) &&
+                    (ForwardRange<ORng>() || SizedRange<ORng>()) &&
+                    Constraint<range_iterator_t<IRng>, range_sentinel_t<IRng>,
+                        range_iterator_t<ORng>, Gen>())>
+            range_safe_iterator_t<ORng> operator()(IRng && rng, ORng && out,
+                Gen && gen = detail::get_random_engine()) const
+            {
+                return sample_fn::sized_impl(begin(rng), end(rng), distance(rng),
+                    begin(out), distance(out), std::forward<Gen>(gen));
+            }
+        };
+
+        /// \sa `sample_fn`
+        /// \ingroup group-algorithms
+        namespace
+        {
+            constexpr auto&& sample = static_const<with_braced_init_args<sample_fn>>::value;
+        }
+        /// @}
+    } // namespace v3
+} // namespace ranges
+
+#endif

--- a/include/range/v3/algorithm/tagspec.hpp
+++ b/include/range/v3/algorithm/tagspec.hpp
@@ -31,6 +31,11 @@ namespace ranges
         RANGES_DEFINE_TAG_SPECIFIER(max)
         RANGES_DEFINE_TAG_SPECIFIER(begin)
         RANGES_DEFINE_TAG_SPECIFIER(end)
+
+        RANGES_DEFINE_TAG_SPECIFIER(current)
+        RANGES_DEFINE_TAG_SPECIFIER(engine)
+        RANGES_DEFINE_TAG_SPECIFIER(range)
+        RANGES_DEFINE_TAG_SPECIFIER(size)
     }
 }
 

--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -58,10 +58,11 @@
 #define RANGES_END_NAMESPACE_STD }
 #endif
 
-#ifndef RANGES_THREAD_LOCAL
-#if (defined(__clang__) && defined(__CYGWIN__)) || \
-    (defined(__clang__) && defined(_LIBCPP_VERSION)) // BUGBUG avoid unresolved __cxa_thread_atexit
-#define RANGES_STATIC_THREAD_LOCAL
+#ifndef RANGES_STATIC_THREAD_LOCAL
+#if defined(__clang__) && (defined(__CYGWIN__) || defined(__apple_build_version__))
+// BUGBUG avoid unresolved __cxa_thread_atexit
+// Also, workaround lack of thread_local support on OSX
+#define RANGES_STATIC_THREAD_LOCAL static __thread
 #else
 #define RANGES_STATIC_THREAD_LOCAL static thread_local
 #endif

--- a/include/range/v3/utility/random.hpp
+++ b/include/range/v3/utility/random.hpp
@@ -1,0 +1,61 @@
+/// \file
+// Range v3 library
+//
+//  Copyright Casey Carter 2016
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#ifndef RANGES_V3_UTILITY_RANDOM_HPP
+#define RANGES_V3_UTILITY_RANDOM_HPP
+
+#include <random>
+#include <meta/meta.hpp>
+#include <range/v3/detail/config.hpp>
+#include <range/v3/utility/concepts.hpp>
+
+namespace ranges
+{
+    inline namespace v3
+    {
+        /// \addtogroup group-concepts
+        /// @{
+        namespace concepts
+        {
+            struct UniformRandomNumberGenerator
+              : refines<Function>
+            {
+                template<typename Gen>
+                auto requires_(Gen&&) -> decltype(
+                    concepts::valid_expr(
+                        concepts::model_of<UnsignedIntegral>(val<Gen>()())
+                    ));
+            };
+        }
+
+        template<typename Gen>
+        using UniformRandomNumberGenerator = concepts::models<concepts::UniformRandomNumberGenerator, Gen>;
+        /// @}
+
+        /// \cond
+        namespace detail
+        {
+            using default_random_engine = std::mt19937;
+
+            inline default_random_engine& get_random_engine()
+            {
+                // TODO: seed properly.
+                RANGES_STATIC_THREAD_LOCAL default_random_engine engine{std::random_device{}()};
+                return engine;
+            }
+        }
+        /// \endcond
+    }
+}
+
+#endif

--- a/include/range/v3/utility/random.hpp
+++ b/include/range/v3/utility/random.hpp
@@ -11,13 +11,75 @@
 // Project home: https://github.com/ericniebler/range-v3
 //
 
+/*
+ * Random-Number Utilities (randutil)
+ *     Addresses common issues with C++11 random number generation.
+ *     Makes good seeding easier, and makes using RNGs easy while retaining
+ *     all the power.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Melissa E. O'Neill
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #ifndef RANGES_V3_UTILITY_RANDOM_HPP
 #define RANGES_V3_UTILITY_RANDOM_HPP
 
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <functional>  // for std::hash
+#include <initializer_list>
 #include <random>
+#include <thread>
+#include <typeinfo>
+#include <utility>
 #include <meta/meta.hpp>
-#include <range/v3/detail/config.hpp>
+#include <range/v3/range_fwd.hpp>
+#include <range/v3/algorithm/copy.hpp>
+#include <range/v3/algorithm/generate.hpp>
 #include <range/v3/utility/concepts.hpp>
+#include <range/v3/utility/iterator_concepts.hpp>
+
+// Ugly platform-specific code for auto_seeded
+#if defined(__has_builtin)
+    #if __has_builtin(__builtin_readcyclecounter)
+        #define RANGES_CPU_ENTROPY __builtin_readcyclecounter()
+    #endif
+#endif
+#if !defined(RANGES_CPU_ENTROPY)
+    #if __i386__
+        #if __GNUC__
+            #define RANGES_CPU_ENTROPY __builtin_ia32_rdtsc()
+        #else
+            #include <immintrin.h>
+            #define RANGES_CPU_ENTROPY __rdtsc()
+        #endif
+    #else
+        #define RANGES_CPU_ENTROPY 0
+    #endif
+#endif
 
 namespace ranges
 {
@@ -45,17 +107,400 @@ namespace ranges
         /// \cond
         namespace detail
         {
-            using default_random_engine = std::mt19937;
+            namespace randutils
+            {
+                template <typename T,
+                    CONCEPT_REQUIRES_(Integral<T>())>
+                RANGES_CXX14_CONSTEXPR std::uint32_t crushto32(T value)
+                {
+                    if (sizeof(T) <= 4)
+                        return static_cast<std::uint32_t>(value);
+                    else {
+                        auto result = static_cast<std::uint64_t>(value);
+                        result *= 0xbc2ad017d719504d;
+                        return static_cast<std::uint32_t>(result ^ (result >> 32));
+                    }
+                }
 
+                template <typename T>
+                RANGES_CXX14_CONSTEXPR std::uint32_t hash(T && value)
+                {
+                    auto hasher = std::hash<uncvref_t<T>>{};
+                    return randutils::crushto32(hasher(detail::forward<T>(value)));
+                }
+
+                constexpr std::uint32_t fnv(std::uint32_t hash, const char* pos)
+                {
+                    return *pos == '\0' ? hash : randutils::fnv(
+                        (hash * 16777619U) ^ static_cast<unsigned char>(*pos), pos+1);
+                }
+
+                template<std::size_t nwords = 18>
+                std::array<std::uint32_t, nwords> local_entropy(std::uint32_t s1, std::uint32_t s2)
+                {
+                    CONCEPT_ASSERT(nwords >= 10);
+                    std::array<std::uint32_t, nwords> seeds;
+                    auto it = seeds.begin();
+
+                    // The heap can vary from run to run as well.
+                    void* malloc_addr = std::malloc(sizeof(int));
+                    std::free(malloc_addr);
+                    *it++ = randutils::hash(malloc_addr);
+                    *it++ = randutils::hash(&malloc_addr);
+
+                    // Classic seed, the time.  It ought to change, especially since
+                    // this is (hopefully) nanosecond resolution time.
+                    auto hitime = std::chrono::high_resolution_clock::now()
+                                    .time_since_epoch().count();
+                    *it++ = randutils::crushto32(hitime);
+
+                    // Address of the thing being initialized.  That can mean that
+                    // different seed sequences in different places in memory will be
+                    // different.  Even for the same object, it may vary from run to
+                    // run in systems with ASLR, such as OS X, but on Linux it might not
+                    // unless we compile with -fPIC -pic.
+                    *it++ = s1;
+
+                    // The address of the time function.  It should hopefully be in
+                    // a system library that hopefully isn't always in the same place
+                    // (might not change until system is rebooted though)
+                    *it++ = randutils::hash(&std::chrono::high_resolution_clock::now);
+
+                    // The address of the exit function.  It should hopefully be in
+                    // a system library that hopefully isn't always in the same place
+                    // (might not change until system is rebooted though).  Hopefully
+                    // it's in a different library from time_func.
+                    *it++ = randutils::hash(&std::_Exit);
+
+                    // The address of a local function.  That may be in a totally
+                    // different part of memory.  On OS X it'll vary from run to run thanks
+                    // to ASLR, on Linux it might not unless we compile with -fPIC -pic.
+                    // Need the cast because it's an overloaded function and we need to
+                    // pick the right one.
+                    *it++ = randutils::hash(
+                        static_cast<std::uint32_t(*)(std::uint64_t)>(&randutils::crushto32));
+
+                    // Hash our thread id.  It seems to vary from run to run on OS X, not
+                    // so much on Linux.
+                    *it++ = randutils::hash(std::this_thread::get_id());
+
+                    // Hash of the ID of a type.  May or may not vary, depending on
+                    // implementation.
+                    *it++ = s2;
+
+                    // Platform-specific entropy
+                    *it++ = randutils::crushto32(RANGES_CPU_ENTROPY);
+
+                    // Hopefully high-quality entropy from random_device.
+                    std::random_device rd{};
+                    ranges::generate(it, seeds.end(), ranges::ref(rd)).out();
+
+                    RANGES_ASSERT(it <= seeds.end());
+
+                    return seeds;
+                }
+
+                template<typename I, CONCEPT_REQUIRES_(UnsignedIntegral<I>())>
+                constexpr I fast_exp(I x, I power, I result = I{1})
+                {
+                    return power == I{0} ? result
+                        : randutils::fast_exp(x * x, power >> 1, result * (power & I{1} ? x : 1));
+                }
+
+                //////////////////////////////////////////////////////////////////////////////
+                //
+                // seed_seq_fe
+                //
+                //////////////////////////////////////////////////////////////////////////////
+
+                /*
+                * seed_seq_fe implements a fixed-entropy seed sequence; it conforms to all
+                * the requirements of a Seed Sequence concept.
+                *
+                * seed_seq_fe<N> implements a seed sequence which seeds based on a store of
+                * N * 32 bits of entropy.  Typically, it would be initialized with N or more
+                * integers.
+                *
+                * seed_seq_fe128 and seed_seq_fe256 are provided as convenience typedefs for
+                * 128- and 256-bit entropy stores respectively.  These variants outperform
+                * std::seed_seq, while being better mixing the bits it is provided as entropy.
+                * In almost all common use cases, they serve as better drop-in replacements
+                * for seed_seq.
+                *
+                * Technical details
+                *
+                * Assuming it constructed with M seed integers as input, it exhibits the
+                * following properties
+                *
+                * * Diffusion/Avalanche:  A single-bit change in any of the M inputs has a
+                *   50% chance of flipping every bit in the bitstream produced by generate.
+                *   Initializing the N-word entropy store with M words requires O(N * M)
+                *   time precisely because of the avalanche requirements.  Once constructed,
+                *   calls to generate are linear in the number of words generated.
+                *
+                * * Bias freedom/Bijection: If M == N, the state of the entropy store is a
+                *   bijection from the M inputs (i.e., no states occur twice, none are
+                *   omitted). If M > N the number of times each state can occur is the same
+                *   (each state occurs 2**(32*(M-N)) times, where ** is the power function).
+                *   If M < N, some states cannot occur (bias) but no state occurs more
+                *   than once (it's impossible to avoid bias if M < N; ideally N should not
+                *   be chosen so that it is more than M).
+                *
+                *   Likewise, the generate function has similar properties (with the entropy
+                *   store as the input data).  If more outputs are requested than there is
+                *   entropy, some outputs cannot occur.  For example, the Mersenne Twister
+                *   will request 624 outputs, to initialize its 19937-bit state, which is
+                *   much larger than a 128-bit or 256-bit entropy pool.  But in practice,
+                *   limiting the Mersenne Twister to 2**128 possible initializations gives
+                *   us enough initializations to give a unique initialization to trillions
+                *   of computers for billions of years.  If you really have 624 words of
+                *   *real* high-quality entropy you want to use, you probably don't need
+                *   an entropy mixer like this class at all.  But if you *really* want to,
+                *   nothing is stopping you from creating a randutils::seed_seq_fe<624>.
+                *
+                * * As a consequence of the above properties, if all parts of the provided
+                *   seed data are kept constant except one, and the remaining part is varied
+                *   through K different states, K different output sequences will be produced.
+                *
+                * * Also, because the amount of entropy stored is fixed, this class never
+                *   performs dynamic allocation and is free of the possibility of generating
+                *   an exception.
+                *
+                * Ideas used to implement this code include hashing, a simple PCG generator
+                * based on an MCG base with an XorShift output function and permutation
+                * functions on tuples.
+                *
+                * More detail at
+                *     http://www.pcg-random.org/posts/developing-a-seed_seq-alternative.html
+                */
+
+                template<std::size_t count = 4, typename IntRep = std::uint32_t,
+                    std::size_t mix_rounds = 1 + (count <= 2)>
+                struct seed_seq_fe {
+                public:
+                    CONCEPT_ASSERT(UnsignedIntegral<IntRep>());
+                    typedef IntRep result_type;
+
+                private:
+                    static constexpr std::uint32_t INIT_A = 0x43b0d7e5;
+                    static constexpr std::uint32_t MULT_A = 0x931e8875;
+
+                    static constexpr std::uint32_t INIT_B = 0x8b51f9dd;
+                    static constexpr std::uint32_t MULT_B = 0x58f38ded;
+
+                    static constexpr std::uint32_t MIX_MULT_L = 0xca01f9dd;
+                    static constexpr std::uint32_t MIX_MULT_R = 0x4973f715;
+                    static constexpr std::uint32_t XSHIFT = sizeof(IntRep)*8/2;
+
+                    std::array<IntRep, count> mixer_;
+
+                    template <typename I, typename S,
+                        CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
+                            ConvertibleTo<iterator_reference_t<I>, IntRep>())>
+                    void mix_entropy(I begin, S end)
+                    {
+                        auto hash_const = INIT_A;
+                        auto hash = [&](IntRep value) {
+                            value ^= hash_const;
+                            hash_const *= MULT_A;
+                            value *= hash_const;
+                            value ^= value >> XSHIFT;
+                            return value;
+                        };
+                        auto mix = [](IntRep x, IntRep y) {
+                            IntRep result = MIX_MULT_L*x - MIX_MULT_R*y;
+                            result ^= result >> XSHIFT;
+                            return result;
+                        };
+
+                        for (auto& elem : mixer_) {
+                            if (begin != end)
+                                elem = hash(static_cast<IntRep>(*begin++));
+                            else
+                                elem = hash(IntRep{0});
+                        }
+                        for (auto& src : mixer_)
+                            for (auto& dest : mixer_)
+                                if (&src != &dest)
+                                    dest = mix(dest,hash(src));
+                        for (; begin != end; ++begin)
+                            for (auto& dest : mixer_)
+                                dest = mix(dest,hash(static_cast<IntRep>(*begin)));
+                    }
+
+                public:
+                    seed_seq_fe(const seed_seq_fe&)     = delete;
+                    void operator=(const seed_seq_fe&)  = delete;
+
+                    template <typename T,
+                        CONCEPT_REQUIRES_(ConvertibleTo<T const&, IntRep>())>
+                    seed_seq_fe(std::initializer_list<T> init)
+                    {
+                        seed(init.begin(), init.end());
+                    }
+
+                    template <typename I, typename S,
+                        CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
+                            ConvertibleTo<iterator_reference_t<I>, IntRep>())>
+                    seed_seq_fe(I begin, S end)
+                    {
+                        seed(begin, end);
+                    }
+
+                    // generating functions
+                    template <typename I, typename S,
+                        CONCEPT_REQUIRES_(RandomAccessIterator<I>() && IteratorRange<I, S>())>
+                    void generate(I dest_begin, S dest_end) const
+                    {
+                        auto src_begin = mixer_.begin();
+                        auto src_end   = mixer_.end();
+                        auto src       = src_begin;
+                        auto hash_const = INIT_B;
+                        for (auto dest = dest_begin; dest != dest_end; ++dest) {
+                            auto dataval = *src;
+                            if (++src == src_end)
+                                src = src_begin;
+                            dataval ^= hash_const;
+                            hash_const *= MULT_B;
+                            dataval *= hash_const;
+                            dataval ^= dataval >> XSHIFT;
+                            *dest = dataval;
+                        }
+                    }
+
+                    constexpr std::size_t size() const
+                    {
+                        return count;
+                    }
+
+                    template <typename O,
+                        CONCEPT_REQUIRES_(WeaklyIncrementable<O>() &&
+                            IndirectlyCopyable<decltype(mixer_.begin()), O>())>
+                    void param(O dest) const
+                    {
+                        const IntRep INV_A = randutils::fast_exp(MULT_A, IntRep(-1));
+                        const IntRep MIX_INV_L = randutils::fast_exp(MIX_MULT_L, IntRep(-1));
+
+                        auto mixer_copy = mixer_;
+                        for (std::size_t round = 0; round < mix_rounds; ++round) {
+                            // Advance to the final value.  We'll backtrack from that.
+                            auto hash_const = INIT_A*randutils::fast_exp(MULT_A, IntRep(count * count));
+
+                            for (auto src = mixer_copy.rbegin(); src != mixer_copy.rend(); ++src)
+                                for (auto dest = mixer_copy.rbegin(); dest != mixer_copy.rend();
+                                    ++dest)
+                                    if (src != dest) {
+                                        IntRep revhashed = *src;
+                                        auto mult_const = hash_const;
+                                        hash_const *= INV_A;
+                                        revhashed ^= hash_const;
+                                        revhashed *= mult_const;
+                                        revhashed ^= revhashed >> XSHIFT;
+                                        IntRep unmixed = *dest;
+                                        unmixed ^= unmixed >> XSHIFT;
+                                        unmixed += MIX_MULT_R*revhashed;
+                                        unmixed *= MIX_INV_L;
+                                        *dest = unmixed;
+                                    }
+                            for (auto i = mixer_copy.rbegin(); i != mixer_copy.rend(); ++i) {
+                                IntRep unhashed = *i;
+                                unhashed ^= unhashed >> XSHIFT;
+                                unhashed *= randutils::fast_exp(hash_const, IntRep(-1));
+                                hash_const *= INV_A;
+                                unhashed ^= hash_const;
+                                *i = unhashed;
+                            }
+                        }
+                        ranges::copy(mixer_copy, dest);
+                    }
+
+                    template <typename I, typename S,
+                        CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
+                            ConvertibleTo<iterator_reference_t<I>, IntRep>())>
+                    void seed(I begin, S end)
+                    {
+                        mix_entropy(begin, end);
+                        // For very small sizes, we do some additional mixing.  For normal
+                        // sizes, this loop never performs any iterations.
+                        for (std::size_t i = 1; i < mix_rounds; ++i)
+                            stir();
+                    }
+
+                    seed_seq_fe& stir()
+                    {
+                        mix_entropy(mixer_.begin(), mixer_.end());
+                        return *this;
+                    }
+
+                };
+
+                using seed_seq_fe128 = seed_seq_fe<4, std::uint32_t>;
+                using seed_seq_fe256 = seed_seq_fe<8, std::uint32_t>;
+
+                //////////////////////////////////////////////////////////////////////////////
+                //
+                // auto_seeded
+                //
+                //////////////////////////////////////////////////////////////////////////////
+
+                /*
+                * randutils::auto_seeded
+                *
+                *   Extends a seed sequence class with a nondeterministic default constructor.
+                *   Uses a variety of local sources of entropy to portably initialize any
+                *   seed sequence to a good default state.
+                *
+                *   In normal use, it's accessed via one of the following type aliases, which
+                *   use seed_seq_fe128 and seed_seq_fe256 above.
+                *
+                *       randutils::auto_seed_128
+                *       randutils::auto_seed_256
+                *
+                *   It's discussed in detail at
+                *       http://www.pcg-random.org/posts/simple-portable-cpp-seed-entropy.html
+                *   and its motivation (why you can't just use std::random_device) here
+                *       http://www.pcg-random.org/posts/cpps-random_device.html
+                */
+
+                template <typename SeedSeq>
+                struct auto_seeded : public SeedSeq {
+                    auto_seeded()
+                        : auto_seeded(randutils::local_entropy(
+                            randutils::hash(this), randutils::crushto32(typeid(*this).hash_code())))
+                    {}
+                    template <std::size_t N>
+                    auto_seeded(std::array<std::uint32_t, N> const& seeds)
+                        : SeedSeq(seeds.begin(), seeds.end())
+                    {}
+                    using SeedSeq::SeedSeq;
+
+                    const SeedSeq& base() const
+                    {
+                        return *this;
+                    }
+                    SeedSeq& base()
+                    {
+                        return *this;
+                    }
+                };
+
+                using auto_seed_128 = auto_seeded<seed_seq_fe128>;
+                using auto_seed_256 = auto_seeded<seed_seq_fe256>;
+            }
+
+            using default_random_engine =
+                meta::if_c<sizeof(void*) >= 8, std::mt19937_64, std::mt19937>;
             inline default_random_engine& get_random_engine()
             {
-                // TODO: seed properly.
-                RANGES_STATIC_THREAD_LOCAL default_random_engine engine{std::random_device{}()};
+                RANGES_STATIC_THREAD_LOCAL default_random_engine engine{
+                    randutils::auto_seed_256{}.base()};
                 return engine;
             }
         }
         /// \endcond
     }
 }
+
+#undef RANGES_CPU_ENTROPY
 
 #endif

--- a/include/range/v3/utility/random.hpp
+++ b/include/range/v3/utility/random.hpp
@@ -135,12 +135,16 @@ namespace ranges
                         (hash * 16777619U) ^ static_cast<unsigned char>(*pos), pos+1);
                 }
 
-                template<std::size_t nwords = 18>
-                std::array<std::uint32_t, nwords> local_entropy(std::uint32_t s1, std::uint32_t s2)
+                static constexpr std::size_t seed_count = 19;
+                template<class = void>
+                std::array<std::uint32_t, seed_count> local_entropy(std::uint32_t s1, std::uint32_t s2)
                 {
-                    CONCEPT_ASSERT(nwords >= 10);
-                    std::array<std::uint32_t, nwords> seeds;
+                    CONCEPT_ASSERT(seed_count >= 11);
+                    std::array<std::uint32_t, seed_count> seeds;
                     auto it = seeds.begin();
+
+                    static std::atomic<std::uint32_t> counter;
+                    *it++ = counter.fetch_add(std::uint32_t{0xedf19156}, std::memory_order_relaxed);
 
                     // The heap can vary from run to run as well.
                     void* malloc_addr = std::malloc(sizeof(int));

--- a/include/range/v3/utility/random.hpp
+++ b/include/range/v3/utility/random.hpp
@@ -101,7 +101,8 @@ namespace ranges
         }
 
         template<typename Gen>
-        using UniformRandomNumberGenerator = concepts::models<concepts::UniformRandomNumberGenerator, Gen>;
+        using UniformRandomNumberGenerator =
+            concepts::models<concepts::UniformRandomNumberGenerator, Gen>;
         /// @}
 
         /// \cond
@@ -299,7 +300,7 @@ namespace ranges
                     std::array<IntRep, count> mixer_;
 
                     template <typename I, typename S,
-                        CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
+                        CONCEPT_REQUIRES_(InputIterator<I>() && Sentinel<S, I>() &&
                             ConvertibleTo<iterator_reference_t<I>, IntRep>())>
                     void mix_entropy(I begin, S end)
                     {
@@ -344,7 +345,7 @@ namespace ranges
                     }
 
                     template <typename I, typename S,
-                        CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
+                        CONCEPT_REQUIRES_(InputIterator<I>() && Sentinel<S, I>() &&
                             ConvertibleTo<iterator_reference_t<I>, IntRep>())>
                     seed_seq_fe(I begin, S end)
                     {
@@ -353,7 +354,7 @@ namespace ranges
 
                     // generating functions
                     template <typename I, typename S,
-                        CONCEPT_REQUIRES_(RandomAccessIterator<I>() && IteratorRange<I, S>())>
+                        CONCEPT_REQUIRES_(RandomAccessIterator<I>() && Sentinel<S, I>())>
                     void generate(I dest_begin, S dest_end) const
                     {
                         auto src_begin = mixer_.begin();
@@ -419,7 +420,7 @@ namespace ranges
                     }
 
                     template <typename I, typename S,
-                        CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
+                        CONCEPT_REQUIRES_(InputIterator<I>() && Sentinel<S, I>() &&
                             ConvertibleTo<iterator_reference_t<I>, IntRep>())>
                     void seed(I begin, S end)
                     {

--- a/include/range/v3/view/sample.hpp
+++ b/include/range/v3/view/sample.hpp
@@ -31,7 +31,7 @@ namespace ranges
         /// \cond
         namespace detail
         {
-            template<typename Rng, bool = SizedIteratorRange<range_iterator_t<Rng>, range_sentinel_t<Rng>>::value>
+            template<typename Rng, bool = SizedSentinel<range_sentinel_t<Rng>, range_iterator_t<Rng>>::value>
             class size_tracker
             {
                 range_difference_t<Rng> size_;
@@ -51,7 +51,7 @@ namespace ranges
                 }
             };
 
-            // Impl for SizedIteratorRange (no need to store anything)
+            // Impl for SizedSentinel (no need to store anything)
             template<typename Rng>
             class size_tracker<Rng, true>
             {
@@ -190,7 +190,7 @@ namespace ranges
                         range_difference_t<Rng>>,
                     meta::or_<
                         SizedRange<Rng>,
-                        SizedIteratorRange<range_iterator_t<Rng>, range_sentinel_t<Rng>>,
+                        SizedSentinel<range_sentinel_t<Rng>, range_iterator_t<Rng>>,
                         ForwardRange<Rng>>>;
 
                 friend view_access;
@@ -227,11 +227,11 @@ namespace ranges
                         "UniformRandomNumberGenerator concept.");
                     CONCEPT_ASSERT_MSG(meta::or_<
                         SizedRange<Rng>,
-                        SizedIteratorRange<range_iterator_t<Rng>, range_sentinel_t<Rng>>,
+                        SizedSentinel<range_sentinel_t<Rng>, range_iterator_t<Rng>>,
                         ForwardRange<Rng>>(),
                         "The underlying range for view::sample must either satisfy the SizedRange"
                         "concept, have iterator and sentinel types that satisfy the "
-                        "SizedIteratorRange concept, or be a forward range.");
+                        "SizedSentinel concept, or be a forward range.");
                     CONCEPT_ASSERT_MSG(ConvertibleTo<
                         concepts::UniformRandomNumberGenerator::result_t<URNG>,
                         range_difference_t<Rng>>(),

--- a/include/range/v3/view/sample.hpp
+++ b/include/range/v3/view/sample.hpp
@@ -1,0 +1,255 @@
+/// \file
+// Range v3 library
+//
+//  Copyright Casey Carter 2016
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#ifndef RANGES_V3_VIEW_SAMPLE_HPP
+#define RANGES_V3_VIEW_SAMPLE_HPP
+
+#include <meta/meta.hpp>
+#include <range/v3/range_concepts.hpp>
+#include <range/v3/view_facade.hpp>
+#include <range/v3/algorithm/shuffle.hpp>
+#include <range/v3/utility/compressed_pair.hpp>
+#include <range/v3/utility/iterator_concepts.hpp>
+#include <range/v3/utility/static_const.hpp>
+#include <range/v3/view/all.hpp>
+#include <range/v3/view/view.hpp>
+
+namespace ranges
+{
+    inline namespace v3
+    {
+        /// \cond
+        namespace detail
+        {
+            template<typename Rng, bool = SizedIteratorRange<range_iterator_t<Rng>, range_sentinel_t<Rng>>::value>
+            class size_tracker
+            {
+                range_difference_t<Rng> size_;
+            public:
+                CONCEPT_ASSERT(ForwardRange<Rng>() || SizedRange<Rng>());
+                size_tracker() = default;
+                size_tracker(Rng &rng)
+                  : size_(ranges::distance(rng))
+                {}
+                void decrement()
+                {
+                    --size_;
+                }
+                range_difference_t<Rng> get(Rng &, range_iterator_t<Rng> &) const
+                {
+                    return size_;
+                }
+            };
+
+            // Impl for SizedIteratorRange (no need to store anything)
+            template<typename Rng>
+            class size_tracker<Rng, true>
+            {
+            public:
+                size_tracker() = default;
+                size_tracker(Rng &)
+                {}
+                void decrement()
+                {}
+                range_difference_t<Rng> get(Rng &rng, range_iterator_t<Rng> const &it) const
+                {
+                    return ranges::end(rng) - it;
+                }
+            };
+        }
+        /// \endcond
+
+        /// \addtogroup group-views
+        /// @{
+
+        // Take a random sampling from another view
+        template<typename Rng, typename URNG>
+        class sample_view
+          : public view_facade<sample_view<Rng, URNG>, finite>
+          , tagged_compressed_tuple<
+                tag::range(Rng),
+                tag::size(mutable_<range_difference_t<Rng>>),
+                tag::engine(reference_wrapper<URNG>)>
+        {
+            friend range_access;
+            using D = range_difference_t<Rng>;
+            using base_t = tagged_compressed_tuple<
+                tag::range(Rng), tag::size(mutable_<D>), tag::engine(reference_wrapper<URNG>)>;
+            using base_t::engine;
+            using base_t::range;
+            using base_t::size;
+
+            class cursor
+              : tagged_compressed_tuple<
+                    tag::range(sample_view const *),
+                    tag::current(range_iterator_t<Rng const>),
+                    tag::size(detail::size_tracker<Rng const>)>
+            {
+                using base_t = tagged_compressed_tuple<
+                    tag::range(sample_view const*),
+                    tag::current(range_iterator_t<Rng const>),
+                    tag::size(detail::size_tracker<Rng const>)>;
+                using base_t::current;
+                using base_t::range;
+                using base_t::size;
+
+                D pop_size()
+                {
+                    RANGES_ASSERT(range());
+                    return size().get(range()->range(), current());
+                }
+                void advance()
+                {
+                    RANGES_ASSERT(range());
+                    if (range()->size() > 0)
+                    {
+                        using Dist = std::uniform_int_distribution<D>;
+                        using Param_t = typename Dist::param_type;
+                        Dist dist{};
+                        URNG& engine = range()->engine().get();
+
+                        for (; ; ++current(), size().decrement())
+                        {
+                            RANGES_ASSERT(current() != ranges::end(range()->range()));
+                            auto n = pop_size();
+                            RANGES_ENSURE(n > 0);
+                            const Param_t interval{ 0, n - 1 };
+                            if (dist(engine, interval) < range()->size())
+                                break;
+                        }
+                    }
+                }
+            public:
+                using value_type = range_value_t<Rng>;
+                using difference_type = D;
+
+                cursor() = default;
+                explicit cursor(sample_view const &rng)
+                : base_t{&rng, ranges::begin(rng.range()), rng.range()}
+                {
+                    auto n = pop_size();
+                    if (rng.size() > n)
+                        rng.size() = n;
+                    advance();
+                }
+                range_reference_t<Rng> get() const
+                {
+                    return *current();
+                }
+                bool done() const
+                {
+                    RANGES_ASSERT(range());
+                    return range()->size() <= 0;
+                }
+                void next()
+                {
+                    RANGES_ASSERT(range());
+                    RANGES_ASSERT(range()->size() > 0);
+                    --range()->size();
+                    RANGES_ASSERT(current() != ranges::end(range()->range()));
+                    ++current();
+                    size().decrement();
+                    advance();
+                }
+            };
+
+            cursor begin_cursor() const
+            {
+                return cursor{*this};
+            }
+
+        public:
+            sample_view() = default;
+
+            explicit sample_view(Rng rng, D sample_size, URNG& generator)
+            : base_t{std::move(rng), sample_size, generator}
+            {
+                RANGES_ENSURE(sample_size >= 0);
+            }
+        };
+
+        namespace view
+        {
+            class sample_fn
+            {
+                template<typename Rng, typename URNG>
+                using Constraint = meta::and_<
+                    InputRange<Rng>, UniformRandomNumberGenerator<URNG>,
+                    ConvertibleTo<
+                        concepts::UniformRandomNumberGenerator::result_t<URNG>,
+                        range_difference_t<Rng>>,
+                    meta::or_<
+                        SizedRange<Rng>,
+                        SizedIteratorRange<range_iterator_t<Rng>, range_sentinel_t<Rng>>,
+                        ForwardRange<Rng>>>;
+
+                friend view_access;
+                template<typename Size, typename URNG = detail::default_random_engine,
+                    CONCEPT_REQUIRES_(Integral<Size>(), UniformRandomNumberGenerator<URNG>())>
+                static auto bind(sample_fn fn, Size n, URNG &urng = detail::get_random_engine())
+                RANGES_DECLTYPE_AUTO_RETURN
+                (
+                    make_pipeable(std::bind(fn, std::placeholders::_1, n, bind_forward<URNG &>(urng)))
+                )
+
+            public:
+                template<typename Rng, typename URNG = detail::default_random_engine,
+                    CONCEPT_REQUIRES_(Constraint<Rng, URNG>())>
+                sample_view<all_t<Rng>, URNG> operator()(
+                    Rng && rng, range_difference_t<Rng> sample_size,
+                    URNG &generator = detail::get_random_engine()) const
+                {
+                    return sample_view<all_t<Rng>, URNG>{
+                        all(std::forward<Rng>(rng)), sample_size, generator
+                    };
+                }
+
+            #ifndef RANGES_DOXYGEN_INVOKED
+                template<typename Rng, typename URNG = detail::default_random_engine,
+                    CONCEPT_REQUIRES_(!Constraint<Rng, URNG>())>
+                void operator()(Rng &&, URNG && = URNG{}) const
+                {
+                    CONCEPT_ASSERT_MSG(InputRange<Rng>(),
+                        "The object on which view::sample operates must satisfy the InputRange "
+                        "concept.");
+                    CONCEPT_ASSERT_MSG(UniformRandomNumberGenerator<URNG>(),
+                        "The generator passed to view::sample must satisfy the "
+                        "UniformRandomNumberGenerator concept.");
+                    CONCEPT_ASSERT_MSG(meta::or_<
+                        SizedRange<Rng>,
+                        SizedIteratorRange<range_iterator_t<Rng>, range_sentinel_t<Rng>>,
+                        ForwardRange<Rng>>(),
+                        "The underlying range for view::sample must either satisfy the SizedRange"
+                        "concept, have iterator and sentinel types that satisfy the "
+                        "SizedIteratorRange concept, or be a forward range.");
+                    CONCEPT_ASSERT_MSG(ConvertibleTo<
+                        concepts::UniformRandomNumberGenerator::result_t<URNG>,
+                        range_difference_t<Rng>>(),
+                        "The random generator passed to view::sample has to have a return type "
+                        "convertible to the base iterator difference type.");
+                }
+            #endif
+            };
+
+            /// \relates sample_fn
+            /// \ingroup group-views
+            namespace
+            {
+                constexpr auto&& sample = static_const<view<sample_fn>>::value;
+            }
+        }
+        /// @}
+    }
+}
+
+#endif

--- a/range-v3.vcxproj
+++ b/range-v3.vcxproj
@@ -1082,6 +1082,7 @@
     <ClInclude Include="include\range\v3\utility\move.hpp" />
     <ClInclude Include="include\range\v3\utility\nullptr_v.hpp" />
     <ClInclude Include="include\range\v3\utility\optional.hpp" />
+    <ClInclude Include="include\range\v3\utility\random.hpp" />
     <ClInclude Include="include\range\v3\utility\safe_int.hpp" />
     <ClInclude Include="include\range\v3\utility\semiregular.hpp" />
     <ClInclude Include="include\range\v3\utility\static_const.hpp" />

--- a/range-v3.vcxproj
+++ b/range-v3.vcxproj
@@ -510,6 +510,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="test\algorithm\sample.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="test\algorithm\search.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
@@ -1018,6 +1022,7 @@
     <ClInclude Include="include\range\v3\algorithm\reverse_copy.hpp" />
     <ClInclude Include="include\range\v3\algorithm\rotate.hpp" />
     <ClInclude Include="include\range\v3\algorithm\rotate_copy.hpp" />
+    <ClInclude Include="include\range\v3\algorithm\sample.hpp" />
     <ClInclude Include="include\range\v3\algorithm\search.hpp" />
     <ClInclude Include="include\range\v3\algorithm\search_n.hpp" />
     <ClInclude Include="include\range\v3\algorithm\set_algorithm.hpp" />

--- a/range-v3.vcxproj
+++ b/range-v3.vcxproj
@@ -862,6 +862,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="test\view\sample.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="test\view\set_difference.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>

--- a/range-v3.vcxproj.filters
+++ b/range-v3.vcxproj.filters
@@ -321,6 +321,9 @@
     <ClCompile Include="test\algorithm\rotate_copy.cpp">
       <Filter>Test Files\algorithm</Filter>
     </ClCompile>
+    <ClCompile Include="test\algorithm\sample.cpp">
+      <Filter>Test Files\algorithm</Filter>
+    </ClCompile>
     <ClCompile Include="test\algorithm\search.cpp">
       <Filter>Test Files\algorithm</Filter>
     </ClCompile>
@@ -900,6 +903,9 @@
       <Filter>Header Files\range\v3\algorithm</Filter>
     </ClInclude>
     <ClInclude Include="include\range\v3\algorithm\rotate_copy.hpp">
+      <Filter>Header Files\range\v3\algorithm</Filter>
+    </ClInclude>
+    <ClInclude Include="include\range\v3\algorithm\sample.hpp">
       <Filter>Header Files\range\v3\algorithm</Filter>
     </ClInclude>
     <ClInclude Include="include\range\v3\algorithm\search.hpp">

--- a/range-v3.vcxproj.filters
+++ b/range-v3.vcxproj.filters
@@ -1088,6 +1088,9 @@
     <ClInclude Include="include\range\v3\utility\optional.hpp">
       <Filter>Header Files\range\v3\utility</Filter>
     </ClInclude>
+    <ClInclude Include="include\range\v3\utility\random.hpp">
+      <Filter>Header Files\range\v3\utility</Filter>
+    </ClInclude>
     <ClInclude Include="include\range\v3\utility\safe_int.hpp">
       <Filter>Header Files\range\v3\utility</Filter>
     </ClInclude>

--- a/range-v3.vcxproj.filters
+++ b/range-v3.vcxproj.filters
@@ -603,6 +603,9 @@
     <ClCompile Include="test\view\reverse.cpp">
       <Filter>Test Files\view</Filter>
     </ClCompile>
+    <ClCompile Include="test\view\sample.cpp">
+      <Filter>Test Files\view</Filter>
+    </ClCompile>
     <ClCompile Include="test\view\slice.cpp">
       <Filter>Test Files\view</Filter>
     </ClCompile>

--- a/test/algorithm/CMakeLists.txt
+++ b/test/algorithm/CMakeLists.txt
@@ -202,6 +202,9 @@ add_test(test.alg.rotate, alg.rotate)
 add_executable(alg.rotate_copy rotate_copy.cpp)
 add_test(test.alg.rotate_copy, alg.rotate_copy)
 
+add_executable(alg.sample sample.cpp)
+add_test(test.alg.sample, alg.sample)
+
 add_executable(alg.search search.cpp)
 add_test(test.alg.search, alg.search)
 

--- a/test/algorithm/sample.cpp
+++ b/test/algorithm/sample.cpp
@@ -1,0 +1,163 @@
+// Range v3 lbrary
+//
+//  Copyright Eric Niebler 2014
+//  Copyright Casey Carter 2016
+//
+//  Use, modification and distrbution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+//  Copyright 2005 - 2007 Adobe Systems Incorporated
+//  Distrbuted under the MIT License(see accompanying file LICENSE_1_0_0.txt
+//  or a copy at http://stlab.adobe.com/licenses.html)
+
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <array>
+#include <range/v3/core.hpp>
+#include <range/v3/algorithm/equal.hpp>
+#include <range/v3/algorithm/sample.hpp>
+#include <range/v3/numeric/iota.hpp>
+#include "../simple_test.hpp"
+#include "../test_utils.hpp"
+#include "../test_iterators.hpp"
+
+int main()
+{
+    constexpr unsigned N = 100;
+    constexpr unsigned K = 10;
+    {
+        std::array<int, N> i;
+        ranges::iota(i, 0);
+        std::array<int, K> a{}, b{}, c{};
+        std::minstd_rand g1, g2 = g1;
+        ranges::sample(random_access_iterator<int*>(i.data()), sentinel<int*>(i.data()+N), a.begin(), K, g1);
+        CHECK(!ranges::equal(a, c));
+
+        CHECK(ranges::sample(i.begin(), i.end(), b.begin(), K, g1) == b.end());
+        CHECK(!ranges::equal(a, b));
+        CHECK(!ranges::equal(b, c));
+
+        CHECK(ranges::sample(i.begin(), i.end(), c.begin(), K, g2) == c.end());
+        CHECK(ranges::equal(a, c));
+    }
+
+    {
+        std::array<int, N> i;
+        ranges::iota(i, 0);
+        std::array<int, K> a{}, b{}, c{};
+        std::minstd_rand g1, g2 = g1;
+        auto rng = ranges::make_iterator_range(random_access_iterator<int*>(i.data()), sentinel<int*>(i.data() + N));
+        ranges::sample(rng, a.begin(), K, g1);
+        CHECK(!ranges::equal(a, b));
+
+        CHECK(ranges::sample(i, b.begin(), K, g2) == b.end());
+        CHECK(ranges::equal(a, b));
+
+        CHECK(ranges::sample(i, b.begin(), K, g1) == b.end());
+        CHECK(!ranges::equal(a, b));
+        CHECK(!ranges::equal(b, c));
+
+        a.fill(0);
+        CHECK(ranges::sample(std::move(rng), a.begin(), K, g1) == a.end());
+        CHECK(!ranges::equal(a, c));
+    }
+
+    {
+        std::array<int, N> i;
+        ranges::iota(i, 0);
+        std::array<int, K> a{}, b{}, c{};
+        ranges::sample(random_access_iterator<int*>(i.data()), sentinel<int*>(i.data() + N), a.begin(), K);
+        CHECK(!ranges::equal(a, b));
+
+        ranges::sample(i, b.begin(), K);
+        CHECK(!ranges::equal(b, c));
+        CHECK(!ranges::equal(a, b));
+    }
+
+    {
+        std::array<MoveOnlyString, 10> source;
+        std::array<MoveOnlyString, 4> dest;
+        ranges::sample(ranges::make_move_iterator(source.begin()), ranges::make_move_sentinel(source.end()),
+            forward_iterator<MoveOnlyString*>(dest.data()), dest.size());
+    }
+
+    {
+        std::array<int, N> i;
+        ranges::iota(i, 0);
+        std::array<int, K> a{}, b{}, c{};
+        std::minstd_rand g1, g2 = g1;
+        ranges::sample(random_access_iterator<int*>(i.data()), sentinel<int*>(i.data()+N), a, g1);
+        CHECK(!ranges::equal(a, c));
+
+        CHECK(ranges::sample(i.begin(), i.end(), b, g1) == b.end());
+        CHECK(!ranges::equal(a, b));
+        CHECK(!ranges::equal(b, c));
+
+        CHECK(ranges::sample(i.begin(), i.end(), c, g2) == c.end());
+        CHECK(ranges::equal(a, c));
+    }
+
+    {
+        std::array<int, N> i;
+        ranges::iota(i, 0);
+        std::array<int, K> a{}, b{}, c{};
+        std::minstd_rand g1, g2 = g1;
+        auto rng = ranges::make_iterator_range(random_access_iterator<int*>(i.data()), sentinel<int*>(i.data() + N));
+        ranges::sample(rng, a, g1);
+        CHECK(!ranges::equal(a, b));
+
+        CHECK(ranges::sample(i, b, g2) == b.end());
+        CHECK(ranges::equal(a, b));
+
+        CHECK(ranges::sample(i, b, g1) == b.end());
+        CHECK(!ranges::equal(a, b));
+        CHECK(!ranges::equal(b, c));
+
+        a.fill(0);
+        CHECK(ranges::sample(std::move(rng), a, g1) == a.end());
+        CHECK(!ranges::equal(a, c));
+    }
+
+    {
+        std::array<int, N> i;
+        ranges::iota(i, 0);
+        std::array<int, K> a{}, b{}, c{};
+        ranges::sample(random_access_iterator<int*>(i.data()), sentinel<int*>(i.data() + N), a);
+        CHECK(!ranges::equal(a, b));
+
+        ranges::sample(i, b);
+        CHECK(!ranges::equal(b, c));
+        CHECK(!ranges::equal(a, b));
+    }
+
+    {
+        std::array<MoveOnlyString, 10> source;
+        std::array<MoveOnlyString, 4> dest;
+        auto out = ranges::make_iterator_range(
+            forward_iterator<MoveOnlyString*>(dest.data()),
+            sentinel<MoveOnlyString*, true>(dest.data() + dest.size()));
+        ranges::sample(ranges::make_move_iterator(source.begin()),
+            ranges::make_move_sentinel(source.end()), out);
+    }
+
+    {
+        int data[] = {0,1,2,3};
+        int sample[2];
+        std::minstd_rand g;
+        ranges::sample(data, sample, g);
+        ranges::sample(data, sample);
+    }
+
+    return ::test_result();
+}

--- a/test/algorithm/sample.cpp
+++ b/test/algorithm/sample.cpp
@@ -32,6 +32,20 @@
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
 
+namespace
+{
+    template<typename I, typename S,
+        CONCEPT_REQUIRES_(ranges::Sentinel<S, I>())>
+    bool in_sequence(I first, I mid, S last)
+    {
+        for (; first != mid; ++first)
+            RANGES_ASSERT(first != last);
+        for (; first != last; ++first)
+            ;
+        return true;
+    }
+}
+
 int main()
 {
     constexpr unsigned N = 100;
@@ -41,15 +55,29 @@ int main()
         ranges::iota(i, 0);
         std::array<int, K> a{}, b{}, c{};
         std::minstd_rand g1, g2 = g1;
-        ranges::sample(random_access_iterator<int*>(i.data()), sentinel<int*>(i.data()+N), a.begin(), K, g1);
-        CHECK(!ranges::equal(a, c));
 
-        CHECK(ranges::sample(i.begin(), i.end(), b.begin(), K, g1) == b.end());
-        CHECK(!ranges::equal(a, b));
-        CHECK(!ranges::equal(b, c));
+        {
+            auto result = ranges::sample(random_access_iterator<int*>(i.data()),
+                sentinel<int*>(i.data()+N), a.begin(), K, g1);
+            CHECK(in_sequence(i.data(), result.in().base(), i.data() + N));
+            CHECK(result.out() == a.end());
+            CHECK(!ranges::equal(a, c));
+        }
 
-        CHECK(ranges::sample(i.begin(), i.end(), c.begin(), K, g2) == c.end());
-        CHECK(ranges::equal(a, c));
+        {
+            auto result = ranges::sample(i.begin(), i.end(), b.begin(), K, g1);
+            CHECK(in_sequence(i.begin(), result.in(), i.end()));
+            CHECK(result.out() == b.end());
+            CHECK(!ranges::equal(a, b));
+            CHECK(!ranges::equal(b, c));
+        }
+
+        {
+            auto result = ranges::sample(i.begin(), i.end(), c.begin(), K, g2);
+            CHECK(in_sequence(i.begin(), result.in(), i.end()));
+            CHECK(result.out() == c.end());
+            CHECK(ranges::equal(a, c));
+        }
     }
 
     {
@@ -58,38 +86,70 @@ int main()
         std::array<int, K> a{}, b{}, c{};
         std::minstd_rand g1, g2 = g1;
         auto rng = ranges::make_iterator_range(random_access_iterator<int*>(i.data()), sentinel<int*>(i.data() + N));
-        ranges::sample(rng, a.begin(), K, g1);
-        CHECK(!ranges::equal(a, b));
 
-        CHECK(ranges::sample(i, b.begin(), K, g2) == b.end());
-        CHECK(ranges::equal(a, b));
+        {
+            auto result = ranges::sample(rng, a.begin(), K, g1);
+            CHECK(in_sequence(ranges::begin(rng), result.in(), ranges::end(rng)));
+            CHECK(result.out() == a.end());
+            CHECK(!ranges::equal(a, b));
+        }
 
-        CHECK(ranges::sample(i, b.begin(), K, g1) == b.end());
-        CHECK(!ranges::equal(a, b));
-        CHECK(!ranges::equal(b, c));
+        {
+            auto result = ranges::sample(i, b.begin(), K, g2);
+            CHECK(in_sequence(i.begin(), result.in(), i.end()));
+            CHECK(result.out() == b.end());
+            CHECK(ranges::equal(a, b));
+        }
 
-        a.fill(0);
-        CHECK(ranges::sample(std::move(rng), a.begin(), K, g1) == a.end());
-        CHECK(!ranges::equal(a, c));
+        {
+            auto result = ranges::sample(i, b.begin(), K, g1);
+            CHECK(in_sequence(i.begin(), result.in(), i.end()));
+            CHECK(result.out() == b.end());
+            CHECK(!ranges::equal(a, b));
+            CHECK(!ranges::equal(b, c));
+        }
+
+        {
+            a.fill(0);
+            auto result = ranges::sample(std::move(rng), a.begin(), K, g1);
+            CHECK(in_sequence(ranges::begin(rng), result.in().get_unsafe(), ranges::end(rng)));
+            CHECK(result.out() == a.end());
+            CHECK(!ranges::equal(a, c));
+        }
     }
 
     {
         std::array<int, N> i;
         ranges::iota(i, 0);
         std::array<int, K> a{}, b{}, c{};
-        ranges::sample(random_access_iterator<int*>(i.data()), sentinel<int*>(i.data() + N), a.begin(), K);
-        CHECK(!ranges::equal(a, b));
 
-        ranges::sample(i, b.begin(), K);
-        CHECK(!ranges::equal(b, c));
-        CHECK(!ranges::equal(a, b));
+        {
+            auto result = ranges::sample(random_access_iterator<int*>(i.data()),
+                sentinel<int*>(i.data() + N), a.begin(), K);
+            CHECK(in_sequence(i.data(), result.in().base(), i.data() + N));
+            CHECK(result.out() == a.end());
+            CHECK(!ranges::equal(a, b));
+        }
+
+        {
+            auto result = ranges::sample(i, b.begin(), K);
+            CHECK(in_sequence(i.begin(), result.in(), i.end()));
+            CHECK(result.out() == b.end());
+            CHECK(!ranges::equal(b, c));
+            CHECK(!ranges::equal(a, b));
+        }
     }
 
     {
         std::array<MoveOnlyString, 10> source;
         std::array<MoveOnlyString, 4> dest;
-        ranges::sample(ranges::make_move_iterator(source.begin()), ranges::make_move_sentinel(source.end()),
+        auto result = ranges::sample(ranges::make_move_iterator(source.begin()),
+            ranges::make_move_sentinel(source.end()),
             forward_iterator<MoveOnlyString*>(dest.data()), dest.size());
+        CHECK(in_sequence(ranges::make_move_iterator(source.begin()),
+            result.in(),
+            ranges::make_move_sentinel(source.end())));
+        CHECK(result.out() == forward_iterator<MoveOnlyString*>(dest.data() + dest.size()));
     }
 
     {
@@ -97,15 +157,29 @@ int main()
         ranges::iota(i, 0);
         std::array<int, K> a{}, b{}, c{};
         std::minstd_rand g1, g2 = g1;
-        ranges::sample(random_access_iterator<int*>(i.data()), sentinel<int*>(i.data()+N), a, g1);
-        CHECK(!ranges::equal(a, c));
 
-        CHECK(ranges::sample(i.begin(), i.end(), b, g1) == b.end());
-        CHECK(!ranges::equal(a, b));
-        CHECK(!ranges::equal(b, c));
+        {
+            auto result = ranges::sample(random_access_iterator<int*>(i.data()),
+                sentinel<int*>(i.data()+N), a, g1);
+            CHECK(in_sequence(i.data(), result.in().base(), i.data() + N));
+            CHECK(result.out() == a.end());
+            CHECK(!ranges::equal(a, c));
+        }
 
-        CHECK(ranges::sample(i.begin(), i.end(), c, g2) == c.end());
-        CHECK(ranges::equal(a, c));
+        {
+            auto result = ranges::sample(i.begin(), i.end(), b, g1);
+            CHECK(in_sequence(i.begin(), result.in(), i.end()));
+            CHECK(result.out() == b.end());
+            CHECK(!ranges::equal(a, b));
+            CHECK(!ranges::equal(b, c));
+        }
+
+        {
+            auto result = ranges::sample(i.begin(), i.end(), c, g2);
+            CHECK(in_sequence(i.begin(), result.in(), i.end()));
+            CHECK(result.out() == c.end());
+            CHECK(ranges::equal(a, c));
+        }
     }
 
     {
@@ -114,31 +188,58 @@ int main()
         std::array<int, K> a{}, b{}, c{};
         std::minstd_rand g1, g2 = g1;
         auto rng = ranges::make_iterator_range(random_access_iterator<int*>(i.data()), sentinel<int*>(i.data() + N));
-        ranges::sample(rng, a, g1);
-        CHECK(!ranges::equal(a, b));
 
-        CHECK(ranges::sample(i, b, g2) == b.end());
-        CHECK(ranges::equal(a, b));
+        {
+            auto result = ranges::sample(rng, a, g1);
+            CHECK(in_sequence(i.data(), result.in().base(), i.data() + N));
+            CHECK(result.out() == a.end());
+            CHECK(!ranges::equal(a, b));
+        }
 
-        CHECK(ranges::sample(i, b, g1) == b.end());
-        CHECK(!ranges::equal(a, b));
-        CHECK(!ranges::equal(b, c));
+        {
+            auto result = ranges::sample(i, b, g2);
+            CHECK(in_sequence(i.begin(), result.in(), i.end()));
+            CHECK(result.out() == b.end());
+            CHECK(ranges::equal(a, b));
+        }
 
-        a.fill(0);
-        CHECK(ranges::sample(std::move(rng), a, g1) == a.end());
-        CHECK(!ranges::equal(a, c));
+        {
+            auto result = ranges::sample(i, b, g1);
+            CHECK(in_sequence(i.begin(), result.in(), i.end()));
+            CHECK(result.out() == b.end());
+            CHECK(!ranges::equal(a, b));
+            CHECK(!ranges::equal(b, c));
+        }
+
+        {
+            a.fill(0);
+            auto result = ranges::sample(std::move(rng), a, g1);
+            CHECK(in_sequence(i.data(), result.in().get_unsafe().base(), i.data() + N));
+            CHECK(result.out() == a.end());
+            CHECK(!ranges::equal(a, c));
+        }
     }
 
     {
         std::array<int, N> i;
         ranges::iota(i, 0);
         std::array<int, K> a{}, b{}, c{};
-        ranges::sample(random_access_iterator<int*>(i.data()), sentinel<int*>(i.data() + N), a);
-        CHECK(!ranges::equal(a, b));
 
-        ranges::sample(i, b);
-        CHECK(!ranges::equal(b, c));
-        CHECK(!ranges::equal(a, b));
+        {
+            auto result = ranges::sample(random_access_iterator<int*>(i.data()),
+                sentinel<int*>(i.data() + N), a);
+            CHECK(in_sequence(i.data(), result.in().base(), i.data() + N));
+            CHECK(result.out() == a.end());
+            CHECK(!ranges::equal(a, b));
+        }
+
+        {
+            auto result = ranges::sample(i, b);
+            CHECK(in_sequence(i.begin(), result.in(), i.end()));
+            CHECK(result.out() == b.end());
+            CHECK(!ranges::equal(b, c));
+            CHECK(!ranges::equal(a, b));
+        }
     }
 
     {
@@ -147,16 +248,26 @@ int main()
         auto out = ranges::make_iterator_range(
             forward_iterator<MoveOnlyString*>(dest.data()),
             sentinel<MoveOnlyString*, true>(dest.data() + dest.size()));
-        ranges::sample(ranges::make_move_iterator(source.begin()),
+        auto result = ranges::sample(ranges::make_move_iterator(source.begin()),
             ranges::make_move_sentinel(source.end()), out);
+        CHECK(in_sequence(source.data(), result.in().base(), source.data() + source.size()));
+        CHECK(result.out() == ranges::end(out));
     }
 
     {
         int data[] = {0,1,2,3};
         int sample[2];
         std::minstd_rand g;
-        ranges::sample(data, sample, g);
-        ranges::sample(data, sample);
+        {
+            auto result = ranges::sample(data, sample, g);
+            CHECK(in_sequence(ranges::begin(data), result.in(), ranges::end(data)));
+            CHECK(result.out() == ranges::end(sample));
+        }
+        {
+            auto result = ranges::sample(data, sample);
+            CHECK(in_sequence(ranges::begin(data), result.in(), ranges::end(data)));
+            CHECK(result.out() == ranges::end(sample));
+        }
     }
 
     return ::test_result();

--- a/test/algorithm/shuffle.cpp
+++ b/test/algorithm/shuffle.cpp
@@ -22,7 +22,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <random>
+#include <array>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/equal.hpp>
 #include <range/v3/algorithm/shuffle.hpp>
@@ -33,63 +33,62 @@
 
 int main()
 {
+    constexpr unsigned N = 100;
     {
-        int ia[100];
-        int ib[100];
-        int orig[100];
-        ranges::iota(ia, 0);
-        ranges::iota(ib, 0);
-        ranges::iota(orig, 0);
-        const unsigned sa = sizeof(ia)/sizeof(ia[0]);
-        std::minstd_rand g;
-        ranges::shuffle(random_access_iterator<int*>(ia), sentinel<int*>(ia+sa), g);
-        CHECK(!ranges::equal(ia, orig));
-        CHECK(ranges::shuffle(ib, ib+sa, g) == ib+sa);
-        CHECK(!ranges::equal(ia, ib));
+        std::array<int, N> a, b, c;
+        for (auto p : {&a, &b, &c})
+            ranges::iota(*p, 0);
+        std::minstd_rand g1, g2 = g1;
+        ranges::shuffle(random_access_iterator<int*>(a.data()), sentinel<int*>(a.data()+N), g1);
+        CHECK(!ranges::equal(a, b));
+
+        CHECK(ranges::shuffle(b.begin(), b.end(), g1) == b.end());
+        CHECK(!ranges::equal(a, b));
+
+        CHECK(ranges::shuffle(c.begin(), c.end(), g2) == c.end());
+        CHECK(ranges::equal(a, c));
+        CHECK(!ranges::equal(b, c));
     }
 
     {
-        int ia[100];
-        int ib[100];
-        int orig[100];
-        ranges::iota(ia, 0);
-        ranges::iota(ib, 0);
-        ranges::iota(orig, 0);
-        const unsigned sa = sizeof(ia)/sizeof(ia[0]);
-        std::minstd_rand g;
-        auto rng = ranges::make_iterator_range(random_access_iterator<int*>(ia), sentinel<int*>(ia+sa));
-        ranges::shuffle(rng, g);
-        CHECK(!ranges::equal(ia, orig));
-        CHECK(ranges::shuffle(ib, g) == ranges::end(ib));
-        CHECK(!ranges::equal(ia, ib));
+        std::array<int, N> a, b, c;
+        for (auto p : {&a, &b, &c})
+            ranges::iota(*p, 0);
+        std::minstd_rand g1, g2 = g1;
+        auto rng = ranges::make_iterator_range(random_access_iterator<int*>(a.data()), sentinel<int*>(a.data() + N));
+        ranges::shuffle(rng, g1);
+        CHECK(!ranges::equal(a, b));
 
-        ranges::iota(ia, 0);
-        CHECK(ranges::shuffle(std::move(rng), g).get_unsafe().base() == ranges::end(ia));
-        CHECK(!ranges::equal(ia, orig));
+        CHECK(ranges::shuffle(b, g2) == b.end());
+        CHECK(ranges::equal(a, b));
+
+        CHECK(ranges::shuffle(b, g1) == b.end());
+        CHECK(!ranges::equal(a, b));
+        CHECK(!ranges::equal(b, c));
+
+        ranges::iota(a, 0);
+        CHECK(ranges::shuffle(std::move(rng), g1).get_unsafe().base() == a.data() + N);
+        CHECK(!ranges::equal(a, c));
     }
 
     {
-        int ia[100];
-        int ib[100];
-        int orig[100];
-        ranges::iota(ia, 0);
-        ranges::iota(ib, 0);
-        ranges::iota(orig, 0);
-        const unsigned sa = sizeof(ia)/sizeof(ia[0]);
-        ranges::shuffle(random_access_iterator<int*>(ia), sentinel<int*>(ia+sa));
-        CHECK(!ranges::equal(ia, orig));
-        ranges::shuffle(ib, ranges::end(ib));
-        CHECK(!ranges::equal(ib, orig));
-        CHECK(!ranges::equal(ia, ib));
+        std::array<int, N> a, b, c;
+        for (auto p : {&a, &b, &c})
+            ranges::iota(*p, 0);
+        ranges::shuffle(random_access_iterator<int*>(a.data()), sentinel<int*>(a.data() + N));
+        CHECK(!ranges::equal(a, c));
+
+        ranges::shuffle(b);
+        CHECK(!ranges::equal(b, c));
+        CHECK(!ranges::equal(a, b));
     }
 
     {
-        int ia[100];
-        int orig[100];
-        ranges::iota(ia, 0);
-        ranges::iota(orig, 0);
-        ranges::shuffle(ia);
-        CHECK(!ranges::equal(ia, orig));
+        std::array<int, N> a, b;
+        for (auto p : {&a, &b})
+            ranges::iota(*p, 0);
+        ranges::shuffle(a);
+        CHECK(!ranges::equal(a, b));
     }
 
     return ::test_result();

--- a/test/view/CMakeLists.txt
+++ b/test/view/CMakeLists.txt
@@ -79,6 +79,9 @@ add_test(test.view.replace_if, view.replace_if)
 add_executable(view.reverse reverse.cpp)
 add_test(test.view.reverse, view.reverse)
 
+add_executable(view.sample sample.cpp)
+add_test(test.view.sample, view.sample)
+
 add_executable(view.set_difference set_difference.cpp)
 add_test(test.view.set_difference, view.set_difference)
 

--- a/test/view/sample.cpp
+++ b/test/view/sample.cpp
@@ -1,0 +1,31 @@
+#include <range/v3/view/sample.hpp>
+#include <range/v3/algorithm/equal.hpp>
+#include <numeric>
+#include <vector>
+#include <random>
+#include "../simple_test.hpp"
+#include "../test_utils.hpp"
+
+using namespace ranges;
+
+int main ()
+{
+    std::vector<int> pop(100);
+    std::iota(std::begin(pop), std::end(pop), 0);
+    {
+        constexpr std::size_t N = 32;
+        std::array<int, N> tmp;
+        std::mt19937 engine;
+        auto rng = pop | view::sample(N, engine);
+        CONCEPT_ASSERT(InputRange<decltype(rng)>());
+        CONCEPT_ASSERT(View<decltype(rng)>());
+        ranges::copy(rng, tmp.begin());
+        rng = pop | view::sample(N, engine);
+        CHECK(!ranges::equal(rng, tmp));
+        engine = decltype(engine){};
+        rng = pop | view::sample(N, engine);
+        CHECK(ranges::equal(rng, tmp));
+    }
+
+    return ::test_result();
+}


### PR DESCRIPTION
* Relocate URNG machinery to utility/random.hpp
* Steal some unpredictable URNG seeding code from the P0347 authors.
* Implement algorithm `sample` from the C++17 WP
* Implement `sample_view`

`sample` has two required implementations: a stable variant for `Forward` source ranges, and an unstable variant for `Input` source ranges with `RandomAccess` result ranges. The stable variant only requires the source range to be `Forward` because it needs to calculate the size. Range-v3 `Input` ranges sometimes know their own size, so range-v3 `sample` uses the stable implementation when the source range is `Forward` or `Sized`.