### PR TITLE
Use inline variables when available

### DIFF
--- a/include/range/v3/action/action.hpp
+++ b/include/range/v3/action/action.hpp
@@ -55,10 +55,7 @@ namespace ranges
 
             /// \ingroup group-actions
             /// \relates make_action_fn
-            namespace
-            {
-                constexpr auto&& make_action = static_const<make_action_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(make_action_fn, make_action)
 
             template<typename Action>
             struct action : pipeable<action<Action>>

--- a/include/range/v3/action/drop.hpp
+++ b/include/range/v3/action/drop.hpp
@@ -88,10 +88,7 @@ namespace ranges
             /// \ingroup group-actions
             /// \relates drop_fn
             /// \sa action
-            namespace
-            {
-                constexpr auto&& drop = static_const<action<drop_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(action<drop_fn>, drop)
         }
         /// @}
     }

--- a/include/range/v3/action/drop_while.hpp
+++ b/include/range/v3/action/drop_while.hpp
@@ -92,10 +92,7 @@ namespace ranges
             /// \ingroup group-actions
             /// \relates drop_while_fn
             /// \sa action
-            namespace
-            {
-                constexpr auto&& drop_while = static_const<action<drop_while_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(action<drop_while_fn>, drop_while)
         }
         /// @}
     }

--- a/include/range/v3/action/erase.hpp
+++ b/include/range/v3/action/erase.hpp
@@ -67,10 +67,7 @@ namespace ranges
         /// \endcond
 
         /// \ingroup group-actions
-        namespace
-        {
-            constexpr auto&& erase = static_const<adl_erase_detail::erase_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(adl_erase_detail::erase_fn, erase)
 
         namespace action
         {

--- a/include/range/v3/action/insert.hpp
+++ b/include/range/v3/action/insert.hpp
@@ -230,10 +230,7 @@ namespace ranges
         /// \endcond
 
         /// \ingroup group-actions
-        namespace
-        {
-            constexpr auto&& insert = static_const<adl_insert_detail::insert_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(adl_insert_detail::insert_fn, insert)
 
         namespace action
         {

--- a/include/range/v3/action/join.hpp
+++ b/include/range/v3/action/join.hpp
@@ -79,10 +79,7 @@ namespace ranges
             /// \ingroup group-actions
             /// \relates join_fn
             /// \sa action
-            namespace
-            {
-                constexpr auto&& join = static_const<action<join_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(action<join_fn>, join)
         }
         /// @}
     }

--- a/include/range/v3/action/push_back.hpp
+++ b/include/range/v3/action/push_back.hpp
@@ -104,10 +104,8 @@ namespace ranges
         {
             /// \ingroup group-actions
             /// \sa with_braced_init_args
-            namespace
-            {
-                constexpr auto&& push_back = static_const<with_braced_init_args<action<adl_push_back_detail::push_back_fn>>>::value;
-            }
+            RANGES_INLINE_VARIABLE(with_braced_init_args<action<adl_push_back_detail::push_back_fn>>,
+                                   push_back)
         }
 
         using action::push_back;

--- a/include/range/v3/action/push_front.hpp
+++ b/include/range/v3/action/push_front.hpp
@@ -104,10 +104,8 @@ namespace ranges
         {
             /// \ingroup group-actions
             /// \sa with_braced_init_args
-            namespace
-            {
-                constexpr auto&& push_front = static_const<with_braced_init_args<action<adl_push_front_detail::push_front_fn>>>::value;
-            }
+            RANGES_INLINE_VARIABLE(with_braced_init_args<action<adl_push_front_detail::push_front_fn>>,
+                                   push_front)
         }
 
         using action::push_front;

--- a/include/range/v3/action/remove_if.hpp
+++ b/include/range/v3/action/remove_if.hpp
@@ -99,10 +99,7 @@ namespace ranges
             /// \ingroup group-actions
             /// \sa action
             /// \sa with_braced_init_args
-            namespace
-            {
-                constexpr auto&& remove_if = static_const<action<remove_if_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(action<remove_if_fn>, remove_if)
         }
         /// @}
     }

--- a/include/range/v3/action/shuffle.hpp
+++ b/include/range/v3/action/shuffle.hpp
@@ -97,10 +97,7 @@ namespace ranges
             /// \ingroup group-actions
             /// \relates shuffle_fn
             /// \sa `action`
-            namespace
-            {
-                constexpr auto&& shuffle = static_const<action<shuffle_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(action<shuffle_fn>, shuffle)
         }
         /// @}
     }

--- a/include/range/v3/action/slice.hpp
+++ b/include/range/v3/action/slice.hpp
@@ -98,10 +98,7 @@ namespace ranges
             /// \ingroup group-actions
             /// \relates slice_fn
             /// \sa action
-            namespace
-            {
-                constexpr auto&& slice = static_const<action<slice_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(action<slice_fn>, slice)
         }
         /// @}
     }

--- a/include/range/v3/action/sort.hpp
+++ b/include/range/v3/action/sort.hpp
@@ -92,10 +92,7 @@ namespace ranges
             /// \ingroup group-actions
             /// \relates sort_fn
             /// \sa `action`
-            namespace
-            {
-                constexpr auto&& sort = static_const<action<sort_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(action<sort_fn>, sort)
         }
         /// @}
     }

--- a/include/range/v3/action/split.hpp
+++ b/include/range/v3/action/split.hpp
@@ -103,10 +103,7 @@ namespace ranges
             /// \ingroup group-actions
             /// \relates split_fn
             /// \sa action
-            namespace
-            {
-                constexpr auto&& split = static_const<action<split_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(action<split_fn>, split)
         }
         /// @}
     }

--- a/include/range/v3/action/stable_sort.hpp
+++ b/include/range/v3/action/stable_sort.hpp
@@ -92,10 +92,7 @@ namespace ranges
             /// \ingroup group-actions
             /// \relates stable_sort_fn
             /// \sa action
-            namespace
-            {
-                constexpr auto&& stable_sort = static_const<action<stable_sort_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(action<stable_sort_fn>, stable_sort)
         }
         /// @}
     }

--- a/include/range/v3/action/stride.hpp
+++ b/include/range/v3/action/stride.hpp
@@ -110,10 +110,7 @@ namespace ranges
             /// \ingroup group-actions
             /// \relates stride_fn
             /// \sa action
-            namespace
-            {
-                constexpr auto&& stride = static_const<action<stride_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(action<stride_fn>, stride)
         }
         /// @}
     }

--- a/include/range/v3/action/take.hpp
+++ b/include/range/v3/action/take.hpp
@@ -91,10 +91,7 @@ namespace ranges
             /// \ingroup group-actions
             /// \relates take_fn
             /// \sa action
-            namespace
-            {
-                constexpr auto&& take = static_const<action<take_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(action<take_fn>, take)
         }
         /// @}
     }

--- a/include/range/v3/action/take_while.hpp
+++ b/include/range/v3/action/take_while.hpp
@@ -93,10 +93,7 @@ namespace ranges
             /// \ingroup group-actions
             /// \relates take_while_fn
             /// \sa action
-            namespace
-            {
-                constexpr auto&& take_while = static_const<action<take_while_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(action<take_while_fn>, take_while)
         }
         /// @}
     }

--- a/include/range/v3/action/transform.hpp
+++ b/include/range/v3/action/transform.hpp
@@ -93,10 +93,7 @@ namespace ranges
             /// \ingroup group-actions
             /// \relates transform_fn
             /// \sa action
-            namespace
-            {
-                constexpr auto&& transform = static_const<action<transform_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(action<transform_fn>, transform)
         }
         /// @}
     }

--- a/include/range/v3/action/unique.hpp
+++ b/include/range/v3/action/unique.hpp
@@ -99,10 +99,7 @@ namespace ranges
             /// \ingroup group-actions
             /// \relates unique_fn
             /// \sa action
-            namespace
-            {
-                constexpr auto&& unique = static_const<action<unique_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(action<unique_fn>, unique)
         }
         /// @}
     }

--- a/include/range/v3/algorithm/adjacent_find.hpp
+++ b/include/range/v3/algorithm/adjacent_find.hpp
@@ -66,11 +66,8 @@ namespace ranges
 
         /// \sa `adjacent_find_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& adjacent_find = static_const<with_braced_init_args<adjacent_find_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<adjacent_find_fn>,
+                               adjacent_find)
         /// @}
 
     } // namespace v3

--- a/include/range/v3/algorithm/all_of.hpp
+++ b/include/range/v3/algorithm/all_of.hpp
@@ -57,11 +57,7 @@ namespace ranges
 
         /// \sa `all_of_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& all_of = static_const<with_braced_init_args<all_of_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<all_of_fn>, all_of)
         /// @}
 
     } // inline namespace v3

--- a/include/range/v3/algorithm/any_of.hpp
+++ b/include/range/v3/algorithm/any_of.hpp
@@ -58,11 +58,7 @@ namespace ranges
 
         /// \sa `any_of_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& any_of = static_const<with_braced_init_args<any_of_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<any_of_fn>, any_of)
         /// @}
     } // inline namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/aux_/equal_range_n.hpp
+++ b/include/range/v3/algorithm/aux_/equal_range_n.hpp
@@ -74,10 +74,7 @@ namespace ranges
                 }
             };
 
-            namespace
-            {
-                constexpr auto&& equal_range_n = static_const<equal_range_n_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(equal_range_n_fn, equal_range_n)
         }
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/aux_/lower_bound_n.hpp
+++ b/include/range/v3/algorithm/aux_/lower_bound_n.hpp
@@ -65,10 +65,7 @@ namespace ranges
                 }
             };
 
-            namespace
-            {
-                constexpr auto&& lower_bound_n = static_const<lower_bound_n_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(lower_bound_n_fn, lower_bound_n)
         }
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/aux_/merge_n.hpp
+++ b/include/range/v3/algorithm/aux_/merge_n.hpp
@@ -98,10 +98,7 @@ namespace ranges
                 }
             };
 
-            namespace
-            {
-                constexpr auto&& merge_n = static_const<merge_n_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(merge_n_fn, merge_n)
         }
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/aux_/merge_n_with_buffer.hpp
+++ b/include/range/v3/algorithm/aux_/merge_n_with_buffer.hpp
@@ -62,11 +62,7 @@ namespace ranges
                 }
             };
 
-            namespace
-            {
-                constexpr auto&& merge_n_with_buffer = static_const<merge_n_with_buffer_fn>::value;
-            }
-
+            RANGES_INLINE_VARIABLE(merge_n_with_buffer_fn, merge_n_with_buffer)
         } // namespace aux
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/aux_/partition_point_n.hpp
+++ b/include/range/v3/algorithm/aux_/partition_point_n.hpp
@@ -60,10 +60,7 @@ namespace ranges
                 }
             };
 
-            namespace
-            {
-                constexpr auto&& partition_point_n = static_const<partition_point_n_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(partition_point_n_fn, partition_point_n)
         }
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/aux_/sort_n_with_buffer.hpp
+++ b/include/range/v3/algorithm/aux_/sort_n_with_buffer.hpp
@@ -64,11 +64,7 @@ namespace ranges
                 }
             };
 
