### PR TITLE
Specialise Boost Range metafns for range-v3 views

### DIFF
--- a/include/range/v3/detail/boost_range_hook.hpp
+++ b/include/range/v3/detail/boost_range_hook.hpp
@@ -1,0 +1,48 @@
+/// \file
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#ifndef RANGES_V3_DETAIL_BOOST_RANGE_HOOK_HPP
+#define RANGES_V3_DETAIL_BOOST_RANGE_HOOK_HPP
+
+#include <range/v3/range_fwd.hpp>
+
+namespace boost {
+
+	/// \brief Boost Range specialisation point, for making Boost ranges out of range-v3 views
+	template<typename T, typename U> struct range_mutable_iterator;
+
+	/// \brief Boost Range specialisation point, for making Boost ranges out of range-v3 views
+	template<typename T, typename U> struct range_const_iterator;
+
+	/// \brief Boost Range specialisation point, for making Boost ranges out of range-v3 views
+	template<typename T            > struct range_value;
+}
+
+/// \brief Macro to specialises Boost Range metafunctions for the specified view
+#define BOOST_RANGE_HOOK(view_name) \
+namespace boost {                                                          \
+    template <typename... Ts>                                              \
+    struct range_mutable_iterator< view_name< Ts... >, void> {             \
+    	using type = ranges::range_iterator_t<       view_name< Ts... > >; \
+    };                                                                     \
+    template <typename... Ts>                                              \
+    struct range_const_iterator  < view_name< Ts... >, void> {             \
+    	using type = ranges::range_iterator_t< const view_name< Ts... > >; \
+    };                                                                     \
+    template <typename... Ts>                                              \
+    struct range_value           < view_name< Ts... >      > {             \
+    	using type = ranges::range_value_t   <       view_name< Ts... > >; \
+    };                                                                     \
+}
+
+#endif

--- a/include/range/v3/detail/satisfy_boost_range.hpp
+++ b/include/range/v3/detail/satisfy_boost_range.hpp
@@ -11,8 +11,8 @@
 // Project home: https://github.com/ericniebler/range-v3
 //
 
-#ifndef RANGES_V3_DETAIL_BOOST_RANGE_HOOK_HPP
-#define RANGES_V3_DETAIL_BOOST_RANGE_HOOK_HPP
+#ifndef RANGES_V3_DETAIL_SATISFY_BOOST_RANGE_HPP
+#define RANGES_V3_DETAIL_SATISFY_BOOST_RANGE_HPP
 
 #include <range/v3/range_fwd.hpp>
 
@@ -28,8 +28,8 @@ namespace boost {
 	template<typename T            > struct range_value;
 }
 
-/// \brief Macro to specialises Boost Range metafunctions for the specified view
-#define BOOST_RANGE_HOOK(view_name) \
+/// \brief Macro to specialise Boost Range metafunctions for the specified view
+#define RANGES_SATISFY_BOOST_RANGE(view_name) \
 namespace boost {                                                          \
     template <typename... Ts>                                              \
     struct range_mutable_iterator< view_name< Ts... >, void> {             \

--- a/include/range/v3/detail/satisfy_boost_range.hpp
+++ b/include/range/v3/detail/satisfy_boost_range.hpp
@@ -28,7 +28,7 @@ namespace boost {
 	template<typename T            > struct range_value;
 }
 
-/// \brief Macro to specialise Boost Range metafunctions for the specified view
+/// \brief Macro specialising Boost Range metafunctions for the specified view
 #define RANGES_SATISFY_BOOST_RANGE(view_name) \
 namespace boost {                                                          \
     template <typename... Ts>                                              \

--- a/include/range/v3/view/adjacent_filter.hpp
+++ b/include/range/v3/view/adjacent_filter.hpp
@@ -16,7 +16,7 @@
 
 #include <utility>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/view_adaptor.hpp>
@@ -131,6 +131,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::adjacent_filter_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::adjacent_filter_view)
 
 #endif

--- a/include/range/v3/view/adjacent_filter.hpp
+++ b/include/range/v3/view/adjacent_filter.hpp
@@ -16,6 +16,7 @@
 
 #include <utility>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/view_adaptor.hpp>
@@ -129,5 +130,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::adjacent_filter_view)
 
 #endif

--- a/include/range/v3/view/adjacent_remove_if.hpp
+++ b/include/range/v3/view/adjacent_remove_if.hpp
@@ -16,6 +16,7 @@
 
 #include <utility>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/view_adaptor.hpp>
@@ -166,5 +167,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::adjacent_remove_if_view)
 
 #endif

