### PR TITLE
sample: handle count > population size in reservoir sampling implementation

### DIFF
--- a/include/range/v3/algorithm/sample.hpp
+++ b/include/range/v3/algorithm/sample.hpp
@@ -86,22 +86,27 @@ namespace ranges
             operator()(I first, S last, O out, iterator_difference_t<I> n,
                 Gen && gen = detail::get_random_engine()) const
             {
-                if (n > 0)
+                if (n <= 0)
+                    goto done;
+                for (iterator_difference_t<I> i = 0; i < n; (void)++i, ++first)
                 {
-                    for (auto i = n - n; i < n && first != last; (void)++i, ++first)
+                    if (first == last)
                     {
-                        out[i] = *first;
+                        out += i;
+                        goto done;
                     }
-                    std::uniform_int_distribution<iterator_difference_t<I>> dist;
-                    using param_t = typename decltype(dist)::param_type;
-                    for (auto pop_size = n; first != last; (void)++first, ++pop_size)
-                    {
-                        auto const i = dist(gen, param_t{0, pop_size});
-                        if (i < n)
-                            out[i] = *first;
-                    }
-                    out += n;
+                    out[i] = *first;
                 }
+                std::uniform_int_distribution<iterator_difference_t<I>> dist;
+                using param_t = typename decltype(dist)::param_type;
+                for (auto pop_size = n; first != last; (void)++first, ++pop_size)
+                {
+                    auto const i = dist(gen, param_t{0, pop_size});
+                    if (i < n)
+                        out[i] = *first;
+                }
+                out += n;
+            done:
                 return {std::move(first), std::move(out)};
             }
             template<typename I, typename S, typename ORng,

--- a/include/range/v3/utility/random.hpp
+++ b/include/range/v3/utility/random.hpp
@@ -198,7 +198,7 @@ namespace ranges
 
                     // Hopefully high-quality entropy from random_device.
                     std::random_device rd{};
-                    ranges::generate(it, seeds.end(), ranges::ref(rd)).out();
+                    ranges::generate(it, seeds.end(), ranges::ref(rd));
 
                     RANGES_ASSERT(it <= seeds.end());
 

--- a/test/algorithm/sample.cpp
+++ b/test/algorithm/sample.cpp
@@ -268,6 +268,11 @@ int main()
             CHECK(in_sequence(ranges::begin(data), result.in(), ranges::end(data)));
             CHECK(result.out() == ranges::end(sample));
         }
+        {
+            auto result = ranges::sample(data + 0, data + 2, sample + 0, 9999);
+            CHECK(result.in() == data + 2);
+            CHECK(result.out() == sample + 2);
+        }
     }
 
     return ::test_result();


### PR DESCRIPTION
Don't return `out + n` when we've written less than `n` elements into the result sequence.