### PR TITLE
Miscellaneous fixes:

### DIFF
--- a/include/range/v3/utility/box.hpp
+++ b/include/range/v3/utility/box.hpp
@@ -193,16 +193,19 @@ namespace ranges
         public:
             CONCEPT_REQUIRES(std::is_default_constructible<Element>::value)
             constexpr box()
+                noexcept(std::is_nothrow_default_constructible<Element>::value)
               : value{}
             {}
             template<typename E,
                 CONCEPT_REQUIRES_(std::is_constructible<Element, E>::value && std::is_convertible<E, Element>::value)>
             constexpr box(E && e)
+                noexcept(std::is_nothrow_constructible<Element, E>::value)
               : value(detail::forward<E>(e))
             {}
             template<typename E,
                 CONCEPT_REQUIRES_(std::is_constructible<Element, E>::value && !std::is_convertible<E, Element>::value)>
             constexpr explicit box(E && e)
+                noexcept(std::is_nothrow_constructible<Element, E>::value)
               : value(detail::forward<E>(e))
             {}
 
@@ -227,16 +230,19 @@ namespace ranges
         public:
             CONCEPT_REQUIRES(std::is_default_constructible<Element>::value)
             constexpr box()
+                noexcept(std::is_nothrow_default_constructible<Element>::value)
               : Element{}
             {}
             template<typename E,
                 CONCEPT_REQUIRES_(std::is_constructible<Element, E>::value && std::is_convertible<E, Element>::value)>
             constexpr box(E && e)
+                noexcept(std::is_nothrow_constructible<Element, E>::value)
               : Element(detail::forward<E>(e))
             {}
             template<typename E,
                 CONCEPT_REQUIRES_(std::is_constructible<Element, E>::value && !std::is_convertible<E, Element>::value)>
             constexpr explicit box(E && e)
+                noexcept(std::is_nothrow_constructible<Element, E>::value)
               : Element(detail::forward<E>(e))
             {}
 

--- a/include/range/v3/utility/random.hpp
+++ b/include/range/v3/utility/random.hpp
@@ -65,10 +65,15 @@
 #include <range/v3/utility/iterator_concepts.hpp>
 
 // Ugly platform-specific code for auto_seeded
+
+// Clang/C2 bug: __has_builtin(__builtin_readcyclecounter) reports true, but
+// there is no corresponding builtin in C2.
+#if !(defined(__clang__) && defined(__c2__))
 #if defined(__has_builtin)
     #if __has_builtin(__builtin_readcyclecounter)
         #define RANGES_CPU_ENTROPY __builtin_readcyclecounter()
     #endif
+#endif
 #endif
 #if !defined(RANGES_CPU_ENTROPY)
     #if __i386__

--- a/include/range/v3/view/const.hpp
+++ b/include/range/v3/view/const.hpp
@@ -49,13 +49,14 @@ namespace ranges
             struct adaptor
               : adaptor_base
             {
-                reference_ get(range_iterator_t<Rng> it) const
+                reference_ get(range_iterator_t<Rng> const &it) const
                 {
                     return *it;
                 }
-                rvalue_reference_ indirect_move(range_iterator_t<Rng> it) const
+                rvalue_reference_ indirect_move(range_iterator_t<Rng> const &it) const
+                    noexcept(noexcept(ranges::iter_move(it)))
                 {
-                    return iter_move(it);
+                    return ranges::iter_move(it);
                 }
             };
             adaptor begin_adaptor() const
@@ -71,8 +72,13 @@ namespace ranges
             explicit const_view(Rng rng)
               : const_view::view_adaptor{std::move(rng)}
             {}
-            CONCEPT_REQUIRES(SizedRange<Rng>())
+            CONCEPT_REQUIRES(SizedRange<Rng const>())
             range_size_t<Rng> size() const
+            {
+                return ranges::size(this->base());
+            }
+            CONCEPT_REQUIRES(SizedRange<Rng>())
+            range_size_t<Rng> size()
             {
                 return ranges::size(this->base());
             }

--- a/include/range/v3/view/move.hpp
+++ b/include/range/v3/view/move.hpp
@@ -42,13 +42,13 @@ namespace ranges
             struct adaptor : adaptor_base
             {
                 using value_type = range_value_t<Rng>;
-                range_rvalue_reference_t<Rng> get(range_iterator_t<Rng> it) const
+                range_rvalue_reference_t<Rng> get(range_iterator_t<Rng> const &it) const
                 {
-                    return iter_move(it);
+                    return ranges::iter_move(it);
                 }
-                range_rvalue_reference_t<Rng> indirect_move(range_iterator_t<Rng> it) const
+                range_rvalue_reference_t<Rng> indirect_move(range_iterator_t<Rng> const &it) const
                 {
-                    return iter_move(it);
+                    return ranges::iter_move(it);
                 }
             };
             adaptor begin_adaptor() const
@@ -64,8 +64,13 @@ namespace ranges
             explicit move_view(Rng rng)
               : move_view::view_adaptor{std::move(rng)}
             {}
-            CONCEPT_REQUIRES(SizedRange<Rng>())
+            CONCEPT_REQUIRES(SizedRange<Rng const>())
             range_size_t<Rng> size() const
+            {
+                return ranges::size(this->base());
+            }
+            CONCEPT_REQUIRES(SizedRange<Rng>())
+            range_size_t<Rng> size()
             {
                 return ranges::size(this->base());
             }