-            namespace
-            {
-                constexpr auto&& sort_n_with_buffer = static_const<sort_n_with_buffer_fn>::value;
-            }
-
+            RANGES_INLINE_VARIABLE(sort_n_with_buffer_fn, sort_n_with_buffer)
         } // namespace aux
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/aux_/upper_bound_n.hpp
+++ b/include/range/v3/algorithm/aux_/upper_bound_n.hpp
@@ -70,10 +70,7 @@ namespace ranges
                 }
             };
 
-            namespace
-            {
-                constexpr auto&& upper_bound_n = static_const<upper_bound_n_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(upper_bound_n_fn, upper_bound_n)
         }
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/binary_search.hpp
+++ b/include/range/v3/algorithm/binary_search.hpp
@@ -65,11 +65,8 @@ namespace ranges
 
         /// \sa `binary_search_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& binary_search = static_const<with_braced_init_args<binary_search_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<binary_search_fn>,
+                               binary_search)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/copy.hpp
+++ b/include/range/v3/algorithm/copy.hpp
@@ -67,11 +67,7 @@ namespace ranges
 
         /// \sa `copy_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& copy = static_const<with_braced_init_args<copy_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<copy_fn>, copy)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/copy_backward.hpp
+++ b/include/range/v3/algorithm/copy_backward.hpp
@@ -63,11 +63,8 @@ namespace ranges
 
         /// \sa `copy_backward_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& copy_backward = static_const<with_braced_init_args<copy_backward_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<copy_backward_fn>,
+                               copy_backward)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/copy_if.hpp
+++ b/include/range/v3/algorithm/copy_if.hpp
@@ -68,11 +68,7 @@ namespace ranges
 
         /// \sa `copy_if_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& copy_if = static_const<with_braced_init_args<copy_if_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<copy_if_fn>, copy_if)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/copy_n.hpp
+++ b/include/range/v3/algorithm/copy_n.hpp
@@ -56,11 +56,7 @@ namespace ranges
 
         /// \sa `copy_n_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& copy_n = static_const<with_braced_init_args<copy_n_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<copy_n_fn>, copy_n)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/count.hpp
+++ b/include/range/v3/algorithm/count.hpp
@@ -58,11 +58,8 @@ namespace ranges
 
         /// \sa `count_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& count = static_const<with_braced_init_args<with_braced_init_args<count_fn>>>::value;
-        }
-
+      RANGES_INLINE_VARIABLE(with_braced_init_args<with_braced_init_args<count_fn>>,
+                               count)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/count_if.hpp
+++ b/include/range/v3/algorithm/count_if.hpp
@@ -58,11 +58,7 @@ namespace ranges
 
         /// \sa `count_if_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& count_if = static_const<with_braced_init_args<count_if_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<count_if_fn>, count_if)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/equal.hpp
+++ b/include/range/v3/algorithm/equal.hpp
@@ -118,11 +118,7 @@ namespace ranges
 
         /// \sa `equal_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& equal = static_const<with_braced_init_args<equal_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<equal_fn>, equal)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/equal_range.hpp
+++ b/include/range/v3/algorithm/equal_range.hpp
@@ -120,11 +120,7 @@ namespace ranges
 
         /// \sa `equal_range_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& equal_range = static_const<with_braced_init_args<equal_range_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<equal_range_fn>, equal_range)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/fill.hpp
+++ b/include/range/v3/algorithm/fill.hpp
@@ -48,11 +48,7 @@ namespace ranges
 
         /// \sa `fill_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& fill = static_const<with_braced_init_args<fill_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<fill_fn>, fill)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/fill_n.hpp
+++ b/include/range/v3/algorithm/fill_n.hpp
@@ -45,11 +45,7 @@ namespace ranges
 
         /// \sa `fill_n_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& fill_n = static_const<fill_n_fn>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(fill_n_fn, fill_n)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/find.hpp
+++ b/include/range/v3/algorithm/find.hpp
@@ -65,11 +65,7 @@ namespace ranges
 
         /// \sa `find_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& find = static_const<with_braced_init_args<find_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<find_fn>, find)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/find_end.hpp
+++ b/include/range/v3/algorithm/find_end.hpp
@@ -193,11 +193,7 @@ namespace ranges
 
         /// \sa `find_end_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& find_end = static_const<with_braced_init_args<find_end_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<find_end_fn>, find_end)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/find_first_of.hpp
+++ b/include/range/v3/algorithm/find_first_of.hpp
@@ -69,11 +69,8 @@ namespace ranges
 
         /// \sa `find_first_of_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& find_first_of = static_const<with_braced_init_args<find_first_of_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<find_first_of_fn>,
+                               find_first_of)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/find_if.hpp
+++ b/include/range/v3/algorithm/find_if.hpp
@@ -68,11 +68,7 @@ namespace ranges
 
         /// \sa `find_if_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& find_if = static_const<with_braced_init_args<find_if_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<find_if_fn>, find_if)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/find_if_not.hpp
+++ b/include/range/v3/algorithm/find_if_not.hpp
@@ -68,11 +68,7 @@ namespace ranges
 
         /// \sa `find_if_not_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& find_if_not = static_const<with_braced_init_args<find_if_not_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<find_if_not_fn>, find_if_not)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/for_each.hpp
+++ b/include/range/v3/algorithm/for_each.hpp
@@ -55,11 +55,7 @@ namespace ranges
 
         /// \sa `for_each_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& for_each = static_const<with_braced_init_args<for_each_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<for_each_fn>, for_each)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/generate.hpp
+++ b/include/range/v3/algorithm/generate.hpp
@@ -55,11 +55,7 @@ namespace ranges
 
         /// \sa `generate_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& generate = static_const<with_braced_init_args<generate_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<generate_fn>, generate)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/generate_n.hpp
+++ b/include/range/v3/algorithm/generate_n.hpp
@@ -50,11 +50,7 @@ namespace ranges
 
         /// \sa `generate_n_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& generate_n = static_const<generate_n_fn>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(generate_n_fn, generate_n)
         // @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/heap_algorithm.hpp
+++ b/include/range/v3/algorithm/heap_algorithm.hpp
@@ -75,10 +75,7 @@ namespace ranges
                 }
             };
 
-            namespace
-            {
-                constexpr auto&& is_heap_until_n = static_const<is_heap_until_n_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(is_heap_until_n_fn, is_heap_until_n)
 
             struct is_heap_n_fn
             {
@@ -90,10 +87,7 @@ namespace ranges
                 }
             };
 
-            namespace
-            {
-                constexpr auto&& is_heap_n = static_const<is_heap_n_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(is_heap_n_fn, is_heap_n)
         }
         /// \endcond
 
@@ -121,10 +115,8 @@ namespace ranges
 
         /// \sa `is_heap_until_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& is_heap_until = static_const<with_braced_init_args<is_heap_until_fn>>::value;
-        }
+        RANGES_INLINE_VARIABLE(with_braced_init_args<is_heap_until_fn>,
+                               is_heap_until)
 
         struct is_heap_fn
         {
@@ -147,10 +139,7 @@ namespace ranges
 
         /// \sa `is_heap_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& is_heap = static_const<with_braced_init_args<is_heap_fn>>::value;
-        }
+        RANGES_INLINE_VARIABLE(with_braced_init_args<is_heap_fn>, is_heap)
         /// @}
 
         /// \cond
@@ -186,10 +175,7 @@ namespace ranges
                 }
             };
 
-            namespace
-            {
-                constexpr auto&& sift_up_n = static_const<sift_up_n_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(sift_up_n_fn, sift_up_n)
 
             struct sift_down_n_fn
             {
@@ -248,10 +234,7 @@ namespace ranges
                 }
             };
 
-            namespace
-            {
-                constexpr auto&& sift_down_n = static_const<sift_down_n_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(sift_down_n_fn, sift_down_n)
         }
         /// \endcond
 
@@ -282,10 +265,7 @@ namespace ranges
 
         /// \sa `push_heap_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& push_heap = static_const<with_braced_init_args<push_heap_fn>>::value;
-        }
+        RANGES_INLINE_VARIABLE(with_braced_init_args<push_heap_fn>, push_heap)
         /// @}
 
         /// \cond
@@ -306,10 +286,7 @@ namespace ranges
                 }
             };
 
-            namespace
-            {
-                constexpr auto&& pop_heap_n = static_const<pop_heap_n_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(pop_heap_n_fn, pop_heap_n)
         }
         /// \endcond
 
@@ -340,10 +317,7 @@ namespace ranges
 
         /// \sa `pop_heap_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& pop_heap = static_const<with_braced_init_args<pop_heap_fn>>::value;
-        }
+        RANGES_INLINE_VARIABLE(with_braced_init_args<pop_heap_fn>, pop_heap)
 
         struct make_heap_fn
         {
@@ -380,10 +354,7 @@ namespace ranges
 
         /// \sa `make_heap_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& make_heap = static_const<with_braced_init_args<make_heap_fn>>::value;
-        }
+        RANGES_INLINE_VARIABLE(with_braced_init_args<make_heap_fn>, make_heap)
 
         struct sort_heap_fn
         {
@@ -416,11 +387,7 @@ namespace ranges
 
         /// \sa `sort_heap_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& sort_heap = static_const<with_braced_init_args<sort_heap_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<sort_heap_fn>, sort_heap)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/inplace_merge.hpp
+++ b/include/range/v3/algorithm/inplace_merge.hpp
@@ -175,10 +175,7 @@ namespace ranges
                 }
             };
 
-            namespace
-            {
-                constexpr auto&& merge_adaptive = static_const<merge_adaptive_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(merge_adaptive_fn, merge_adaptive)
 
             struct inplace_merge_no_buffer_fn
             {
@@ -192,10 +189,8 @@ namespace ranges
                 }
             };
 
-            namespace
-            {
-                constexpr auto&& inplace_merge_no_buffer = static_const<inplace_merge_no_buffer_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(inplace_merge_no_buffer_fn,
+                                   inplace_merge_no_buffer)
         }
         /// \endcond
 
@@ -238,11 +233,8 @@ namespace ranges
 
         /// \sa `inplace_merge_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& inplace_merge = static_const<with_braced_init_args<inplace_merge_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<inplace_merge_fn>,
+                               inplace_merge)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/is_partitioned.hpp
+++ b/include/range/v3/algorithm/is_partitioned.hpp
@@ -71,11 +71,8 @@ namespace ranges
 
         /// \sa `is_partitioned_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& is_partitioned = static_const<with_braced_init_args<is_partitioned_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<is_partitioned_fn>,
+                               is_partitioned)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/is_sorted.hpp
+++ b/include/range/v3/algorithm/is_sorted.hpp
@@ -60,11 +60,7 @@ namespace ranges
 
         /// \sa `is_sorted_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& is_sorted = static_const<with_braced_init_args<is_sorted_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<is_sorted_fn>, is_sorted)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/is_sorted_until.hpp
