### PR TITLE
single-pass implementations of the partition_point family

### DIFF
--- a/include/range/v3/algorithm/aux_/equal_range_n.hpp
+++ b/include/range/v3/algorithm/aux_/equal_range_n.hpp
@@ -40,25 +40,35 @@ namespace ranges
                 operator()(I begin, iterator_difference_t<I> dist, V const & val, R pred_ = R{},
                     P proj_ = P{}) const
                 {
-                    RANGES_ASSERT(0 <= dist);
-                    auto &&pred = as_function(pred_);
-                    auto &&proj = as_function(proj_);
-                    while(0 != dist)
+                    if(0 < dist)
                     {
-                        auto half = dist / 2;
-                        auto middle = next(begin, half);
-                        if(pred(proj(*middle), val))
+                        auto && pred = as_function(pred_);
+                        auto && proj = as_function(proj_);
+                        do
                         {
-                            begin = std::move(++middle);
-                            dist -= half + 1;
-                        }
-                        else if(pred(val, proj(*middle)))
-                        {
-                            dist = half;
-                        }
-                        else
-                            return {lower_bound_n(std::move(begin), half, val, std::ref(pred)),
-                                    upper_bound_n(next(middle), dist - half - 1, val, std::ref(pred))};
+                            auto half = dist / 2;
+                            auto middle = next(begin, half);
+                            auto && v = *middle;
+                            auto && pv = proj((decltype(v) &&) v);
+                            if(pred(pv, val))
+                            {
+                                begin = std::move(++middle);
+                                dist -= half + 1;
+                            }
+                            else if(pred(val, pv))
+                            {
+                                dist = half;
+                            }
+                            else
+                            {
+                                return {
+                                    lower_bound_n(std::move(begin), half, val,
+                                        std::ref(pred), std::ref(proj)),
+                                    upper_bound_n(next(middle), dist - (half + 1),
+                                        val, std::ref(pred), std::ref(proj))
+                                };
+                            }
+                        } while(0 != dist);
                     }
                     return {begin, begin};
                 }

--- a/include/range/v3/algorithm/aux_/lower_bound_n.hpp
+++ b/include/range/v3/algorithm/aux_/lower_bound_n.hpp
@@ -2,6 +2,7 @@
 // Range v3 library
 //
 //  Copyright Eric Niebler 2014
+//  Copyright Casey Carter 2016
 //
 //  Use, modification and distribution is subject to the
 //  Boost Software License, Version 1.0. (See accompanying
@@ -14,10 +15,7 @@
 #define RANGES_V3_ALGORITHM_AUX_LOWER_BOUND_N_HPP
 
 #include <range/v3/range_fwd.hpp>
-#include <range/v3/begin_end.hpp>
-#include <range/v3/distance.hpp>
-#include <range/v3/range_concepts.hpp>
-#include <range/v3/range_traits.hpp>
+#include <range/v3/algorithm/aux_/partition_point_n.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/iterator_traits.hpp>
 #include <range/v3/utility/static_const.hpp>
