### PR TITLE
[travis-ci] re-enables clang 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -175,49 +175,61 @@ matrix:
     #   addons: *clang37
 
     # Test clang-3.8: C++11/C++14, Build=Debug/Release, ASAN=On/Off
-    # - env: CLANG_VERSION=3.8 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
-    #   os: linux
-    #   addons: &clang38
-    #     apt:
-    #       packages:
-    #         - util-linux
-    #         - clang-3.8
-    #         - valgrind
-    #       sources:
-    #         - ubuntu-toolchain-r-test
-    #         - llvm-toolchain-precise-3.8
+    - env: CLANG_VERSION=3.8 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
+      os: linux
+      addons: &clang38
+        apt:
+          packages:
+            - util-linux
+            - clang-3.8
+            - valgrind
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.8
 
-    # - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
-    #   os: linux
-    #   addons: *clang38
+    # Release + ASAN + C++11/14/1z           
+    - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
+      os: linux
+      addons: *clang38
 
-    # - env: CLANG_VERSION=3.8 BUILD_TYPE=Debug CPP=14 ASAN=On LIBCXX=On
-    #   os: linux
-    #   addons: *clang3# 8
+    - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On
+      os: linux
+      addons: *clang38
 
-    # - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On
-    #   os: linux
-    #   addons: *clang38
+    - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=1z ASAN=On LIBCXX=On
+      os: linux
+      addons: *clang38
 
-    # - env: CLANG_VERSION=3.8 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
-    #   os: linux
-    #   addons: *clang38
+    # Release + Valgrind + C++11/14/1z           
+    - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
+      os: linux
+      addons: *clang38
 
-    # - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
-    #   os: linux
-    #   addons: *clang38
+    - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On
+      os: linux
+      addons: *clang38
 
-    # - env: CLANG_VERSION=3.8 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On
-    #   os: linux
-    #   addons: *clang38
+    - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=1z ASAN=Off LIBCXX=On
+      os: linux
+      addons: *clang38
 
-    # - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On
-    #   os: linux
-    #   addons: *clang38
+    # Debug + C++11/14/1z           
+    - env: CLANG_VERSION=3.8 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
+      os: linux
+      addons: *clang38
 
-    # - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off
-    #   os: linux
-    #   addons: *clang38
+    - env: CLANG_VERSION=3.8 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On
+      os: linux
+      addons: *clang38
+
+    - env: CLANG_VERSION=3.8 BUILD_TYPE=Debug CPP=1z ASAN=Off LIBCXX=On
+      os: linux
+      addons: *clang38
+
+    # Debug + C++11 + libstdc++
+    - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off
+      os: linux
+      addons: *clang38
 
     # Test gcc-4.8: C++11, Build=Debug/Release, ASAN=Off
     - env: GCC_VERSION=4.8 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=Off

--- a/.travis.yml
+++ b/.travis.yml
@@ -174,62 +174,62 @@ matrix:
     #   os: linux
     #   addons: *clang37
 
-    # Test clang-3.8: C++11/C++14, Build=Debug/Release, ASAN=On/Off
-    - env: CLANG_VERSION=3.8 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
+    # Test clang-3.9: C++11/C++14, Build=Debug/Release, ASAN=On/Off
+    - env: CLANG_VERSION=3.9 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
       os: linux
-      addons: &clang38
+      addons: &clang39
         apt:
           packages:
             - util-linux
-            - clang-3.8
+            - clang-3.9
             - valgrind
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.8
+            - llvm-toolchain-precise
 
     # Release + ASAN + C++11/14/1z           
-    - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
+    - env: CLANG_VERSION=3.9 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
       os: linux
-      addons: *clang38
+      addons: *clang39
 
-    - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On
+    - env: CLANG_VERSION=3.9 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On
       os: linux
-      addons: *clang38
+      addons: *clang39
 
-    - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=1z ASAN=On LIBCXX=On
+    - env: CLANG_VERSION=3.9 BUILD_TYPE=Release CPP=1z ASAN=On LIBCXX=On
       os: linux
-      addons: *clang38
+      addons: *clang39
 
     # Release + Valgrind + C++11/14/1z           
-    - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
+    - env: CLANG_VERSION=3.9 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
       os: linux
-      addons: *clang38
+      addons: *clang39
 
-    - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On
+    - env: CLANG_VERSION=3.9 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On
       os: linux