+++ b/include/range/v3/algorithm/is_sorted_until.hpp
@@ -73,11 +73,8 @@ namespace ranges
 
         /// \sa `is_sorted_until_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& is_sorted_until = static_const<with_braced_init_args<is_sorted_until_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<is_sorted_until_fn>,
+                               is_sorted_until)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/lexicographical_compare.hpp
+++ b/include/range/v3/algorithm/lexicographical_compare.hpp
@@ -66,11 +66,8 @@ namespace ranges
 
         /// \sa `lexicographical_compare_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& lexicographical_compare = static_const<with_braced_init_args<lexicographical_compare_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<lexicographical_compare_fn>,
+                               lexicographical_compare)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/lower_bound.hpp
+++ b/include/range/v3/algorithm/lower_bound.hpp
@@ -55,11 +55,7 @@ namespace ranges
 
         /// \sa `lower_bound_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& lower_bound = static_const<with_braced_init_args<lower_bound_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<lower_bound_fn>, lower_bound)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/max.hpp
+++ b/include/range/v3/algorithm/max.hpp
@@ -72,11 +72,7 @@ namespace ranges
 
         /// \sa `max_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& max = static_const<with_braced_init_args<max_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<max_fn>, max)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/max_element.hpp
+++ b/include/range/v3/algorithm/max_element.hpp
@@ -57,11 +57,7 @@ namespace ranges
 
         /// \sa `max_element_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& max_element = static_const<with_braced_init_args<max_element_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<max_element_fn>, max_element)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/merge.hpp
+++ b/include/range/v3/algorithm/merge.hpp
@@ -100,11 +100,7 @@ namespace ranges
 
         /// \sa `merge_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& merge = static_const<with_braced_init_args<merge_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<merge_fn>, merge)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/min.hpp
+++ b/include/range/v3/algorithm/min.hpp
@@ -72,11 +72,7 @@ namespace ranges
 
         /// \sa `min_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& min = static_const<with_braced_init_args<min_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<min_fn>, min)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/min_element.hpp
+++ b/include/range/v3/algorithm/min_element.hpp
@@ -57,11 +57,7 @@ namespace ranges
 
         /// \sa `min_element_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& min_element = static_const<with_braced_init_args<min_element_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<min_element_fn>, min_element)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/minmax.hpp
+++ b/include/range/v3/algorithm/minmax.hpp
@@ -108,11 +108,7 @@ namespace ranges
 
         /// \sa `minmax_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& minmax = static_const<with_braced_init_args<minmax_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<minmax_fn>, minmax)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/minmax_element.hpp
+++ b/include/range/v3/algorithm/minmax_element.hpp
@@ -98,11 +98,7 @@ namespace ranges
 
         /// \sa `minmax_element_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& minmax_element = static_const<with_braced_init_args<minmax_element_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<minmax_element_fn>, minmax_element)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/mismatch.hpp
+++ b/include/range/v3/algorithm/mismatch.hpp
@@ -108,10 +108,7 @@ namespace ranges
 
         /// \sa `mismatch_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& mismatch = static_const<with_braced_init_args<mismatch_fn>>::value;
-        }
+        RANGES_INLINE_VARIABLE(with_braced_init_args<mismatch_fn>, mismatch)
 
         // [*] In this case, the 'begin2' iterator is taken by universal reference. Why? So
         // that we can properly distinguish this case:

--- a/include/range/v3/algorithm/move.hpp
+++ b/include/range/v3/algorithm/move.hpp
@@ -59,11 +59,7 @@ namespace ranges
 
         /// \sa `move_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& move = static_const<with_braced_init_args<move_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<move_fn>, move)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/move_backward.hpp
+++ b/include/range/v3/algorithm/move_backward.hpp
@@ -57,11 +57,7 @@ namespace ranges
 
         /// \sa `move_backward_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& move_backward = static_const<with_braced_init_args<move_backward_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<move_backward_fn>, move_backward)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/none_of.hpp
+++ b/include/range/v3/algorithm/none_of.hpp
@@ -58,11 +58,7 @@ namespace ranges
 
         /// \sa `none_of_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& none_of = static_const<with_braced_init_args<none_of_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<none_of_fn>, none_of)
         /// @}
     } // inline namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/nth_element.hpp
+++ b/include/range/v3/algorithm/nth_element.hpp
@@ -311,11 +311,7 @@ namespace ranges
 
         /// \sa `nth_element_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& nth_element = static_const<with_braced_init_args<nth_element_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<nth_element_fn>, nth_element)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/partial_sort.hpp
+++ b/include/range/v3/algorithm/partial_sort.hpp
@@ -68,11 +68,8 @@ namespace ranges
 
         /// \sa `partial_sort_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& partial_sort = static_const<with_braced_init_args<partial_sort_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<partial_sort_fn>,
+                               partial_sort)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/partial_sort_copy.hpp
+++ b/include/range/v3/algorithm/partial_sort_copy.hpp
@@ -91,11 +91,7 @@ namespace ranges
 
         /// \sa `partial_sort_copy_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& partial_sort_copy = static_const<with_braced_init_args<partial_sort_copy_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<partial_sort_copy_fn>, partial_sort_copy)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/partition.hpp
+++ b/include/range/v3/algorithm/partition.hpp
@@ -118,11 +118,7 @@ namespace ranges
 
         /// \sa `partition_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& partition = static_const<with_braced_init_args<partition_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<partition_fn>, partition)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/partition_copy.hpp
+++ b/include/range/v3/algorithm/partition_copy.hpp
@@ -83,11 +83,8 @@ namespace ranges
 
         /// \sa `partition_copy_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& partition_copy = static_const<with_braced_init_args<partition_copy_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<partition_copy_fn>,
+                               partition_copy)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/partition_point.hpp
+++ b/include/range/v3/algorithm/partition_point.hpp
@@ -103,11 +103,7 @@ namespace ranges
 
         /// \sa `partition_point_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& partition_point = static_const<with_braced_init_args<partition_point_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<partition_point_fn>, partition_point)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/permutation.hpp
+++ b/include/range/v3/algorithm/permutation.hpp
@@ -198,10 +198,8 @@ namespace ranges
 
         /// \sa `is_permutation_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& is_permutation = static_const<with_braced_init_args<is_permutation_fn>>::value;
-        }
+        RANGES_INLINE_VARIABLE(with_braced_init_args<is_permutation_fn>,
+                               is_permutation)
 
         struct next_permutation_fn
         {
@@ -247,10 +245,8 @@ namespace ranges
 
         /// \sa `next_permutation_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& next_permutation = static_const<with_braced_init_args<next_permutation_fn>>::value;
-        }
+        RANGES_INLINE_VARIABLE(with_braced_init_args<next_permutation_fn>,
+                               next_permutation)
 
         struct prev_permutation_fn
         {
@@ -296,11 +292,8 @@ namespace ranges
 
         /// \sa `prev_permutation_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& prev_permutation = static_const<with_braced_init_args<prev_permutation_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<prev_permutation_fn>,
+                               prev_permutation)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/remove.hpp
+++ b/include/range/v3/algorithm/remove.hpp
@@ -71,10 +71,7 @@ namespace ranges
 
         /// \sa `remove_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& remove = static_const<with_braced_init_args<remove_fn>>::value;
-        }
+        RANGES_INLINE_VARIABLE(with_braced_init_args<remove_fn>, remove)
 
         /// @}
     } // namespace v3

--- a/include/range/v3/algorithm/remove_copy.hpp
+++ b/include/range/v3/algorithm/remove_copy.hpp
@@ -69,11 +69,7 @@ namespace ranges
 
         /// \sa `remove_copy_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& remove_copy = static_const<with_braced_init_args<remove_copy_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<remove_copy_fn>, remove_copy)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/remove_copy_if.hpp
+++ b/include/range/v3/algorithm/remove_copy_if.hpp
@@ -70,11 +70,8 @@ namespace ranges
 
         /// \sa `remove_copy_if_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& remove_copy_if = static_const<with_braced_init_args<remove_copy_if_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<remove_copy_if_fn>,
+                               remove_copy_if)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/remove_if.hpp
+++ b/include/range/v3/algorithm/remove_if.hpp
@@ -72,11 +72,7 @@ namespace ranges
 
         /// \sa `remove_if_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& remove_if = static_const<with_braced_init_args<remove_if_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<remove_if_fn>, remove_if)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/replace.hpp
+++ b/include/range/v3/algorithm/replace.hpp
@@ -61,11 +61,7 @@ namespace ranges
 
         /// \sa `replace_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& replace = static_const<with_braced_init_args<replace_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<replace_fn>, replace)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/replace_copy.hpp
+++ b/include/range/v3/algorithm/replace_copy.hpp
@@ -71,11 +71,8 @@ namespace ranges
 
         /// \sa `replace_copy_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& replace_copy = static_const<with_braced_init_args<replace_copy_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<replace_copy_fn>,
+                               replace_copy)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/replace_copy_if.hpp
+++ b/include/range/v3/algorithm/replace_copy_if.hpp
@@ -71,11 +71,8 @@ namespace ranges
 
         /// \sa `replace_copy_if_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& replace_copy_if = static_const<with_braced_init_args<replace_copy_if_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<replace_copy_if_fn>,
+                               replace_copy_if)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/replace_if.hpp
+++ b/include/range/v3/algorithm/replace_if.hpp
@@ -62,11 +62,7 @@ namespace ranges
 
         /// \sa `replace_if_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& replace_if = static_const<with_braced_init_args<replace_if_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<replace_if_fn>, replace_if)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/reverse.hpp
+++ b/include/range/v3/algorithm/reverse.hpp
@@ -72,11 +72,7 @@ namespace ranges
 
         /// \sa `reverse_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& reverse = static_const<with_braced_init_args<reverse_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<reverse_fn>, reverse)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/reverse_copy.hpp
+++ b/include/range/v3/algorithm/reverse_copy.hpp
@@ -62,11 +62,8 @@ namespace ranges
 
         /// \sa `reverse_copy_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& reverse_copy = static_const<with_braced_init_args<reverse_copy_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<reverse_copy_fn>,
+                               reverse_copy)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/rotate.hpp
+++ b/include/range/v3/algorithm/rotate.hpp
@@ -217,11 +217,7 @@ namespace ranges
 
         /// \sa `rotate_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& rotate = static_const<with_braced_init_args<rotate_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<rotate_fn>, rotate)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/rotate_copy.hpp
+++ b/include/range/v3/algorithm/rotate_copy.hpp
@@ -59,11 +59,7 @@ namespace ranges
 
         /// \sa `rotate_copy_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& rotate_copy = static_const<with_braced_init_args<rotate_copy_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<rotate_copy_fn>, rotate_copy)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/sample.hpp
+++ b/include/range/v3/algorithm/sample.hpp
@@ -196,10 +196,7 @@ namespace ranges
 
         /// \sa `sample_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& sample = static_const<with_braced_init_args<sample_fn>>::value;