@@ -26,6 +24,32 @@ namespace ranges
 {
     inline namespace v3
     {
+        /// \cond
+        namespace detail
+        {
+            // [&](auto&& i){ return pred(i, val); }
+            template<typename Pred, typename Val>
+            struct lower_bound_predicate
+            {
+                Pred& pred_;
+                Val& val_;
+
+                template<typename T>
+                bool operator()(T&& t) const
+                {
+                    return pred_(std::forward<T>(t), val_);
+                }
+            };
+
+            template<typename Pred, typename Val>
+            lower_bound_predicate<Pred, Val>
+            make_lower_bound_predicate(Pred& pred, Val& val)
+            {
+                return {pred, val};
+            }
+        }
+        /// \endcond
+
         namespace aux
         {
             struct lower_bound_n_fn
@@ -33,24 +57,11 @@ namespace ranges
                 template<typename I, typename V2, typename C = ordered_less, typename P = ident,
                     CONCEPT_REQUIRES_(BinarySearchable<I, V2, C, P>())>
                 I operator()(I begin, iterator_difference_t<I> d, V2 const &val, C pred_ = C{},
-                    P proj_ = P{}) const
+                    P proj = P{}) const
                 {
-                    RANGES_ASSERT(0 <= d);
-                    auto &&pred = as_function(pred_);
-                    auto &&proj = as_function(proj_);
-                    while(0 != d)
-                    {
-                        auto half = d / 2;
-                        auto middle = next(begin, half);
-                        if(pred(proj(*middle), val))
-                        {
-                            begin = std::move(++middle);
-                            d -= half + 1;
-                        }
-                        else
-                            d = half;
-                    }
-                    return begin;
+                    auto&& pred = as_function(pred_);
+                    return partition_point_n(std::move(begin), d,
+                        detail::make_lower_bound_predicate(pred, val), std::move(proj));
                 }
             };
 

--- a/include/range/v3/algorithm/aux_/partition_point_n.hpp
+++ b/include/range/v3/algorithm/aux_/partition_point_n.hpp
@@ -1,0 +1,71 @@
+/// \file
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//  Copyright Casey Carter 2016
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+#ifndef RANGES_V3_ALGORITHM_AUX_PARTITION_POINT_N_HPP
+#define RANGES_V3_ALGORITHM_AUX_PARTITION_POINT_N_HPP
+
+#include <range/v3/range_fwd.hpp>
+#include <range/v3/utility/functional.hpp>
+#include <range/v3/utility/iterator.hpp>
+#include <range/v3/utility/static_const.hpp>
+
+namespace ranges
+{
+    inline namespace v3
+    {
+        /// \ingroup group-concepts
+        template<typename I, typename C, typename P = ident,
+            typename V = iterator_common_reference_t<I>,
+            typename = concepts::Callable::result_t<P, V>>
+        using PartitionPointable = meta::strict_and<
+            ForwardIterator<I>,
+            IndirectCallablePredicate<C, projected<I, P>>>;
+
+        namespace aux
+        {
+            struct partition_point_n_fn
+            {
+                template<typename I, typename C, typename P = ident,
+                    CONCEPT_REQUIRES_(PartitionPointable<I, C, P>())>
+                I operator()(I begin, iterator_difference_t<I> d, C pred_, P proj_ = P{}) const
+                {
+                    if(0 < d)
+                    {
+                        auto &&pred = as_function(pred_);
+                        auto &&proj = as_function(proj_);
+                        do
+                        {
+                            auto half = d / 2;
+                            auto middle = next(uncounted(begin), half);
+                            if(pred(proj(*middle)))
+                            {
+                                begin = recounted(begin, std::move(++middle), half + 1);
+                                d -= half + 1;
+                            }
+                            else
+                                d = half;
+                        } while(0 != d);
+                    }
+                    return begin;
+                }
+            };
+
+            namespace
+            {
+                constexpr auto&& partition_point_n = static_const<partition_point_n_fn>::value;
+            }
+        }
+    } // namespace v3
+} // namespace ranges
+
+#endif // include guard

--- a/include/range/v3/algorithm/lower_bound.hpp
+++ b/include/range/v3/algorithm/lower_bound.hpp
@@ -2,6 +2,7 @@
 // Range v3 library
 //
 //  Copyright Eric Niebler 2014
+//  Copyright Casey Carter 2016
 //
 //  Use, modification and distribution is subject to the
 //  Boost Software License, Version 1.0. (See accompanying
@@ -18,9 +19,10 @@
 #include <range/v3/distance.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/range_traits.hpp>
+#include <range/v3/algorithm/partition_point.hpp>
+#include <range/v3/algorithm/aux_/lower_bound_n.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/iterator_traits.hpp>
-#include <range/v3/algorithm/aux_/lower_bound_n.hpp>
 #include <range/v3/utility/static_const.hpp>
 
 namespace ranges
@@ -33,20 +35,21 @@ namespace ranges
         {
             template<typename I, typename S, typename V, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(Sentinel<S, I>() && BinarySearchable<I, V, C, P>())>
-            I operator()(I begin, S end, V const &val, C pred = C{}, P proj = P{}) const
+            I operator()(I begin, S end, V const &val, C pred_ = C{}, P proj = P{}) const
             {
-                return aux::lower_bound_n(std::move(begin), distance(begin, end), val, std::move(pred),
-                    std::move(proj));
+                auto&& pred = as_function(pred_);
+                return partition_point(std::move(begin), std::move(end),
+                    detail::make_lower_bound_predicate(pred, val), std::move(proj));
             }
 
             template<typename Rng, typename V, typename C = ordered_less, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(Range<Rng>() && BinarySearchable<I, V, C, P>())>
-            range_safe_iterator_t<Rng> operator()(Rng &&rng, V const &val, C pred = C{}, P proj = P{}) const
+            range_safe_iterator_t<Rng> operator()(Rng &&rng, V const &val, C pred_ = C{}, P proj = P{}) const
             {
-                static_assert(!is_infinite<Rng>::value, "Trying to binary search an infinite range");
-                return aux::lower_bound_n(begin(rng), distance(rng), val, std::move(pred),
-                    std::move(proj));
+                auto&& pred = as_function(pred_);
+                return partition_point(rng,
+                    detail::make_lower_bound_predicate(pred, val), std::move(proj));
             }
         };
 

--- a/include/range/v3/algorithm/partition_point.hpp
+++ b/include/range/v3/algorithm/partition_point.hpp
@@ -2,6 +2,7 @@
 // Range v3 library
 //
 //  Copyright Eric Niebler 2014
+//  Copyright Casey Carter 2016
 //
 //  Use, modification and distribution is subject to the
 //  Boost Software License, Version 1.0. (See accompanying
@@ -27,6 +28,7 @@
 #include <range/v3/distance.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/range_traits.hpp>
+#include <range/v3/algorithm/aux_/partition_point_n.hpp>
 #include <range/v3/utility/iterator.hpp>
 #include <range/v3/utility/iterator_concepts.hpp>
 #include <range/v3/utility/iterator_traits.hpp>
@@ -37,47 +39,65 @@ namespace ranges
 {
     inline namespace v3
     {
-        /// \ingroup group-concepts
-        template<typename I, typename C, typename P = ident,
-            typename V = iterator_common_reference_t<I>,
-            typename X = concepts::Callable::result_t<P, V>>
-        using PartitionPointable = meta::strict_and<
-            ForwardIterator<I>,
-            IndirectCallablePredicate<C, projected<I, P>>>;
-
         /// \addtogroup group-algorithms
         /// @{
 
         struct partition_point_fn
         {
             template<typename I, typename S, typename C, typename P = ident,
-                CONCEPT_REQUIRES_(PartitionPointable<I, C, P>() && Sentinel<S, I>())>
+                CONCEPT_REQUIRES_(PartitionPointable<I, C, P>() &&
+                    Sentinel<S, I>() && !SizedSentinel<S, I>())>
             I operator()(I begin, S end, C pred_, P proj_ = P{}) const
             {
+                // Probe exponentially for either end-of-range or an iterator
+                // that is past the partition point (i.e., does not satisfy pred).
                 auto && pred = as_function(pred_);
                 auto && proj = as_function(proj_);
-                auto len = distance(begin, end);
-                while(len != 0)
+
+                auto len = iterator_difference_t<I>{1};
+                while(true)
                 {
-                    auto const half = len / 2;
-                    auto middle = next(uncounted(begin), half);
-                    if(pred(proj(*middle)))
+                    auto mid = begin;
+                    auto d = advance(mid, len, end);
+                    if(mid == end || !pred(proj(*mid)))
                     {
-                        begin = recounted(begin, std::move(++middle), half + 1);
-                        len -= half + 1;
+                        len -= d;
+                        return aux::partition_point_n(
+                            std::move(begin), len, std::ref(pred), std::ref(proj));
                     }
-                    else
-                        len = half;
+                    begin = std::move(mid);
+                    len *= 2;
                 }
-                return begin;
+            }
+
+            template<typename I, typename S, typename C, typename P = ident,
+                CONCEPT_REQUIRES_(PartitionPointable<I, C, P>() &&
+                    SizedSentinel<S, I>())>
+            I operator()(I begin, S end, C pred, P proj = P{}) const
+            {
+                auto len = distance(begin, std::move(end));
+                return aux::partition_point_n(
+                    std::move(begin), len, std::move(pred), std::move(proj));
             }
 
             template<typename Rng, typename C, typename P = ident,
                 typename I = range_iterator_t<Rng>,
-                CONCEPT_REQUIRES_(PartitionPointable<I, C, P>() && Range<Rng>())>
-            range_safe_iterator_t<Rng> operator()(Rng &&rng, C pred, P proj = P{}) const
+                CONCEPT_REQUIRES_(Range<Rng>() && !SizedRange<Rng>() &&
+                    PartitionPointable<I, C, P>())>
+            range_safe_iterator_t<Rng> operator()(Rng && rng, C pred, P proj = P{}) const
             {
-                return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));
+                return (*this)(
+                    begin(rng), end(rng), std::move(pred), std::move(proj));
+            }
+
+            template<typename Rng, typename C, typename P = ident,
+                typename I = range_iterator_t<Rng>,
+                CONCEPT_REQUIRES_(SizedRange<Rng>() && PartitionPointable<I, C, P>())>
+            range_safe_iterator_t<Rng> operator()(Rng && rng, C pred, P proj = P{}) const
+            {
+                auto len = distance(rng);
+                return aux::partition_point_n(
+                    begin(rng), len, std::move(pred), std::move(proj));
             }
         };
 


### PR DESCRIPTION
* New algorithm: `aux::partition_point_n`
* `partition_point` exponentially probes for either end-of-range or a value that is past the partition point (doesn't satisfy the predicate), then defers to `partition_point_n` with the narrowed range.
* `lower_bound{_n}` and `upper_bound{_n}` are implemented in terms of `partition_point{_n}`.
* `equal_range` exponentially probes for:
  * end-of range or an iterator that is past-the-end of the target range (denotes an element greater than the desired value), at which point it defers to `equal_range_n`.
  * an iterator inside the target range (denotes an element equal to the desired value), at which point it delegates to `lower_bound_n(stuff-before-the-iterator)` and `upper_bound(stuff-after)`.
* Fix projection bug in `equal_range_n`; add test coverage.