### PR TITLE
rm virtual keyword in override

### DIFF
--- a/include/range/v3/utility/any.hpp
+++ b/include/range/v3/utility/any.hpp
@@ -28,7 +28,7 @@ namespace ranges
         struct bad_any_cast
           : std::bad_cast
         {
-            virtual const char* what() const noexcept override
+            const char* what() const noexcept override
             {
                 return "bad any_cast";
             }


### PR DESCRIPTION
what good is it stating an override is virtual? the base class,
std::bad_cast, already says the what() member function is virtual.

if the base class' signature is virtual, then the keyword is a no-op. if
the base class' signature were not virtual, then the virtual override
can bring confusion down the line.

EDIT: I hear now that some compilers complain if the derived class doesn't repeat the virtual keyword. Is that so? I think such a warning is unhelpful. I think that repeating the virtual keyword, when it's doing nothing, is at best of no benefit. But it's also fragile..