### PR TITLE
Enable compile with strict clang

### DIFF
--- a/include/meta/meta.hpp
+++ b/include/meta/meta.hpp
@@ -26,6 +26,14 @@
 #pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wdocumentation-deprecated-sync"
+
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wundef"
 #endif
 
 /// \defgroup meta Meta

--- a/include/range/v3/action.hpp
+++ b/include/range/v3/action.hpp
@@ -19,6 +19,9 @@
 #pragma clang diagnostic ignored "-Wshadow"
 #pragma clang diagnostic ignored "-Wdocumentation"
 #pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wundef"
 
 #include <range/v3/action/concepts.hpp>
 #include <range/v3/action/drop.hpp>

--- a/include/range/v3/action.hpp
+++ b/include/range/v3/action.hpp
@@ -14,6 +14,12 @@
 #ifndef RANGES_V3_ACTION_HPP
 #define RANGES_V3_ACTION_HPP
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+
 #include <range/v3/action/concepts.hpp>
 #include <range/v3/action/drop.hpp>
 #include <range/v3/action/drop_while.hpp>
@@ -33,5 +39,7 @@
 #include <range/v3/action/take_while.hpp>
 #include <range/v3/action/transform.hpp>
 #include <range/v3/action/unique.hpp>
+
+#pragma clang diagnostic pop
 
 #endif

--- a/include/range/v3/algorithm.hpp
+++ b/include/range/v3/algorithm.hpp
@@ -14,6 +14,12 @@
 #ifndef RANGES_V3_ALGORITHM_HPP
 #define RANGES_V3_ALGORITHM_HPP
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+
 #include <range/v3/detail/config.hpp>
 RANGES_DISABLE_WARNINGS
 
@@ -99,5 +105,7 @@ RANGES_DISABLE_WARNINGS
 #include <range/v3/algorithm/aux_/upper_bound_n.hpp>
 
 RANGES_RE_ENABLE_WARNINGS
+
+#pragma clang diagnostic pop
 
 #endif

--- a/include/range/v3/algorithm.hpp
+++ b/include/range/v3/algorithm.hpp
@@ -19,6 +19,9 @@
 #pragma clang diagnostic ignored "-Wshadow"
 #pragma clang diagnostic ignored "-Wdocumentation"
 #pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wundef"
 
 #include <range/v3/detail/config.hpp>
 RANGES_DISABLE_WARNINGS

--- a/include/range/v3/all.hpp
+++ b/include/range/v3/all.hpp
@@ -14,12 +14,16 @@
 #ifndef RANGES_V3_ALL_HPP
 #define RANGES_V3_ALL_HPP
 
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wold-style-cast"
 #pragma clang diagnostic ignored "-Wshadow"
 #pragma clang diagnostic ignored "-Wdocumentation"
 #pragma clang diagnostic ignored "-Wunused-parameter"
 #pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wundef"
+#endif
 
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm.hpp>
@@ -27,5 +31,8 @@
 #include <range/v3/numeric.hpp>
 #include <range/v3/view.hpp>
 
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#endif
+
 #endif

--- a/include/range/v3/all.hpp
+++ b/include/range/v3/all.hpp
@@ -14,10 +14,18 @@
 #ifndef RANGES_V3_ALL_HPP
 #define RANGES_V3_ALL_HPP
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wpadded"
+
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm.hpp>
 #include <range/v3/action.hpp>
 #include <range/v3/numeric.hpp>
 #include <range/v3/view.hpp>
 
+#pragma clang diagnostic pop
 #endif

--- a/include/range/v3/core.hpp
+++ b/include/range/v3/core.hpp
@@ -19,6 +19,9 @@
 #pragma clang diagnostic ignored "-Wshadow"
 #pragma clang diagnostic ignored "-Wdocumentation"
 #pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wundef"
 
 #include <range/v3/begin_end.hpp>
 #include <range/v3/distance.hpp>

