### PR TITLE
copy_n + istream_iterator: fix an excess read

### DIFF
--- a/include/range/v3/algorithm/copy_n.hpp
+++ b/include/range/v3/algorithm/copy_n.hpp
@@ -48,8 +48,16 @@ namespace ranges
                 RANGES_ASSERT(0 <= n);
                 auto norig = n;
                 auto b = uncounted(begin);
-                for(; n != 0; ++b, ++out, --n)
+                if(n > 0) {
+                  while(true) {
                     *out = *b;
+                    ++out;
+                    if(--n > 0)
+                      ++b;
+                    else
+                      break;
+                  }
+                }
                 return {recounted(begin, b, norig), out};
             }
         };

--- a/test/algorithm/CMakeLists.txt
+++ b/test/algorithm/CMakeLists.txt
@@ -19,6 +19,9 @@ add_test(test.alg.copy, alg.copy)
 add_executable(alg.copy_backward copy_backward.cpp)
 add_test(test.alg.copy_backward, alg.copy_backward)
 
+add_executable(alg.copy_n copy_n.cpp)
+add_test(test.alg.copy_n, alg.copy_n)
+
 add_executable(alg.count count.cpp)
 add_test(test.alg.count, alg.count)
 

--- a/test/algorithm/copy_n.cpp
+++ b/test/algorithm/copy_n.cpp
@@ -1,0 +1,37 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+
+#include <iterator>
+#include <sstream>
+#include <range/v3/core.hpp>
+#include <range/v3/algorithm/copy_n.hpp>
+#include "../simple_test.hpp"
+
+int main()
+{
+    using ranges::begin;
+    using ranges::end;
+    using ranges::size;
+
+    {
+      std::istringstream iss{ "1 2 3 4 5" };
+      int output[] = { 0, 0, 0, 0 };
+      auto const p = ranges::copy_n(std::istream_iterator<int>{iss}, 2, &output[0]);
+      ranges::copy_n(std::istream_iterator<int>{iss}, 2, p.second);
+      int const expected[] = { 1, 2, 3, 4 };
+      CHECK(output[0] == expected[0]);
+      CHECK(output[1] == expected[1]);
+      CHECK(output[2] == expected[2]);
+      CHECK(output[3] == expected[3]);
+    }
+
+    return test_result();
+}


### PR DESCRIPTION
calling copy_n() with a single-pass input iterator, like an
istream_iterator, triggers an excess read from the iterator:

    std::istringstream iss{"1 2 3 4 5"};
    int output[] = { 0, 0, 0, 0 };
    auto const p = copy_n(std::istream_iterator<int>{iss}, 2, &output[0]);
    copy_n(std::istream_iterator<int>{iss}, 2, p.second);

this fills the output array with

    { 1, 2, 4, 5 }

rather than

    { 1, 2, 3, 4 }