### PR TITLE
Rename not_ to not_fn, implement as in the C++17 WP:

### DIFF
--- a/include/range/v3/algorithm/inplace_merge.hpp
+++ b/include/range/v3/algorithm/inplace_merge.hpp
@@ -79,7 +79,7 @@ namespace ranges
                             make_move_sentinel(RBi{std::move(begin)}),
                             make_move_iterator(Rv{p.base().base()}),
                             make_move_iterator(Rv{buf}), RBi{std::move(end)},
-                            not_(std::ref(pred)), std::ref(proj), std::ref(proj));
+                            not_fn(std::ref(pred)), std::ref(proj), std::ref(proj));
                     }
                 }
 

--- a/include/range/v3/view/filter.hpp
+++ b/include/range/v3/view/filter.hpp
@@ -33,7 +33,7 @@ namespace ranges
                 {
                     CONCEPT_ASSERT(Range<Rng>());
                     CONCEPT_ASSERT(IndirectCallablePredicate<Pred, range_iterator_t<Rng>>());
-                    return {all(std::forward<Rng>(rng)), not_(std::move(pred))};
+                    return {all(std::forward<Rng>(rng)), not_fn(std::move(pred))};
                 }
                 template<typename Pred>
                 auto operator()(Pred pred) const ->

--- a/include/range/v3/view/group_by.hpp
+++ b/include/range/v3/view/group_by.hpp
@@ -76,7 +76,7 @@ namespace ranges
                 }
                 void next()
                 {
-                    cur_ = ranges::next(adjacent_find(cur_, last_, not_(std::ref(fun_))), 1, last_);
+                    cur_ = ranges::next(adjacent_find(cur_, last_, not_fn(std::ref(fun_))), 1, last_);
                 }
                 bool done() const
                 {

--- a/test/algorithm/sort.cpp
+++ b/test/algorithm/sort.cpp
@@ -79,7 +79,7 @@ namespace
         auto sort = make_testable_1<false>(ranges::sort);
         if (f != l)
         {
-            long len = l - f;
+            auto len = l - f;
             value_type* save(new value_type[len]);
             do
             {

--- a/test/algorithm/stable_sort.cpp
+++ b/test/algorithm/stable_sort.cpp
@@ -51,7 +51,7 @@ namespace
         auto stable_sort = make_testable_1<false>(ranges::stable_sort);
         if (f != l)
         {
-            long len = l - f;
+            auto len = l - f;
             value_type* save(new value_type[len]);
             do
             {

--- a/test/view/remove_if.cpp
+++ b/test/view/remove_if.cpp
@@ -56,7 +56,7 @@ int main()
     auto tmp = rng | view::reverse;
     CHECK(&*begin(tmp) == &rgi[8]);
 
-    auto && rng2 = view::counted(rgi, 10) | view::remove_if(not_(is_odd()));
+    auto && rng2 = view::counted(rgi, 10) | view::remove_if(not_fn(is_odd()));
     has_type<int &>(*begin(rng2));
     models<concepts::BidirectionalView>(rng2);
     models_not<concepts::RandomAccessView>(rng2);


### PR DESCRIPTION
* call operators forward value category
* call operators SFINAE on return type of the wrapped function
* extension: call operators propagate `noexcept`
* Keep the name `not_` around with a deprecation notice