--- a/include/range/v3/core.hpp
+++ b/include/range/v3/core.hpp
@@ -14,6 +14,12 @@
 #ifndef RANGES_V3_CORE_HPP
 #define RANGES_V3_CORE_HPP
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+
 #include <range/v3/begin_end.hpp>
 #include <range/v3/distance.hpp>
 #include <range/v3/empty.hpp>
@@ -33,5 +39,7 @@
 #include <range/v3/size.hpp>
 #include <range/v3/to_container.hpp>
 #include <range/v3/utility/common_iterator.hpp>
+
+#pragma clang diagnostic pop
 
 #endif

--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -15,6 +15,17 @@
 #ifndef RANGES_V3_DETAIL_CONFIG_HPP
 #define RANGES_V3_DETAIL_CONFIG_HPP
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wundef"
+#endif
+
 #include <iosfwd>
 #if (defined(NDEBUG) && !defined(RANGES_ENSURE_MSG)) || \
     (!defined(NDEBUG) && !defined(RANGES_ASSERT) && \
@@ -389,5 +400,9 @@ namespace ranges {
         }
     }
 }
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #endif

--- a/include/range/v3/detail/variant.hpp
+++ b/include/range/v3/detail/variant.hpp
@@ -14,6 +14,17 @@
 #ifndef RANGES_V3_DETAIL_VARIANT_HPP
 #define RANGES_V3_DETAIL_VARIANT_HPP
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wundef"
+#endif
+
 #include <new>
 #include <tuple>
 #include <memory>
@@ -761,5 +772,9 @@ namespace std
 }
 
 RANGES_DIAGNOSTIC_POP
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #endif

--- a/include/range/v3/numeric.hpp
+++ b/include/range/v3/numeric.hpp
@@ -11,10 +11,18 @@
 #ifndef RANGES_V3_NUMERIC_HPP
 #define RANGES_V3_NUMERIC_HPP
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+
 #include <range/v3/numeric/accumulate.hpp>
 #include <range/v3/numeric/adjacent_difference.hpp>
 #include <range/v3/numeric/iota.hpp>
 #include <range/v3/numeric/inner_product.hpp>
 #include <range/v3/numeric/partial_sum.hpp>
+
+#pragma clang diagnostic pop
 
 #endif

--- a/include/range/v3/numeric.hpp
+++ b/include/range/v3/numeric.hpp
@@ -16,6 +16,9 @@
 #pragma clang diagnostic ignored "-Wshadow"
 #pragma clang diagnostic ignored "-Wdocumentation"
 #pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wundef"
 
 #include <range/v3/numeric/accumulate.hpp>
 #include <range/v3/numeric/adjacent_difference.hpp>

--- a/include/range/v3/numeric/accumulate.hpp
+++ b/include/range/v3/numeric/accumulate.hpp
@@ -13,6 +13,17 @@
 #ifndef RANGES_V3_NUMERIC_ACCUMULATE_HPP
 #define RANGES_V3_NUMERIC_ACCUMULATE_HPP
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wundef"
+#endif
+
 #include <meta/meta.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_traits.hpp>
@@ -62,5 +73,9 @@ namespace ranges
         RANGES_INLINE_VARIABLE(with_braced_init_args<accumulate_fn>, accumulate)
     }
 }
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #endif

--- a/include/range/v3/range_access.hpp
+++ b/include/range/v3/range_access.hpp
@@ -14,6 +14,17 @@
 #ifndef RANGES_V3_RANGE_ACCESS_HPP
 #define RANGES_V3_RANGE_ACCESS_HPP
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wundef"
+#endif
+
 #include <cstddef>
 #include <utility>
 #include <meta/meta.hpp>
@@ -412,5 +423,9 @@ namespace ranges
         /// \endcond
     }
 }
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #endif

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -14,6 +14,17 @@
 #ifndef RANGES_V3_RANGE_FWD_HPP
 #define RANGES_V3_RANGE_FWD_HPP
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wundef"
+#endif
+
 #include <climits>
 #include <utility>
 #include <type_traits>
