### PR TITLE
Sharpen the fix for #420.

### DIFF
--- a/include/range/v3/utility/iterator_concepts.hpp
+++ b/include/range/v3/utility/iterator_concepts.hpp
@@ -643,27 +643,22 @@ namespace __gnu_debug
 
 #endif
 
-#if defined(_LIBCPP_VERSION) // TODO: && _LIBCPP_VERSION <= VERSION_THAT_FIXES_THIS
-// HACKHACK: workaround underconstrained operator- for libc++'s reverse_iterator
-// by disabling SizedSentinel if reverse_iterator is not a random access iterator.
+#if defined(__GLIBCXX__) || defined(_LIBCPP_VERSION)
+// TODO: && _LIBCPP_VERSION <= VERSION_THAT_FIXES_THIS
+// HACKHACK: workaround libc++ and libstdc++ underconstrained operator- for
+// reverse_iterator by disabling SizedSentinel when the base iterators do not
+// model SizedSentinel.
 namespace ranges
 {
-
     inline namespace v3
     {
-
         template<typename S, typename I>
         struct disable_sized_sentinel<std::reverse_iterator<S>, std::reverse_iterator<I>>
-          : meta::not_<
-                meta::and_<std::is_same<typename std::reverse_iterator<S>::iterator_category,
-                                        std::random_access_iterator_tag>,
-                           std::is_same<typename std::reverse_iterator<I>::iterator_category,
-                                        std::random_access_iterator_tag>>>
+          : meta::not_<SizedSentinel<I, S>>
         {};
-
     }
 }
 
-#endif  // _LIBCPP_VERSION
+#endif // _LIBCPP_VERSION
 
 #endif // RANGES_V3_UTILITY_ITERATOR_CONCEPTS_HPP

--- a/test/utility/iterator.cpp
+++ b/test/utility/iterator.cpp
@@ -52,10 +52,24 @@ void test_move_iterator()
     ::check_equal(out, {"this","is","his","face"});
 }
 
+template<class I>
+using RI = std::reverse_iterator<I>;
+
+void issue_420_regression()
+{
+    // Verify that SizedSentinel<std::reverse_iterator<S>, std::reverse_iterator<I>>
+    // properly requires SizedSentinel<I, S>
+    CONCEPT_ASSERT(SizedSentinel<RI<int*>, RI<int*>>());
+    CONCEPT_ASSERT(!SizedSentinel<RI<int*>, RI<float*>>());
+    using BI = bidirectional_iterator<int*>;
+    CONCEPT_ASSERT(!SizedSentinel<RI<BI>, RI<BI>>());
+}
+
 int main()
 {
     test_insert_iterator();
     test_move_iterator();
+    issue_420_regression();
 
     return ::test_result();
 }


### PR DESCRIPTION
* Two random-access iterators don't necessarily model `SizedSentinel`, two input iterators may. `SizedSentinel<std::reverse_iterator<S>, std::reverse_iterator<I>>` should require `SizedSentinel<I, S>`.
* Quick regression test.

EDIT: Apply the fix for libstdc++ as well, which implements the resolution of LWG685 incorrectly.