### PR TITLE
[libc++] workaround underconstrained reverse_iterator::operator-

### DIFF
--- a/include/range/v3/utility/iterator_concepts.hpp
+++ b/include/range/v3/utility/iterator_concepts.hpp
@@ -643,4 +643,27 @@ namespace __gnu_debug
 
 #endif
 
+#if defined(_LIBCPP_VERSION) // TODO: && _LIBCPP_VERSION <= VERSION_THAT_FIXES_THIS
+// HACKHACK: workaround underconstrained operator- for libc++'s reverse_iterator
+// by disabling SizedSentinel if reverse_iterator is not a random access iterator.
+namespace ranges
+{
+
+    inline namespace v3
+    {
+
+        template<typename S, typename I>
+        struct disable_sized_sentinel<std::reverse_iterator<S>, std::reverse_iterator<I>>
+          : meta::not_<
+                meta::and_<std::is_same<typename std::reverse_iterator<S>::iterator_category,
+                                        std::random_access_iterator_tag>,
+                           std::is_same<typename std::reverse_iterator<I>::iterator_category,
+                                        std::random_access_iterator_tag>>>
+        {};
+
+    }
+}
+
+#endif  // _LIBCPP_VERSION
+
 #endif // RANGES_V3_UTILITY_ITERATOR_CONCEPTS_HPP


### PR DESCRIPTION
Libc++ reverse_iterator::operator- is non-conforming. 

Closes #420.