@@ -757,5 +768,9 @@ namespace ranges
         }
     }
 }
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #endif

--- a/include/range/v3/utility/associated_types.hpp
+++ b/include/range/v3/utility/associated_types.hpp
@@ -15,6 +15,17 @@
 #ifndef RANGES_V3_UTILITY_ASSOCIATED_TYPES_HPP
 #define RANGES_V3_UTILITY_ASSOCIATED_TYPES_HPP
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wundef"
+#endif
+
 #include <iosfwd>
 #include <cstddef>
 #include <utility>
@@ -129,5 +140,9 @@ namespace ranges
         /// @}
     }
 }
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #endif

--- a/include/range/v3/utility/basic_iterator.hpp
+++ b/include/range/v3/utility/basic_iterator.hpp
@@ -13,6 +13,17 @@
 #ifndef RANGES_V3_UTILITY_BASIC_ITERATOR_HPP
 #define RANGES_V3_UTILITY_BASIC_ITERATOR_HPP
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wundef"
+#endif
+
 #include <utility>
 #include <type_traits>
 #include <meta/meta.hpp>
@@ -673,5 +684,9 @@ namespace std
     {};
 }
 /// \endcond
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #endif

--- a/include/range/v3/utility/concepts.hpp
+++ b/include/range/v3/utility/concepts.hpp
@@ -17,6 +17,17 @@
 #ifndef RANGES_V3_UTILITY_CONCEPTS_HPP
 #define RANGES_V3_UTILITY_CONCEPTS_HPP
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wundef"
+#endif
+
 #include <initializer_list>
 #include <utility>
 #include <type_traits>
@@ -886,5 +897,9 @@ RANGES_DIAGNOSTIC_POP
 
 #define CONCEPT_ASSERT_MSG static_assert
 /// @}
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #endif // RANGES_V3_UTILITY_CONCEPTS_HPP

--- a/include/range/v3/utility/dangling.hpp
+++ b/include/range/v3/utility/dangling.hpp
@@ -14,6 +14,17 @@
 #ifndef RANGES_V3_UTILITY_DANGLING_HPP
 #define RANGES_V3_UTILITY_DANGLING_HPP
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wundef"
+#endif
+
 #include <utility>
 #include <meta/meta.hpp>
 #include <range/v3/range_fwd.hpp>
@@ -195,5 +206,9 @@ namespace ranges
         RANGES_INLINE_VARIABLE(sanitize_fn, sanitize)
     }
 }
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #endif

--- a/include/range/v3/utility/functional.hpp
+++ b/include/range/v3/utility/functional.hpp
@@ -13,6 +13,17 @@
 #ifndef RANGES_V3_UTILITY_FUNCTIONAL_HPP
 #define RANGES_V3_UTILITY_FUNCTIONAL_HPP
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wundef"
+#endif
+
 #include <memory> // std::addressof
 #include <utility>
 #include <functional> // std::reference_wrapper
@@ -1061,5 +1072,9 @@ namespace ranges
 }
 
 RANGES_RE_ENABLE_WARNINGS
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #endif

--- a/include/range/v3/utility/iterator.hpp
+++ b/include/range/v3/utility/iterator.hpp
@@ -14,6 +14,17 @@
 #ifndef RANGES_V3_UTILITY_ITERATOR_HPP
 #define RANGES_V3_UTILITY_ITERATOR_HPP
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wundef"
+#endif
+
 #include <new>
 #include <utility>
 #include <iterator>
@@ -1033,5 +1044,9 @@ namespace ranges
         /// @}
     }
 }
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #endif