--- a/include/range/v3/view/adjacent_remove_if.hpp
+++ b/include/range/v3/view/adjacent_remove_if.hpp
@@ -16,7 +16,7 @@
 
 #include <utility>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/view_adaptor.hpp>
@@ -168,6 +168,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::adjacent_remove_if_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::adjacent_remove_if_view)
 
 #endif

--- a/include/range/v3/view/any_view.hpp
+++ b/include/range/v3/view/any_view.hpp
@@ -17,7 +17,7 @@
 #include <memory>
 #include <utility>
 #include <type_traits>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_traits.hpp>
@@ -404,6 +404,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::any_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::any_view)
 
 #endif

--- a/include/range/v3/view/any_view.hpp
+++ b/include/range/v3/view/any_view.hpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <utility>
 #include <type_traits>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_traits.hpp>
@@ -402,5 +403,7 @@ namespace ranges
         using any_random_access_view = any_view<Ref, category::random_access>;
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::any_view)
 
 #endif

--- a/include/range/v3/view/bounded.hpp
+++ b/include/range/v3/view/bounded.hpp
@@ -14,6 +14,7 @@
 #define RANGES_V3_VIEW_BOUNDED_HPP
 
 #include <type_traits>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/iterator_range.hpp>
 #include <range/v3/range_concepts.hpp>
@@ -139,5 +140,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::bounded_view)
 
 #endif

--- a/include/range/v3/view/bounded.hpp
+++ b/include/range/v3/view/bounded.hpp
@@ -14,7 +14,7 @@
 #define RANGES_V3_VIEW_BOUNDED_HPP
 
 #include <type_traits>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/iterator_range.hpp>
 #include <range/v3/range_concepts.hpp>
@@ -141,6 +141,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::bounded_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::bounded_view)
 
 #endif

--- a/include/range/v3/view/chunk.hpp
+++ b/include/range/v3/view/chunk.hpp
@@ -17,7 +17,7 @@
 #include <utility>
 #include <functional>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/iterator_range.hpp>
@@ -181,6 +181,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::chunk_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::chunk_view)
 
 #endif

--- a/include/range/v3/view/chunk.hpp
+++ b/include/range/v3/view/chunk.hpp
@@ -17,6 +17,7 @@
 #include <utility>
 #include <functional>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/iterator_range.hpp>
@@ -179,5 +180,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::chunk_view)
 
 #endif

--- a/include/range/v3/view/concat.hpp
+++ b/include/range/v3/view/concat.hpp
@@ -18,6 +18,7 @@
 #include <utility>
 #include <type_traits>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/size.hpp>
 #include <range/v3/begin_end.hpp>
@@ -336,5 +337,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::concat_view)
 
 #endif

--- a/include/range/v3/view/concat.hpp
+++ b/include/range/v3/view/concat.hpp
@@ -18,7 +18,7 @@
 #include <utility>
 #include <type_traits>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/size.hpp>
 #include <range/v3/begin_end.hpp>
@@ -338,6 +338,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::concat_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::concat_view)
 
 #endif

--- a/include/range/v3/view/const.hpp
+++ b/include/range/v3/view/const.hpp
@@ -16,6 +16,7 @@
 
 #include <utility>
 #include <type_traits>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/size.hpp>
 #include <range/v3/begin_end.hpp>
@@ -104,5 +105,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::const_view)
 
 #endif

--- a/include/range/v3/view/const.hpp
+++ b/include/range/v3/view/const.hpp
@@ -16,7 +16,7 @@
 
 #include <utility>
 #include <type_traits>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/size.hpp>
 #include <range/v3/begin_end.hpp>
@@ -106,6 +106,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::const_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::const_view)
 
 #endif

--- a/include/range/v3/view/counted.hpp
+++ b/include/range/v3/view/counted.hpp
@@ -14,7 +14,7 @@
 #define RANGES_V3_VIEW_COUNTED_HPP
 
 #include <utility>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/view_facade.hpp>
 #include <range/v3/iterator_range.hpp>