-        }
+        RANGES_INLINE_VARIABLE(with_braced_init_args<sample_fn>, sample)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/search.hpp
+++ b/include/range/v3/algorithm/search.hpp
@@ -173,11 +173,7 @@ namespace ranges
 
         /// \sa `search_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& search = static_const<with_braced_init_args<search_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<search_fn>, search)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/search_n.hpp
+++ b/include/range/v3/algorithm/search_n.hpp
@@ -155,11 +155,7 @@ namespace ranges
 
         /// \sa `search_n_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& search_n = static_const<with_braced_init_args<search_n_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<search_n_fn>, search_n)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/set_algorithm.hpp
+++ b/include/range/v3/algorithm/set_algorithm.hpp
@@ -80,10 +80,7 @@ namespace ranges
 
         /// \sa `includes_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& includes = static_const<with_braced_init_args<includes_fn>>::value;
-        }
+        RANGES_INLINE_VARIABLE(with_braced_init_args<includes_fn>, includes)
 
         struct set_union_fn
         {
@@ -141,10 +138,7 @@ namespace ranges
 
         /// \sa `set_union_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& set_union = static_const<with_braced_init_args<set_union_fn>>::value;
-        }
+        RANGES_INLINE_VARIABLE(with_braced_init_args<set_union_fn>, set_union)
 
         struct set_intersection_fn
         {
@@ -192,10 +186,8 @@ namespace ranges
 
         /// \sa `set_intersection_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& set_intersection = static_const<with_braced_init_args<set_intersection_fn>>::value;
-        }
+        RANGES_INLINE_VARIABLE(with_braced_init_args<set_intersection_fn>,
+                               set_intersection)
 
         struct set_difference_fn
         {
@@ -245,10 +237,8 @@ namespace ranges
 
         /// \sa `set_difference_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& set_difference = static_const<with_braced_init_args<set_difference_fn>>::value;
-        }
+        RANGES_INLINE_VARIABLE(with_braced_init_args<set_difference_fn>,
+                               set_difference)
 
         struct set_symmetric_difference_fn
         {
@@ -308,11 +298,8 @@ namespace ranges
 
         /// \sa `set_symmetric_difference_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& set_symmetric_difference = static_const<with_braced_init_args<set_symmetric_difference_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<set_symmetric_difference_fn>,
+                               set_symmetric_difference)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/shuffle.hpp
+++ b/include/range/v3/algorithm/shuffle.hpp
@@ -70,11 +70,7 @@ namespace ranges
 
         /// \sa `shuffle_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& shuffle = static_const<with_braced_init_args<shuffle_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<shuffle_fn>, shuffle)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/sort.hpp
+++ b/include/range/v3/algorithm/sort.hpp
@@ -202,11 +202,7 @@ namespace ranges
 
         /// \sa `sort_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& sort = static_const<with_braced_init_args<sort_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<sort_fn>, sort)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/stable_partition.hpp
+++ b/include/range/v3/algorithm/stable_partition.hpp
@@ -286,11 +286,8 @@ namespace ranges
 
         /// \sa `stable_partition_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& stable_partition = static_const<with_braced_init_args<stable_partition_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<stable_partition_fn>,
+                               stable_partition)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/stable_sort.hpp
+++ b/include/range/v3/algorithm/stable_sort.hpp
@@ -185,11 +185,7 @@ namespace ranges
 
         /// \sa `stable_sort_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& stable_sort = static_const<with_braced_init_args<stable_sort_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<stable_sort_fn>, stable_sort)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/swap_ranges.hpp
+++ b/include/range/v3/algorithm/swap_ranges.hpp
@@ -79,11 +79,7 @@ namespace ranges
 
         /// \sa `swap_ranges_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& swap_ranges = static_const<with_braced_init_args<swap_ranges_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<swap_ranges_fn>, swap_ranges)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/transform.hpp
+++ b/include/range/v3/algorithm/transform.hpp
@@ -143,11 +143,7 @@ namespace ranges
 
         /// \sa `transform_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& transform = static_const<with_braced_init_args<transform_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<transform_fn>, transform)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/unique.hpp
+++ b/include/range/v3/algorithm/unique.hpp
@@ -72,11 +72,7 @@ namespace ranges
 
         /// \sa `unique_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& unique = static_const<with_braced_init_args<unique_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<unique_fn>, unique)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/unique_copy.hpp
+++ b/include/range/v3/algorithm/unique_copy.hpp
@@ -148,11 +148,7 @@ namespace ranges
 
         /// \sa `unique_copy_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& unique_copy = static_const<with_braced_init_args<unique_copy_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<unique_copy_fn>, unique_copy)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/algorithm/upper_bound.hpp
+++ b/include/range/v3/algorithm/upper_bound.hpp
@@ -55,11 +55,7 @@ namespace ranges
 
         /// \sa `upper_bound_fn`
         /// \ingroup group-algorithms
-        namespace
-        {
-            constexpr auto&& upper_bound = static_const<with_braced_init_args<upper_bound_fn>>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(with_braced_init_args<upper_bound_fn>, upper_bound)
         /// @}
     } // namespace v3
 } // namespace ranges

--- a/include/range/v3/at.hpp
+++ b/include/range/v3/at.hpp
@@ -41,10 +41,7 @@ namespace ranges
 
         /// \ingroup group-core
         /// \sa `at_fn`
-        namespace
-        {
-            constexpr auto&& at = static_const<at_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(at_fn, at)
     }
 }
 

--- a/include/range/v3/back.hpp
+++ b/include/range/v3/back.hpp
@@ -40,10 +40,7 @@ namespace ranges
 
         /// \ingroup group-core
         /// \sa `back_fn`
-        namespace
-        {
-            constexpr auto&& back = static_const<back_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(back_fn, back)
     }
 }
 

--- a/include/range/v3/begin_end.hpp
+++ b/include/range/v3/begin_end.hpp
@@ -217,15 +217,35 @@ namespace ranges
                     return ranges::reverse_iterator<T const*>(il.begin());
                 }
             };
+        }
+        /// \endcond
 
+        /// \ingroup group-core
+        /// \return The result of an unqualified call to the `begin` free function
+        RANGES_INLINE_VARIABLE(begin_fn, begin)
+
+        /// \ingroup group-core
+        /// \return The result of an unqualified call to the `end` free function
+        RANGES_INLINE_VARIABLE(end_fn, end)
+
+        /// \ingroup group-core
+        /// \return The result of an unqualified call to the `rbegin` free function
+        RANGES_INLINE_VARIABLE(rbegin_fn, rbegin)
+
+        /// \ingroup group-core
+        /// \return The result of an unqualified call to the `rend` free function
+        RANGES_INLINE_VARIABLE(rend_fn, rend)
+
+        namespace adl_begin_end_detail
+        {
             struct cbegin_fn
             {
                 template<typename Rng>
                 constexpr auto operator()(Rng const & rng) const
-                    noexcept(noexcept(static_const<begin_fn>::value(rng))) ->
-                    decltype(static_const<begin_fn>::value(rng))
+                  noexcept(noexcept(::ranges::begin(rng)))
+                  -> decltype(::ranges::begin(rng))
                 {
-                    return static_const<begin_fn>::value(rng);
+                    return ::ranges::begin(rng);
                 }
             };
 
@@ -233,10 +253,10 @@ namespace ranges
             {
                 template<typename Rng>
                 constexpr auto operator()(Rng const & rng) const
-                    noexcept(noexcept(static_const<end_fn>::value(rng))) ->
-                    decltype(static_const<end_fn>::value(rng))
+                  noexcept(noexcept(::ranges::end(rng)))
+                  -> decltype(::ranges::end(rng))
                 {
-                    return static_const<end_fn>::value(rng);
+                    return ::ranges::end(rng);
                 }
             };
 
@@ -244,10 +264,10 @@ namespace ranges
             {
                 template<typename Rng>
                 constexpr auto operator()(Rng const & rng) const
-                    noexcept(noexcept(static_const<rbegin_fn>::value(rng))) ->
-                    decltype(static_const<rbegin_fn>::value(rng))
+                  noexcept(noexcept(::ranges::rbegin(rng)))
+                  -> decltype(::ranges::rbegin(rng))
                 {
-                    return static_const<rbegin_fn>::value(rng);
+                    return ::ranges::rbegin(rng);
                 }
             };
 
@@ -255,74 +275,33 @@ namespace ranges
             {
                 template<typename Rng>
                 constexpr auto operator()(Rng const & rng) const
-                    noexcept(noexcept(static_const<rend_fn>::value(rng))) ->
-                    decltype(static_const<rend_fn>::value(rng))
+                  noexcept(noexcept(::ranges::rend(rng)))
+                  -> decltype(::ranges::rend(rng))
                 {
-                    return static_const<rend_fn>::value(rng);
+                    return ::ranges::rend(rng);
                 }
             };
         }
-        /// \endcond
-
-        /// \ingroup group-core
-        /// \return The result of an unqualified call to the `begin` free function
-        RANGES_GCC_BROKEN_CUSTPOINT namespace
-        {
-            constexpr auto&& begin = static_const<begin_fn>::value;
-        }
-
-        /// \ingroup group-core
-        /// \return The result of an unqualified call to the `end` free function
-        RANGES_GCC_BROKEN_CUSTPOINT namespace
-        {
-            constexpr auto&& end = static_const<end_fn>::value;
-        }
 
         /// \ingroup group-core
         /// \return The result of an unqualified call to the `begin` free function
         /// with a const-qualified argument.