-      addons: *clang38
+      addons: *clang39
 
-    - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=1z ASAN=Off LIBCXX=On
+    - env: CLANG_VERSION=3.9 BUILD_TYPE=Release CPP=1z ASAN=Off LIBCXX=On
       os: linux
-      addons: *clang38
+      addons: *clang39
 
     # Debug + C++11/14/1z           
-    - env: CLANG_VERSION=3.8 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
+    - env: CLANG_VERSION=3.9 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
       os: linux
-      addons: *clang38
+      addons: *clang39
 
-    - env: CLANG_VERSION=3.8 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On
+    - env: CLANG_VERSION=3.9 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On
       os: linux
-      addons: *clang38
+      addons: *clang39
 
-    - env: CLANG_VERSION=3.8 BUILD_TYPE=Debug CPP=1z ASAN=Off LIBCXX=On
+    - env: CLANG_VERSION=3.9 BUILD_TYPE=Debug CPP=1z ASAN=Off LIBCXX=On
       os: linux
-      addons: *clang38
+      addons: *clang39
 
     # Debug + C++11 + libstdc++
-    - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off
+    - env: CLANG_VERSION=3.9 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off
       os: linux
-      addons: *clang38
+      addons: *clang39
 
     # Test gcc-4.8: C++11, Build=Debug/Release, ASAN=Off
     - env: GCC_VERSION=4.8 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=Off

--- a/include/meta/meta.hpp
+++ b/include/meta/meta.hpp
@@ -1965,8 +1965,17 @@ namespace meta
             template <typename... T, typename V>
             struct find_index_<list<T...>, V>
             {
+              #if defined(__clang__) && __cplusplus > 201402L
+                // work-around clang bug: https://llvm.org/bugs/show_bug.cgi?id=28385
+                static constexpr std::size_t index_() {
+                    constexpr bool s_v[] = {std::is_same<T, V>::value...};
+                    return find_index_i_(s_v, s_v + sizeof...(T));
+                }
+                using type = size_t<index_()>;
+              #else
                 static constexpr bool s_v[] = {std::is_same<T, V>::value...};
                 using type = size_t<find_index_i_(s_v, s_v + sizeof...(T))>;
+              #endif
             };
         } // namespace detail
         /// \endcond
@@ -2017,8 +2026,17 @@ namespace meta
             template <typename... T, typename V>
             struct reverse_find_index_<list<T...>, V>
             {
+              #if defined(__clang__) && __cplusplus > 201402L
+                // work-around clang bug: https://llvm.org/bugs/show_bug.cgi?id=28385
+                static constexpr std::size_t index_() {
+                    constexpr bool s_v[] = {std::is_same<T, V>::value...};
+                    return reverse_find_index_i_(s_v, s_v + sizeof...(T), sizeof...(T));
+                }
+                using type = size_t<index_()>;
+              #else
                 static constexpr bool s_v[] = {std::is_same<T, V>::value...};
                 using type = size_t<reverse_find_index_i_(s_v, s_v + sizeof...(T), sizeof...(T))>;
+              #endif
             };
         } // namespace detail
         /// \endcond
@@ -2104,9 +2122,18 @@ namespace meta
             struct find_if_<list<List...>, Fun,
                             void_<integer_sequence<bool, bool(invoke<Fun, List>::type::value)...>>>
             {
+              #if defined(__clang__) && __cplusplus > 201402L
+                // work-around clang bug: https://llvm.org/bugs/show_bug.cgi?id=28385
+                static constexpr std::size_t index_() {
+                    constexpr bool s_v[] = {invoke<Fun, List>::type::value...};
+                    return detail::find_if_i_(s_v, s_v + sizeof...(List)) - s_v;
+                }
+                using type = drop_c<list<List...>, index_()>;
+              #else
                 static constexpr bool s_v[] = {invoke<Fun, List>::type::value...};
                 using type =
                     drop_c<list<List...>, detail::find_if_i_(s_v, s_v + sizeof...(List)) - s_v>;
+              #endif
             };
         } // namespace detail
         /// \endcond
