### PR TITLE
Various simple Doxygen fixes.

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -86,8 +86,9 @@ SEARCH_INCLUDES         = YES
 INCLUDE_PATH            = @Range-v3_SOURCE_DIR@/include
 INCLUDE_FILE_PATTERNS   =
 PREDEFINED              = RANGES_DOXYGEN_INVOKED \
-                          CONCEPT_REQUIRES_IMPL_(X)=requires=X \
-                          "CONCEPT_REQUIRES_IMPL(X)=/// \pre X" \
+                          CONCEPT_REQUIRES_=requires= \
+                          "CONCEPT_REQUIRES(X)=/// \pre X" \
+                          "RANGES_INLINE_VARIABLE(T,N)=inline constexpr T N{};"
 SKIP_FUNCTION_MACROS    = NO
 
 # Source browsing

--- a/include/meta/meta.hpp
+++ b/include/meta/meta.hpp
@@ -791,7 +791,7 @@ namespace meta
         /// \endcond
 
         /// Test whether a type \c T is an instantiation of class
-        /// template \t C.
+        /// template \c C.
         /// \ingroup trait
         template <typename T, template <typename...> class C>
         using is = _t<detail::is_<T, C>>;

--- a/include/range/v3/utility/compressed_pair.hpp
+++ b/include/range/v3/utility/compressed_pair.hpp
@@ -81,6 +81,8 @@ namespace ranges
                 return static_cast<storage<T, I, Ts...> &&>(tuple).get();
             }
         }
+        /// \endcond
+
         using compressed_tuple_detail::compressed_tuple;
 
         struct make_compressed_tuple_fn

--- a/include/range/v3/utility/functional.hpp
+++ b/include/range/v3/utility/functional.hpp
@@ -179,7 +179,6 @@ namespace ranges
           : coerce<T>
         {};
 
-        /// \addtogroup group-utility
         struct as_function_fn
         {
         private:


### PR DESCRIPTION
Fixes a couple Doxygen warnings.

Also added special handling for `RANGES_INLINE_VARIABLE`, `CONCEPT_REQUIRES_`, and `CONCEPT_REQUIRES`.
- The `RANGES_INLINE_VARIABLE` fix is needed for Doxygen to correct treat preceding annotations as applying to the function object rather than the namespace.
- The `CONCEPT_REQUIRES` and `CONCEPT_REQUIRES_` change replace them with slightly more readable pseudocode instead of something like `int _concept_requires___LINE__ = 42, typename std::enable_if< (_concept_requires___LINE__==43)||(Range< Rng & >()&&Function< Action, Rng &, Rest &&... >()), int >::type = 0`, which is rather ridiculous in documentation.