### PR TITLE
Fix Clang and libc++ Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -174,7 +174,7 @@ matrix:
     #   os: linux
     #   addons: *clang37
 
-    # Test clang-3.9: C++11/C++14, Build=Debug/Release, ASAN=On/Off
+    # Test clang-4.0: C++11/C++14/1z, LIBCXX=On/Off, Build=Debug/Release, ASAN=On/Off
     - env: CLANG_VERSION=4.0 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
       os: linux
       addons: &clang40

--- a/.travis.yml
+++ b/.travis.yml
@@ -175,61 +175,61 @@ matrix:
     #   addons: *clang37
 
     # Test clang-3.9: C++11/C++14, Build=Debug/Release, ASAN=On/Off
-    - env: CLANG_VERSION=3.9 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
+    - env: CLANG_VERSION=4.0 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
       os: linux
-      addons: &clang39
+      addons: &clang40
         apt:
           packages:
             - util-linux
-            - clang-3.9
+            - clang-4.0
             - valgrind
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-precise
 
     # Release + ASAN + C++11/14/1z
-    - env: CLANG_VERSION=3.9 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
+    - env: CLANG_VERSION=4.0 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
       os: linux
-      addons: *clang39
+      addons: *clang40
 
-    - env: CLANG_VERSION=3.9 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On
+    - env: CLANG_VERSION=4.0 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On
       os: linux
-      addons: *clang39
+      addons: *clang40
 
-    - env: CLANG_VERSION=3.9 BUILD_TYPE=Release CPP=1z ASAN=On LIBCXX=On
+    - env: CLANG_VERSION=4.0 BUILD_TYPE=Release CPP=1z ASAN=On LIBCXX=On
       os: linux
-      addons: *clang39
+      addons: *clang40
 
     # Release + Valgrind + C++11/14/1z
-    - env: CLANG_VERSION=3.9 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
+    - env: CLANG_VERSION=4.0 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
       os: linux
-      addons: *clang39
+      addons: *clang40
 
-    - env: CLANG_VERSION=3.9 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On
+    - env: CLANG_VERSION=4.0 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On
       os: linux
-      addons: *clang39
+      addons: *clang40
 
-    - env: CLANG_VERSION=3.9 BUILD_TYPE=Release CPP=1z ASAN=Off LIBCXX=On
+    - env: CLANG_VERSION=4.0 BUILD_TYPE=Release CPP=1z ASAN=Off LIBCXX=On
       os: linux
-      addons: *clang39
+      addons: *clang40
 
     # Debug + C++11/14/1z
-    - env: CLANG_VERSION=3.9 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
+    - env: CLANG_VERSION=4.0 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
       os: linux
-      addons: *clang39
+      addons: *clang40
 
-    - env: CLANG_VERSION=3.9 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On
+    - env: CLANG_VERSION=4.0 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On
       os: linux
-      addons: *clang39
+      addons: *clang40
 
-    - env: CLANG_VERSION=3.9 BUILD_TYPE=Debug CPP=1z ASAN=Off LIBCXX=On
+    - env: CLANG_VERSION=4.0 BUILD_TYPE=Debug CPP=1z ASAN=Off LIBCXX=On
       os: linux
-      addons: *clang39
+      addons: *clang40
 
     # Debug + C++11 + libstdc++
-    - env: CLANG_VERSION=3.9 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off
+    - env: CLANG_VERSION=4.0 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off
       os: linux
-      addons: *clang39
+      addons: *clang40
 
     # Test gcc-4.8: C++11, Build=Debug/Release, ASAN=Off
     - env: GCC_VERSION=4.8 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=Off
@@ -337,7 +337,9 @@ before_install:
   - which $CC
   - which valgrind
   - $CXX --version
+  - if [ "$ASAN" == "On" ]; then export SANITIZER=Address; fi
   - if [ -n "$CLANG_VERSION" ]; then sudo CXX=$CXX CC=$CC ./install_libcxx.sh; fi
+
 
 install:
   - cd $CHECKOUT_PATH
@@ -353,7 +355,6 @@ install:
   - if [ -n "$GCC_VERSION" -a "$ASAN" == "On" ]; then CXX_FLAGS="${CXX_FLAGS} -fsanitize=address,undefined -fno-omit-frame-pointer"; fi
   - if [ -n "$CLANG_VERSION" ]; then CXX_FLAGS="${CXX_FLAGS} -D__extern_always_inline=inline"; fi
   - if [ "$LIBCXX" == "On" ]; then CXX_FLAGS="${CXX_FLAGS} -stdlib=libc++ -I/usr/include/c++/v1/"; fi