@@ -85,6 +85,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::counted_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::counted_view)
 
 #endif

--- a/include/range/v3/view/counted.hpp
+++ b/include/range/v3/view/counted.hpp
@@ -14,6 +14,7 @@
 #define RANGES_V3_VIEW_COUNTED_HPP
 
 #include <utility>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/view_facade.hpp>
 #include <range/v3/iterator_range.hpp>
@@ -83,5 +84,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::counted_view)
 
 #endif

--- a/include/range/v3/view/cycle.hpp
+++ b/include/range/v3/view/cycle.hpp
@@ -19,7 +19,7 @@
 #include <utility>
 #include <type_traits>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/size.hpp>
 #include <range/v3/distance.hpp>
@@ -236,6 +236,6 @@ namespace ranges
     } // namespace v3
 } // namespace ranges
 
-BOOST_RANGE_HOOK(ranges::v3::cycled_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::cycled_view)
 
 #endif

--- a/include/range/v3/view/cycle.hpp
+++ b/include/range/v3/view/cycle.hpp
@@ -19,6 +19,7 @@
 #include <utility>
 #include <type_traits>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/size.hpp>
 #include <range/v3/distance.hpp>
@@ -234,5 +235,7 @@ namespace ranges
        /// @}
     } // namespace v3
 } // namespace ranges
+
+BOOST_RANGE_HOOK(ranges::v3::cycled_view)
 
 #endif

--- a/include/range/v3/view/delimit.hpp
+++ b/include/range/v3/view/delimit.hpp
@@ -15,7 +15,7 @@
 #define RANGES_V3_VIEW_DELIMIT_HPP
 
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/view_adaptor.hpp>
@@ -127,6 +127,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::delimit_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::delimit_view)
 
 #endif

--- a/include/range/v3/view/delimit.hpp
+++ b/include/range/v3/view/delimit.hpp
@@ -15,6 +15,7 @@
 #define RANGES_V3_VIEW_DELIMIT_HPP
 
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/view_adaptor.hpp>
@@ -125,5 +126,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::delimit_view)
 
 #endif

--- a/include/range/v3/view/drop.hpp
+++ b/include/range/v3/view/drop.hpp
@@ -16,6 +16,7 @@
 
 #include <type_traits>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
@@ -205,5 +206,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::drop_view)
 
 #endif

--- a/include/range/v3/view/drop.hpp
+++ b/include/range/v3/view/drop.hpp
@@ -16,7 +16,7 @@
 
 #include <type_traits>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
@@ -207,6 +207,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::drop_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::drop_view)
 
 #endif

--- a/include/range/v3/view/drop_exactly.hpp
+++ b/include/range/v3/view/drop_exactly.hpp
@@ -16,7 +16,7 @@
 
 #include <type_traits>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
@@ -203,6 +203,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::drop_exactly_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::drop_exactly_view)
 
 #endif

--- a/include/range/v3/view/drop_exactly.hpp
+++ b/include/range/v3/view/drop_exactly.hpp
@@ -16,6 +16,7 @@
 
 #include <type_traits>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
@@ -201,5 +202,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::drop_exactly_view)
 
 #endif

--- a/include/range/v3/view/drop_while.hpp
+++ b/include/range/v3/view/drop_while.hpp
@@ -17,6 +17,7 @@
 #include <utility>
 #include <functional>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
@@ -144,5 +145,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::drop_while_view)
 
 #endif

--- a/include/range/v3/view/drop_while.hpp
+++ b/include/range/v3/view/drop_while.hpp
@@ -17,7 +17,7 @@
 #include <utility>
 #include <functional>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
@@ -146,6 +146,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::drop_while_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::drop_while_view)
 
 #endif

--- a/include/range/v3/view/empty.hpp
+++ b/include/range/v3/view/empty.hpp
@@ -14,6 +14,7 @@
 #ifndef RANGES_V3_VIEW_EMPTY_HPP
 #define RANGES_V3_VIEW_EMPTY_HPP
 
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/view_facade.hpp>
 
@@ -85,5 +86,7 @@ namespace ranges
         }
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::empty_view)
 
 #endif