-        RANGES_GCC_BROKEN_CUSTPOINT namespace
-        {
-            constexpr auto&& cbegin = static_const<cbegin_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(cbegin_fn, cbegin)
 
         /// \ingroup group-core
         /// \return The result of an unqualified call to the `end` free function
         /// with a const-qualified argument.
-        RANGES_GCC_BROKEN_CUSTPOINT namespace
-        {
-            constexpr auto&& cend = static_const<cend_fn>::value;
-        }
-
-        /// \ingroup group-core
-        /// \return The result of an unqualified call to the `rbegin` free function
-        RANGES_GCC_BROKEN_CUSTPOINT namespace
-        {
-            constexpr auto&& rbegin = static_const<rbegin_fn>::value;
-        }
-
-        /// \ingroup group-core
-        /// \return The result of an unqualified call to the `rend` free function
-        RANGES_GCC_BROKEN_CUSTPOINT namespace
-        {
-            constexpr auto&& rend = static_const<rend_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(cend_fn, cend)
 
         /// \ingroup group-core
         /// \return The result of an unqualified call to the `rbegin` free function
         /// with a const-qualified argument.
-        RANGES_GCC_BROKEN_CUSTPOINT namespace
-        {
-            constexpr auto&& crbegin = static_const<crbegin_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(crbegin_fn, crbegin)
 
         /// \ingroup group-core
         /// \return The result of an unqualified call to the `rend` free function
         /// with a const-qualified argument.
-        RANGES_GCC_BROKEN_CUSTPOINT namespace
-        {
-            constexpr auto&& crend = static_const<crend_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(crend_fn, crend)
 
         /// \ingroup group-core
         struct safe_begin_fn
@@ -353,18 +332,12 @@ namespace ranges
         /// \ingroup group-core
         /// \return `begin(rng)` if `rng` is an lvalue; otherwise, it returns `begin(rng)`
         /// wrapped in \c ranges::dangling.
-        RANGES_GCC_BROKEN_CUSTPOINT namespace
-        {
-            constexpr auto&& safe_begin = static_const<safe_begin_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(safe_begin_fn, safe_begin)
 
         /// \ingroup group-core
         /// \return `end(rng)` if `rng` is an lvalue; otherwise, it returns `end(rng)`
         /// wrapped in \c ranges::dangling.
-        RANGES_GCC_BROKEN_CUSTPOINT namespace
-        {
-            constexpr auto&& safe_end = static_const<safe_end_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(safe_end_fn, safe_end)
     }
 }
 

--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -282,14 +282,38 @@
 #define RANGES_NDEBUG_CONSTEXPR inline
 #endif
 
-// Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70552
-#if defined(__GNUC__) && !defined(__clang__) && \
-    ((__GNUC__ == 4 && __GNUC_MINOR__ == 9 && __GNUC_PATCHLEVEL__ >= 4) || \
-     (__GNUC__ == 5 && __GNUC_MINOR__ >= 3))
-#define RANGES_GCC_BROKEN_CUSTPOINT inline
+#define RANGES_CXX_INLINE_VARIABLES_11 0
+#define RANGES_CXX_INLINE_VARIABLES_14 0
+#define RANGES_CXX_INLINE_VARIABLES_17 201606
+#ifndef RANGES_CXX_INLINE_VARIABLES
+
+#ifdef __cpp_inline_variables // TODO: fix this if SD-6 picks another name
+#define RANGES_CXX_INLINE_VARIABLES __cpp_inline_variables
+#elif defined(__clang__) && \
+    (__clang__major__ > 3 || __clang_major__ == 3 && __clang_minor__ == 9) && \
+    __cplusplus > 201402L
+// TODO: remove once clang defines __cpp_inline_variables (or equivalent)
+#define RANGES_CXX_INLINE_VARIABLES RANGES_CXX_INLINE_VARIABLES_17
 #else
-#define RANGES_GCC_BROKEN_CUSTPOINT
-#endif
+#define RANGES_CXX_INLINE_VARIABLES RANGES_CXX_FEATURE(INLINE_VARIABLES)
+#endif  // __cpp_inline_variables
+
+#endif  // RANGES_CXX_INLINE_VARIABLES
+
+#if RANGES_CXX_INLINE_VARIABLES < RANGES_CXX_INLINE_VARIABLES_17
+#define RANGES_INLINE_VARIABLE(type, name)                  \
+    inline namespace                   \
+    {                                                       \
+        constexpr auto& name = static_const<type>::value;   \
+    }                                                     
+
+#else  // RANGES_CXX_INLINE_VARIABLES >= RANGES_CXX_INLINE_VARIABLES_17
+#define RANGES_INLINE_VARIABLE(type, name) \
+    inline namespace function_objects             \
+    {                                      \
+        inline constexpr type name{};      \
+    }
+#endif // RANGES_CXX_INLINE_VARIABLES
 
 #ifdef RANGES_FEWER_WARNINGS
 #define RANGES_DISABLE_WARNINGS                 \

--- a/include/range/v3/detail/optional.hpp
+++ b/include/range/v3/detail/optional.hpp
@@ -25,10 +25,7 @@ namespace ranges
     {
         /// \ingroup group-utility
         struct in_place_t {};
-        namespace
-        {
-            constexpr auto &in_place = static_const<in_place_t>::value;
-        }
+        RANGES_INLINE_VARIABLE(in_place_t, in_place)
 
         template<typename T>
         struct optional

--- a/include/range/v3/detail/variant.hpp
+++ b/include/range/v3/detail/variant.hpp
@@ -52,11 +52,21 @@ namespace ranges
     #define RANGES_EMPLACED_INDEX_T(I) _emplaced_index_t_<I>
     #else
         /// \endcond
-        namespace
+
+    #if RANGES_CXX_INLINE_VARIABLES < RANGES_CXX_INLINE_VARIABLES_17
+        inline namespace
+        {
+            template <std::size_t I>
+            constexpr auto& emplaced_index = static_const<emplaced_index_t<I>>::value;
+        }
+    #else // RANGES_CXX_INLINE_VARIABLES >= RANGES_CXX_INLINE_VARIABLES_17
+        inline namespace function_objects
         {
             template<std::size_t I>
-            constexpr auto &emplaced_index = static_const<emplaced_index_t<I>>::value;
+            inline constexpr emplaced_index_t<I> emplaced_index{};
         }
+    #endif  // RANGES_CXX_INLINE_VARIABLES
+
         /// \cond
     #define RANGES_EMPLACED_INDEX_T(I) emplaced_index_t<I>
     #endif

--- a/include/range/v3/distance.hpp
+++ b/include/range/v3/distance.hpp
@@ -62,10 +62,7 @@ namespace ranges
 
         /// \ingroup group-core
         /// \sa `enumerate_fn`
-        namespace
-        {
-            constexpr auto&& enumerate = static_const<enumerate_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(enumerate_fn, enumerate)
 
         struct distance_fn : iter_distance_fn
         {
@@ -95,10 +92,7 @@ namespace ranges
 
         /// \ingroup group-core
         /// \sa `distance_fn`
-        namespace
-        {
-            constexpr auto&& distance = static_const<distance_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(distance_fn, distance)
 
         // The interface of distance_compare is taken from Util.listLengthCmp in the GHC API.
         struct distance_compare_fn : iter_distance_compare_fn
@@ -141,11 +135,7 @@ namespace ranges
 
         /// \ingroup group-core
         /// \sa `distance_compare_fn`
-        namespace
-        {
-            constexpr auto&& distance_compare = static_const<distance_compare_fn>::value;
-        }
-
+        RANGES_INLINE_VARIABLE(distance_compare_fn, distance_compare)
         /// @}
     }
 }

--- a/include/range/v3/empty.hpp
+++ b/include/range/v3/empty.hpp
@@ -38,10 +38,7 @@ namespace ranges
 
         /// \ingroup group-core
         /// \sa `empty_fn`
-        namespace
-        {
-            constexpr auto&& empty = static_const<empty_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(empty_fn, empty)
     }
 }
 

--- a/include/range/v3/front.hpp
+++ b/include/range/v3/front.hpp
@@ -40,10 +40,7 @@ namespace ranges
 
         /// \ingroup group-core
         /// \sa `front_fn`
-        namespace
-        {
-            constexpr auto&& front = static_const<front_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(front_fn, front)
     }
 }
 

--- a/include/range/v3/getlines.hpp
+++ b/include/range/v3/getlines.hpp
@@ -89,10 +89,7 @@ namespace ranges
             }
         };
 
-        namespace
-        {
-            constexpr auto && getlines = static_const<getlines_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(getlines_fn, getlines)
         /// @}
     }
 }

--- a/include/range/v3/istream_range.hpp
+++ b/include/range/v3/istream_range.hpp
@@ -107,12 +107,21 @@ namespace ranges
             }
         };
 
-        namespace
+    #if RANGES_CXX_INLINE_VARIABLES < RANGES_CXX_INLINE_VARIABLES_17
+        inline namespace
         {
-            template<typename Val>
-            constexpr auto && istream = static_const<istream_fn<Val>>::value;
+            template <typename Val>
+            constexpr auto& istream = static_const<istream_fn<Val>>::value;
         }
-    #endif
+    #else  // RANGES_CXX_INLINE_VARIABLES >= RANGES_CXX_INLINE_VARIABLES_17
+        inline namespace function_objects
+        {
+            template <typename Val>
+            inline constexpr istream_fn<Val> istream{};
+        }
+    #endif  // RANGES_CXX_INLINE_VARIABLES
+
+    #endif  // RANGES_CXX_VARIABLE_TEMPLATES
         /// @}
     }
 }

--- a/include/range/v3/iterator_range.hpp
+++ b/include/range/v3/iterator_range.hpp
@@ -187,10 +187,7 @@ namespace ranges
 
         /// \ingroup group-core
         /// \sa `make_iterator_range_fn`
-        namespace
-        {
-            constexpr auto&& make_iterator_range = static_const<make_iterator_range_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(make_iterator_range_fn, make_iterator_range)
 
         /// Tuple-like access for `sized_iterator_range`
         template<std::size_t N, typename I, typename S,

--- a/include/range/v3/numeric/accumulate.hpp
+++ b/include/range/v3/numeric/accumulate.hpp
@@ -59,10 +59,7 @@ namespace ranges
             }
         };
 
-        namespace
-        {
-            constexpr auto&& accumulate = static_const<with_braced_init_args<accumulate_fn>>::value;
-        }
+        RANGES_INLINE_VARIABLE(with_braced_init_args<accumulate_fn>, accumulate)
     }
 }
 

--- a/include/range/v3/numeric/adjacent_difference.hpp
+++ b/include/range/v3/numeric/adjacent_difference.hpp
@@ -128,10 +128,7 @@ namespace ranges
             }
         };
 
-        namespace
-        {
-            constexpr auto&& adjacent_difference = static_const<adjacent_difference_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(adjacent_difference_fn, adjacent_difference)
     }
 }
 

--- a/include/range/v3/numeric/inner_product.hpp
+++ b/include/range/v3/numeric/inner_product.hpp
@@ -120,10 +120,8 @@ namespace ranges
             }
         };
 
-        namespace
-        {
-            constexpr auto&& inner_product = static_const<with_braced_init_args<inner_product_fn>>::value;
-        }
+        RANGES_INLINE_VARIABLE(with_braced_init_args<inner_product_fn>,
+                               inner_product)
     }
 }
 

--- a/include/range/v3/numeric/iota.hpp
+++ b/include/range/v3/numeric/iota.hpp
@@ -43,10 +43,7 @@ namespace ranges
             }
         };
 
-        namespace
-        {
-            constexpr auto&& iota = static_const<iota_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(iota_fn, iota)
     }
 }
 

--- a/include/range/v3/numeric/partial_sum.hpp
+++ b/include/range/v3/numeric/partial_sum.hpp
@@ -123,10 +123,7 @@ namespace ranges
             }
         };
 
