### PR TITLE
Implement non_propagating_cache:

### DIFF
--- a/include/range/v3/detail/optional.hpp
+++ b/include/range/v3/detail/optional.hpp
@@ -70,6 +70,46 @@ namespace ranges
                 ranges::emplace<0>(data_);
             }
         };
+
+        namespace detail
+        {
+            template<typename T, typename Tag = void, bool Enable = true>
+            struct non_propagating_cache
+              : optional<T>
+            {
+                using optional<T>::optional;
+                using optional<T>::operator=;
+
+                non_propagating_cache() = default;
+                constexpr
+                non_propagating_cache(non_propagating_cache const &) noexcept
+                  : optional<T>{}
+                {}
+                RANGES_CXX14_CONSTEXPR
+                non_propagating_cache(non_propagating_cache && that) noexcept
+                  : optional<T>{}
+                {
+                    that.optional<T>::reset();
+                }
+                RANGES_CXX14_CONSTEXPR
+                non_propagating_cache& operator=(non_propagating_cache const &) noexcept
+                {
+                    this->optional<T>::reset();
+                    return *this;
+                }
+                RANGES_CXX14_CONSTEXPR
+                non_propagating_cache& operator=(non_propagating_cache && that) noexcept
+                {
+                    that.optional<T>::reset();
+                    this->optional<T>::reset();
+                    return *this;
+                }
+            };
+
+            template<typename T, typename Tag>
+            struct non_propagating_cache<T, Tag, false>
+            {};
+        }
     }
 }
 

--- a/include/range/v3/view/adjacent_remove_if.hpp
+++ b/include/range/v3/view/adjacent_remove_if.hpp
@@ -20,9 +20,9 @@
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/view_adaptor.hpp>
+#include <range/v3/detail/optional.hpp>
 #include <range/v3/utility/iterator.hpp>
 #include <range/v3/utility/functional.hpp>
-#include <range/v3/utility/optional.hpp>
 #include <range/v3/utility/semiregular.hpp>
 #include <range/v3/utility/static_const.hpp>
 #include <range/v3/view/view.hpp>
@@ -43,7 +43,7 @@ namespace ranges
         private:
             friend range_access;
             semiregular_t<function_type<Pred>> pred_;
-            optional<range_iterator_t<Rng>> begin_;
+            detail::non_propagating_cache<range_iterator_t<Rng>> begin_;
 
             struct adaptor : adaptor_base
             {
@@ -93,30 +93,10 @@ namespace ranges
             }
         public:
             adjacent_remove_if_view() = default;
-            adjacent_remove_if_view(adjacent_remove_if_view const &that)
-              : adjacent_remove_if_view::view_adaptor(that)
-              , pred_(that.pred_)
-              , begin_{}
-            {}
             adjacent_remove_if_view(Rng rng, Pred pred)
               : adjacent_remove_if_view::view_adaptor{std::move(rng)}
               , pred_(as_function(std::move(pred)))
-              , begin_{}
             {}
-            adjacent_remove_if_view& operator=(adjacent_remove_if_view &&that)
-            {
-                this->adjacent_remove_if_view::view_adaptor::operator=(std::move(that));
-                pred_ = std::move(that).pred_;
-                begin_.reset();
-                return *this;
-            }
-            adjacent_remove_if_view& operator=(adjacent_remove_if_view const &that)
-            {
-                this->adjacent_remove_if_view::view_adaptor::operator=(that);
-                pred_ = that.pred_;
-                begin_.reset();
-                return *this;
-            }
        };
 
         namespace view

--- a/include/range/v3/view/cycle.hpp
+++ b/include/range/v3/view/cycle.hpp
@@ -22,16 +22,16 @@
 #include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/size.hpp>
-#include <range/v3/distance.hpp>
 #include <range/v3/begin_end.hpp>
+#include <range/v3/empty.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/view_facade.hpp>
+#include <range/v3/detail/optional.hpp>
 #include <range/v3/view/all.hpp>
 #include <range/v3/view/view.hpp>
 #include <range/v3/utility/box.hpp>
 #include <range/v3/utility/get.hpp>
-#include <range/v3/utility/optional.hpp>
 #include <range/v3/utility/iterator.hpp>
 #include <range/v3/utility/static_const.hpp>
 