--- a/include/range/v3/view/empty.hpp
+++ b/include/range/v3/view/empty.hpp
@@ -14,7 +14,7 @@
 #ifndef RANGES_V3_VIEW_EMPTY_HPP
 #define RANGES_V3_VIEW_EMPTY_HPP
 
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/view_facade.hpp>
 
@@ -87,6 +87,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::empty_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::empty_view)
 
 #endif

--- a/include/range/v3/view/for_each.hpp
+++ b/include/range/v3/view/for_each.hpp
@@ -17,6 +17,7 @@
 #include <utility>
 #include <meta/meta.hpp>
 #include <range/v3/range_fwd.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/view/view.hpp>
 #include <range/v3/view/all.hpp>
 #include <range/v3/view/join.hpp>
@@ -177,5 +178,7 @@ namespace ranges
         /// \endcond
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::for_each_view)
 
 #endif

--- a/include/range/v3/view/for_each.hpp
+++ b/include/range/v3/view/for_each.hpp
@@ -17,7 +17,7 @@
 #include <utility>
 #include <meta/meta.hpp>
 #include <range/v3/range_fwd.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/view/view.hpp>
 #include <range/v3/view/all.hpp>
 #include <range/v3/view/join.hpp>
@@ -179,6 +179,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::for_each_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::for_each_view)
 
 #endif

--- a/include/range/v3/view/generate.hpp
+++ b/include/range/v3/view/generate.hpp
@@ -17,6 +17,7 @@
 #include <utility>
 #include <type_traits>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/size.hpp>
 #include <range/v3/begin_end.hpp>
@@ -119,5 +120,7 @@ namespace ranges
         /// \@}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::generate_view)
 
 #endif

--- a/include/range/v3/view/generate.hpp
+++ b/include/range/v3/view/generate.hpp
@@ -17,7 +17,7 @@
 #include <utility>
 #include <type_traits>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/size.hpp>
 #include <range/v3/begin_end.hpp>
@@ -121,6 +121,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::generate_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::generate_view)
 
 #endif

--- a/include/range/v3/view/generate_n.hpp
+++ b/include/range/v3/view/generate_n.hpp
@@ -17,7 +17,7 @@
 #include <type_traits>
 #include <utility>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/size.hpp>
@@ -131,6 +131,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::generate_n_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::generate_n_view)
 
 #endif

--- a/include/range/v3/view/generate_n.hpp
+++ b/include/range/v3/view/generate_n.hpp
@@ -17,6 +17,7 @@
 #include <type_traits>
 #include <utility>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/size.hpp>
@@ -129,5 +130,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::generate_n_view)
 
 #endif

--- a/include/range/v3/view/group_by.hpp
+++ b/include/range/v3/view/group_by.hpp
@@ -17,6 +17,7 @@
 #include <utility>
 #include <type_traits>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/iterator_range.hpp>
@@ -161,5 +162,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::group_by_view)
 
 #endif

--- a/include/range/v3/view/group_by.hpp
+++ b/include/range/v3/view/group_by.hpp
@@ -17,7 +17,7 @@
 #include <utility>
 #include <type_traits>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/iterator_range.hpp>
@@ -163,6 +163,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::group_by_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::group_by_view)
 
 #endif

--- a/include/range/v3/view/indirect.hpp
+++ b/include/range/v3/view/indirect.hpp
@@ -18,7 +18,7 @@
 #include <iterator>
 #include <type_traits>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/begin_end.hpp>
@@ -115,6 +115,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::indirect_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::indirect_view)
 
 #endif

--- a/include/range/v3/view/indirect.hpp
+++ b/include/range/v3/view/indirect.hpp
@@ -18,6 +18,7 @@
 #include <iterator>
 #include <type_traits>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/begin_end.hpp>
@@ -113,5 +114,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::indirect_view)
 
 #endif

--- a/include/range/v3/view/intersperse.hpp
+++ b/include/range/v3/view/intersperse.hpp
@@ -17,6 +17,7 @@
 #include <utility>
 #include <type_traits>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/empty.hpp>
 #include <range/v3/begin_end.hpp>
@@ -192,5 +193,7 @@ namespace ranges
         }
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::intersperse_view)
 
 #endif