-        namespace
-        {
-            constexpr auto&& partial_sum = static_const<partial_sum_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(partial_sum_fn, partial_sum)
     }
 }
 

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -42,6 +42,28 @@ namespace ranges
 {
     inline namespace v3
     {
+        inline namespace function_objects {}
+
+        namespace aux
+        {
+            inline namespace function_objects {}
+        }
+
+        namespace view
+        {
+            inline namespace function_objects {}
+        }
+
+        namespace action
+        {
+            inline namespace function_objects {}
+        }
+
+        namespace detail
+        {
+            inline namespace function_objects {}
+        }
+
         /// \cond
         namespace adl_begin_end_detail
         {

--- a/include/range/v3/size.hpp
+++ b/include/range/v3/size.hpp
@@ -99,10 +99,7 @@ namespace ranges
 
         /// \ingroup group-core
         /// \return The result of an unqualified call to `size`
-        RANGES_GCC_BROKEN_CUSTPOINT namespace
-        {
-            constexpr auto&& size = static_const<adl_size_detail::size_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(adl_size_detail::size_fn, size)
     }
 }
 

--- a/include/range/v3/to_container.hpp
+++ b/include/range/v3/to_container.hpp
@@ -98,10 +98,9 @@ namespace ranges
         /// @{
 
         /// \ingroup group-core
-        namespace
-        {
-            constexpr auto&& to_vector = static_const<detail::to_container_fn<meta::quote<std::vector>>>::value;
-        }
+        RANGES_INLINE_VARIABLE(detail::to_container_fn<meta::quote<std::vector>>,
+                               to_vector)
+
 
         /// \brief For initializing a container of the specified type with the elements of an Range
         template<template<typename...> class ContT>

--- a/include/range/v3/utility/basic_iterator.hpp
+++ b/include/range/v3/utility/basic_iterator.hpp
@@ -715,10 +715,7 @@ namespace ranges
 
         /// \sa `get_cursor_fn`
         /// \ingroup group-utility
-        namespace
-        {
-            constexpr auto &&get_cursor = static_const<get_cursor_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(get_cursor_fn, get_cursor)
         /// @}
 
         /// \cond

--- a/include/range/v3/utility/common_tuple.hpp
+++ b/include/range/v3/utility/common_tuple.hpp
@@ -189,10 +189,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `make_common_tuple_fn`
-        namespace
-        {
-            constexpr auto&& make_common_tuple = static_const<make_common_tuple_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(make_common_tuple_fn, make_common_tuple)
 
         template<typename F, typename S>
         struct common_pair
@@ -379,10 +376,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `make_common_pair_fn`
-        namespace
-        {
-            constexpr auto&& make_common_pair = static_const<make_common_pair_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(make_common_pair_fn, make_common_pair)
 
         /// \cond
         namespace detail

--- a/include/range/v3/utility/compressed_pair.hpp
+++ b/include/range/v3/utility/compressed_pair.hpp
@@ -95,10 +95,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `make_compressed_tuple_fn`
-        namespace
-        {
-            constexpr auto&& make_compressed_tuple = static_const<make_compressed_tuple_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(make_compressed_tuple_fn, make_compressed_tuple)
 
         template<typename... Ts>
         using tagged_compressed_tuple =
@@ -142,10 +139,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `make_compressed_pair_fn`
-        namespace
-        {
-            constexpr auto&& make_compressed_pair = static_const<make_compressed_pair_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(make_compressed_pair_fn, make_compressed_pair)
     }
 }
 

--- a/include/range/v3/utility/copy.hpp
+++ b/include/range/v3/utility/copy.hpp
@@ -38,10 +38,7 @@ namespace ranges
 
             /// \ingroup group-utility
             /// \sa `copy_fn`
-            namespace
-            {
-                constexpr auto&& copy = static_const<copy_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(copy_fn, copy)
 
             /// \ingroup group-utility
             /// \sa `copy_fn`

--- a/include/range/v3/utility/dangling.hpp
+++ b/include/range/v3/utility/dangling.hpp
@@ -186,19 +186,13 @@ namespace ranges
         /// \ingroup group-core
         /// \return \c t.get_unsafe() if \p t is an instance of `ranges::dangling`; otherwise,
         /// return \p t.
-        namespace
-        {
-            constexpr auto&& get_unsafe = static_const<get_unsafe_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(get_unsafe_fn, get_unsafe)
 
         /// \ingroup group-core
         /// \return the result of replacing all \c ranges::dangling<T> objects with
         /// \c ranges::dangling<void>, introspecting \c std::pair and \c std::tuple
         /// objects recursively.
-        namespace
-        {
-            constexpr auto&& sanitize = static_const<sanitize_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(sanitize_fn, sanitize)
     }
 }
 

--- a/include/range/v3/utility/functional.hpp
+++ b/include/range/v3/utility/functional.hpp
@@ -255,10 +255,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `make_invokable_fn`
-        namespace
-        {
-            constexpr auto&& as_function = static_const<as_function_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(as_function_fn, as_function)
 
         template<typename T>
         using function_type = decltype(as_function(std::declval<T>()));
@@ -356,10 +353,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `not_fn`
-        namespace
-        {
-            constexpr auto&& not_ = static_const<not_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(not_fn, not_)
 
         template<typename Second, typename First>
         struct composed
@@ -431,10 +425,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `compose_fn`
-        namespace
-        {
-            constexpr auto&& compose = static_const<compose_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(compose_fn, compose)
 
         template<>
         struct overloaded<>
@@ -506,10 +497,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `overload_fn`
-        namespace
-        {
-            constexpr auto&& overload = static_const<overload_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(overload_fn, overload)
 
         template<typename Fn>
         struct indirected
@@ -573,10 +561,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `indirect_fn`
-        namespace
-        {
-            constexpr auto&& indirect = static_const<indirect_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(indirect_fn, indirect)
 
         template<typename Fn1, typename Fn2>
         struct transformed
@@ -621,10 +606,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `on_fn`
-        namespace
-        {
-            constexpr auto&& on = static_const<on_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(on_fn, on)
 
         /// \cond
         namespace detail
@@ -665,10 +647,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `make_pipeable_fn`
-        namespace
-        {
-            constexpr auto&& make_pipeable = static_const<make_pipeable_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(make_pipeable_fn, make_pipeable)
 
         template<typename T,
             typename U = meta::if_<
@@ -882,10 +861,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `ref_fn`
-        namespace
-        {
-            constexpr auto&& ref = static_const<ref_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(ref_fn, ref)
 
         template<typename T>
         using ref_t = decltype(ref(std::declval<T>()));
@@ -909,10 +885,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `rref_fn`
-        namespace
-        {
-            constexpr auto&& rref = static_const<rref_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(rref_fn, rref)
 
         template<typename T>
         using rref_t = decltype(rref(std::declval<T>()));
@@ -940,10 +913,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `unwrap_reference_fn`
-        namespace
-        {
-            constexpr auto&& unwrap_reference = static_const<unwrap_reference_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(unwrap_reference_fn, unwrap_reference)
 
         template<typename T>
         using unwrap_reference_t = decltype(unwrap_reference(std::declval<T>()));
@@ -997,10 +967,7 @@ namespace ranges
         /// accidentally becoming a "nested" bind.
         /// \ingroup group-utility
         /// \sa `protect_fn`
-        namespace
-        {
-            constexpr auto&& protect = static_const<protect_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(protect_fn, protect)
 
         // Accepts initializer_lists as either the first or second parameter, or both,
         // and forwards on to an implementation.

--- a/include/range/v3/utility/iterator.hpp
+++ b/include/range/v3/utility/iterator.hpp
@@ -140,10 +140,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `advance_fn`
-        namespace
-        {
-            constexpr auto&& advance = static_const<adl_advance_detail::advance_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(adl_advance_detail::advance_fn,advance)
 
         namespace adl_advance_detail
         {
@@ -240,10 +237,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `next_fn`
-        namespace
-        {
-            constexpr auto&& next = static_const<next_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(next_fn, next)
 
         struct prev_fn
         {
@@ -259,10 +253,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `prev_fn`
-        namespace
-        {
-            constexpr auto&& prev = static_const<prev_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(prev_fn, prev)
 
         struct iter_enumerate_fn
         {
@@ -307,10 +298,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `iter_enumerate_fn`
-        namespace
-        {
-            constexpr auto&& iter_enumerate = static_const<iter_enumerate_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(iter_enumerate_fn, iter_enumerate)
 
         struct iter_distance_fn
         {
@@ -342,10 +330,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `iter_distance_fn`
-        namespace
-        {
-            constexpr auto&& iter_distance = static_const<iter_distance_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(iter_distance_fn, iter_distance)
 
         struct iter_distance_compare_fn
         {
@@ -392,10 +377,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `iter_distance_compare_fn`
-        namespace
-        {
-            constexpr auto&& iter_distance_compare = static_const<iter_distance_compare_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(iter_distance_compare_fn, iter_distance_compare)
 
         // Like distance(b,e), but guaranteed to be O(1)
         struct iter_size_fn
@@ -412,10 +394,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `iter_size_fn`
-        namespace
-        {
-            constexpr auto&& iter_size = static_const<iter_size_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(iter_size_fn, iter_size)
 
         struct iter_swap_fn
         {
@@ -431,10 +410,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `iter_swap_fn`
-        namespace
-        {
-            constexpr auto&& iter_swap = static_const<iter_swap_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(iter_swap_fn, iter_swap)
 
         struct iter_move_fn
         {
@@ -450,10 +426,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `iter_move_fn`
-        namespace
-        {
-            constexpr auto&& iter_move = static_const<iter_move_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(iter_move_fn, iter_move)
 
         /// \cond
         namespace detail
@@ -507,10 +480,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `back_inserter_fn`
-        namespace
-        {
-            constexpr auto&& back_inserter = static_const<back_inserter_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(back_inserter_fn, back_inserter)
 
         /// \cond
         namespace detail
@@ -564,10 +534,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `front_inserter_fn`
-        namespace
-        {
-            constexpr auto&& front_inserter = static_const<front_inserter_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(front_inserter_fn, front_inserter)
 
         /// \cond
         namespace detail
@@ -622,10 +589,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `inserter_fn`
-        namespace
-        {
-            constexpr auto&& inserter = static_const<inserter_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(inserter_fn, inserter)
 
         template<typename T = void, typename Char = char, typename Traits = std::char_traits<Char>>
         struct ostream_iterator
@@ -853,10 +817,7 @@ namespace ranges
             }
         };
 
-        namespace
-        {
-            constexpr auto &&make_move_iterator = static_const<make_move_iterator_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(make_move_iterator_fn, make_move_iterator)
 
         template<typename S>
         struct move_sentinel
@@ -930,10 +891,7 @@ namespace ranges
             }
         };
 
-        namespace
-        {
-            constexpr auto &&make_move_sentinel = static_const<make_move_sentinel_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(make_move_sentinel_fn, make_move_sentinel)
 
         /// \cond
         namespace detail
@@ -1042,10 +1000,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `move_into_fn`
-        namespace
-        {
-            constexpr auto&& move_into = static_const<move_into_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(move_into_fn, move_into)
         /// @}
 
         /// \cond
@@ -1089,11 +1044,10 @@ namespace ranges
 
         /// \addtogroup group-utility
         /// @{
-        namespace
-        {
-            constexpr auto&& uncounted = static_const<adl_uncounted_recounted_detail::uncounted_fn>::value;
-            constexpr auto&& recounted = static_const<adl_uncounted_recounted_detail::recounted_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(adl_uncounted_recounted_detail::uncounted_fn,
+                               uncounted)
+        RANGES_INLINE_VARIABLE(adl_uncounted_recounted_detail::recounted_fn,
+                               recounted)
         /// @}
     }
 }

--- a/include/range/v3/utility/move.hpp
+++ b/include/range/v3/utility/move.hpp
@@ -40,10 +40,7 @@ namespace ranges
 
             /// \ingroup group-utility
             /// \sa `move_fn`
-            namespace
-            {
-                constexpr auto&& move = static_const<move_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(move_fn, move)
 
             /// \ingroup group-utility
             /// \sa `move_fn`
@@ -90,11 +87,7 @@ namespace ranges
         }
         /// \endcond
 
-        namespace
-        {
-            constexpr auto&& indirect_move =
-                static_const<adl_move_detail::indirect_move_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(adl_move_detail::indirect_move_fn, indirect_move)
 
         namespace detail
         {

--- a/include/range/v3/utility/static_const.hpp
+++ b/include/range/v3/utility/static_const.hpp
@@ -20,6 +20,7 @@ namespace ranges
     inline namespace v3
     {
         /// \ingroup group-utility
+        
         template<typename T>
         struct static_const
         {

--- a/include/range/v3/utility/swap.hpp
+++ b/include/range/v3/utility/swap.hpp
@@ -257,17 +257,11 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \relates adl_swap_detail::swap_fn
-        RANGES_GCC_BROKEN_CUSTPOINT namespace
-        {
-            constexpr auto&& swap = static_const<adl_swap_detail::swap_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(adl_swap_detail::swap_fn, swap)
 
         /// \ingroup group-utility
         /// \relates adl_swap_detail::indirect_swap_fn
-        RANGES_GCC_BROKEN_CUSTPOINT namespace
-        {
-            constexpr auto&& indirect_swap = static_const<adl_swap_detail::indirect_swap_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(adl_swap_detail::indirect_swap_fn, indirect_swap)
     }
 }
 

--- a/include/range/v3/utility/tuple_algorithm.hpp
+++ b/include/range/v3/utility/tuple_algorithm.hpp
@@ -55,10 +55,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `tuple_apply_fn`
-        namespace
-        {
-            constexpr auto&& tuple_apply = static_const<tuple_apply_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(tuple_apply_fn, tuple_apply)
 
         struct tuple_transform_fn
         {
@@ -98,10 +95,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `tuple_transform_fn`
-        namespace
-        {
-            constexpr auto&& tuple_transform = static_const<tuple_transform_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(tuple_transform_fn, tuple_transform)
 
         struct tuple_foldl_fn
         {
@@ -139,10 +133,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `tuple_foldl_fn`
-        namespace
-        {
-            constexpr auto&& tuple_foldl = static_const<tuple_foldl_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(tuple_foldl_fn, tuple_foldl)
 
         struct tuple_for_each_fn
         {
@@ -165,10 +156,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `tuple_for_each_fn`
-        namespace
-        {
-            constexpr auto&& tuple_for_each = static_const<tuple_for_each_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(tuple_for_each_fn, tuple_for_each)
 
         struct make_tuple_fn
         {
@@ -182,10 +170,7 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `make_tuple_fn`
-        namespace
-        {
-            constexpr auto&& make_tuple = static_const<make_tuple_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(make_tuple_fn, make_tuple)
         /// @}
     }
 }

--- a/include/range/v3/view/adjacent_filter.hpp
+++ b/include/range/v3/view/adjacent_filter.hpp
@@ -124,10 +124,7 @@ namespace ranges
 
             /// \relates adjacent_filter_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& adjacent_filter = static_const<view<adjacent_filter_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<adjacent_filter_fn>, adjacent_filter)
         }
         /// @}
     }

--- a/include/range/v3/view/adjacent_remove_if.hpp
+++ b/include/range/v3/view/adjacent_remove_if.hpp
@@ -161,10 +161,7 @@ namespace ranges
 
             /// \relates adjacent_remove_if_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& adjacent_remove_if = static_const<view<adjacent_remove_if_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<adjacent_remove_if_fn>, adjacent_remove_if)
         }
         /// @}
     }

--- a/include/range/v3/view/all.hpp
+++ b/include/range/v3/view/all.hpp
@@ -99,10 +99,7 @@ namespace ranges
 
             /// \relates all_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& all = static_const<all_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(all_fn, all)
 
             template<typename Rng>
             using all_t =

--- a/include/range/v3/view/bounded.hpp
+++ b/include/range/v3/view/bounded.hpp
@@ -130,10 +130,7 @@ namespace ranges
 
             /// \relates bounded_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& bounded = static_const<view<bounded_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<bounded_fn>, bounded)
 
             template<typename Rng>
             using bounded_t =

--- a/include/range/v3/view/c_str.hpp
+++ b/include/range/v3/view/c_str.hpp
@@ -115,10 +115,9 @@ namespace ranges
                 }
             };
 
-            namespace
-            {
-                constexpr auto&& c_str = static_const<c_str_fn>::value;
-            }
+            /// \relates c_str_fn
+            /// \ingroup group-views
+            RANGES_INLINE_VARIABLE(c_str_fn, c_str)
         }
     }
 }

--- a/include/range/v3/view/chunk.hpp
+++ b/include/range/v3/view/chunk.hpp
@@ -172,10 +172,9 @@ namespace ranges
             #endif
             };
 
-            namespace
-            {
-                constexpr auto &&chunk = static_const<view<chunk_fn>>::value;
-            }
+            /// \relates chunk_fn
+            /// \ingroup group-views
+            RANGES_INLINE_VARIABLE(view<chunk_fn>, chunk)
         }
         /// @}
     }

--- a/include/range/v3/view/concat.hpp
+++ b/include/range/v3/view/concat.hpp
@@ -331,10 +331,7 @@ namespace ranges
 
             /// \relates concat_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& concat = static_const<concat_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(concat_fn, concat)
         }
         /// @}
     }

--- a/include/range/v3/view/const.hpp
+++ b/include/range/v3/view/const.hpp
@@ -99,10 +99,7 @@ namespace ranges
 
             /// \relates const_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& const_ = static_const<view<const_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<const_fn>, const_)
         }
         /// @}
     }

--- a/include/range/v3/view/counted.hpp
+++ b/include/range/v3/view/counted.hpp
@@ -78,10 +78,7 @@ namespace ranges
 
             /// \relates counted_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& counted = static_const<counted_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(counted_fn, counted)
         }
         /// @}
     }

--- a/include/range/v3/view/cycle.hpp
+++ b/include/range/v3/view/cycle.hpp
@@ -229,11 +229,7 @@ namespace ranges
 
             /// \relates cycle_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto &&cycle = static_const<view<cycle_fn>>::value;
-            }
-
+            RANGES_INLINE_VARIABLE(view<cycle_fn>, cycle)
        } // namespace view
        /// @}
     } // namespace v3

--- a/include/range/v3/view/delimit.hpp
+++ b/include/range/v3/view/delimit.hpp
@@ -120,10 +120,7 @@ namespace ranges
 
             /// \relates delimit_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& delimit = static_const<delimit_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(delimit_fn, delimit)
         }
         /// @}
     }

--- a/include/range/v3/view/drop.hpp
+++ b/include/range/v3/view/drop.hpp
@@ -200,10 +200,7 @@ namespace ranges
 
             /// \relates drop_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& drop = static_const<view<drop_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<drop_fn>, drop)
         }
         /// @}
     }

--- a/include/range/v3/view/drop_exactly.hpp
+++ b/include/range/v3/view/drop_exactly.hpp
@@ -196,10 +196,7 @@ namespace ranges
 
             /// \relates drop_exactly_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& drop_exactly = static_const<view<drop_exactly_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<drop_exactly_fn>, drop_exactly)
         }
         /// @}
     }

--- a/include/range/v3/view/drop_while.hpp
+++ b/include/range/v3/view/drop_while.hpp
@@ -139,10 +139,7 @@ namespace ranges
 
             /// \relates drop_while_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& drop_while = static_const<view<drop_while_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<drop_while_fn>, drop_while)
         }
         /// @}
     }

--- a/include/range/v3/view/filter.hpp
+++ b/include/range/v3/view/filter.hpp
@@ -47,10 +47,7 @@ namespace ranges
 
             /// \relates filter_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& filter = static_const<filter_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(filter_fn, filter)
         }
     }
 }

--- a/include/range/v3/view/for_each.hpp
+++ b/include/range/v3/view/for_each.hpp
@@ -90,10 +90,7 @@ namespace ranges
 
             /// \relates for_each_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& for_each = static_const<view<for_each_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<for_each_fn>, for_each)
         }
 
         struct yield_fn
@@ -107,10 +104,7 @@ namespace ranges
 
         /// \relates yield_fn
         /// \ingroup group-views
-        namespace
-        {
-            constexpr auto&& yield = static_const<yield_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(yield_fn, yield)
 
         struct yield_from_fn
         {
@@ -123,10 +117,7 @@ namespace ranges
 
         /// \relates yield_from_fn
         /// \ingroup group-views
-        namespace
-        {
-            constexpr auto&& yield_from = static_const<yield_from_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(yield_from_fn, yield_from)
 
         struct yield_if_fn
         {
@@ -139,10 +130,7 @@ namespace ranges
 
         /// \relates yield_if_fn
         /// \ingroup group-views
-        namespace
-        {
-            constexpr auto&& yield_if = static_const<yield_if_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(yield_if_fn, yield_if)
 
         struct lazy_yield_if_fn
         {
@@ -156,10 +144,7 @@ namespace ranges
 
         /// \relates lazy_yield_if_fn
         /// \ingroup group-views
-        namespace
-        {
-            constexpr auto&& lazy_yield_if = static_const<lazy_yield_if_fn>::value;
-        }
+        RANGES_INLINE_VARIABLE(lazy_yield_if_fn, lazy_yield_if)
         /// @}
 
         /// \cond

--- a/include/range/v3/view/generate.hpp
+++ b/include/range/v3/view/generate.hpp
@@ -114,10 +114,7 @@ namespace ranges
 
             /// \relates generate_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& generate = static_const<generate_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(generate_fn, generate)
         }
         /// \@}
     }

--- a/include/range/v3/view/generate_n.hpp
+++ b/include/range/v3/view/generate_n.hpp
@@ -124,10 +124,7 @@ namespace ranges
 
             /// \relates generate_n_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& generate_n = static_const<generate_n_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(generate_n_fn, generate_n)
         }
         /// @}
     }

--- a/include/range/v3/view/group_by.hpp
+++ b/include/range/v3/view/group_by.hpp
@@ -156,10 +156,7 @@ namespace ranges
 
             /// \relates group_by_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& group_by = static_const<view<group_by_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<group_by_fn>, group_by)
         }
         /// @}
     }

--- a/include/range/v3/view/indirect.hpp
+++ b/include/range/v3/view/indirect.hpp
@@ -108,10 +108,7 @@ namespace ranges
 
             /// \relates indirect_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& indirect = static_const<view<indirect_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<indirect_fn>, indirect)
         }
         /// @}
     }

--- a/include/range/v3/view/intersperse.hpp
+++ b/include/range/v3/view/intersperse.hpp
@@ -188,10 +188,7 @@ namespace ranges
 
             /// \relates intersperse_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& intersperse = static_const<view<intersperse_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<intersperse_fn>, intersperse)
         }
     }
 }

--- a/include/range/v3/view/iota.hpp
+++ b/include/range/v3/view/iota.hpp
@@ -435,17 +435,11 @@ namespace ranges
 
             /// \relates iota_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& iota = static_const<iota_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(iota_fn, iota)
 
             /// \relates closed_iota_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& closed_iota = static_const<closed_iota_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(closed_iota_fn, closed_iota)
 
             struct ints_fn
               : iota_view<int>
@@ -512,17 +506,11 @@ namespace ranges
 
             /// \relates ints_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& ints = static_const<ints_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(ints_fn, ints)
 
             /// \relates closed_ints_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& closed_ints = static_const<closed_ints_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(closed_ints_fn, closed_ints)
         }
         /// @}
     }

--- a/include/range/v3/view/join.hpp
+++ b/include/range/v3/view/join.hpp
@@ -354,10 +354,7 @@ namespace ranges
 
             /// \relates join_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& join = static_const<view<join_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<join_fn>, join)
         }
         /// @}
     }

--- a/include/range/v3/view/map.hpp
+++ b/include/range/v3/view/map.hpp
@@ -114,17 +114,11 @@ namespace ranges
 
             /// \relates keys_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& keys = static_const<view<keys_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<keys_fn>, keys)
 
             /// \relates values_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& values = static_const<view<values_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<values_fn>, values)
         }
         /// @}
     }

--- a/include/range/v3/view/move.hpp
+++ b/include/range/v3/view/move.hpp
@@ -100,10 +100,7 @@ namespace ranges
 
             /// \relates move_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& move = static_const<view<move_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<move_fn>, move)
         }
         /// @}
     }

