### PR TITLE
Contracts system followup:

### DIFF
--- a/include/range/v3/action/drop.hpp
+++ b/include/range/v3/action/drop.hpp
@@ -63,7 +63,7 @@ namespace ranges
                     CONCEPT_REQUIRES_(Concept<Rng, D>())>
                 Rng operator()(Rng && rng, range_difference_t<Rng> n) const
                 {
-                    RANGES_ASSERT(n >= 0);
+                    RANGES_EXPECT(n >= 0);
                     ranges::action::erase(rng, begin(rng), ranges::next(begin(rng), n, end(rng)));
                     return std::forward<Rng>(rng);
                 }

--- a/include/range/v3/action/slice.hpp
+++ b/include/range/v3/action/slice.hpp
@@ -68,7 +68,7 @@ namespace ranges
                 Rng operator()(Rng && rng, range_difference_t<Rng> from,
                     range_difference_t<Rng> to) const
                 {
-                    RANGES_ASSERT(from <= to);
+                    RANGES_EXPECT(from <= to);
                     ranges::action::erase(rng, next(begin(rng), to), end(rng));
                     ranges::action::erase(rng, begin(rng), next(begin(rng), from));
                     return std::forward<Rng>(rng);

--- a/include/range/v3/action/stride.hpp
+++ b/include/range/v3/action/stride.hpp
@@ -66,7 +66,7 @@ namespace ranges
                 {
                     using I = range_iterator_t<Rng>;
                     using S = range_sentinel_t<Rng>;
-                    RANGES_ASSERT(0 < step);
+                    RANGES_EXPECT(0 < step);
                     if(1 < step)
                     {
                         I begin = ranges::begin(rng);

--- a/include/range/v3/action/take.hpp
+++ b/include/range/v3/action/take.hpp
@@ -64,7 +64,7 @@ namespace ranges
                     CONCEPT_REQUIRES_(Concept<Rng, D>())>
                 Rng operator()(Rng && rng, range_difference_t<Rng> n) const
                 {
-                    RANGES_ASSERT(n >= 0);
+                    RANGES_EXPECT(n >= 0);
                     ranges::action::erase(rng, ranges::next(begin(rng), n, end(rng)), end(rng));
                     return std::forward<Rng>(rng);
                 }

--- a/include/range/v3/algorithm/copy_n.hpp
+++ b/include/range/v3/algorithm/copy_n.hpp
@@ -45,7 +45,7 @@ namespace ranges
             tagged_pair<tag::in(I), tag::out(O)>
             operator()(I begin, iterator_difference_t<I> n, O out) const
             {
-                RANGES_ASSERT(0 <= n);
+                RANGES_EXPECT(0 <= n);
                 auto norig = n;
                 auto b = uncounted(begin);
                 for(; n != 0; ++b, ++out, --n)

--- a/include/range/v3/algorithm/fill_n.hpp
+++ b/include/range/v3/algorithm/fill_n.hpp
@@ -34,7 +34,7 @@ namespace ranges
                 CONCEPT_REQUIRES_(OutputIterator<O, V const &>())>
             O operator()(O begin, iterator_difference_t<O> n, V const & val) const
             {
-                RANGES_ASSERT(n >= 0);
+                RANGES_EXPECT(n >= 0);
                 auto norig = n;
                 auto b = uncounted(begin);
                 for(; n != 0; ++b, --n)

--- a/include/range/v3/algorithm/generate_n.hpp
+++ b/include/range/v3/algorithm/generate_n.hpp
@@ -39,7 +39,7 @@ namespace ranges
             tagged_pair<tag::out(O), tag::fun(F)>
             operator()(O begin, iterator_difference_t<O> n, F fun) const
             {
-                RANGES_ASSERT(n >= 0);
+                RANGES_EXPECT(n >= 0);
                 auto norig = n;
                 auto b = uncounted(begin);
                 for(; 0 != n; ++b, --n)

--- a/include/range/v3/algorithm/heap_algorithm.hpp
+++ b/include/range/v3/algorithm/heap_algorithm.hpp
@@ -53,7 +53,7 @@ namespace ranges
                     CONCEPT_REQUIRES_(IsHeapable<I, C, P>())>
                 I operator()(I const begin_, iterator_difference_t<I> const n_, C pred_ = C{}, P proj_ = P{}) const
                 {
-                    RANGES_ASSERT(0 <= n_);
+                    RANGES_EXPECT(0 <= n_);
                     auto &&pred = as_function(pred_);
                     auto &&proj = as_function(proj_);
                     iterator_difference_t<I> p = 0, c = 1;

--- a/include/range/v3/algorithm/max.hpp
+++ b/include/range/v3/algorithm/max.hpp
@@ -50,7 +50,7 @@ namespace ranges
                 auto && proj = as_function(proj_);
                 auto begin = ranges::begin(rng);
                 auto end = ranges::end(rng);
-                RANGES_ASSERT(begin != end);
+                RANGES_EXPECT(begin != end);
                 V result = *begin;
                 while(++begin != end)
                 {

--- a/include/range/v3/algorithm/min.hpp
+++ b/include/range/v3/algorithm/min.hpp
@@ -50,7 +50,7 @@ namespace ranges
                 auto && proj = as_function(proj_);
                 auto begin = ranges::begin(rng);
                 auto end = ranges::end(rng);
-                RANGES_ASSERT(begin != end);
+                RANGES_EXPECT(begin != end);
                 V result = *begin;
                 while(++begin != end)
                 {

--- a/include/range/v3/algorithm/minmax.hpp
+++ b/include/range/v3/algorithm/minmax.hpp
@@ -53,7 +53,7 @@ namespace ranges
             {
                 auto begin = ranges::begin(rng);
                 auto end = ranges::end(rng);
-                RANGES_ASSERT(begin != end);
+                RANGES_EXPECT(begin != end);
                 auto result = R{*begin, *begin};
                 if(++begin != end) {
                     auto && pred = as_function(pred_);

--- a/include/range/v3/algorithm/nth_element.hpp
+++ b/include/range/v3/algorithm/nth_element.hpp
@@ -89,7 +89,7 @@ namespace ranges
                 CONCEPT_REQUIRES_(BidirectionalIterator<I>() && Function<P, V>() && Relation<C, X>())>
             void selection_sort(I begin, I end, C &pred, P &proj)
             {
-                RANGES_ASSERT(begin != end);
+                RANGES_EXPECT(begin != end);
                 for(I lm1 = ranges::prev(end); begin != lm1; ++begin)
                 {
                     I i = ranges::min_element(begin, end, std::ref(pred), std::ref(proj));

--- a/include/range/v3/detail/optional.hpp
+++ b/include/range/v3/detail/optional.hpp
@@ -47,12 +47,12 @@ namespace ranges
             }
             T & operator*()
             {
-                RANGES_ASSERT(*this);
+                RANGES_EXPECT(*this);
                 return ranges::get<1>(data_);
             }
             T const & operator*() const
             {
-                RANGES_ASSERT(*this);
+                RANGES_EXPECT(*this);
                 return ranges::get<1>(data_);
             }
             optional &operator=(T const &t)

--- a/include/range/v3/detail/variant.hpp
+++ b/include/range/v3/detail/variant.hpp
@@ -736,7 +736,7 @@ namespace ranges
             using To = variant_unique_t<From>;
             auto res = detail::variant_core_access::make_empty(meta::id<To>{});
             var.visit_i(detail::unique_visitor<To, From>{&res});
-            RANGES_ASSERT(res.valid());
+            RANGES_EXPECT(res.valid());
             return res;
         }
         /// @}

--- a/include/range/v3/distance.hpp
+++ b/include/range/v3/distance.hpp
@@ -54,7 +54,7 @@ namespace ranges
             std::pair<D, I> operator()(Rng &&rng, D d = 0) const
             {
                 // Better not be trying to compute the distance of an infinite range:
-                RANGES_ASSERT(!is_infinite<Rng>::value);
+                RANGES_EXPECT(!is_infinite<Rng>::value);
                 return this->impl_r(rng, d, bounded_range_concept<Rng>(),
                     sized_range_concept<Rng>());
             }
@@ -85,7 +85,7 @@ namespace ranges
             D operator()(Rng &&rng, D d = 0) const
             {
                 // Better not be trying to compute the distance of an infinite range:
-                RANGES_ASSERT(!is_infinite<Rng>::value);
+                RANGES_EXPECT(!is_infinite<Rng>::value);
                 return this->impl_r(rng, d, sized_range_concept<Rng>());
             }
         };

--- a/include/range/v3/utility/common_iterator.hpp
+++ b/include/range/v3/utility/common_iterator.hpp
@@ -70,22 +70,22 @@ namespace ranges
                 {}
                 bool is_sentinel() const
                 {
-                    RANGES_ASSERT(data_.valid());
+                    RANGES_EXPECT(data_.valid());
                     return data_.index() == 1u;
                 }
                 I & it()
                 {
-                    RANGES_ASSERT(!is_sentinel());
+                    RANGES_EXPECT(!is_sentinel());
                     return ranges::get<0>(data_);
                 }
                 I const & it() const
                 {
-                    RANGES_ASSERT(!is_sentinel());
+                    RANGES_EXPECT(!is_sentinel());
                     return ranges::get<0>(data_);
                 }
                 S const & se() const
                 {
-                    RANGES_ASSERT(is_sentinel());
+                    RANGES_EXPECT(is_sentinel());
                     return ranges::get<1>(data_);
                 }
                 CONCEPT_REQUIRES((bool)SizedSentinel<S, I>() && (bool)SizedSentinel<I, I>())
@@ -102,7 +102,7 @@ namespace ranges
                 iterator_rvalue_reference_t<I> move() const
                     noexcept(noexcept(iter_move(std::declval<I const &>())))
                 {
-                    RANGES_ASSERT(!is_sentinel());
+                    RANGES_EXPECT(!is_sentinel());
                     return iter_move(it());
                 }
                 CONCEPT_REQUIRES(Readable<I>())

--- a/include/range/v3/utility/iterator.hpp
+++ b/include/range/v3/utility/iterator.hpp
@@ -41,7 +41,7 @@ namespace ranges
             RANGES_CXX14_CONSTEXPR
             void advance_impl(I &i, iterator_difference_t<I> n, concepts::InputIterator *)
             {
-                RANGES_ASSERT(n >= 0);
+                RANGES_EXPECT(n >= 0);
                 for(; n > 0; --n)
                     ++i;
             }
@@ -156,7 +156,7 @@ namespace ranges
             void advance_fn::to_(I &i, S s, concepts::SizedSentinel*)
             {
                 iterator_difference_t<I> d = s - i;
-                RANGES_ASSERT(0 <= d);
+                RANGES_EXPECT(0 <= d);
                 ranges::advance(i, d);
             }
             template<typename I, typename D, typename S>
@@ -164,7 +164,7 @@ namespace ranges
             D advance_fn::bounded_(I &it, D n, S bound, concepts::Sentinel*,
                 concepts::InputIterator*)
             {
-                RANGES_ASSERT(0 <= n);
+                RANGES_EXPECT(0 <= n);
                 for(; 0 != n && it != bound; --n)
                     ++it;
                 return n;
@@ -187,9 +187,9 @@ namespace ranges
             D advance_fn::bounded_(I &it, D n, S bound, concepts::SizedSentinel*,
                 Concept)
             {
-                RANGES_ASSERT((Same<I, S>() || 0 <= n));
+                RANGES_EXPECT((Same<I, S>() || 0 <= n));
                 D d = bound - it;
-                RANGES_ASSERT(0 <= n ? 0 <= d : 0 >= d);
+                RANGES_EXPECT(0 <= n ? 0 <= d : 0 >= d);
                 if(0 <= n ? n >= d : n <= d)
                 {
                     ranges::advance(it, std::move(bound));
@@ -274,7 +274,7 @@ namespace ranges
             {
                 I end = ranges::next(begin, end_);
                 auto n = static_cast<D>(end - begin);
-                RANGES_ASSERT((Same<I, S>() || 0 <= n));
+                RANGES_EXPECT((Same<I, S>() || 0 <= n));
                 return {n + d, end};
             }
             template<typename I, typename S, typename D>
@@ -282,7 +282,7 @@ namespace ranges
             std::pair<D, I> impl_i(I begin, S end, D d, concepts::SizedSentinel*) const
             {
                 auto n = static_cast<D>(end - begin);
-                RANGES_ASSERT((Same<I, S>() || 0 <= n));
+                RANGES_EXPECT((Same<I, S>() || 0 <= n));
                 return {n + d, ranges::next(begin, end)};
             }
         public:
@@ -314,7 +314,7 @@ namespace ranges
             D impl_i(I begin, S end, D d, concepts::SizedSentinel*) const
             {
                 auto n = static_cast<D>(end - begin);
-                RANGES_ASSERT((Same<I, S>() || 0 <= n));
+                RANGES_EXPECT((Same<I, S>() || 0 <= n));
                 return n + d;
             }
         public:
@@ -387,7 +387,7 @@ namespace ranges
             iterator_size_t<I> operator()(I begin, S end) const
             {
                 iterator_difference_t<I> n = end - begin;
-                RANGES_ASSERT(0 <= n);
+                RANGES_EXPECT(0 <= n);
                 return static_cast<iterator_size_t<I>>(n);
             }
         };
@@ -604,7 +604,7 @@ namespace ranges
                     CONCEPT_REQUIRES_(ConvertibleTo<U, V const&>())>
                 void set(U && u)
                 {
-                    RANGES_ASSERT(sout_);
+                    RANGES_EXPECT(sout_);
                     *sout_ << u;
                     if(delim_)
                         *sout_ << delim_;

--- a/include/range/v3/utility/safe_int.hpp
+++ b/include/range/v3/utility/safe_int.hpp
@@ -120,7 +120,7 @@ namespace ranges
             }
             SignedInteger get() const noexcept
             {
-                RANGES_ASSERT(is_finite());
+                RANGES_EXPECT(is_finite());
                 return i_;
             }
             explicit operator SignedInteger() const noexcept

--- a/include/range/v3/utility/semiregular.hpp
+++ b/include/range/v3/utility/semiregular.hpp
@@ -42,12 +42,12 @@ namespace ranges
             {}
             T & get()
             {
-                RANGES_ASSERT(!!t_);
+                RANGES_EXPECT(t_);
                 return *t_;
             }
             T const & get() const
             {
-                RANGES_ASSERT(!!t_);
+                RANGES_EXPECT(t_);
                 return *t_;
             }
             semiregular &operator=(T const &t)

--- a/include/range/v3/utility/variant.hpp
+++ b/include/range/v3/utility/variant.hpp
@@ -45,8 +45,7 @@ namespace ranges
                 }
                 void fill_default_(T *p, std::false_type)
                 {
-                    (void)p;
-                    RANGES_ASSERT(p == ranges::end(data_));
+                    RANGES_EXPECT(p == ranges::end(data_));
                 }
             public:
                 CONCEPT_REQUIRES(DefaultConstructible<T>())

--- a/include/range/v3/view/adjacent_filter.hpp
+++ b/include/range/v3/view/adjacent_filter.hpp
@@ -58,7 +58,7 @@ namespace ranges
                 {
                     auto const end = ranges::end(rng_->mutable_base());
                     auto &&pred = rng_->pred_;
-                    RANGES_ASSERT(it != end);
+                    RANGES_EXPECT(it != end);
                     for(auto prev = it; ++it != end; prev = it)
                         if(pred(*prev, *it))
                             break;

--- a/include/range/v3/view/any_view.hpp
+++ b/include/range/v3/view/any_view.hpp
@@ -262,40 +262,40 @@ namespace ranges
                 }
                 Ref get() const
                 {
-                    RANGES_ASSERT(ptr_);
+                    RANGES_EXPECT(ptr_);
                     return ptr_->get();
                 }
                 bool equal(any_cursor const &that) const
                 {
-                    RANGES_ASSERT(!ptr_ == !that.ptr_);
+                    RANGES_EXPECT(!ptr_ == !that.ptr_);
                     return (!ptr_ && !that.ptr_) || ptr_->equal(*that.ptr_);
                 }
                 bool equal(any_sentinel const &that) const
                 {
-                    RANGES_ASSERT(!ptr_ == !that.ptr_);
+                    RANGES_EXPECT(!ptr_ == !that.ptr_);
                     return (!ptr_ && !that.ptr_) || that.ptr_->equal(ptr_->iter());
                 }
                 void next()
                 {
-                    RANGES_ASSERT(ptr_);
+                    RANGES_EXPECT(ptr_);
                     ptr_->next();
                 }
                 CONCEPT_REQUIRES(Cat >= category::bidirectional)
                 void prev()
                 {
-                    RANGES_ASSERT(ptr_);
+                    RANGES_EXPECT(ptr_);
                     ptr_->prev();
                 }
                 CONCEPT_REQUIRES(Cat >= category::random_access)
                 void advance(std::ptrdiff_t n)
                 {
-                    RANGES_ASSERT(ptr_);
+                    RANGES_EXPECT(ptr_);
                     ptr_->advance(n);
                 }
                 CONCEPT_REQUIRES(Cat >= category::random_access)
                 std::ptrdiff_t distance_to(any_cursor const &that) const
                 {
-                    RANGES_ASSERT(!ptr_ == !that.ptr_);
+                    RANGES_EXPECT(!ptr_ == !that.ptr_);
                     return !ptr_ ? 0 : ptr_->distance_to(*that.ptr_);
                 }
             };

--- a/include/range/v3/view/chunk.hpp
+++ b/include/range/v3/view/chunk.hpp
@@ -63,7 +63,7 @@ namespace ranges
             chunk_view(Rng rng, range_difference_t<Rng> n)
               : chunk_view::view_adaptor(std::move(rng)), n_(n)
             {
-                RANGES_ASSERT(0 < n_);
+                RANGES_EXPECT(0 < n_);
             }
             CONCEPT_REQUIRES(SizedRange<Rng>())
             range_size_t<Rng> size() const
@@ -90,14 +90,14 @@ namespace ranges
             auto get(range_iterator_t<Rng> it) const ->
                 decltype(view::take(make_iterator_range(std::move(it), end_), n_))
             {
-                RANGES_ASSERT(it != end_);
-                RANGES_ASSERT(0 == offset());
+                RANGES_EXPECT(it != end_);
+                RANGES_EXPECT(0 == offset());
                 return view::take(make_iterator_range(std::move(it), end_), n_);
             }
             void next(range_iterator_t<Rng> &it)
             {
-                RANGES_ASSERT(it != end_);
-                RANGES_ASSERT(0 == offset());
+                RANGES_EXPECT(it != end_);
+                RANGES_EXPECT(0 == offset());
                 offset() = ranges::advance(it, n_, end_);
             }
             CONCEPT_REQUIRES(BidirectionalRange<Rng>())
@@ -112,7 +112,7 @@ namespace ranges
                 range_iterator_t<Rng> const &there, adaptor const &that) const
             {
                 // This assertion is true for all range types except cyclic ranges:
-                //RANGES_ASSERT(0 == ((there - here) + that.offset() - offset()) % n_);
+                //RANGES_EXPECT(0 == ((there - here) + that.offset() - offset()) % n_);
                 return ((there - here) + that.offset() - offset()) / n_;
             }
             CONCEPT_REQUIRES(RandomAccessRange<Rng>())

--- a/include/range/v3/view/concat.hpp
+++ b/include/range/v3/view/concat.hpp
@@ -113,7 +113,7 @@ namespace ranges
                 template<std::size_t N>
                 void satisfy(meta::size_t<N>)
                 {
-                    RANGES_ASSERT(its_.index() == N);
+                    RANGES_EXPECT(its_.index() == N);
                     if(ranges::get<N>(its_) == end(std::get<N>(rng_->rngs_)))
                     {
                         ranges::emplace<N + 1>(its_, begin(std::get<N + 1>(rng_->rngs_)));
@@ -122,7 +122,7 @@ namespace ranges
                 }
                 void satisfy(meta::size_t<cranges - 1>)
                 {
-                    RANGES_ASSERT(its_.index() == cranges - 1);
+                    RANGES_EXPECT(its_.index() == cranges - 1);
                 }
                 struct next_fun
                 {
@@ -227,7 +227,7 @@ namespace ranges
                     if(from.its_.index() < N && to.its_.index() > N)
                         return distance(std::get<N>(from.rng_->rngs_)) +
                             cursor::distance_to_(meta::size_t<N + 1>{}, from, to);
-                    RANGES_ASSERT(to.its_.index() == N);
+                    RANGES_EXPECT(to.its_.index() == N);
                     return distance(begin(std::get<N>(from.rng_->rngs_)), ranges::get<N>(to.its_));
                 }
             public:

--- a/include/range/v3/view/counted.hpp
+++ b/include/range/v3/view/counted.hpp
@@ -49,7 +49,7 @@ namespace ranges
             counted_view(I it, D n)
               : it_(it), n_(n)
             {
-                RANGES_ASSERT(0 <= n_);
+                RANGES_EXPECT(0 <= n_);
             }
             size_type_ size() const
             {

--- a/include/range/v3/view/cycle.hpp
+++ b/include/range/v3/view/cycle.hpp
@@ -76,7 +76,7 @@ namespace ranges
                 iterator get_end_(std::false_type, meta::bool_<CanBeEmpty> = {}) const
                 {
                     auto &end_ = static_cast<cache_t&>(*rng_);
-                    RANGES_ASSERT(CanBeEmpty || end_);
+                    RANGES_EXPECT(CanBeEmpty || end_);
                     if(CanBeEmpty && !end_)
                         end_ = ranges::next(it_, ranges::end(rng_->rng_));
                     return *end_;
@@ -107,13 +107,13 @@ namespace ranges
                 )
                 bool equal(cursor const &pos) const
                 {
-                    RANGES_ASSERT(rng_ == pos.rng_);
+                    RANGES_EXPECT(rng_ == pos.rng_);
                     return it_ == pos.it_;
                 }
                 void next()
                 {
                     auto const end = ranges::end(rng_->rng_);
-                    RANGES_ASSERT(it_ != end);
+                    RANGES_EXPECT(it_ != end);
                     if(++it_ == end)
                     {
                         this->set_end_(BoundedRange<Rng>());
@@ -139,7 +139,7 @@ namespace ranges
                 CONCEPT_REQUIRES(SizedSentinel<iterator, iterator>())
                 difference_type_ distance_to(cursor const &that) const
                 {
-                    RANGES_ASSERT(that.rng_ == rng_);
+                    RANGES_EXPECT(that.rng_ == rng_);
                     return that.it_ - it_;
                 }
             };
@@ -160,7 +160,7 @@ namespace ranges
             explicit cycled_view(Rng rng)
               : rng_(std::move(rng))
             {
-                RANGES_ASSERT(!ranges::empty(rng));
+                RANGES_EXPECT(!ranges::empty(rng));
             }
         };
 

--- a/include/range/v3/view/drop.hpp
+++ b/include/range/v3/view/drop.hpp
@@ -70,7 +70,7 @@ namespace ranges
             drop_view(Rng rng, difference_type_ n)
               : rng_(std::move(rng)), n_(n)
             {
-                RANGES_ASSERT(n >= 0);
+                RANGES_EXPECT(n >= 0);
             }
             range_iterator_t<Rng> begin()
             {

--- a/include/range/v3/view/drop_exactly.hpp
+++ b/include/range/v3/view/drop_exactly.hpp
@@ -70,7 +70,7 @@ namespace ranges
             drop_exactly_view(Rng rng, difference_type_ n)
               : rng_(std::move(rng)), n_(n)
             {
-                RANGES_ASSERT(n >= 0);
+                RANGES_EXPECT(n >= 0);
             }
             range_iterator_t<Rng> begin()
             {

--- a/include/range/v3/view/empty.hpp
+++ b/include/range/v3/view/empty.hpp
@@ -52,8 +52,7 @@ namespace ranges
                 }
                 void advance(std::ptrdiff_t n)
                 {
-                    (void)n;
-                    RANGES_ASSERT(n == 0);
+                    RANGES_EXPECT(n == 0);
                 }
                 std::ptrdiff_t distance_to(cursor const &) const
                 {

--- a/include/range/v3/view/generate_n.hpp
+++ b/include/range/v3/view/generate_n.hpp
@@ -63,7 +63,7 @@ namespace ranges
                 }
                 void next()
                 {
-                    RANGES_ASSERT(0 != n_);
+                    RANGES_EXPECT(0 != n_);
                     if(0 != --n_)
                         rng_->next();
                 }

--- a/include/range/v3/view/iota.hpp
+++ b/include/range/v3/view/iota.hpp
@@ -205,7 +205,7 @@ namespace ranges
 
             From get() const
             {
-                RANGES_ASSERT(!done_);
+                RANGES_EXPECT(!done_);
                 return from_;
             }
             void next()
@@ -276,7 +276,7 @@ namespace ranges
             void check_advance_(difference_type_ n)
             {
                 detail::ignore_unused(n);
-                RANGES_ASSERT(detail::iota_minus_(to_, from_) >= n);
+                RANGES_EXPECT(detail::iota_minus_(to_, from_) >= n);
             }
             template<typename = void>
             void check_advance_(difference_type_) const

--- a/include/range/v3/view/repeat_n.hpp
+++ b/include/range/v3/view/repeat_n.hpp
@@ -68,7 +68,7 @@ namespace ranges
                 }
                 void next()
                 {
-                    RANGES_ASSERT(0 != n_);
+                    RANGES_EXPECT(0 != n_);
                     --n_;
                 }
                 void prev()
@@ -91,7 +91,7 @@ namespace ranges
         public:
             repeat_n_view() = default;
             constexpr repeat_n_view(Val value, std::ptrdiff_t n)
-              : value_(detail::move(value)), n_((RANGES_ASSERT(0 <= n), n))
+              : value_(detail::move(value)), n_((RANGES_EXPECT(0 <= n), n))
             {}
             constexpr std::size_t size() const
             {

--- a/include/range/v3/view/reverse.hpp
+++ b/include/range/v3/view/reverse.hpp
@@ -111,8 +111,7 @@ namespace ranges
                 distance_to(range_iterator_t<Rng> const &here, range_iterator_t<Rng> const &there,
                     adaptor const &other_adapt) const
                 {
-                    (void)rng_; (void)other_adapt;
-                    RANGES_ASSERT(rng_ == other_adapt.rng_);
+                    RANGES_EXPECT(rng_ == other_adapt.rng_);
                     if(there == ranges::end(rng_->mutable_base()))
                         return here == ranges::end(rng_->mutable_base())
                             ? 0 : (here - ranges::begin(rng_->mutable_base())) + 1;

--- a/include/range/v3/view/sample.hpp
+++ b/include/range/v3/view/sample.hpp
@@ -106,12 +106,12 @@ namespace ranges
 
                 D pop_size()
                 {
-                    RANGES_ASSERT(range());
+                    RANGES_EXPECT(range());
                     return size().get(range()->range(), current());
                 }
                 void advance()
                 {
-                    RANGES_ASSERT(range());
+                    RANGES_EXPECT(range());
                     if (range()->size() > 0)
                     {
                         using Dist = std::uniform_int_distribution<D>;
@@ -149,13 +149,13 @@ namespace ranges
                 }
                 bool equal(default_sentinel) const
                 {
-                    RANGES_ASSERT(range());
+                    RANGES_EXPECT(range());
                     return range()->size() <= 0;
                 }
                 void next()
                 {
-                    RANGES_ASSERT(range());
-                    RANGES_ASSERT(range()->size() > 0);
+                    RANGES_EXPECT(range());
+                    RANGES_EXPECT(range()->size() > 0);
                     --range()->size();
                     RANGES_ASSERT(current() != ranges::end(range()->range()));
                     ++current();

--- a/include/range/v3/view/single.hpp
+++ b/include/range/v3/view/single.hpp
@@ -72,7 +72,7 @@ namespace ranges
                 void advance(std::ptrdiff_t n)
                 {
                     n += done_;
-                    RANGES_ASSERT(n == 0 || n == 1);
+                    RANGES_EXPECT(n == 0 || n == 1);
                     done_ = n != 0;
                 }
                 std::ptrdiff_t distance_to(cursor const &that) const

--- a/include/range/v3/view/slice.hpp
+++ b/include/range/v3/view/slice.hpp
@@ -43,7 +43,7 @@ namespace ranges
             range_iterator_t<Rng> pos_at_(Rng && rng, Int i, concepts::InputRange *,
                 std::true_type)
             {
-                RANGES_ASSERT(0 <= i);
+                RANGES_EXPECT(0 <= i);
                 return next(ranges::begin(rng), i);
             }
 
@@ -66,7 +66,7 @@ namespace ranges
             range_iterator_t<Rng> pos_at_(Rng && rng, Int i, concepts::InputRange *,
                 std::false_type)
             {
-                RANGES_ASSERT(i >= 0 || SizedRange<Rng>() || ForwardRange<Rng>());
+                RANGES_EXPECT(i >= 0 || SizedRange<Rng>() || ForwardRange<Rng>());
                 if(0 > i)
                     return next(ranges::begin(rng), distance(rng) + i);
                 return next(ranges::begin(rng), i);
@@ -126,7 +126,7 @@ namespace ranges
                 slice_view_(Rng rng, difference_type_ from, difference_type_ count)
                   : rng_(std::move(rng)), from_(from), count_(count)
                 {
-                    RANGES_ASSERT(0 <= count_);
+                    RANGES_EXPECT(0 <= count_);
                 }
                 range_iterator_t<Rng> begin()
                 {
@@ -174,7 +174,7 @@ namespace ranges
             template<typename Int, CONCEPT_REQUIRES_(Integral<Int>())>
             detail::from_end_<meta::_t<std::make_signed<Int>>> operator-(end_fn, Int dist)
             {
-                RANGES_ASSERT(0 <= static_cast<meta::_t<std::make_signed<Int>>>(dist));
+                RANGES_EXPECT(0 <= static_cast<meta::_t<std::make_signed<Int>>>(dist));
                 return {-static_cast<meta::_t<std::make_signed<Int>>>(dist)};
             }
         }
@@ -254,7 +254,7 @@ namespace ranges
                     decltype(slice_fn::invoke_(std::forward<Rng>(rng), from, to - from,
                         range_concept<Rng>{}))
                 {
-                    RANGES_ASSERT(0 <= from && from <= to);
+                    RANGES_EXPECT(0 <= from && from <= to);
                     return slice_fn::invoke_(std::forward<Rng>(rng), from, to - from,
                         range_concept<Rng>{});
                 }
@@ -270,7 +270,7 @@ namespace ranges
                 {
                     static_assert(!is_infinite<Rng>(),
                         "Can't index from the end of an infinite range!");
-                    RANGES_ASSERT(0 <= from);
+                    RANGES_EXPECT(0 <= from);
                     RANGES_ASSERT(from <= distance(rng) + to.dist_);
                     return slice_fn::invoke_(std::forward<Rng>(rng), from,
                         distance(rng) + to.dist_ - from, range_concept<Rng>{});
@@ -287,7 +287,7 @@ namespace ranges
                 {
                     static_assert(!is_infinite<Rng>(),
                         "Can't index from the end of an infinite range!");
-                    RANGES_ASSERT(from.dist_ <= to.dist_);
+                    RANGES_EXPECT(from.dist_ <= to.dist_);
                     return slice_fn::invoke_(std::forward<Rng>(rng), from.dist_,
                         to.dist_ - from.dist_, range_concept<Rng>{},
                         bounded_range_concept<Rng>{}());
@@ -298,7 +298,7 @@ namespace ranges
                 auto operator()(Rng && rng, range_difference_t<Rng> from, end_fn) const ->
                     decltype(ranges::view::drop_exactly(std::forward<Rng>(rng), from))
                 {
-                    RANGES_ASSERT(0 <= from);
+                    RANGES_EXPECT(0 <= from);
                     return ranges::view::drop_exactly(std::forward<Rng>(rng), from);
                 }
                 // slice(rng, end-4, end)

--- a/include/range/v3/view/split.hpp
+++ b/include/range/v3/view/split.hpp
@@ -84,7 +84,7 @@ namespace ranges
                 }
                 void next()
                 {
-                    RANGES_ASSERT(cur_ != last_);
+                    RANGES_EXPECT(cur_ != last_);
                     // If the last match consumed zero elements, bump the position.
                     advance(cur_, (int)zero_, last_);
                     zero_ = false;
@@ -166,8 +166,7 @@ namespace ranges
                     operator()(range_iterator_t<Rng> cur, range_sentinel_t<Rng> end) const
                     {
                         using P = std::pair<bool, range_iterator_t<Rng>>;
-                        RANGES_ASSERT(cur != end);
-                        (void)end;
+                        RANGES_EXPECT(cur != end);
                         return *cur == val_ ? P{true, ranges::next(cur)} : P{false, cur};
                     }
                 };
@@ -183,7 +182,7 @@ namespace ranges
                     std::pair<bool, range_iterator_t<Rng>>
                     operator()(range_iterator_t<Rng> cur, range_sentinel_t<Rng> end) const
                     {
-                        RANGES_ASSERT(cur != end);
+                        RANGES_EXPECT(cur != end);
                         if(SizedSentinel<range_sentinel_t<Rng>, range_iterator_t<Rng>>() &&
                             distance(cur, end) < len_)
                             return {false, cur};

--- a/include/range/v3/view/stride.hpp
+++ b/include/range/v3/view/stride.hpp
@@ -107,7 +107,7 @@ namespace ranges
                 void next(iterator &it)
                 {
                     difference_type_ off = offset();
-                    RANGES_ASSERT(0 == off);
+                    RANGES_EXPECT(0 == off);
                     RANGES_ASSERT(it != ranges::end(rng_->mutable_base()));
                     offset() = ranges::advance(it, rng_->stride_ + off,
                         ranges::end(rng_->mutable_base()));
@@ -118,16 +118,16 @@ namespace ranges
                     difference_type_ off = clean();
                     offset() = off = ranges::advance(it, -rng_->stride_ + off,
                         ranges::begin(rng_->mutable_base()));
-                    RANGES_ASSERT(0 == off);
+                    RANGES_EXPECT(0 == off);
                 }
                 CONCEPT_REQUIRES(SizedSentinel<iterator, iterator>())
                 difference_type_ distance_to(iterator here, iterator there, adaptor const &that) const
                 {
-                    RANGES_ASSERT(rng_ == that.rng_);
+                    RANGES_EXPECT(rng_ == that.rng_);
                     difference_type_ delta = (there - here) + (that.clean() - clean());
                     if(BidirectionalIterator<iterator>())
                     {
-                        RANGES_ASSERT(0 == delta % rng_->stride_);
+                        RANGES_EXPECT(0 == delta % rng_->stride_);
                     }
                     else
                     {
@@ -174,7 +174,7 @@ namespace ranges
               : stride_view::view_adaptor{std::move(rng)}
               , stride_(stride)
             {
-                RANGES_ASSERT(0 < stride_);
+                RANGES_EXPECT(0 < stride_);
             }
             CONCEPT_REQUIRES(SizedRange<Rng>())
             size_type_ size() const

--- a/include/range/v3/view/tail.hpp
+++ b/include/range/v3/view/tail.hpp
@@ -54,7 +54,7 @@ namespace ranges
               : rng_(std::forward<Rng>(rng))
             {
                 CONCEPT_ASSERT(InputRange<Rng>());
-                RANGES_ASSERT(!ForwardRange<Rng>() || !empty(rng_));
+                RANGES_EXPECT(!ForwardRange<Rng>() || !empty(rng_));
             }
             iterator begin()
             {

--- a/include/range/v3/view/take.hpp
+++ b/include/range/v3/view/take.hpp
@@ -89,7 +89,7 @@ namespace ranges
             take_view(Rng rng, range_difference_t<Rng> n)
               : view_adaptor<take_view<Rng>, Rng, finite>(std::move(rng)), n_{n}
             {
-                RANGES_ASSERT(n >= 0);
+                RANGES_EXPECT(n >= 0);
             }
         };
 

--- a/include/range/v3/view/take_exactly.hpp
+++ b/include/range/v3/view/take_exactly.hpp
@@ -68,7 +68,7 @@ namespace ranges
                 take_exactly_view_(Rng rng, difference_type_ n)
                   : rng_(std::move(rng)), n_(n)
                 {
-                    RANGES_ASSERT(n >= 0);
+                    RANGES_EXPECT(n >= 0);
                 }
                 range_size_t<Rng> size() const
                 {
@@ -97,7 +97,7 @@ namespace ranges
                 take_exactly_view_(Rng rng, difference_type_ n)
                   : rng_(std::move(rng)), n_(n)
                 {
-                    RANGES_ASSERT(n >= 0);
+                    RANGES_EXPECT(n >= 0);
                 }
                 range_iterator_t<Rng> begin()
                 {

--- a/test/algorithm/inplace_merge.cpp
+++ b/test/algorithm/inplace_merge.cpp
@@ -18,7 +18,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <cassert>
 #include <algorithm>
 #include <random>
 #include <range/v3/core.hpp>
@@ -38,7 +37,7 @@ namespace
     void
     test_one_iter(unsigned N, unsigned M)
     {
-        assert(M <= N);
+        RANGES_ENSURE(M <= N);
         int* ia = new int[N];
         for (unsigned i = 0; i < N; ++i)
             ia[i] = i;
@@ -60,7 +59,7 @@ namespace
     void
     test_one_rng(unsigned N, unsigned M)
     {
-        assert(M <= N);
+        RANGES_ENSURE(M <= N);
         int* ia = new int[N];
         for (unsigned i = 0; i < N; ++i)
             ia[i] = i;

--- a/test/algorithm/max.cpp
+++ b/test/algorithm/max.cpp
@@ -20,7 +20,6 @@
 //===----------------------------------------------------------------------===//
 
 #include <range/v3/algorithm/max.hpp>
-#include <cassert>
 #include <memory>
 #include <numeric>
 #include <random>
@@ -39,7 +38,7 @@ namespace
     void
     test_iter(Iter first, Sent last)
     {
-        assert(first != last);
+        RANGES_ENSURE(first != last);
         auto rng = ranges::make_iterator_range(first, last);
         auto v = ranges::max(rng);
         for (Iter i = first; i != last; ++i)
@@ -50,7 +49,7 @@ namespace
     void
     test_iter(unsigned N)
     {
-        assert(N > 0);
+        RANGES_ENSURE(N > 0);
         std::unique_ptr<int[]> a{new int[N]};
         std::iota(a.get(), a.get()+N, 0);
         std::shuffle(a.get(), a.get()+N, gen);
@@ -72,7 +71,7 @@ namespace
     void
     test_iter_comp(Iter first, Sent last)
     {
-        assert(first != last);
+        RANGES_ENSURE(first != last);
         auto rng = ranges::make_iterator_range(first, last);
         auto comp = std::greater<int>();
         auto v = ranges::max(rng, comp);
@@ -84,7 +83,7 @@ namespace
     void
     test_iter_comp(unsigned N)
     {
-        assert(N > 0);
+        RANGES_ENSURE(N > 0);
         std::unique_ptr<int[]> a{new int[N]};
         std::iota(a.get(), a.get()+N, 0);
         std::shuffle(a.get(), a.get()+N, gen);

--- a/test/algorithm/min.cpp
+++ b/test/algorithm/min.cpp
@@ -20,7 +20,6 @@
 //===----------------------------------------------------------------------===//
 
 #include <range/v3/algorithm/min.hpp>
-#include <cassert>
 #include <memory>
 #include <random>
 #include <numeric>
@@ -39,7 +38,7 @@ namespace
     void
     test_iter(Iter first, Sent last)
     {
-        assert(first != last);
+        RANGES_ENSURE(first != last);
         auto rng = ranges::make_iterator_range(first, last);
         auto v1 = ranges::min(rng);
         for (Iter i = first; i != last; ++i)
@@ -50,7 +49,7 @@ namespace
     void
     test_iter(unsigned N)
     {
-        assert(N > 0);
+        RANGES_ENSURE(N > 0);
         std::unique_ptr<int[]> a{new int[N]};
         std::iota(a.get(), a.get()+N, 0);
         std::shuffle(a.get(), a.get()+N, gen);
@@ -72,7 +71,7 @@ namespace
     void
     test_iter_comp(Iter first, Sent last)
     {
-        assert(first != last);
+        RANGES_ENSURE(first != last);
         auto rng = ranges::make_iterator_range(first, last);
         auto v = ranges::min(rng, std::greater<int>());
         for (Iter i = first; i != last; ++i)
@@ -83,7 +82,7 @@ namespace
     void
     test_iter_comp(unsigned N)
     {
-        assert(N > 0);
+        RANGES_ENSURE(N > 0);
         std::unique_ptr<int[]> a{new int[N]};
         std::iota(a.get(), a.get()+N, 0);
         std::shuffle(a.get(), a.get()+N, gen);

--- a/test/algorithm/minmax.cpp
+++ b/test/algorithm/minmax.cpp
@@ -20,7 +20,6 @@
 //===----------------------------------------------------------------------===//
 
 #include <range/v3/algorithm/minmax.hpp>
-#include <cassert>
 #include <memory>
 #include <numeric>
 #include <random>
@@ -39,7 +38,7 @@ namespace
     void
     test_iter(Iter first, Sent last)
     {
-        assert(first != last);
+        RANGES_ENSURE(first != last);
         auto rng = ranges::make_iterator_range(first, last);
         auto res = ranges::minmax(rng);
         for (Iter i = first; i != last; ++i) {
@@ -52,7 +51,7 @@ namespace
     void
     test_iter(unsigned N)
     {
-        assert(N > 0);
+        RANGES_ENSURE(N > 0);
         std::unique_ptr<int[]> a{new int[N]};
         std::iota(a.get(), a.get()+N, 0);
         std::shuffle(a.get(), a.get()+N, gen);
@@ -74,7 +73,7 @@ namespace
     void
     test_iter_comp(Iter first, Sent last)
     {
-        assert(first != last);
+        RANGES_ENSURE(first != last);
         typedef std::greater<int> Compare;
         Compare comp;
         auto rng = ranges::make_iterator_range(first, last);
@@ -89,7 +88,7 @@ namespace
     void
     test_iter_comp(unsigned N)
     {
-        assert(N > 0);
+        RANGES_ENSURE(N > 0);
         std::unique_ptr<int[]> a{new int[N]};
         std::iota(a.get(), a.get()+N, 0);
         std::shuffle(a.get(), a.get()+N, gen);

--- a/test/algorithm/nth_element.cpp
+++ b/test/algorithm/nth_element.cpp
@@ -18,7 +18,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <cassert>
 #include <memory>
 #include <random>
 #include <algorithm>
@@ -38,8 +37,8 @@ namespace
     void
     test_one(unsigned N, unsigned M)
     {
-        assert(N != 0);
-        assert(M < N);
+        RANGES_ENSURE(N != 0);
+        RANGES_ENSURE(M < N);
         std::unique_ptr<int[]> array{new int[N]};
         for (int i = 0; (unsigned)i < N; ++i)
             array[i] = i;

--- a/test/algorithm/partial_sort.cpp
+++ b/test/algorithm/partial_sort.cpp
@@ -18,7 +18,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <cassert>
 #include <memory>
 #include <random>
 #include <algorithm>
@@ -46,8 +45,8 @@ namespace
     void
     test_larger_sorts(int N, int M)
     {
-        assert(N > 0);
-        assert(M >= 0 && M <= N);
+        RANGES_ENSURE(N > 0);
+        RANGES_ENSURE(M >= 0 && M <= N);
         int* array = new int[N];
         for(int i = 0; i < N; ++i)
             array[i] = i;

--- a/test/algorithm/partial_sort_copy.cpp
+++ b/test/algorithm/partial_sort_copy.cpp
@@ -18,7 +18,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <cassert>
 #include <memory>
 #include <random>
 #include <vector>

--- a/test/algorithm/sample.cpp
+++ b/test/algorithm/sample.cpp
@@ -39,7 +39,7 @@ namespace
     bool in_sequence(I first, I mid, S last)
     {
         for (; first != mid; ++first)
-            RANGES_ASSERT(first != last);
+            RANGES_ENSURE(first != last);
         for (; first != last; ++first)
             ;
         return true;

--- a/test/algorithm/sort.cpp
+++ b/test/algorithm/sort.cpp
@@ -18,7 +18,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <cassert>
 #include <memory>
 #include <random>
 #include <vector>
@@ -138,8 +137,8 @@ namespace
     void
     test_larger_sorts(int N, int M)
     {
-        assert(N > 0);
-        assert(M > 0);
+        RANGES_ENSURE(N > 0);
+        RANGES_ENSURE(M > 0);
         // create array length N filled with M different numbers
         int* array = new int[N];
         int x = 0;

--- a/test/algorithm/stable_sort.cpp
+++ b/test/algorithm/stable_sort.cpp
@@ -18,7 +18,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <cassert>
 #include <memory>
 #include <random>
 #include <vector>
@@ -110,8 +109,8 @@ namespace
     void
     test_larger_sorts(int N, int M)
     {
-        assert(N > 0);
-        assert(M > 0);
+        RANGES_ENSURE(N > 0);
+        RANGES_ENSURE(M > 0);
         // create array length N filled with M different numbers
         int* array = new int[N];
         int x = 0;

--- a/test/span.cpp
+++ b/test/span.cpp
@@ -352,7 +352,7 @@ namespace
         {
 #ifdef CONFIRM_COMPILATION_ERRORS
             auto get_an_array = []() { return std::array<int, 4>{{1, 2, 3, 4}}; };
-            auto take_a_span = [](span<int> s) { (void) s; };
+            auto take_a_span = [](span<int>) {};
             // try to take a temporary std::array
             take_a_span(get_an_array());
 #endif
@@ -384,7 +384,7 @@ namespace
         {
 #ifdef CONFIRM_COMPILATION_ERRORS
             auto get_an_array = []() -> const std::array<int, 4> { return {{1, 2, 3, 4}}; };
-            auto take_a_span = [](span<const int> s) { (void) s; };
+            auto take_a_span = [](span<const int>) {};
             // try to take a temporary std::array
             take_a_span(get_an_array());
 #endif
@@ -432,7 +432,7 @@ namespace
         {
 #ifdef CONFIRM_COMPILATION_ERRORS
             auto get_temp_vector = []() -> std::vector<int> { return {}; };
-            auto use_span = [](span<int> s) { (void) s; };
+            auto use_span = [](span<int>) {};
             use_span(get_temp_vector());
 #endif
         }
@@ -440,7 +440,7 @@ namespace
         {
 #ifdef CONFIRM_COMPILATION_ERRORS
             auto get_temp_string = []() -> std::string { return {}; };
-            auto use_span = [](span<char> s) { (void) s; };
+            auto use_span = [](span<char>) {};
             use_span(get_temp_string());
 #endif
         }
@@ -448,7 +448,7 @@ namespace
         {
 #ifdef CONFIRM_COMPILATION_ERRORS
             auto get_temp_vector = []() -> const std::vector<int> { return {}; };
-            auto use_span = [](span<const char> s) { (void) s; };
+            auto use_span = [](span<const char>) {};
             use_span(get_temp_vector());
 #endif
         }
@@ -456,7 +456,7 @@ namespace
         {
 #ifdef CONFIRM_COMPILATION_ERRORS
             auto get_temp_string = []() -> const std::string { return {}; };
-            auto use_span = [](span<const char> s) { (void) s; };
+            auto use_span = [](span<const char>) {};
             use_span(get_temp_string());
 #endif
         }

--- a/test/test_iterators.hpp
+++ b/test/test_iterators.hpp
@@ -10,7 +10,6 @@
 #ifndef RANGES_TEST_ITERATORS_HPP
 #define RANGES_TEST_ITERATORS_HPP
 
-#include <cassert>
 #include <iterator>
 
 template <class It, bool Sized = false>
@@ -64,14 +63,12 @@ public:
     RANGES_CXX14_CONSTEXPR It base() const { return it_; }
     RANGES_CXX14_CONSTEXPR friend bool operator==(const sentinel& x, const sentinel& y)
     {
-        (void)x; (void)y;
-        assert(x.it_ == y.it_);
+        RANGES_ENSURE(x.it_ == y.it_);
         return true;
     }
     RANGES_CXX14_CONSTEXPR friend bool operator!=(const sentinel& x, const sentinel& y)
     {
-        (void)x; (void)y;
-        assert(x.it_ == y.it_);
+        RANGES_ENSURE(x.it_ == y.it_);
         return false;
     }
     template<typename I>

--- a/test/utility/reverse_iterator.cpp
+++ b/test/utility/reverse_iterator.cpp
@@ -26,7 +26,7 @@
 #include "../simple_test.hpp"
 #include "../test_iterators.hpp"
 
-template <class It> void test() { ranges::reverse_iterator<It> r; (void)r; }
+template <class It> void test() { ranges::reverse_iterator<It>{}; }
 
 template <class It> void test2(It i) {
   ranges::reverse_iterator<It> r(i);


### PR DESCRIPTION
* Replace many uses of `RANGES_ASSERT` with `RANGES_EXPECT`.
* Replace uses of `assert` in tests with `RANGES_ENSURE`.

"many" is actually "most." The majority of assertions provide useful optimizer hints and evaluate expressions that themselves optimize to nothing in release builds, making them excellent candidates for `RANGES_EXPECT`.