### PR TITLE
[AppVeyor] Fix cmake caching bug

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,10 +13,10 @@ cache:
 
 install:
   - ps: |
-      if (![IO.File]::Exists("C:\cmake-3.6.1-win32-x86.zip")) {
+      if (![IO.File]::Exists("C:\cmake-3.6.1-win32-x86\bin\cmake.exe")) {
         pushd c:\
         Start-FileDownload 'https://cmake.org/files/v3.6/cmake-3.6.1-win32-x86.zip'
-        7z x cmake-3.6.1-win32-x86.zip
+        7z x -y cmake-3.6.1-win32-x86.zip
         popd
       }
   - mkdir build && cd build


### PR DESCRIPTION
I apparently never managed to correctly test the AppVeyor build script in the "cmake is cached" case.