### PR TITLE
Rework contract enforcement system:

### DIFF
--- a/include/range/v3/view/sample.hpp
+++ b/include/range/v3/view/sample.hpp
@@ -123,7 +123,7 @@ namespace ranges
                         {
                             RANGES_ASSERT(current() != ranges::end(range()->range()));
                             auto n = pop_size();
-                            RANGES_ENSURE(n > 0);
+                            RANGES_EXPECT(n > 0);
                             const Param_t interval{ 0, n - 1 };
                             if (dist(engine, interval) < range()->size())
                                 break;
@@ -175,7 +175,7 @@ namespace ranges
             explicit sample_view(Rng rng, D sample_size, URNG& generator)
             : base_t{std::move(rng), sample_size, generator}
             {
-                RANGES_ENSURE(sample_size >= 0);
+                RANGES_EXPECT(sample_size >= 0);
             }
         };
 


### PR DESCRIPTION
* `RANGES_ASSERT(pred)`
  * Implement by hand on GCC4, instead of using `assert` from the standard library, so that `RANGES_ASSERT `is usable in `constexpr` functions. (This is not the case for `assert` in libstdc++ for GCC < 5.)

* Add `RANGES_ASSUME(pred)`
  * Has undefined behavior if `pred` is not `true`. (Makes an effort to inform the optimizer that `pred` must hold.)
  * Unlike `RANGES_ASSERT(pred)`, which does not evaluate `pred` in release builds, `pred` is *always* potentially evaluated. It must be inexpensive to evaluate.

* Add `RANGES_EXPECT(pred)`
  * When debugging (`!defined(NDEBUG)`), equivalent to `RANGES_ASSERT(pred)`.
  * When NOT debugging, equivalent to `RANGES_ASSUME(pred)`.

Replace `void()` with `void(0)` throughout the contract system to workaround https://llvm.org/bugs/show_bug.cgi?id=30592.