--- a/include/range/v3/view/partial_sum.hpp
+++ b/include/range/v3/view/partial_sum.hpp
@@ -171,10 +171,7 @@ namespace ranges
 
             /// \relates partial_sum_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& partial_sum = static_const<view<partial_sum_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<partial_sum_fn>, partial_sum)
         }
         /// @}
     }

--- a/include/range/v3/view/remove_if.hpp
+++ b/include/range/v3/view/remove_if.hpp
@@ -173,10 +173,7 @@ namespace ranges
 
             /// \relates remove_if_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& remove_if = static_const<view<remove_if_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<remove_if_fn>, remove_if)
         }
         /// @}
     }

--- a/include/range/v3/view/repeat.hpp
+++ b/include/range/v3/view/repeat.hpp
@@ -109,10 +109,7 @@ namespace ranges
 
             /// \relates repeat_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& repeat = static_const<repeat_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(repeat_fn, repeat)
         }
         /// @}
     }

--- a/include/range/v3/view/repeat_n.hpp
+++ b/include/range/v3/view/repeat_n.hpp
@@ -121,10 +121,7 @@ namespace ranges
 
             /// \relates repeat_n_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& repeat_n = static_const<repeat_n_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(repeat_n_fn, repeat_n)
         }
         /// @}
     }

