### PR TITLE
Properly constrain detail::advance_::operator()

### DIFF
--- a/include/range/v3/view/zip_with.hpp
+++ b/include/range/v3/view/zip_with.hpp
@@ -70,10 +70,10 @@ namespace ranges
 
             constexpr struct
             {
-                template<typename T, typename D>
-                void operator()(T & t, D d) const
+                template<typename I, CONCEPT_REQUIRES_(Iterator<I>())>
+                void operator()(I & i, iterator_difference_t<I> n) const
                 {
-                    advance(t, d);
+                    advance(i, n);
                 }
             } advance_ {};
 


### PR DESCRIPTION
Silences truncation warning in test/view/keys_value.cpp to fix the AppVeyor Clang/C2 build.