--- a/include/range/v3/view/intersperse.hpp
+++ b/include/range/v3/view/intersperse.hpp
@@ -17,7 +17,7 @@
 #include <utility>
 #include <type_traits>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/empty.hpp>
 #include <range/v3/begin_end.hpp>
@@ -194,6 +194,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::intersperse_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::intersperse_view)
 
 #endif

--- a/include/range/v3/view/iota.hpp
+++ b/include/range/v3/view/iota.hpp
@@ -19,6 +19,7 @@
 #include <limits>
 #include <type_traits>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/view_facade.hpp>
@@ -515,5 +516,8 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::closed_iota_view)
+BOOST_RANGE_HOOK(ranges::v3::iota_view)
 
 #endif

--- a/include/range/v3/view/iota.hpp
+++ b/include/range/v3/view/iota.hpp
@@ -19,7 +19,7 @@
 #include <limits>
 #include <type_traits>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/view_facade.hpp>
@@ -517,7 +517,7 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::closed_iota_view)
-BOOST_RANGE_HOOK(ranges::v3::iota_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::closed_iota_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::iota_view)
 
 #endif

--- a/include/range/v3/view/join.hpp
+++ b/include/range/v3/view/join.hpp
@@ -17,7 +17,7 @@
 #include <utility>
 #include <type_traits>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/size.hpp>
 #include <range/v3/numeric.hpp> // for accumulate
@@ -361,6 +361,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::join_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::join_view)
 
 #endif

--- a/include/range/v3/view/join.hpp
+++ b/include/range/v3/view/join.hpp
@@ -17,6 +17,7 @@
 #include <utility>
 #include <type_traits>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/size.hpp>
 #include <range/v3/numeric.hpp> // for accumulate
@@ -359,5 +360,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::join_view)
 
 #endif

--- a/include/range/v3/view/move.hpp
+++ b/include/range/v3/view/move.hpp
@@ -16,6 +16,7 @@
 
 #include <utility>
 #include <type_traits>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/size.hpp>
 #include <range/v3/begin_end.hpp>
@@ -105,5 +106,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::move_view)
 
 #endif

--- a/include/range/v3/view/move.hpp
+++ b/include/range/v3/view/move.hpp
@@ -16,7 +16,7 @@
 
 #include <utility>
 #include <type_traits>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/size.hpp>
 #include <range/v3/begin_end.hpp>
@@ -107,6 +107,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::move_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::move_view)
 
 #endif

--- a/include/range/v3/view/partial_sum.hpp
+++ b/include/range/v3/view/partial_sum.hpp
@@ -19,6 +19,7 @@
 #include <functional>
 #include <type_traits>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/size.hpp>
 #include <range/v3/empty.hpp>
@@ -176,5 +177,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::partial_sum_view)
 
 #endif

--- a/include/range/v3/view/partial_sum.hpp
+++ b/include/range/v3/view/partial_sum.hpp
@@ -19,7 +19,7 @@
 #include <functional>
 #include <type_traits>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/size.hpp>
 #include <range/v3/empty.hpp>
@@ -178,6 +178,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::partial_sum_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::partial_sum_view)
 
 #endif

--- a/include/range/v3/view/remove_if.hpp
+++ b/include/range/v3/view/remove_if.hpp
@@ -17,7 +17,7 @@
 #include <utility>
 #include <type_traits>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_traits.hpp>
@@ -182,6 +182,6 @@ namespace ranges
 
 RANGES_RE_ENABLE_WARNINGS
 
-BOOST_RANGE_HOOK(ranges::v3::remove_if_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::remove_if_view)
 
 #endif

--- a/include/range/v3/view/remove_if.hpp
+++ b/include/range/v3/view/remove_if.hpp
@@ -17,6 +17,7 @@
 #include <utility>
 #include <type_traits>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_traits.hpp>
@@ -180,5 +181,7 @@ namespace ranges
 }
 
 RANGES_RE_ENABLE_WARNINGS
+
+BOOST_RANGE_HOOK(ranges::v3::remove_if_view)
 
 #endif

--- a/include/range/v3/view/repeat.hpp
+++ b/include/range/v3/view/repeat.hpp
@@ -15,7 +15,7 @@
 #define RANGES_V3_VIEW_REPEAT_HPP
 
 #include <utility>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/view_facade.hpp>