@@ -39,36 +39,21 @@ namespace ranges
 {
     inline namespace v3
     {
-        /// \cond
-        namespace detail
-        {
-            template<typename Rng>
-            using cycle_end_ =
-                meta::if_<
-                    BoundedRange<Rng>,
-                    meta::nil_,
-                    box<optional<range_iterator_t<Rng>>, end_tag>>;
-        }
-        /// \endcond
-
         /// \addtogroup group-views
         ///@{
         template<typename Rng>
         struct cycled_view
           : view_facade<cycled_view<Rng>, infinite>
-          , private detail::cycle_end_<Rng>
+          , private detail::non_propagating_cache<
+                range_iterator_t<Rng>, cycled_view<Rng>, !BoundedRange<Rng>()>
         {
         private:
             CONCEPT_ASSERT(ForwardRange<Rng>());
             friend range_access;
             Rng rng_;
 
-            void dirty_(std::true_type) const
-            {}
-            void dirty_(std::false_type)
-            {
-                ranges::get<end_tag>(*this).reset();
-            }
+            using cache_t = detail::non_propagating_cache<
+                range_iterator_t<Rng>, cycled_view<Rng>, !BoundedRange<Rng>()>;
 
             template<bool IsConst>
             struct cursor
@@ -90,7 +75,7 @@ namespace ranges
                 template<bool CanBeEmpty = false>
                 iterator get_end_(std::false_type, meta::bool_<CanBeEmpty> = {}) const
                 {
-                    auto &end_ = ranges::get<end_tag>(*rng_);
+                    auto &end_ = static_cast<cache_t&>(*rng_);
                     RANGES_ASSERT(CanBeEmpty || end_);
                     if(CanBeEmpty && !end_)
                         end_ = ranges::next(it_, ranges::end(rng_->rng_));
@@ -100,7 +85,7 @@ namespace ranges
                 {}
                 void set_end_(std::false_type) const
                 {
-                    auto &end_ = ranges::get<end_tag>(*rng_);
+                    auto &end_ = static_cast<cache_t&>(*rng_);
                     if(!end_)
                         end_ = it_;
                 }
@@ -171,32 +156,11 @@ namespace ranges
 
         public:
             cycled_view() = default;
-            cycled_view(cycled_view &&that)
-              : detail::cycle_end_<Rng>{}
-              , rng_(std::move(that.rng_))
-            {}
-            cycled_view(cycled_view const &that)
-              : detail::cycle_end_<Rng>{}
-              , rng_(that.rng_)
-            {}
-            /// \pre <tt>distance(rng) != 0</tt>
+            /// \pre <tt>!empty(rng)</tt>
             explicit cycled_view(Rng rng)
-              : detail::cycle_end_<Rng>{}
-              , rng_(std::move(rng))
+              : rng_(std::move(rng))
             {
-                RANGES_ASSERT(ranges::distance(rng) != 0);
-            }
-            cycled_view& operator=(cycled_view &&that)
-            {
-                rng_ = std::move(that.rng_);
-                this->dirty_(BoundedRange<Rng>{});
-                return *this;
-            }
-            cycled_view& operator=(cycled_view const &that)
-            {
-                rng_ = that.rng_;
-                this->dirty_(BoundedRange<Rng>{});
-                return *this;
+                RANGES_ASSERT(!ranges::empty(rng));
             }
         };
 
@@ -210,7 +174,7 @@ namespace ranges
                 using Concept = ForwardRange<T>;
 
             public:
-                /// \pre <tt>distance(rng) != 0</tt>
+                /// \pre <tt>!empty(rng)</tt>
                 template<typename Rng, CONCEPT_REQUIRES_(Concept<Rng>())>
                 cycled_view<all_t<Rng>> operator()(Rng &&rng) const
                 {

--- a/include/range/v3/view/drop_exactly.hpp
+++ b/include/range/v3/view/drop_exactly.hpp
@@ -22,8 +22,8 @@
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/view_interface.hpp>
 #include <range/v3/iterator_range.hpp>
+#include <range/v3/detail/optional.hpp>
 #include <range/v3/utility/box.hpp>
-#include <range/v3/utility/optional.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/iterator_traits.hpp>
 #include <range/v3/utility/static_const.hpp>
@@ -38,11 +38,11 @@ namespace ranges
         /// @{
         template<typename Rng>
         struct drop_exactly_view
-          : view_interface<drop_exactly_view<Rng>, is_finite<Rng>::value ? finite : range_cardinality<Rng>::value>
-          , private meta::if_<
-                RandomAccessRange<Rng>,
-                meta::nil_,
-                box<optional<range_iterator_t<Rng>>, begin_tag>>
+          : view_interface<
+                drop_exactly_view<Rng>,
+                is_finite<Rng>::value ? finite : range_cardinality<Rng>::value>
+          , private detail::non_propagating_cache<
+                range_iterator_t<Rng>, drop_exactly_view<Rng>, !RandomAccessRange<Rng>()>
         {
         private:
             friend range_access;
@@ -58,46 +58,19 @@ namespace ranges
             // RandomAccessRange == false
             range_iterator_t<Rng> get_begin_(std::false_type)
             {
-                auto &begin_ = ranges::get<begin_tag>(*this);
+                using cache_t = detail::non_propagating_cache<
+                    range_iterator_t<Rng>, drop_exactly_view<Rng>>;
+                auto &begin_ = static_cast<cache_t&>(*this);
                 if(!begin_)
                     begin_ = next(ranges::begin(rng_), n_);
                 return *begin_;
             }
-            // RandomAccessRange == true
-            void dirty_(std::true_type) const
-            {}
-            // RandomAccessRange == false
-            void dirty_(std::false_type)
-            {
-                auto &begin_ = ranges::get<begin_tag>(*this);
-                begin_.reset();
-            }
         public:
             drop_exactly_view() = default;
-            drop_exactly_view(drop_exactly_view &&that)
-              : rng_(std::move(that).rng_), n_(that.n_)
-            {}
-            drop_exactly_view(drop_exactly_view const &that)
-              : rng_(that.rng_), n_(that.n_)
-            {}
             drop_exactly_view(Rng rng, difference_type_ n)
               : rng_(std::move(rng)), n_(n)
             {
                 RANGES_ASSERT(n >= 0);
-            }
-            drop_exactly_view& operator=(drop_exactly_view &&that)
-            {
-                rng_ = std::move(that).rng_;
-                n_ = that.n_;
-                this->dirty_(RandomAccessRange<Rng>{});
-                return *this;
-            }
-            drop_exactly_view& operator=(drop_exactly_view const &that)
-            {
-                rng_ = that.rng_;
-                n_ = that.n_;
-                this->dirty_(RandomAccessRange<Rng>{});
-                return *this;
             }
             range_iterator_t<Rng> begin()
             {

--- a/include/range/v3/view/drop_while.hpp
+++ b/include/range/v3/view/drop_while.hpp
@@ -22,7 +22,7 @@
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/view_interface.hpp>
-#include <range/v3/utility/optional.hpp>
+#include <range/v3/detail/optional.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/semiregular.hpp>
 #include <range/v3/utility/static_const.hpp>
@@ -44,7 +44,7 @@ namespace ranges
             friend range_access;
             Rng rng_;
             semiregular_t<function_type<Pred>> pred_;
-            optional<range_iterator_t<Rng>> begin_;
+            detail::non_propagating_cache<range_iterator_t<Rng>> begin_;
 
             range_iterator_t<Rng> get_begin_()
             {
@@ -54,31 +54,9 @@ namespace ranges
             }
         public:
             drop_while_view() = default;
-            drop_while_view(drop_while_view &&that)
-              : drop_while_view::view_interface(std::move(that))
-              , rng_(std::move(that).rng_), pred_(std::move(that).pred_), begin_{}
-            {}
-            drop_while_view(drop_while_view const &that)
-              : drop_while_view::view_interface(that)
-              , rng_(that.rng_), pred_(that.pred_), begin_{}
-            {}
             drop_while_view(Rng rng, Pred pred)
-              : rng_(std::move(rng)), pred_(as_function(std::move(pred))), begin_{}
+              : rng_(std::move(rng)), pred_(as_function(std::move(pred)))
             {}
-            drop_while_view& operator=(drop_while_view &&that)
-            {
-                rng_ = std::move(that).rng_;
-                pred_ = std::move(that).pred_;
-                begin_.reset();
-                return *this;
-            }
-            drop_while_view& operator=(drop_while_view const &that)
-            {
-                rng_ = that.rng_;
-                pred_ = that.pred_;
-                begin_.reset();
-                return *this;
-            }
             range_iterator_t<Rng> begin()
             {
                 return get_begin_();

--- a/include/range/v3/view/remove_if.hpp
+++ b/include/range/v3/view/remove_if.hpp
@@ -23,7 +23,7 @@
 #include <range/v3/range_traits.hpp>
 #include <range/v3/view_adaptor.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/utility/optional.hpp>
+#include <range/v3/detail/optional.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/semiregular.hpp>
 #include <range/v3/utility/static_const.hpp>
@@ -48,7 +48,7 @@ namespace ranges
         private:
             friend range_access;
             semiregular_t<function_type<Pred>> pred_;
-            optional<range_iterator_t<Rng>> begin_;
+            detail::non_propagating_cache<range_iterator_t<Rng>> begin_;
 
             struct adaptor
               : adaptor_base
@@ -100,35 +100,10 @@ namespace ranges
             }
         public:
             remove_if_view() = default;
-            remove_if_view(remove_if_view &&that)
-              : remove_if_view::view_adaptor(std::move(that))
-              , pred_(std::move(that).pred_)
-              , begin_{}
-            {}
-            remove_if_view(remove_if_view const &that)
-              : remove_if_view::view_adaptor(that)
-              , pred_(that.pred_)
-              , begin_{}
-            {}
             remove_if_view(Rng rng, Pred pred)
               : remove_if_view::view_adaptor{std::move(rng)}
               , pred_(as_function(std::move(pred)))
-              , begin_{}
             {}
-            remove_if_view& operator=(remove_if_view &&that)
-            {
-                this->remove_if_view::view_adaptor::operator=(std::move(that));
-                pred_ = std::move(that).pred_;
-                begin_.reset();
-                return *this;
-            }
-            remove_if_view& operator=(remove_if_view const &that)
-            {
-                this->remove_if_view::view_adaptor::operator=(that);
-                pred_ = that.pred_;
-                begin_.reset();
-                return *this;
-            }
         };
 
         namespace view

--- a/include/range/v3/view/slice.hpp
+++ b/include/range/v3/view/slice.hpp
@@ -22,7 +22,7 @@
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/view_interface.hpp>
 #include <range/v3/iterator_range.hpp>
-#include <range/v3/utility/optional.hpp>
+#include <range/v3/detail/optional.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/iterator_traits.hpp>
 #include <range/v3/utility/counted_iterator.hpp>
@@ -81,7 +81,7 @@ namespace ranges
                 using difference_type_ = range_difference_t<Rng>;
                 Rng rng_;
                 difference_type_ from_, count_;
-                optional<range_iterator_t<Rng>> begin_;
+                detail::non_propagating_cache<range_iterator_t<Rng>> begin_;
 
                 range_iterator_t<Rng> get_begin_()
                 {
@@ -96,31 +96,9 @@ namespace ranges
                 }
             public:
                 slice_view_() = default;
-                slice_view_(slice_view_ &&that)
-                  : rng_(std::move(that).rng_), from_(that.from_), count_(that.count_), begin_{}
-                {}
-                slice_view_(slice_view_ const &that)
-                  : rng_(that.rng_), from_(that.from_), count_(that.count_), begin_{}
-                {}
                 slice_view_(Rng rng, difference_type_ from, difference_type_ count)
-                  : rng_(std::move(rng)), from_(from), count_(count), begin_{}
+                  : rng_(std::move(rng)), from_(from), count_(count)
                 {}
-                slice_view_& operator=(slice_view_ &&that)
-                {
-                    rng_ = std::move(that).rng_;
-                    from_ = that.from_;
-                    count_ = that.count_;
-                    begin_.reset();
-                    return *this;
-                }
-                slice_view_& operator=(slice_view_ const &that)
-                {
-                    rng_ = that.rng_;
-                    from_ = that.from_;
-                    count_ = that.count_;
-                    begin_.reset();
-                    return *this;
-                }
                 range_size_t<Rng> size() const
                 {
                     return static_cast<range_size_t<Rng>>(count_);


### PR DESCRIPTION
A rule-of-five wrapper for an optional iterator that points into a contained range. Does not copy/move construct/assign the iterator, but *does* invalidate the cached value when assigned, or when used as the source of a move (i.e., invalidates the cache when the range into which it points has presumably been assigned to / moved from.)

Use to simplify the "caching" views:
* adjacent_remove_if
* cycle
* drop
* drop_exactly
* drop_while
* remove_if
* reverse
* slice