@@ -2159,11 +2186,20 @@ namespace meta
                 list<List...>, Fun,
                 void_<integer_sequence<bool, bool(invoke<Fun, List>::type::value)...>>>
             {
+              #if defined(__clang__) && __cplusplus > 201402L
+                // work-around clang bug: https://llvm.org/bugs/show_bug.cgi?id=28385
+                static constexpr std::size_t index_() {
+                    constexpr bool s_v[] = {invoke<Fun, List>::type::value...};
+                    return detail::reverse_find_if_i_(s_v, s_v + sizeof...(List),
+                                                      s_v + sizeof...(List)) - s_v;
+                }
+                using type = drop_c<list<List...>, index_()>;
+              #else
                 static constexpr bool s_v[] = {invoke<Fun, List>::type::value...};
                 using type =
-                    drop_c<list<List...>, detail::reverse_find_if_i_(s_v, s_v + sizeof...(List),
-                                                                     s_v + sizeof...(List)) -
-                                              s_v>;
+                  drop_c<list<List...>, detail::reverse_find_if_i_(s_v, s_v + sizeof...(List),
+                                                                   s_v + sizeof...(List)) - s_v>;
+              #endif
             };
         }
         /// \endcond
@@ -2282,8 +2318,17 @@ namespace meta
             template <typename... List, typename T>
             struct count_<list<List...>, T>
             {
+              #if defined(__clang__) && __cplusplus > 201402L
+                // work-around clang bug: https://llvm.org/bugs/show_bug.cgi?id=28385
+                static constexpr std::size_t count__() {
+                    constexpr bool s_v[] = {std::is_same<T, List>::value...};
+                    return detail::count_i_(s_v, s_v + sizeof...(List), 0u);
+                }
+                using type = meta::size_t<count__()>;
+              #else
                 static constexpr bool s_v[] = {std::is_same<T, List>::value...};
                 using type = meta::size_t<detail::count_i_(s_v, s_v + sizeof...(List), 0u)>;
+              #endif
             };
         }
 
@@ -2321,8 +2366,17 @@ namespace meta
             struct count_if_<list<List...>, Fn,
                              void_<integer_sequence<bool, bool(invoke<Fn, List>::type::value)...>>>
             {
+              #if defined(__clang__) && __cplusplus > 201402L
+                // work-around clang bug: https://llvm.org/bugs/show_bug.cgi?id=28385
+                static constexpr std::size_t count_() {
+                    constexpr bool s_v[] = {invoke<Fn, List>::type::value...};
+                    return detail::count_i_(s_v, s_v + sizeof...(List), 0u);
+                }
+                using type = meta::size_t<count_()>;
+              #else
                 static constexpr bool s_v[] = {invoke<Fn, List>::type::value...};
                 using type = meta::size_t<detail::count_i_(s_v, s_v + sizeof...(List), 0u)>;
+              #endif
             };
         }
 

--- a/install_libcxx.sh
+++ b/install_libcxx.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 #
 # Install libc++ under travis
-
-svn --quiet co http://llvm.org/svn/llvm-project/libcxx/trunk libcxx
+CMAKE_URL="http://www.cmake.org/files/v3.5/cmake-3.5.0-Linux-x86_64.tar.gz"
+wget ${CMAKE_URL} --no-check-certificate
+mkdir cmake
+tar -xzf cmake-3.5.0-Linux-x86_64.tar.gz -C cmake --strip-components=1
+git clone --depth=1 https://github.com/llvm-mirror/libcxx.git
 mkdir libcxx/build
-(cd libcxx/build && cmake .. -DLIBCXX_CXX_ABI=libstdc++ -DLIBCXX_CXX_ABI_INCLUDE_PATHS="/usr/include/c++/4.6;/usr/include/c++/4.6/x86_64-linux-gnu")
+(cd libcxx/build && ../../cmake/bin/cmake .. -DLIBCXX_CXX_ABI=libstdc++ -DLIBCXX_CXX_ABI_INCLUDE_PATHS="/usr/include/c++/4.6;/usr/include/c++/4.6/x86_64-linux-gnu")
 make -C libcxx/build cxx -j2
 sudo cp libcxx/build/lib/libc++.so.1.0 /usr/lib/
 sudo cp -r libcxx/build/include/c++/v1 /usr/include/c++/v1/


### PR DESCRIPTION
- re-enable clang-trunk in travis-ci,
- add new version of cmake (required to compile libc++-trunk, the one in travis is too old),
- test clang-trunk in C++1z mode as well, and
- meta: workaround [clang bug 28385](https://llvm.org/bugs/show_bug.cgi?id=28385).