### PR TITLE
Consistently specify global namespace

### DIFF
--- a/include/range/v3/detail/variant.hpp
+++ b/include/range/v3/detail/variant.hpp
@@ -750,12 +750,12 @@ RANGES_DIAGNOSTIC_IGNORE_MISMATCHED_TAGS
 namespace std
 {
     template<typename...Ts>
-    struct tuple_size<ranges::variant<Ts...>>
+    struct tuple_size<::ranges::variant<Ts...>>
       : tuple_size<tuple<Ts...>>
     {};
 
     template<size_t I, typename...Ts>
-    struct tuple_element<I, ranges::variant<Ts...>>
+    struct tuple_element<I, ::ranges::variant<Ts...>>
       : tuple_element<I, tuple<Ts...>>
     {};
 }

--- a/include/range/v3/iterator_range.hpp
+++ b/include/range/v3/iterator_range.hpp
@@ -258,7 +258,7 @@ namespace std
     template<typename I, typename S>
     struct tuple_element<2, ::ranges::v3::sized_iterator_range<I, S>>
     {
-        using type = ranges::v3::iterator_size_t<I>;
+        using type = ::ranges::v3::iterator_size_t<I>;
     };
 }
 /// \endcond

--- a/include/range/v3/utility/compressed_pair.hpp
+++ b/include/range/v3/utility/compressed_pair.hpp
@@ -151,14 +151,14 @@ RANGES_DIAGNOSTIC_IGNORE_MISMATCHED_TAGS
 namespace std
 {
     template<typename... Ts, size_t... Is>
-    struct tuple_size< ::ranges::v3::compressed_tuple_detail::compressed_tuple_<meta::list<Ts...>, meta::index_sequence<Is...>>>
+    struct tuple_size< ::ranges::v3::compressed_tuple_detail::compressed_tuple_<::meta::list<Ts...>, ::meta::index_sequence<Is...>>>
       : integral_constant<size_t, sizeof...(Ts)>
     {};
 
     template<size_t I, typename... Ts, size_t... Is>
-    struct tuple_element<I, ::ranges::v3::compressed_tuple_detail::compressed_tuple_<meta::list<Ts...>, meta::index_sequence<Is...>>>
+    struct tuple_element<I, ::ranges::v3::compressed_tuple_detail::compressed_tuple_<::meta::list<Ts...>, ::meta::index_sequence<Is...>>>
     {
-        using type = ::meta::at_c<meta::list<Ts...>, I>;
+        using type = ::meta::at_c<::meta::list<Ts...>, I>;
     };
 
     template<typename First, typename Second>

--- a/include/range/v3/utility/safe_int.hpp
+++ b/include/range/v3/utility/safe_int.hpp
@@ -306,15 +306,15 @@ namespace ranges
 namespace std
 {
     template<typename T>
-    struct is_integral<ranges::v3::safe_int<T>>
+    struct is_integral<::ranges::v3::safe_int<T>>
       : is_integral<T>
     {};
 
     template<typename T>
-    class numeric_limits<ranges::v3::safe_int<T>>
+    class numeric_limits<::ranges::v3::safe_int<T>>
       : public numeric_limits<T>
     {
-        using safe_int = ranges::v3::safe_int<T>;
+        using safe_int = ::ranges::v3::safe_int<T>;
     public:
         static constexpr bool is_specialized = true;
         static constexpr safe_int min() noexcept { return safe_int{-numeric_limits<T>::max() + 1}; }
@@ -327,13 +327,13 @@ namespace std
     };
 
     template<typename T>
-    constexpr bool numeric_limits<ranges::v3::safe_int<T>>::is_specialized;
+    constexpr bool numeric_limits<::ranges::v3::safe_int<T>>::is_specialized;
 
     template<typename T>
-    constexpr bool numeric_limits<ranges::v3::safe_int<T>>::has_infinity;
+    constexpr bool numeric_limits<::ranges::v3::safe_int<T>>::has_infinity;
 
     template<typename T>
-    constexpr bool numeric_limits<ranges::v3::safe_int<T>>::has_quiet_NaN;
+    constexpr bool numeric_limits<::ranges::v3::safe_int<T>>::has_quiet_NaN;
 }
 
 #endif


### PR DESCRIPTION
Adds explicit global namespace specifier in std spezialisations.
Currently this is done very inconsistent which breaks compatibility e.g. with the C++ reflection proposals, which introduces an std::meta namespace.