### PR TITLE
Add AppVeyor CI for Clang/C2; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Other resources (mind the dates, the library probably has changed since then):
 - Design / Implementation:
   - Rationale behind range-v3: [N4128: Ranges for the standard library Revision 1](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4128.html), 2014.
   - Ranges TS: [N4560: C++ Extensions for Ranges](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4560.pdf), 2015.
-  - Implementation of customization points in range-v3: 
+  - Implementation of customization points in range-v3:
     - [N4381: Suggested Design for Customization Points](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4381.html), 2015.
     - [P0386: Inline variables](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0386r0.pdf), 2016.
     - [Customization Point Design in C++11 and Beyond](http://ericniebler.com/2014/10/21/customization-point-design-in-c11-and-beyond/), 2014.
@@ -54,10 +54,13 @@ The code is known to work on the following compilers:
 
 - clang 3.5.2
 - GCC 4.8.5 (C++14 support requires GCC 5.2; C++14 "extended constexpr" support is poor before 6.1.)
+- VS2015 Update 3 "Clang with Microsoft CodeGen" (Clang/C2)
 
 **Development Status:** This code is fairly stable, well-tested, and suitable for casual use, although currently lacking documentation. No promise is made about support or long-term stability. This code *will* evolve without regard to backwards compatibility.
 
-**Build status (on Travis-CI):** [![Build Status](https://travis-ci.org/ericniebler/range-v3.svg?branch=master)](https://travis-ci.org/ericniebler/range-v3)
+**Build status**
+- on Travis-CI: [![Travis Build Status](https://travis-ci.org/ericniebler/range-v3.svg?branch=master)](https://travis-ci.org/ericniebler/range-v3)
+- on AppVeyor: [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/yh3fufmhm53rkf3d/branch/master?svg=true)](https://ci.appveyor.com/project/devdiv/range-v3)
 
 Say Thanks!
 -----------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,33 @@
+shallow_clone: true
+
+platform:
+  - x86
+  - x64
+
+configuration:
+  - Debug
+  - Release
+
+cache:
+  - C:\cmake-3.6.1-win32-x86
+
+install:
+  - ps: |
+      if (![IO.File]::Exists("C:\cmake-3.6.1-win32-x86.zip")) {
+        pushd c:\
+        Start-FileDownload 'https://cmake.org/files/v3.6/cmake-3.6.1-win32-x86.zip'
+        7z x cmake-3.6.1-win32-x86.zip
+        popd
+      }
+  - mkdir build && cd build
+  - C:\cmake-3.6.1-win32-x86\bin\cmake .. -DRANGE_V3_NO_HEADER_CHECK=1 -T v140_clang_c2
+
+build:
+  project: c:/projects/range-v3/build/ALL_BUILD.vcxproj
+  parallel: true
+  verbosity: minimal
+
+test_script:
+  - C:\cmake-3.6.1-win32-x86\bin\ctest
+
+deploy: off

--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -115,7 +115,7 @@
 #define RANGES_DIAGNOSTIC_IGNORE_PRAGMAS RANGES_DIAGNOSTIC_IGNORE(4068)
 #define RANGES_DIAGNOSTIC_IGNORE_INDENTATION
 #define RANGES_DIAGNOSTIC_IGNORE_UNDEFINED_INTERNAL
-#define RANGES_DIAGNOSTIC_IGNORE_MISMATCHED_TAGS
+#define RANGES_DIAGNOSTIC_IGNORE_MISMATCHED_TAGS RANGES_DIAGNOSTIC_IGNORE(4099)
 #define RANGES_DIAGNOSTIC_IGNORE_GLOBAL_CONSTRUCTORS
 #define RANGES_DIAGNOSTIC_IGNORE_SIGN_CONVERSION
 #define RANGES_DIAGNOSTIC_IGNORE_UNNEEDED_INTERNAL
@@ -299,7 +299,7 @@
     inline namespace                   \
     {                                                       \
         constexpr auto& name = static_const<type>::value;   \
-    }                                                     
+    }
 
 #else  // RANGES_CXX_INLINE_VARIABLES >= RANGES_CXX_INLINE_VARIABLES_17
 #define RANGES_INLINE_VARIABLE(type, name) \


### PR DESCRIPTION
We (I?) now officially support Clang/C2 in range-v3.