### PR TITLE
Eliminate basic_sentinel as in P0186

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -150,7 +150,7 @@ Range v3 provides a utility for easily creating your own range types, called `vi
         friend range_access;
         char const * sz_;
         char const & get() const { return *sz_; }
-        bool done() const { return *sz_ == '\0'; }
+        bool equal(default_sentinel) const { return *sz_ == '\0'; }
         void next() { ++sz_; }
     public:
         c_string_range() = default;

--- a/example/calendar.cpp
+++ b/example/calendar.cpp
@@ -232,7 +232,7 @@ struct interleave_view<Rngs>::cursor  {
         if(0 == ((++n_) %= its_.size()))
             for_each(its_, [](auto& it){ ++it; });
     }
-    bool done() const {
+    bool equal(default_sentinel) const {
         return n_ == 0 && its_.end() != mismatch(its_, *rngs_,
             std::not_equal_to<>(), ident(), ranges::end).in1();
     }

--- a/include/range/v3/getlines.hpp
+++ b/include/range/v3/getlines.hpp
@@ -51,7 +51,7 @@ namespace ranges
                 {
                     return rng_->str_;
                 }
-                bool done() const
+                bool equal(default_sentinel) const
                 {
                     return !*rng_->sin_;
                 }

--- a/include/range/v3/istream_range.hpp
+++ b/include/range/v3/istream_range.hpp
@@ -51,7 +51,7 @@ namespace ranges
                 {
                     return rng_->cached();
                 }
-                bool done() const
+                bool equal(default_sentinel) const
                 {
                     return !*rng_->sin_;
                 }

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -377,11 +377,8 @@ namespace ranges
         template<typename Cur>
         struct basic_mixin;
 
-        template<typename Cur, typename S = Cur>
+        template<typename Cur>
         struct basic_iterator;
-
-        template<typename S>
-        struct basic_sentinel;
 
         template<cardinality>
         struct basic_view : view_base
@@ -480,20 +477,19 @@ namespace ranges
             struct counted_fn;
         }
 
-        struct default_end_cursor;
-        using default_sentinel = basic_sentinel<default_end_cursor>;
+        struct default_sentinel { };
 
         template<typename I, typename D = meta::_t<difference_type<I>>>
         using counted_iterator =
-            basic_iterator<detail::counted_cursor<I, D>, default_end_cursor>;
+            basic_iterator<detail::counted_cursor<I, D>>;
 
         template<typename I>
         using move_iterator =
-            basic_iterator<detail::move_cursor<I>, default_end_cursor>;
+            basic_iterator<detail::move_cursor<I>>;
 
         template<typename I>
         using move_into_iterator =
-            basic_iterator<detail::move_into_cursor<I>, default_end_cursor>;
+            basic_iterator<detail::move_into_cursor<I>>;
 
         template<typename Rng>
         struct cycled_view;
@@ -511,8 +507,7 @@ namespace ranges
         /// \endcond
 
         template<typename I>
-        using reverse_iterator = basic_iterator<detail::reverse_cursor<I>,
-                                                detail::reverse_cursor<I>>;
+        using reverse_iterator = basic_iterator<detail::reverse_cursor<I>>;
 
         template<typename T>
         struct empty_view;

--- a/include/range/v3/utility/counted_iterator.hpp
+++ b/include/range/v3/utility/counted_iterator.hpp
@@ -127,7 +127,7 @@ namespace ranges
                 {
                     *it_ = (T &&) t;
                 }
-                bool done() const
+                bool equal(default_sentinel) const
                 {
                     return 0 == n_;
                 }
@@ -157,7 +157,7 @@ namespace ranges
                 {
                     return n_ - that.n_;
                 }
-                D distance_remaining() const
+                D distance_to(default_sentinel) const
                 {
                     return n_;
                 }

--- a/include/range/v3/utility/iterator.hpp
+++ b/include/range/v3/utility/iterator.hpp
@@ -65,11 +65,11 @@ namespace ranges
             // Handle range-v3 iterators specially, since many range-v3 iterators will want to
             // decrement an iterator that is bidirectional from the perspective of range-v3,
             // but only input from the perspective of std::advance.
-            template<typename Cur, typename Sent>
+            template<typename Cur>
             RANGES_CXX14_CONSTEXPR
-            void advance(basic_iterator<Cur, Sent> &i, iterator_difference_t<basic_iterator<Cur, Sent>> n)
+            void advance(basic_iterator<Cur> &i, iterator_difference_t<basic_iterator<Cur>> n)
             {
-                adl_advance_detail::advance_impl(i, n, iterator_concept<basic_iterator<Cur, Sent>>{});
+                adl_advance_detail::advance_impl(i, n, iterator_concept<basic_iterator<Cur>>{});
             }
             // Hijack std::advance for raw pointers, since std::advance is not constexpr
             template<typename T>

--- a/include/range/v3/view/cycle.hpp
+++ b/include/range/v3/view/cycle.hpp
@@ -111,7 +111,7 @@ namespace ranges
                 explicit cursor(cycled_view_t &rng)
                   : rng_(&rng), it_(ranges::begin(rng.rng_))
                 {}
-                constexpr bool done() const
+                constexpr bool equal(default_sentinel) const
                 {
                     return false;
                 }

--- a/include/range/v3/view/empty.hpp
+++ b/include/range/v3/view/empty.hpp
@@ -34,7 +34,7 @@ namespace ranges
                 {
                     RANGES_ENSURE(false);
                 }
-                constexpr bool done() const
+                constexpr bool equal(default_sentinel) const
                 {
                     return true;
                 }

--- a/include/range/v3/view/generate.hpp
+++ b/include/range/v3/view/generate.hpp
@@ -52,7 +52,7 @@ namespace ranges
                 cursor(generate_view &view)
                   : view_(&view)
                 {}
-                constexpr bool done() const
+                constexpr bool equal(default_sentinel) const
                 {
                     return false;
                 }

--- a/include/range/v3/view/generate_n.hpp
+++ b/include/range/v3/view/generate_n.hpp
@@ -53,7 +53,7 @@ namespace ranges
                 cursor(generate_n_view &rng, std::size_t n)
                   : rng_(&rng), n_(n)
                 {}
-                bool done() const
+                bool equal(default_sentinel) const
                 {
                     return 0 == n_;
                 }

--- a/include/range/v3/view/group_by.hpp
+++ b/include/range/v3/view/group_by.hpp
@@ -79,7 +79,7 @@ namespace ranges
                 {
                     cur_ = ranges::next(adjacent_find(cur_, last_, not_fn(std::ref(fun_))), 1, last_);
                 }
-                bool done() const
+                bool equal(default_sentinel) const
                 {
                     return cur_ == last_;
                 }

--- a/include/range/v3/view/iota.hpp
+++ b/include/range/v3/view/iota.hpp
@@ -215,7 +215,7 @@ namespace ranges
                 else
                     ++from_;
             }
-            bool done() const
+            bool equal(default_sentinel) const
             {
                 return done_;
             }
@@ -258,7 +258,7 @@ namespace ranges
             {
                 ++from_;
             }
-            bool done() const
+            bool equal(default_sentinel) const
             {
                 return from_ == to_;
             }
@@ -319,7 +319,7 @@ namespace ranges
             {
                 ++value_;
             }
-            constexpr bool done() const
+            constexpr bool equal(default_sentinel) const
             {
                 return false;
             }

--- a/include/range/v3/view/join.hpp
+++ b/include/range/v3/view/join.hpp
@@ -126,7 +126,7 @@ namespace ranges
                         satisfy();
                     }
                 }
-                bool done() const
+                bool equal(default_sentinel) const
                 {
                     return outer_it_ == ranges::end(rng_->outer_);
                 }
@@ -244,7 +244,7 @@ namespace ranges
                         satisfy();
                     }
                 }
-                bool done() const
+                bool equal(default_sentinel) const
                 {
                     return outer_it_ == ranges::end(rng_->outer_);
                 }

--- a/include/range/v3/view/repeat.hpp
+++ b/include/range/v3/view/repeat.hpp
@@ -50,14 +50,14 @@ namespace ranges
                 Val const *value_;
             public:
                 cursor() = default;
-                cursor(Val const &value)
+                explicit cursor(Val const &value)
                   : value_(std::addressof(value))
                 {}
                 Val const &get() const
                 {
                     return *value_;
                 }
-                constexpr bool done() const
+                constexpr bool equal(default_sentinel) const
                 {
                     return false;
                 }
@@ -78,7 +78,7 @@ namespace ranges
             };
             cursor begin_cursor() const
             {
-                return {value_};
+                return cursor{value_};
             }
         public:
             repeat_view() = default;

--- a/include/range/v3/view/repeat_n.hpp
+++ b/include/range/v3/view/repeat_n.hpp
@@ -58,7 +58,7 @@ namespace ranges
                 {
                     return *value_;
                 }
-                constexpr bool done() const
+                constexpr bool equal(default_sentinel) const
                 {
                     return 0 == n_;
                 }

--- a/include/range/v3/view/sample.hpp
+++ b/include/range/v3/view/sample.hpp
@@ -147,7 +147,7 @@ namespace ranges
                 {
                     return *current();
                 }
-                bool done() const
+                bool equal(default_sentinel) const
                 {
                     RANGES_ASSERT(range());
                     return range()->size() <= 0;

--- a/include/range/v3/view/set_algorithm.hpp
+++ b/include/range/v3/view/set_algorithm.hpp
@@ -155,7 +155,7 @@ namespace ranges
                 {
                     return it1_ == that.it1_; // does not support comparing iterators from different ranges
                 }
-                bool done() const
+                bool equal(default_sentinel) const
                 {
                     return it1_ == end1_;
                 }
@@ -327,7 +327,7 @@ namespace ranges
                 {
                     return it1_ == that.it1_; // does not support comparing iterators from different ranges;
                 }
-                bool done() const
+                bool equal(default_sentinel) const
                 {
                     return (it1_ == end1_) || (it2_ == end2_);
                 }
@@ -535,7 +535,7 @@ namespace ranges
                 {
                     return (it1_ == that.it1_) && (it2_ == that.it2_); // does not support comparing iterators from different ranges
                 }
-                bool done() const
+                bool equal(default_sentinel) const
                 {
                     return (it1_ == end1_) && (it2_ == end2_);
                 }
@@ -760,7 +760,7 @@ namespace ranges
                 {
                     return (it1_ == that.it1_) && (it2_ == that.it2_); // does not support comparing iterators from different ranges
                 }
-                bool done() const
+                bool equal(default_sentinel) const
                 {
                     return (it1_ == end1_) && (it2_ == end2_);
                 }

--- a/include/range/v3/view/single.hpp
+++ b/include/range/v3/view/single.hpp
@@ -53,7 +53,7 @@ namespace ranges
                 {
                     return value_;
                 }
-                bool done() const
+                bool equal(default_sentinel) const
                 {
                     return done_;
                 }

--- a/include/range/v3/view/split.hpp
+++ b/include/range/v3/view/split.hpp
@@ -99,7 +99,7 @@ namespace ranges
                         }
                     }
                 }
-                bool done() const
+                bool equal(default_sentinel) const
                 {
                     return cur_ == last_;
                 }

--- a/include/range/v3/view_facade.hpp
+++ b/include/range/v3/view_facade.hpp
@@ -39,15 +39,14 @@ namespace ranges
                 decltype(range_access::end_cursor(std::declval<Derived &>(), 42));
 
             template<typename Derived>
-            using facade_iterator_t =
-                basic_iterator<begin_cursor_t<Derived>, end_cursor_t<Derived>>;
+            using facade_iterator_t = basic_iterator<begin_cursor_t<Derived>>;
 
             template<typename Derived>
             using facade_sentinel_t =
                 meta::if_<
                     Same<begin_cursor_t<Derived>, end_cursor_t<Derived>>,
-                    basic_iterator<begin_cursor_t<Derived>, end_cursor_t<Derived>>,
-                    basic_sentinel<end_cursor_t<Derived>>>;
+                    facade_iterator_t<Derived>,
+                    end_cursor_t<Derived>>;
         }
         /// \endcond
 
@@ -66,7 +65,7 @@ namespace ranges
             {
                 return derived();
             }
-            default_end_cursor end_cursor() const
+            constexpr default_sentinel end_cursor() const
             {
                 return {};
             }
@@ -85,13 +84,15 @@ namespace ranges
             template<typename D = Derived, CONCEPT_REQUIRES_(Same<D, Derived>())>
             detail::facade_sentinel_t<D> end()
             {
-                return {range_access::end_cursor(derived(), 42)};
+                return static_cast<detail::facade_sentinel_t<D>>(
+                    range_access::end_cursor(derived(), 42));
             }
             /// \overload
             template<typename D = Derived, CONCEPT_REQUIRES_(Same<D, Derived>())>
             detail::facade_sentinel_t<D const> end() const
             {
-                return {range_access::end_cursor(derived(), 42)};
+                return static_cast<detail::facade_sentinel_t<D const>>(
+                    range_access::end_cursor(derived(), 42));
             }
         };
 

--- a/test/utility/basic_iterator.cpp
+++ b/test/utility/basic_iterator.cpp
@@ -38,7 +38,7 @@ namespace test_weak_input
     };
 
     CONCEPT_ASSERT(ranges::detail::InputCursor<cursor<char*>>());
-    CONCEPT_ASSERT(!ranges::detail::HasEqualCursor<cursor<char*>>());
+    CONCEPT_ASSERT(!ranges::detail::CursorSentinel<cursor<char*>, cursor<char*>>());
 
     template<class I>
     using iterator = ranges::basic_iterator<cursor<I>>;
@@ -152,7 +152,7 @@ namespace test_weak_output
     };
 
     CONCEPT_ASSERT(ranges::detail::OutputCursor<cursor<char*>, char>());
-    CONCEPT_ASSERT(!ranges::detail::HasEqualCursor<cursor<char*>>());
+    CONCEPT_ASSERT(!ranges::detail::CursorSentinel<cursor<char*>, cursor<char*>>());
 
     template<class I>
     using iterator = ranges::basic_iterator<cursor<I>>;
@@ -320,7 +320,7 @@ namespace test_forward_sized
         }
     };
 
-    CONCEPT_ASSERT(ranges::detail::SizedCursor<cursor<char*>>());
+    CONCEPT_ASSERT(ranges::detail::SizedCursorSentinel<cursor<char*>, cursor<char*>>());
     CONCEPT_ASSERT(ranges::detail::ForwardCursor<cursor<char*>>());
 
     template<class I>

--- a/test_package/example.cpp
+++ b/test_package/example.cpp
@@ -21,7 +21,7 @@ class c_string_range
     friend range_access;
     char const * sz_;
     char const & get() const { return *sz_; }
-    bool done() const { return *sz_ == '\0'; }
+    bool equal(default_sentinel) const { return *sz_ == '\0'; }
     void next() { ++sz_; }
 public:
     c_string_range() = default;


### PR DESCRIPTION
This design change concentrates logic into cursor classes. Range designs like:
```c++
    struct range : view_facade</**/> {
        struct sentinel;

        struct cursor {
            friend sentinel;
            // ...
        };

        struct sentinel {
            bool equal(cursor&) {
                // inspect cursor's privates
            }
        };

        sentinel end_cursor();
        // range_sentinel_t<range> is basic_sentinel<range::sentinel>

        cursor begin_cursor();
        // range_iterator_t<range> is basic_iterator<range::cursor, range::sentinel>
    };
