### PR TITLE
Travis updates:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,10 @@
 language: cpp
 script: cmake
 
-# Test matrix:
-# - Build matrix per compiler: C++11/C++14 + Debug/Release
-# - Optionally: AddressSanitizer (ASAN)
-# - Valgrind: all release builds are also tested with valgrind
-# - clang 3.5, 3.6, trunk
-#   - Note: trunk is tested with/without ASAN,
-#     the rest are only tested with ASAN=On.
-# - gcc 4.9, 5
-#
+cache:
+  directories:
+    - ${TRAVIS_BUILD_DIR}/deps/cmake
+
 matrix:
   include:
     - env: BUILD_TYPE=Release CPP=11 ASAN=Off SYSTEM_LIBCXX=On
@@ -326,10 +321,23 @@ matrix:
 # Install dependencies
 before_install:
   - export CHECKOUT_PATH=`pwd`;
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install valgrind; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install gnu-sed --with-default-names; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install gnu-which --with-default-names; fi
+  - |
+    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+      brew update
+      brew install valgrind
+      brew install gnu-sed --with-default-names
+      brew install gnu-which --with-default-names
+    fi
+  - |
+    if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+      if [ -z "$(ls -A ${TRAVIS_BUILD_DIR}/deps/cmake/bin)" ]; then
+        CMAKE_URL="https://cmake.org/files/v3.6/cmake-3.6.2-Linux-x86_64.tar.gz"
+        mkdir -p ${TRAVIS_BUILD_DIR}/deps/cmake && travis_retry wget --no-check-certificate --quiet -O - "${CMAKE_URL}" | tar --strip-components=1 -xz -C ${TRAVIS_BUILD_DIR}/deps/cmake
+      fi
+      export PATH="${TRAVIS_BUILD_DIR}/deps/cmake/bin:${PATH}"
+    else
+      if ! brew ls --version cmake &>/dev/null; then brew install cmake; fi
+    fi
   - if [ -n "$GCC_VERSION" ]; then export CXX="g++-${GCC_VERSION}" CC="gcc-${GCC_VERSION}"; fi
   - if [ -n "$CLANG_VERSION" ]; then export CXX="clang++-${CLANG_VERSION}" CC="clang-${CLANG_VERSION}"; fi
   - if [ "$CLANG_VERSION" == "3.4" ]; then export CXX="/usr/local/clang-3.4/bin/clang++" CC="/usr/local/clang-3.4/bin/clang"; fi
@@ -338,7 +346,7 @@ before_install:
   - which valgrind
   - $CXX --version
   - if [ "$ASAN" == "On" ]; then export SANITIZER=Address; fi
-  - if [ -n "$CLANG_VERSION" ]; then sudo CXX=$CXX CC=$CC ./install_libcxx.sh; fi
+  - if [ -n "$CLANG_VERSION" ]; then sudo PATH="${PATH}" CXX="$CXX" CC="$CC" ./install_libcxx.sh; fi
 
 
 install:
@@ -356,12 +364,12 @@ install:
   - if [ -n "$CLANG_VERSION" ]; then CXX_FLAGS="${CXX_FLAGS} -D__extern_always_inline=inline"; fi
   - if [ "$LIBCXX" == "On" ]; then CXX_FLAGS="${CXX_FLAGS} -stdlib=libc++ -nostdinc++ -cxx-isystem /usr/include/c++/v1/ -Wno-unused-command-line-argument"; fi
   - cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" -DCMAKE_EXE_LINKER_FLAGS="${CXX_LINKER_FLAGS}" -DRANGES_CXX_STD=$CPP -DRANGE_V3_NO_HEADER_CHECK=1
-  - make VERBOSE=1
+  - make -j2 VERBOSE=1
 
 script:
   # Only enable valgrind for non-ASAN Release builds (keep this in sync with line 309)
   - if [ "$BUILD_TYPE" == "Release" ] && [ "$ASAN" == "Off" ]; then CTEST_FLAGS="-D ExperimentalMemCheck"; fi
-  - ctest -VV ${CTEST_FLAGS}
+  - ctest -j2 -VV ${CTEST_FLAGS}
 
 notifications:
   email: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8)
-set(CMAKE_LEGACY_CYGWIN_WIN32 0)
+cmake_minimum_required(VERSION 3.0)
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 project(Range-v3 CXX)
@@ -35,11 +35,10 @@ if(NOT RANGES_CXX_STD)
   set(RANGES_CXX_STD 11)
 endif()
 
-if("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xClang")
+if("x${CMAKE_CXX_COMPILER_ID}" MATCHES "x.*Clang")
   # Clang/C2 will blow up with various parts of the standard library
   # if compiling with -std less than c++14.