@@ -117,6 +117,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::repeat_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::repeat_view)
 
 #endif

--- a/include/range/v3/view/repeat.hpp
+++ b/include/range/v3/view/repeat.hpp
@@ -15,6 +15,7 @@
 #define RANGES_V3_VIEW_REPEAT_HPP
 
 #include <utility>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/view_facade.hpp>
@@ -115,5 +116,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::repeat_view)
 
 #endif

--- a/include/range/v3/view/repeat_n.hpp
+++ b/include/range/v3/view/repeat_n.hpp
@@ -15,7 +15,7 @@
 #define RANGES_V3_VIEW_REPEAT_N_HPP
 
 #include <utility>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/view_facade.hpp>
@@ -129,6 +129,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::repeat_n_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::repeat_n_view)
 
 #endif

--- a/include/range/v3/view/repeat_n.hpp
+++ b/include/range/v3/view/repeat_n.hpp
@@ -15,6 +15,7 @@
 #define RANGES_V3_VIEW_REPEAT_N_HPP
 
 #include <utility>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/view_facade.hpp>
@@ -127,5 +128,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::repeat_n_view)
 
 #endif

--- a/include/range/v3/view/reverse.hpp
+++ b/include/range/v3/view/reverse.hpp
@@ -17,7 +17,7 @@
 #include <utility>
 #include <iterator>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/size.hpp>
 #include <range/v3/begin_end.hpp>
@@ -233,6 +233,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::reverse_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::reverse_view)
 
 #endif

--- a/include/range/v3/view/reverse.hpp
+++ b/include/range/v3/view/reverse.hpp
@@ -17,6 +17,7 @@
 #include <utility>
 #include <iterator>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/size.hpp>
 #include <range/v3/begin_end.hpp>
@@ -231,5 +232,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::reverse_view)
 
 #endif

--- a/include/range/v3/view/sample.hpp
+++ b/include/range/v3/view/sample.hpp
@@ -15,7 +15,7 @@
 #define RANGES_V3_VIEW_SAMPLE_HPP
 
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/view_facade.hpp>
 #include <range/v3/algorithm/shuffle.hpp>
@@ -250,6 +250,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::sample_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::sample_view)
 
 #endif

--- a/include/range/v3/view/sample.hpp
+++ b/include/range/v3/view/sample.hpp
@@ -15,6 +15,7 @@
 #define RANGES_V3_VIEW_SAMPLE_HPP
 
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/view_facade.hpp>
 #include <range/v3/algorithm/shuffle.hpp>
@@ -248,5 +249,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::sample_view)
 
 #endif

--- a/include/range/v3/view/single.hpp
+++ b/include/range/v3/view/single.hpp
@@ -16,7 +16,7 @@
 
 #include <utility>
 #include <type_traits>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_concepts.hpp>
@@ -129,6 +129,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::single_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::single_view)
 
 #endif

--- a/include/range/v3/view/single.hpp
+++ b/include/range/v3/view/single.hpp
@@ -16,6 +16,7 @@
 
 #include <utility>
 #include <type_traits>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_concepts.hpp>
@@ -127,5 +128,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::single_view)
 
 #endif

--- a/include/range/v3/view/slice.hpp
+++ b/include/range/v3/view/slice.hpp
@@ -16,6 +16,7 @@
 
 #include <type_traits>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
@@ -411,5 +412,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::slice_view)
 
 #endif

--- a/include/range/v3/view/slice.hpp
+++ b/include/range/v3/view/slice.hpp
@@ -16,7 +16,7 @@
 
 #include <type_traits>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
@@ -413,6 +413,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::slice_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::slice_view)
 
 #endif

--- a/include/range/v3/view/split.hpp
+++ b/include/range/v3/view/split.hpp
@@ -17,6 +17,7 @@
 #include <utility>
 #include <type_traits>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/iterator_range.hpp>
@@ -277,5 +278,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::split_view)
 
 #endif

--- a/include/range/v3/view/split.hpp
+++ b/include/range/v3/view/split.hpp
@@ -17,7 +17,7 @@
 #include <utility>
 #include <type_traits>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/iterator_range.hpp>
@@ -279,6 +279,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::split_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::split_view)
 
 #endif

