### PR TITLE
Make "next()" optional for OutputCursors;

### DIFF
--- a/include/range/v3/range_access.hpp
+++ b/include/range/v3/range_access.hpp
@@ -71,7 +71,14 @@ namespace ranges
                         concepts::model_of<concepts::SemiRegular, T>(),
                         concepts::model_of<concepts::SemiRegular, mixin_base_t<T>>(),
                         concepts::model_of<concepts::Constructible, mixin_base_t<T>, T &&>(),
-                        concepts::model_of<concepts::Constructible, mixin_base_t<T>, T const &>(),
+                        concepts::model_of<concepts::Constructible, mixin_base_t<T>, T const &>()
+                    ));
+            };
+            struct HasCursorNext
+            {
+                template<typename T>
+                auto requires_(T&& t) -> decltype(
+                    concepts::valid_expr(
                         (t.next(), concepts::void_)
                     ));
             };
@@ -113,7 +120,7 @@ namespace ranges
               : concepts::refines<WritableCursor, Cursor(concepts::_1)>
             {};
             struct InputCursor
-              : concepts::refines<ReadableCursor, Cursor>
+              : concepts::refines<ReadableCursor, Cursor, HasCursorNext>
             {};
             struct ForwardCursor
               : concepts::refines<InputCursor, CursorSentinel(concepts::_1, concepts::_1)>
@@ -341,6 +348,10 @@ namespace ranges
             template<typename T, typename U>
             using WritableCursor =
                 concepts::models<range_access::WritableCursor, T, U>;
+
+            template<typename T>
+            using HasCursorNext =
+                concepts::models<range_access::HasCursorNext, T>;
 
             template<typename S, typename C>
             using SizedCursorSentinel =

--- a/include/range/v3/utility/counted_iterator.hpp
+++ b/include/range/v3/utility/counted_iterator.hpp
@@ -110,20 +110,27 @@ namespace ranges
                     RANGES_ASSERT(!ForwardIterator<I>() || ranges::next(j.base(), n) == i);
                     return {i, j.count() - n};
                 }
-                CONCEPT_REQUIRES(Readable<I>())
-                iterator_rvalue_reference_t<I> move() const
-                    noexcept(noexcept(iter_move(std::declval<I const &>())))
+                template<typename II = I,
+                    CONCEPT_REQUIRES_(Readable<II>())>
+                iterator_rvalue_reference_t<II> move() const
+                    noexcept(noexcept(iter_move(std::declval<II const &>())))
                 {
                     return iter_move(it_);
                 }
                 CONCEPT_REQUIRES(Readable<I>())
-                auto get() const -> decltype(*it_)
+                iterator_reference_t<I> get() const
                 {
                     return *it_;
                 }
                 template<typename T,
+                    CONCEPT_REQUIRES_(ExclusivelyWritable_<I const, T &&>())>
+                void set(T && t) const
+                {
+                    *it_ = (T &&) t;
+                }
+                template<typename T,
                     CONCEPT_REQUIRES_(ExclusivelyWritable_<I, T &&>())>
-                void set(T &&t) const
+                void set(T && t)
                 {
                     *it_ = (T &&) t;
                 }

--- a/test/utility/iterator.cpp
+++ b/test/utility/iterator.cpp
@@ -150,5 +150,10 @@ int main()
     test_move_iterator();
     issue_420_regression();
 
+    {
+        struct S { using value_type = int; };
+        CONCEPT_ASSERT(Same<int, ranges::value_type<S const>::type>());
+    }
+
     return ::test_result();
 }


### PR DESCRIPTION
an `OutputCursor` without `next` acts as its own proxy type.