-  - if [ "$LIBCXX" == "On" ]; then CXX_LINKER_FLAGS="${CXX_FLAGS} -L/usr/lib/ -lc++"; fi
   - cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" -DCMAKE_EXE_LINKER_FLAGS="${CXX_LINKER_FLAGS}" -DRANGES_CXX_STD=$CPP -DRANGE_V3_NO_HEADER_CHECK=1
   - make VERBOSE=1
 

--- a/install_libcxx.sh
+++ b/install_libcxx.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 # Install a newer CMake version
-curl -sSL https://cmake.org/files/v3.6/cmake-3.6.1-Linux-x86_64.sh -o install-cmake.sh
+# Update this when LLVM requirements change
+CMAKE_URL = https://cmake.org/files/v3.6/cmake-3.6.1-Linux-x86_64.sh
+curl -sSL $CMAKE_URL -o install-cmake.sh
 chmod +x install-cmake.sh
 sudo ./install-cmake.sh --prefix=/usr/local --skip-license
 

--- a/install_libcxx.sh
+++ b/install_libcxx.sh
@@ -1,15 +1,22 @@
-#!/bin/bash
-#
-# Install libc++ under travis
-CMAKE_URL="http://www.cmake.org/files/v3.5/cmake-3.5.0-Linux-x86_64.tar.gz"
-wget ${CMAKE_URL} --no-check-certificate
-mkdir cmake
-tar -xzf cmake-3.5.0-Linux-x86_64.tar.gz -C cmake --strip-components=1
-git clone --depth=1 https://github.com/llvm-mirror/libcxx.git
-mkdir libcxx/build
-(cd libcxx/build && ../../cmake/bin/cmake .. -DLIBCXX_CXX_ABI=libstdc++ -DLIBCXX_CXX_ABI_INCLUDE_PATHS="/usr/include/c++/4.6;/usr/include/c++/4.6/x86_64-linux-gnu")
-make -C libcxx/build cxx -j2
-sudo cp libcxx/build/lib/libc++.so.1.0 /usr/lib/
-sudo cp -r libcxx/build/include/c++/v1 /usr/include/c++/v1/
-sudo ln -sf /usr/lib/libc++.so.1.0 /usr/lib/libc++.so
-sudo ln -sf /usr/lib/libc++.so.1.0 /usr/lib/libc++.so.1
+#!/usr/bin/env bash
+
+# Install a newer CMake version
+curl -sSL https://cmake.org/files/v3.6/cmake-3.6.1-Linux-x86_64.sh -o install-cmake.sh
+chmod +x install-cmake.sh
+sudo ./install-cmake.sh --prefix=/usr/local --skip-license
+
+# Checkout LLVM sources
+git clone --depth=1 https://github.com/llvm-mirror/llvm.git llvm-source
+git clone --depth=1 https://github.com/llvm-mirror/libcxx.git llvm-source/projects/libcxx
+git clone --depth=1 https://github.com/llvm-mirror/libcxxabi.git llvm-source/projects/libcxxabi
+
+# Build and install libc++ (Use unstable ABI for better sanitizer coverage)
+mkdir llvm-build && cd llvm-build
+cmake -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${COMPILER} \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr \
+      -DLIBCXX_ABI_UNSTABLE=ON \
+      -DLLVM_USE_SANITIZER=${SANITIZER} \
+      ../llvm-source
+make cxx -j2
+sudo make install-cxxabi install-cxx
+cd ../

--- a/install_libcxx.sh
+++ b/install_libcxx.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
 # Install a newer CMake version
-# Update this when LLVM requirements change
-CMAKE_URL = https://cmake.org/files/v3.6/cmake-3.6.1-Linux-x86_64.sh
-curl -sSL $CMAKE_URL -o install-cmake.sh
+curl -sSL https://cmake.org/files/v3.6/cmake-3.6.1-Linux-x86_64.sh -o install-cmake.sh
 chmod +x install-cmake.sh
 sudo ./install-cmake.sh --prefix=/usr/local --skip-license
 

--- a/install_libcxx.sh
+++ b/install_libcxx.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # Install a newer CMake version
 curl -sSL https://cmake.org/files/v3.6/cmake-3.6.1-Linux-x86_64.sh -o install-cmake.sh
 chmod +x install-cmake.sh


### PR DESCRIPTION
This patch fixes the Clang and libcxx travis builders. The main changes are:

1. Upgrade to Clang 4.0 since that's what the llvm-nightly repository contains.
2. Rewrite the install_libcxx.sh script so it works better, and supports building with sanitizers.