--- a/include/range/v3/view/stride.hpp
+++ b/include/range/v3/view/stride.hpp
@@ -18,7 +18,7 @@
 #include <utility>
 #include <type_traits>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/size.hpp>
 #include <range/v3/distance.hpp>
@@ -239,6 +239,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::stride_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::stride_view)
 
 #endif

--- a/include/range/v3/view/stride.hpp
+++ b/include/range/v3/view/stride.hpp
@@ -18,6 +18,7 @@
 #include <utility>
 #include <type_traits>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/size.hpp>
 #include <range/v3/distance.hpp>
@@ -237,5 +238,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::stride_view)
 
 #endif

--- a/include/range/v3/view/tail.hpp
+++ b/include/range/v3/view/tail.hpp
@@ -16,7 +16,7 @@
 
 #include <utility>
 #include <type_traits>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/empty.hpp>
@@ -122,6 +122,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::tail_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::tail_view)
 
 #endif

--- a/include/range/v3/view/tail.hpp
+++ b/include/range/v3/view/tail.hpp
@@ -16,6 +16,7 @@
 
 #include <utility>
 #include <type_traits>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/empty.hpp>
@@ -120,5 +121,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::tail_view)
 
 #endif

--- a/include/range/v3/view/take.hpp
+++ b/include/range/v3/view/take.hpp
@@ -15,6 +15,7 @@
 #define RANGES_V3_VIEW_TAKE_HPP
 
 #include <type_traits>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
@@ -164,5 +165,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::take_view)
 
 #endif

--- a/include/range/v3/view/take.hpp
+++ b/include/range/v3/view/take.hpp
@@ -15,7 +15,7 @@
 #define RANGES_V3_VIEW_TAKE_HPP
 
 #include <type_traits>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
@@ -166,6 +166,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::take_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::take_view)
 
 #endif

--- a/include/range/v3/view/take_exactly.hpp
+++ b/include/range/v3/view/take_exactly.hpp
@@ -15,6 +15,7 @@
 #define RANGES_V3_VIEW_TAKE_EXACTLY_HPP
 
 #include <type_traits>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
@@ -208,5 +209,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::detail::take_exactly_view_)
 
 #endif

--- a/include/range/v3/view/take_exactly.hpp
+++ b/include/range/v3/view/take_exactly.hpp
@@ -15,7 +15,7 @@
 #define RANGES_V3_VIEW_TAKE_EXACTLY_HPP
 
 #include <type_traits>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
@@ -210,6 +210,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::detail::take_exactly_view_)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::detail::take_exactly_view_)
 
 #endif

--- a/include/range/v3/view/take_while.hpp
+++ b/include/range/v3/view/take_while.hpp
@@ -18,7 +18,7 @@
 #include <functional>
 #include <type_traits>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/view_adaptor.hpp>
@@ -181,7 +181,7 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::iter_take_while_view)
-BOOST_RANGE_HOOK(ranges::v3::take_while_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::iter_take_while_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::take_while_view)
 
 #endif

--- a/include/range/v3/view/take_while.hpp
+++ b/include/range/v3/view/take_while.hpp
@@ -18,6 +18,7 @@
 #include <functional>
 #include <type_traits>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/view_adaptor.hpp>
@@ -179,5 +180,8 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::iter_take_while_view)
+BOOST_RANGE_HOOK(ranges::v3::take_while_view)
 
 #endif

--- a/include/range/v3/view/tokenize.hpp
+++ b/include/range/v3/view/tokenize.hpp
@@ -19,6 +19,7 @@
 #include <utility>
 #include <type_traits>
 #include <initializer_list>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/view_interface.hpp>
 #include <range/v3/begin_end.hpp>
@@ -207,5 +208,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::tokenize_view)
 
 #endif

--- a/include/range/v3/view/tokenize.hpp
+++ b/include/range/v3/view/tokenize.hpp
@@ -19,7 +19,7 @@
 #include <utility>
 #include <type_traits>
 #include <initializer_list>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/view_interface.hpp>
 #include <range/v3/begin_end.hpp>
@@ -209,6 +209,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::tokenize_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::tokenize_view)
 
 #endif

