### PR TITLE
GCC6.3 will fix PR78841; disable the workaround...

### DIFF
--- a/test/view/sliding.cpp
+++ b/test/view/sliding.cpp
@@ -118,8 +118,8 @@ int main()
         ::models<concepts::RandomAccessRange>(rng);
         auto it = rng.begin();
         CONCEPT_ASSERT(RandomAccessIterator<decltype(it)>());
-#if defined(__GNUC__) && __GNUC__ == 6 && !defined(__clang__)
-        // Avoid https://gcc.gnu.org/bugzilla/show_bug.cgi?id=78841
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ == 6 && __GNUC_MINOR__ < 3
+        // Avoid https://gcc.gnu.org/bugzilla/show_bug.cgi?id=78047
         {
             auto deref = *it;
             auto i = deref.begin();


### PR DESCRIPTION
... in test/view/sliding.cpp for GCC 6.3+. Fixes #529.

I decided to build my own gcc-6-branch compiler and perform the requisite test.