--- a/include/range/v3/utility/iterator_concepts.hpp
+++ b/include/range/v3/utility/iterator_concepts.hpp
@@ -14,6 +14,17 @@
 #ifndef RANGES_V3_UTILITY_ITERATOR_CONCEPTS_HPP
 #define RANGES_V3_UTILITY_ITERATOR_CONCEPTS_HPP
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wundef"
+#endif
+
 #include <iterator>
 #include <type_traits>
 #include <meta/meta.hpp>
@@ -681,5 +692,9 @@ namespace ranges
     }
 }
 #endif // defined(__GLIBCXX__) || (defined(_LIBCPP_VERSION) && _LIBCPP_VERSION <= 3900)
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #endif // RANGES_V3_UTILITY_ITERATOR_CONCEPTS_HPP

--- a/include/range/v3/utility/move.hpp
+++ b/include/range/v3/utility/move.hpp
@@ -14,6 +14,17 @@
 #ifndef RANGES_V3_UTILITY_MOVE_HPP
 #define RANGES_V3_UTILITY_MOVE_HPP
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wundef"
+#endif
+
 #include <utility>
 #include <type_traits>
 #include <meta/meta.hpp>
@@ -131,5 +142,9 @@ namespace ranges
         {};
     }
 }
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #endif

--- a/include/range/v3/utility/swap.hpp
+++ b/include/range/v3/utility/swap.hpp
@@ -16,6 +16,17 @@
 #ifndef RANGES_V3_UTILITY_SWAP_HPP
 #define RANGES_V3_UTILITY_SWAP_HPP
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wundef"
+#endif
+
 #include <tuple>
 #include <utility>
 #include <type_traits>
@@ -264,5 +275,9 @@ namespace ranges
         RANGES_INLINE_VARIABLE(adl_swap_detail::indirect_swap_fn, indirect_swap)
     }
 }
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #endif

--- a/include/range/v3/utility/tagged_pair.hpp
+++ b/include/range/v3/utility/tagged_pair.hpp
@@ -14,6 +14,17 @@
 #ifndef RANGES_V3_UTILITY_TAGGED_PAIR_HPP
 #define RANGES_V3_UTILITY_TAGGED_PAIR_HPP
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wundef"
+#endif
+
 #include <utility>
 #include <meta/meta.hpp>
 #include <range/v3/range_fwd.hpp>
@@ -225,5 +236,9 @@ namespace std
 }
 
 RANGES_DIAGNOSTIC_POP
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #endif

--- a/include/range/v3/view.hpp
+++ b/include/range/v3/view.hpp
@@ -14,6 +14,12 @@
 #ifndef RANGES_V3_VIEW_HPP
 #define RANGES_V3_VIEW_HPP
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+
 #include <range/v3/detail/config.hpp>
 RANGES_DISABLE_WARNINGS
 
@@ -68,5 +74,7 @@ RANGES_DISABLE_WARNINGS
 #include <range/v3/view/zip.hpp>
 
 RANGES_RE_ENABLE_WARNINGS
+
+#pragma clang diagnostic pop
 
 #endif

--- a/include/range/v3/view.hpp
+++ b/include/range/v3/view.hpp
@@ -19,6 +19,9 @@
 #pragma clang diagnostic ignored "-Wshadow"
 #pragma clang diagnostic ignored "-Wdocumentation"
 #pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wundef"
 
 #include <range/v3/detail/config.hpp>
 RANGES_DISABLE_WARNINGS


### PR DESCRIPTION
range-v3 will not compile when compiling under Clang (I am on v4.0.0, but no reason to believe the same won't happen on any version) with -Weverything -Werror*.  I ignored the warnings that the compiler reported, initially at the highest level (all.hpp), but this did not seem to be effective.  I then went one level down (same result), so I ended up disabling warnings in the offending files themselves.

If you know of a better way to do this, let me know, and I will re-submit the PR.

*The exact set of warning switches I am using for my project is `-Weverything -Werror -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-newline-eof -Wno-exit-time-destructors -Wno-weak-vtables`.  This PR suppresses any remaining warnings in range-v3 only.