--- a/include/range/v3/view/transform.hpp
+++ b/include/range/v3/view/transform.hpp
@@ -18,7 +18,7 @@
 #include <iterator>
 #include <type_traits>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/size.hpp>
 #include <range/v3/begin_end.hpp>
@@ -490,7 +490,7 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::iter_transform_view)
-BOOST_RANGE_HOOK(ranges::v3::transform_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::iter_transform_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::transform_view)
 
 #endif

--- a/include/range/v3/view/transform.hpp
+++ b/include/range/v3/view/transform.hpp
@@ -18,6 +18,7 @@
 #include <iterator>
 #include <type_traits>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/size.hpp>
 #include <range/v3/begin_end.hpp>
@@ -488,5 +489,8 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::iter_transform_view)
+BOOST_RANGE_HOOK(ranges::v3::transform_view)
 
 #endif

--- a/include/range/v3/view/unbounded.hpp
+++ b/include/range/v3/view/unbounded.hpp
@@ -12,7 +12,7 @@
 #ifndef RANGES_V3_VIEW_UNBOUNDED_HPP
 #define RANGES_V3_VIEW_UNBOUNDED_HPP
 
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/view_interface.hpp>
 #include <range/v3/utility/unreachable.hpp>
@@ -64,6 +64,6 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::unbounded_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::unbounded_view)
 
 #endif

--- a/include/range/v3/view/unbounded.hpp
+++ b/include/range/v3/view/unbounded.hpp
@@ -12,6 +12,7 @@
 #ifndef RANGES_V3_VIEW_UNBOUNDED_HPP
 #define RANGES_V3_VIEW_UNBOUNDED_HPP
 
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/view_interface.hpp>
 #include <range/v3/utility/unreachable.hpp>
@@ -62,5 +63,7 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::unbounded_view)
 
 #endif

--- a/include/range/v3/view/zip.hpp
+++ b/include/range/v3/view/zip.hpp
@@ -17,7 +17,7 @@
 #include <tuple>
 #include <utility>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/utility/iterator_concepts.hpp>
 #include <range/v3/utility/iterator_traits.hpp>
@@ -145,6 +145,6 @@ namespace ranges
 
 RANGES_RE_ENABLE_WARNINGS
 
-BOOST_RANGE_HOOK(ranges::v3::zip_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::zip_view)
 
 #endif

--- a/include/range/v3/view/zip.hpp
+++ b/include/range/v3/view/zip.hpp
@@ -17,6 +17,7 @@
 #include <tuple>
 #include <utility>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/utility/iterator_concepts.hpp>
 #include <range/v3/utility/iterator_traits.hpp>
@@ -143,5 +144,7 @@ namespace ranges
 }
 
 RANGES_RE_ENABLE_WARNINGS
+
+BOOST_RANGE_HOOK(ranges::v3::zip_view)
 
 #endif

--- a/include/range/v3/view/zip_with.hpp
+++ b/include/range/v3/view/zip_with.hpp
@@ -20,7 +20,7 @@
 #include <functional>
 #include <type_traits>
 #include <meta/meta.hpp>
-#include <range/v3/detail/boost_range_hook.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_traits.hpp>
@@ -397,7 +397,7 @@ namespace ranges
     }
 }
 
-BOOST_RANGE_HOOK(ranges::v3::iter_zip_with_view)
-BOOST_RANGE_HOOK(ranges::v3::zip_with_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::iter_zip_with_view)
+RANGES_SATISFY_BOOST_RANGE(ranges::v3::zip_with_view)
 
 #endif

--- a/include/range/v3/view/zip_with.hpp
+++ b/include/range/v3/view/zip_with.hpp
@@ -20,6 +20,7 @@
 #include <functional>
 #include <type_traits>
 #include <meta/meta.hpp>
+#include <range/v3/detail/boost_range_hook.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_traits.hpp>
@@ -395,5 +396,8 @@ namespace ranges
         /// @}
     }
 }
+
+BOOST_RANGE_HOOK(ranges::v3::iter_zip_with_view)
+BOOST_RANGE_HOOK(ranges::v3::zip_with_view)
 
 #endif


### PR DESCRIPTION
This allows range-v3 views to be treated as ranges by the Boost Range
library and other related Boost libraries.

This is an attempt to tackle ericniebler/range-v3#486.