--- a/include/range/v3/view/single.hpp
+++ b/include/range/v3/view/single.hpp
@@ -45,7 +45,7 @@ namespace ranges
                 bool done_;
             public:
                 cursor() = default;
-                cursor(Val value)
+                explicit cursor(Val value)
                   : value_(std::move(value)), done_(false)
                 {}
                 Val get() const
@@ -81,7 +81,7 @@ namespace ranges
             };
             cursor begin_cursor() const
             {
-                return {value_};
+                return cursor{value_};
             }
         public:
             single_view() = default;

--- a/include/range/v3/view/transform.hpp
+++ b/include/range/v3/view/transform.hpp
@@ -31,7 +31,6 @@
 #include <range/v3/utility/static_const.hpp>
 #include <range/v3/view/view.hpp>
 #include <range/v3/view/all.hpp>
-#include <range/v3/view/zip_with.hpp>
 
 namespace ranges
 {

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -52,25 +52,34 @@ namespace ranges
 
             template<typename BaseIter, typename Adapt, typename Enable = void>
             struct adaptor_value_type_2_
-            {};
+              : compressed_pair<BaseIter, Adapt>
+            {
+                using compressed_pair<BaseIter, Adapt>::compressed_pair;
+            };
 
             template<typename BaseIter, typename Adapt>
             struct adaptor_value_type_2_<
                 BaseIter,
                 Adapt,
                 meta::void_<decltype(Adapt::get(BaseIter{}, adaptor_base_current_mem_fn{}))>>
+              : compressed_pair<BaseIter, Adapt>
             {
+                using compressed_pair<BaseIter, Adapt>::compressed_pair;
                 using value_type = iterator_value_t<BaseIter>;
             };
 
             template<typename BaseIter, typename Adapt, typename Enable = void>
             struct adaptor_value_type_
               : adaptor_value_type_2_<BaseIter, Adapt>
-            {};
+            {
+                using adaptor_value_type_2_<BaseIter, Adapt>::adaptor_value_type_2_;
+            };
 
             template<typename BaseIter, typename Adapt>
             struct adaptor_value_type_<BaseIter, Adapt, meta::void_<typename Adapt::value_type>>
+              : compressed_pair<BaseIter, Adapt>
             {
+                using compressed_pair<BaseIter, Adapt>::compressed_pair;
                 using value_type = typename Adapt::value_type;
             };
         }
@@ -150,13 +159,13 @@ namespace ranges
         // adaptor that customizes behavior.
         template<typename BaseIter, typename Adapt>
         struct adaptor_cursor
-          : private compressed_pair<BaseIter, Adapt>
-          , private detail::adaptor_value_type_<BaseIter, Adapt>
+          : private detail::adaptor_value_type_<BaseIter, Adapt>
         {
         private:
             template<typename BaseSent, typename SentAdapt>
             friend struct adaptor_sentinel;
             friend range_access;
+            using base_t = detail::adaptor_value_type_<BaseIter, Adapt>;
             using single_pass = meta::or_<
                 range_access::single_pass_t<Adapt>,
                 SinglePass<BaseIter>>;
@@ -173,8 +182,8 @@ namespace ranges
                 }
             };
 
-            using compressed_pair<BaseIter, Adapt>::first;
-            using compressed_pair<BaseIter, Adapt>::second;
+            using base_t::first;
+            using base_t::second;
 
             template<typename A = Adapt, typename R = decltype(
                 std::declval<A const &>().get(std::declval<BaseIter const &>()))>
@@ -310,7 +319,7 @@ namespace ranges
                 return indirect_move_(42);
             }
         public:
-            using compressed_pair<BaseIter, Adapt>::compressed_pair;
+            using base_t::base_t;
         };
 
         // Build a sentinel out of a sentinel into the adapted range, and an

--- a/test/algorithm/sample.cpp
+++ b/test/algorithm/sample.cpp
@@ -250,7 +250,7 @@ int main()
             sentinel<MoveOnlyString*, true>(dest.data() + dest.size()));
         auto result = ranges::sample(ranges::make_move_iterator(source.begin()),
             ranges::make_move_sentinel(source.end()), out);
-        CHECK(in_sequence(source.data(), result.in().base(), source.data() + source.size()));
+        CHECK(in_sequence(source.begin(), result.in().base(), source.end()));
         CHECK(result.out() == ranges::end(out));
     }
 


### PR DESCRIPTION
* Clang/C2 lies about `__has_builtin(__builtin_readcyclecounter)`
* alg.sample test compares array iterator with pointer.
* `view::const`:
  * const correctness (no joke) for `size`
  * Don't return references bound to temporary iterators. This is insane with sub-forward iterators, and may be on shaky ground for general proxy iterators. (Does the reference denote an object? Where does that object live? What is the required lifetime of a reference bound to an iterator?)
* `view::move`: Same.
* `noexcept` specifications for remaining `box` constructors.
* Make `view::single::cursor`'s value constructor explicit
* view/transform.hpp need not include zip_with.hpp ("zip" appears only in a comment.)
* `adaptor_cursor`: inherit `compressed_pair` via `detail::adaptor_value_type_` instead of directly to ensure that `detail::adaptor_value_type_::value_type` hides members of the same name in the compressed pair and its bases.
