### PR TITLE
Disambiguate iterator_category and difference_type

### DIFF
--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -159,13 +159,13 @@ namespace ranges
 
         struct iter_size_fn;
 
-        template<typename T, typename = void>
+        template<typename T>
         struct difference_type;
 
         template<typename T>
         struct value_type;
 
-        template<typename T, typename = void>
+        template<typename T>
         struct iterator_category;
 
         template<typename T>

--- a/include/range/v3/utility/basic_iterator.hpp
+++ b/include/range/v3/utility/basic_iterator.hpp
@@ -242,8 +242,7 @@ namespace ranges
             template<typename Cur, bool Readable = (bool) ReadableCursor<Cur>()>
             struct iterator_associated_types_base
             {
-            private:
-                friend struct basic_iterator<Cur>;
+            protected:
                 using reference_t = basic_proxy_reference<Cur>;
                 using const_reference_t = basic_proxy_reference<Cur const>;
                 using cursor_concept_t = range_access::OutputCursor;
@@ -254,10 +253,8 @@ namespace ranges
 
             template<typename Cur>
             struct iterator_associated_types_base<Cur, true>
-              : iterator_associated_types_base<Cur, false>
             {
-            private:
-                friend struct basic_iterator<Cur>;
+            protected:
                 using cursor_concept_t = detail::cursor_concept_t<Cur>;
                 using reference_t =
                     meta::if_<
@@ -269,6 +266,7 @@ namespace ranges
                             cursor_reference_t<Cur>>>;
                 using const_reference_t = reference_t;
             public:
+                using difference_type = range_access::cursor_difference_t<Cur>;
                 using value_type = range_access::cursor_value_t<Cur>;
                 using reference = reference_t;
                 using iterator_category =

--- a/include/range/v3/utility/iterator_concepts.hpp
+++ b/include/range/v3/utility/iterator_concepts.hpp
@@ -104,38 +104,31 @@ namespace ranges
               : decltype(detail::downgrade_iterator_category_(_nullptr_v<Tag>(), _nullptr_v<Tag>(),
                     std::integral_constant<bool, std::is_reference<Reference>::value>()))
             {};
+
+            ////////////////////////////////////////////////////////////////////////////////////////
+            template<typename T>
+            meta::if_<std::is_object<T>, ranges::random_access_iterator_tag>
+            iterator_category_helper(T **);
+
+            template<typename T>
+            meta::_t<upgrade_iterator_category<typename T::iterator_category>>
+            iterator_category_helper(T *);
+
+            template<class T>
+            using iterator_category_ = decltype(detail::iterator_category_helper(_nullptr_v<T>()));
         }
         /// \endcond
 
         /// \addtogroup group-concepts
         /// @{
-        template<typename T, typename /*= void*/>
-        struct iterator_category
-        {};
-
         template<typename T>
-        struct iterator_category<T *>
-          : meta::lazy::if_<std::is_object<T>, ranges::random_access_iterator_tag>
+        struct iterator_category
+          : meta::defer<detail::iterator_category_, T>
         {};
 
         template<typename T>
         struct iterator_category<T const>
           : iterator_category<T>
-        {};
-
-        template<typename T>
-        struct iterator_category<T volatile>
-          : iterator_category<T>
-        {};
-
-        template<typename T>
-        struct iterator_category<T const volatile>
-          : iterator_category<T>
-        {};
-
-        template<typename T>
-        struct iterator_category<T, meta::void_<typename T::iterator_category>>
-          : detail::upgrade_iterator_category<typename T::iterator_category>
         {};
 
         namespace concepts


### PR DESCRIPTION
...so that `foo<const T>` works correctly when `T` is a class type with member `foo_type`.

I tried to give `difference_type` the same overload-set design as `value_type` and `iterator_category`, and fell face-first into a steaming pile of recursive instantiation errors: it's critical that the code does not attempt to instantiate `T - T` when `T` has a member `difference_type`.