--- a/include/range/v3/view/replace.hpp
+++ b/include/range/v3/view/replace.hpp
@@ -160,10 +160,7 @@ namespace ranges
 
             /// \relates replace_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& replace = static_const<view<replace_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<replace_fn>, replace)
         }
         /// @}
     }

--- a/include/range/v3/view/replace_if.hpp
+++ b/include/range/v3/view/replace_if.hpp
@@ -166,10 +166,7 @@ namespace ranges
 
             /// \relates replace_if_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& replace_if = static_const<view<replace_if_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<replace_if_fn>, replace_if)
         }
         /// @}
     }

--- a/include/range/v3/view/reverse.hpp
+++ b/include/range/v3/view/reverse.hpp
@@ -226,10 +226,7 @@ namespace ranges
 
             /// \relates reverse_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& reverse = static_const<view<reverse_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<reverse_fn>, reverse)
         }
         /// @}
     }

--- a/include/range/v3/view/sample.hpp
+++ b/include/range/v3/view/sample.hpp
@@ -243,10 +243,7 @@ namespace ranges
 
             /// \relates sample_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& sample = static_const<view<sample_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<sample_fn>, sample)
         }
         /// @}
     }

--- a/include/range/v3/view/set_algorithm.hpp
+++ b/include/range/v3/view/set_algorithm.hpp
@@ -248,10 +248,7 @@ namespace ranges
 
             /// \relates set_difference_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& set_difference = static_const<view<set_difference_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<set_difference_fn>, set_difference)
         }
         /// @}
 
@@ -422,10 +419,7 @@ namespace ranges
 
             /// \relates set_intersection_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& set_intersection = static_const<view<set_intersection_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<set_intersection_fn>, set_intersection)
         }
         /// @}
 
@@ -645,10 +639,7 @@ namespace ranges
 
             /// \relates set_union_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& set_union = static_const<view<set_union_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<set_union_fn>, set_union)
         }
         /// @}
 
@@ -874,10 +865,7 @@ namespace ranges
 
             /// \relates set_symmetric_difference_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& set_symmetric_difference = static_const<view<set_symmetric_difference_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<set_symmetric_difference_fn>, set_symmetric_difference)
         }
         /// @}
 

--- a/include/range/v3/view/single.hpp
+++ b/include/range/v3/view/single.hpp
@@ -118,10 +118,7 @@ namespace ranges
 
             /// \relates single_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& single = static_const<single_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(single_fn, single)
         }
         /// @}
     }

--- a/include/range/v3/view/slice.hpp
+++ b/include/range/v3/view/slice.hpp
@@ -406,10 +406,7 @@ namespace ranges
 
             /// \relates slice_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& slice = static_const<view<slice_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<slice_fn>, slice)
         }
         /// @}
     }

--- a/include/range/v3/view/split.hpp
+++ b/include/range/v3/view/split.hpp
@@ -272,10 +272,7 @@ namespace ranges
 
             /// \relates split_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& split = static_const<view<split_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<split_fn>, split)
         }
         /// @}
     }

--- a/include/range/v3/view/stride.hpp
+++ b/include/range/v3/view/stride.hpp
@@ -232,10 +232,7 @@ namespace ranges
 
             /// \relates stride_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& stride = static_const<view<stride_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<stride_fn>, stride)
         }
         /// @}
     }

--- a/include/range/v3/view/tail.hpp
+++ b/include/range/v3/view/tail.hpp
@@ -115,10 +115,7 @@ namespace ranges
 
             /// \relates tail_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& tail = static_const<view<tail_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<tail_fn>, tail)
         }
         /// @}
     }

--- a/include/range/v3/view/take.hpp
+++ b/include/range/v3/view/take.hpp
@@ -159,10 +159,7 @@ namespace ranges
 
             /// \relates take_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& take = static_const<view<take_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<take_fn>, take)
         }
         /// @}
     }

--- a/include/range/v3/view/take_exactly.hpp
+++ b/include/range/v3/view/take_exactly.hpp
@@ -203,10 +203,7 @@ namespace ranges
 
             /// \relates take_exactly_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& take_exactly = static_const<view<take_exactly_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<take_exactly_fn>, take_exactly)
         }
         /// @}
     }

--- a/include/range/v3/view/take_while.hpp
+++ b/include/range/v3/view/take_while.hpp
@@ -170,17 +170,11 @@ namespace ranges
 
             /// \relates iter_take_while_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& iter_take_while = static_const<view<iter_take_while_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<iter_take_while_fn>, iter_take_while)
 
             /// \relates take_while_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& take_while = static_const<view<take_while_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<take_while_fn>, take_while)
         }
         /// @}
     }

--- a/include/range/v3/view/tokenize.hpp
+++ b/include/range/v3/view/tokenize.hpp
@@ -202,10 +202,7 @@ namespace ranges
 
             /// \relates tokenize_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& tokenize = static_const<tokenize_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(tokenize_fn, tokenize)
         }
         /// @}
     }

--- a/include/range/v3/view/transform.hpp
+++ b/include/range/v3/view/transform.hpp
@@ -408,10 +408,7 @@ namespace ranges
 
             /// \relates iter_transform_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& iter_transform = static_const<view<iter_transform_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<iter_transform_fn>, iter_transform)
 
             struct transform_fn
             {
@@ -486,10 +483,7 @@ namespace ranges
 
             /// \relates transform_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& transform = static_const<view<transform_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<transform_fn>, transform)
         }
         /// @}
     }

--- a/include/range/v3/view/unbounded.hpp
+++ b/include/range/v3/view/unbounded.hpp
@@ -57,10 +57,7 @@ namespace ranges
 
             /// \relates unbounded_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& unbounded = static_const<unbounded_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(unbounded_fn, unbounded)
         }
         /// @}
     }

--- a/include/range/v3/view/unique.hpp
+++ b/include/range/v3/view/unique.hpp
@@ -60,10 +60,7 @@ namespace ranges
 
             /// \relates unique_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& unique = static_const<view<unique_fn>>::value;
-            }
+            RANGES_INLINE_VARIABLE(view<unique_fn>, unique)
         }
         /// @}
     }

--- a/include/range/v3/view/view.hpp
+++ b/include/range/v3/view/view.hpp
@@ -68,10 +68,7 @@ namespace ranges
 
             /// \ingroup group-views
             /// \sa make_view_fn
-            namespace
-            {
-                constexpr auto&& make_view = static_const<make_view_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(make_view_fn, make_view)
 
             template<typename Rng>
             using ViewableRange = meta::and_<

--- a/include/range/v3/view/zip.hpp
+++ b/include/range/v3/view/zip.hpp
@@ -136,10 +136,7 @@ namespace ranges
 
             /// \relates zip_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& zip = static_const<zip_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(zip_fn, zip)
         }
         /// @}
     }

--- a/include/range/v3/view/zip_with.hpp
+++ b/include/range/v3/view/zip_with.hpp
@@ -352,10 +352,7 @@ namespace ranges
 
             /// \relates iter_zip_with_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& iter_zip_with = static_const<iter_zip_with_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(iter_zip_with_fn, iter_zip_with)
 
             struct zip_with_fn
             {
@@ -392,10 +389,7 @@ namespace ranges
 
             /// \relates zip_with_fn
             /// \ingroup group-views
-            namespace
-            {
-                constexpr auto&& zip_with = static_const<zip_with_fn>::value;
-            }
+            RANGES_INLINE_VARIABLE(zip_with_fn, zip_with)
         }
         /// @}
     }


### PR DESCRIPTION
- adds RANGES_INLINE_VARIABLE(type, name); macro to declare inline variables
- deprecates static_const utility on all C++ versions
  - clients might be using it in their own code => deprecate for a while
  - adds a detail::inline_variable_ utility equivalent to static_const that
    is used internally in range-v3 and that clients are not supposed to use