### PR TITLE
Make gh-pages.clean actually clean

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -39,7 +39,7 @@ if (NOT GIT_FOUND)
 endif()
 
 add_custom_target(gh-pages.clean
-    COMMAND ${CMAKE_COMMAND} -E remove *.png *.css *.js *.html
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_LIST_DIR}/clean-gh-pages.cmake
     COMMAND ${CMAKE_COMMAND} -E remove_directory search
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/gh-pages
     COMMENT "Cleaning up doc/gh-pages"

--- a/doc/clean-gh-pages.cmake
+++ b/doc/clean-gh-pages.cmake
@@ -1,0 +1,4 @@
+FILE(GLOB gh_files "*.html" "*.js" "*.css" "*.png")
+IF( gh_files )
+    execute_process( COMMAND ${CMAKE_COMMAND} -E remove ${gh_files} )
+ENDIF()


### PR DESCRIPTION
Right now at least on my system it's seemingly trying to remove a file literally named `*.meow` rather than all files with the extension `meow`.