```
become:
```c++
    struct range : view_facade</**/> {
        struct cursor;

        struct sentinel {
            friend cursor;
            // sentinel becomes a dumb class for storing end state
        };

        struct cursor {
            // ...
            // cursor also knows how to compare itself to sentinel(s):
            bool equal(sentinel&) {
                // inspect sentinel's privates
            }
        };

        sentinel end_cursor();
        // range_sentinel_t<range> is range::sentinel

        cursor begin_cursor();
        // range_iterator_t<range> is basic_iterator<range::cursor>
    };
```
Details:

* Remove the "sentinel" parameter from `basic_iterator`.
* Remove `basic_sentinel`.

* Update cursor concepts:
  * Replace `HasEqualCursor<C>` with `CursorSentinel<S, C>`.
    * `range_access::equal(C, C)` becomes `template<class T> bool equal(C, T)`.
    * Replace usage of `range_access::empty(C, S)` with `range_access::equal(C, S)`.
    * Remove `range_access::done(C)` and replace all cursor `done()` members with `equal(defaul_sentinel)`.
  * Coalesce `SizedCursor<C>` and `SizedCursorRange<C, S>` into `SizedCursorSentinel<S, C>`.
    * `range_access::distance_to(C, C)` becomes `template<class T> difference_type<C> distance_to(C, T)`.
    * Remove `range_access::distance_remaining` and replace `counted_cursor::distance_remaining(default_sentinel)` with `distance_to(default_sentinel)`.
  * Remove `range_access::end`.
  * Remove `range_access::sentinel(basic_sentinel</**/>)`.

* Update `view_facade` to agree:
  * If `begin_cursor` and `end_cursor` return the same type, `facade_sentinel_t` is the same type as `facade_iterator_t`. Otherwise, `facade_sentinel_t` is the type returned by `end_cursor`.
  * The default implementation of `end_cursor` returns `default_sentinel`.

* Remove `default_end_cursor`, redefine `default_sentinel` as a simple empty `struct`.

* Transform range definitions as in the example above to fit the new design:
  * `any_view`
  * `concat`
  * `transform`
  * `iter_zip_with`
  * `view_adaptor`

* Make `repeat_view::cursor`'s converting constructor explicit, so that e.g. `Sentinel<int, range_iterator_t<repeat_view<int>>()` is not `true`.

* Rewrite `take_view` in terms of `view_adaptor`, greatly simplifying it and removing a few lines of code.