-  if(("x${CMAKE_CXX_SIMULATE_ID}" STREQUAL "xMSVC") AND
-     ("${RANGES_CXX_STD}" STREQUAL "11"))
+  if(("x${CMAKE_CXX_SIMULATE_ID}" STREQUAL "xMSVC") AND (RANGES_CXX_STD EQUAL 11))
     set(CMAKE_CXX_STANDARD 14)
     set(RANGES_CXX_STD 14)
   endif()
@@ -50,7 +49,7 @@ if("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xClang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-prototypes -Wno-missing-variable-declarations")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-shadow -Wno-old-style-cast")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-documentation -Wno-documentation-unknown-command")
-  if("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
+  if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-global-constructors -Wno-exit-time-destructors")
   endif()
   set(CMAKE_CXX_FLAGS_DEBUG "-O0 -fno-inline -g3 -fstack-protector-all")
@@ -58,7 +57,7 @@ if("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xClang")
 elseif(CMAKE_COMPILER_IS_GNUCXX)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++${RANGES_CXX_STD} -ftemplate-backtrace-limit=0")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Werror -pedantic-errors")
-  if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "5.0")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.0")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-field-initializers")
   endif()
   set(CMAKE_CXX_FLAGS_DEBUG "-O0 -fno-inline -g3 -fstack-protector-all")
@@ -70,26 +69,17 @@ endif()
 range_v3_append_flag(RANGE_V3_HAS_MARCH_NATIVE "-march=native")
 range_v3_append_flag(RANGE_V3_HAS_MTUNE_NATIVE "-mtune=native")
 
-#   range_v3_list_remove_glob(<list> <GLOB|GLOB_RECURSE> [globbing expressions]...)
-#
-# Generates a list of files matching the given glob expressions, and remove
-# the matched elements from the given <list>.
-#
-# Adapted from Boost.Hana: https://github.com/ldionne/hana/
-#
-macro(range_v3_list_remove_glob list glob)
-    file(${glob} _bhlrg10321023_avoid_macro_clash_matches ${ARGN})
-    list(REMOVE_ITEM ${list} ${_bhlrg10321023_avoid_macro_clash_matches})
-endmacro()
-
 # Test all headers
-if(NOT RANGE_V3_NO_HEADER_CHECK)
-  file(GLOB_RECURSE RANGE_V3_PUBLIC_HEADERS
-                    RELATIVE "${CMAKE_SOURCE_DIR}/include"
-                    "${CMAKE_SOURCE_DIR}/include/*.hpp")
-  include(TestHeaders)
-  generate_standalone_header_tests(HEADERS ${RANGE_V3_PUBLIC_HEADERS})
+file(GLOB_RECURSE RANGE_V3_PUBLIC_HEADERS
+                  RELATIVE "${CMAKE_SOURCE_DIR}/include"
+                  "${CMAKE_SOURCE_DIR}/include/*.hpp")
+include(TestHeaders)
+if(RANGE_V3_NO_HEADER_CHECK)
+  add_custom_target(headers)
+else()
+  add_custom_target(headers ALL)
 endif()
+generate_standalone_header_tests(EXCLUDE_FROM_ALL MASTER_TARGET headers HEADERS ${RANGE_V3_PUBLIC_HEADERS})
 
 add_subdirectory(doc)
 add_subdirectory(test)

--- a/install_libcxx.sh
+++ b/install_libcxx.sh
@@ -3,9 +3,9 @@
 set -e
 
 # Install a newer CMake version
-curl -sSL https://cmake.org/files/v3.6/cmake-3.6.1-Linux-x86_64.sh -o install-cmake.sh
-chmod +x install-cmake.sh
-sudo ./install-cmake.sh --prefix=/usr/local --skip-license
+# curl -sSL https://cmake.org/files/v3.6/cmake-3.6.1-Linux-x86_64.sh -o install-cmake.sh
+# chmod +x install-cmake.sh
+# sudo ./install-cmake.sh --prefix=/usr/local --skip-license
 
 # Checkout LLVM sources
 git clone --depth=1 https://github.com/llvm-mirror/llvm.git llvm-source
@@ -21,4 +21,3 @@ cmake -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${COMPILER} \
       ../llvm-source
 make cxx -j2
 sudo make install-cxxabi install-cxx
-cd ../


### PR DESCRIPTION
* Always install a recent cmake on Travis.
* Build and test with 2 parallel jobs
* Update CMakeLists:
  * Raise the required cmake version
  * Recent cmake identifies OSX clang as "AppleClang"; match ".*Clang" when looking for any old clang.
  * `range_v3_list_remove_glob` is dead code.
  * Add a custom target "headers" to make the header tests. "all" depends on "headers" unless `RANGE_V3_NO_HEADER_CHECK=1`.
* Update install_libcxx.sh:
  * *Don't* install cmake here; .travis.yml already handled it.
