### PR TITLE
Rework Callable concepts to TS spec + ericniebler/stl2#189

### DIFF
--- a/example/recursive_range.hpp
+++ b/example/recursive_range.hpp
@@ -92,10 +92,10 @@ namespace ranges
             };
         public:
             template<typename Fun,
-                CONCEPT_REQUIRES_(Function<Fun>() &&
-                    ConvertibleTo<concepts::Function::result_t<Fun>, any_input_view<Ref>>())>
+                CONCEPT_REQUIRES_(CopyConstructible<Fun>() && Invocable<Fun&>() &&
+                    ConvertibleTo<result_of_t<Fun&()>, any_input_view<Ref>>())>
             explicit recursive_range_fn(Fun fun)
-              : fun_{[=](){return view::concat(fun(), view::empty<value_type>());}}
+              : fun_{[=]{return view::concat(invoke(fun), view::empty<value_type>());}}
             {}
             recursive_range_fn(recursive_range_fn const &) = delete;
             recursive_range_fn &operator=(recursive_range_fn const &) = delete;

--- a/include/range/v3/action/action.hpp
+++ b/include/range/v3/action/action.hpp
@@ -39,7 +39,7 @@ namespace ranges
                     static auto bind(Ts &&...ts)
                     RANGES_DECLTYPE_AUTO_RETURN
                     (
-                        A::bind(std::forward<Ts>(ts)...)
+                        A::bind(detail::forward<Ts>(ts)...)
                     )
                 };
             };
@@ -49,7 +49,7 @@ namespace ranges
                 template<typename Fun>
                 action<Fun> operator()(Fun fun) const
                 {
-                    return {std::move(fun)};
+                    return {detail::move(fun)};
                 }
             };
 
@@ -65,7 +65,7 @@ namespace ranges
                 friend pipeable_access;
                 template<typename Rng>
                 using ActionPipeConcept = meta::and_<
-                    Function<Action, Rng>,
+                    Invocable<Action&, Rng>,
                     Range<Rng>,
                     meta::not_<std::is_reference<Rng>>>;
                 // Pipeing requires things are passed by value.
@@ -74,7 +74,7 @@ namespace ranges
                 static auto pipe(Rng && rng, Act && act)
                 RANGES_DECLTYPE_AUTO_RETURN
                 (
-                    act.action_(std::move(rng))
+                    invoke(act.action_, detail::move(rng))
                 )
             #ifndef RANGES_DOXYGEN_INVOKED
                 // For better error messages:
@@ -86,7 +86,7 @@ namespace ranges
                         "The type Rng must be a model of the Range concept.");
                     // BUGBUG This isn't a very helpful message. This is probably the wrong place
                     // to put this check:
-                    CONCEPT_ASSERT_MSG(Function<Action, Rng>(),
+                    CONCEPT_ASSERT_MSG(Invocable<Action&, Rng>(),
                         "This action is not callable with this range type.");
                     static_assert(!std::is_reference<Rng>(),
                         "You can't pipe an lvalue into an action. Try using std::move on the argument, "
@@ -97,31 +97,31 @@ namespace ranges
             public:
                 action() = default;
                 action(Action a)
-                  : action_(std::move(a))
+                  : action_(detail::move(a))
                 {}
                 // Calling directly requires things are passed by reference.
                 template<typename Rng, typename...Rest,
-                    CONCEPT_REQUIRES_(Range<Rng &>() && Function<Action, Rng &, Rest &&...>())>
+                    CONCEPT_REQUIRES_(Range<Rng &>() && Invocable<Action const&, Rng &, Rest &&...>())>
                 auto operator()(Rng & rng, Rest &&... rest) const
                 RANGES_DECLTYPE_AUTO_RETURN
                 (
-                    action_(rng, std::forward<Rest>(rest)...)
+                    invoke(action_, rng, detail::forward<Rest>(rest)...)
                 )
                 // Currying overload.
                 template<typename T, typename...Rest, typename A = Action>
                 auto operator()(T && t, Rest &&... rest) const
                 RANGES_DECLTYPE_AUTO_RETURN
                 (
-                    make_action(action_access::impl<A>::bind(action_, std::forward<T>(t),
-                        std::forward<Rest>(rest)...))
+                    make_action(action_access::impl<A>::bind(action_, detail::forward<T>(t),
+                        detail::forward<Rest>(rest)...))
                 )
             };
 
             template<typename Rng, typename Action,
                 CONCEPT_REQUIRES_(is_pipeable<Action>() && Range<Rng &>() &&
-                    Function<bitwise_or, ref_t<Rng &> &&, Action>() &&
+                    Invocable<bitwise_or, ref_t<Rng &> &&, Action &>() &&
                     Same<ref_t<Rng &>,
-                        concepts::Function::result_t<bitwise_or, ref_t<Rng &> &&, Action>>())>
+                        result_of_t<bitwise_or(ref_t<Rng &> &&, Action &)>>())>
             Rng & operator|=(Rng & rng, Action && action)
             {
                 ref(rng) | action;

--- a/include/range/v3/action/drop_while.hpp
+++ b/include/range/v3/action/drop_while.hpp
@@ -51,7 +51,7 @@ namespace ranges
                     auto requires_(Rng&&, Fun&&) -> decltype(
                         concepts::valid_expr(
                             concepts::model_of<concepts::ForwardRange, Rng>(),
-                            concepts::is_true(IndirectCallablePredicate<Fun, range_iterator_t<Rng>>{}),
+                            concepts::is_true(IndirectPredicate<Fun, range_iterator_t<Rng>>{}),
                             concepts::model_of<concepts::ErasableRange, Rng, I, I>()
                         ));
                 };
@@ -77,7 +77,7 @@ namespace ranges
                     CONCEPT_ASSERT_MSG(ForwardRange<Rng>(),
                         "The object on which action::drop_while operates must be a model of the "
                         "ForwardRange concept.");
-                    CONCEPT_ASSERT_MSG(IndirectCallablePredicate<Fun, range_iterator_t<Rng>>(),
+                    CONCEPT_ASSERT_MSG(IndirectPredicate<Fun, range_iterator_t<Rng>>(),
                         "The function passed to action::drop_while must be callable with objects "
                         "of the range's common reference type, and it must return something convertible to "
                         "bool.");

--- a/include/range/v3/action/remove_if.hpp
+++ b/include/range/v3/action/remove_if.hpp
@@ -81,10 +81,10 @@ namespace ranges
                     CONCEPT_ASSERT_MSG(ErasableRange<Rng, I, I>(),
                         "The object on which action::remove_if operates must allow element "
                         "removal.");
-                    CONCEPT_ASSERT_MSG(IndirectCallable<P, I>(),
+                    CONCEPT_ASSERT_MSG(IndirectInvocable<P, I>(),
                         "The projection function must accept objects of the iterator's value type, "
                         "reference type, and common reference type.");
-                    CONCEPT_ASSERT_MSG(IndirectCallablePredicate<C, projected<I, P>>(),
+                    CONCEPT_ASSERT_MSG(IndirectPredicate<C, projected<I, P>>(),
                         "The predicate passed to action::remove_if must accept objects returned "
                         "by the projection function, or of the range's value type if no projection "
                         "is specified.");

--- a/include/range/v3/action/sort.hpp
+++ b/include/range/v3/action/sort.hpp
@@ -43,19 +43,9 @@ namespace ranges
                         protect(std::move(proj)))
                 )
             public:
-                struct ConceptImpl
-                {
-                    template<typename Rng, typename C = ordered_less, typename P = ident,
-                        typename I = range_iterator_t<Rng>>
-                    auto requires_(Rng&&, C&& = C{}, P&& = P{}) -> decltype(
-                        concepts::valid_expr(
-                            concepts::model_of<concepts::ForwardRange, Rng>(),
-                            concepts::is_true(Sortable<I, C, P>())
-                        ));
-                };
-
                 template<typename Rng, typename C = ordered_less, typename P = ident>
-                using Concept = concepts::models<ConceptImpl, Rng, C, P>;
+                using Concept = meta::and_<
+                    ForwardRange<Rng>, Sortable<range_iterator_t<Rng>, C, P>>;
 
                 template<typename Rng, typename C = ordered_less, typename P = ident,
                     CONCEPT_REQUIRES_(Concept<Rng, C, P>())>
@@ -74,10 +64,10 @@ namespace ranges
                         "The object on which action::sort operates must be a model of the "
                         "ForwardRange concept.");
                     using I = range_iterator_t<Rng>;
-                    CONCEPT_ASSERT_MSG(IndirectCallable<P, I>(),
+                    CONCEPT_ASSERT_MSG(IndirectInvocable<P, I>(),
                         "The projection function must accept objects of the iterator's value type, "
                         "reference type, and common reference type.");
-                    CONCEPT_ASSERT_MSG(IndirectCallableRelation<C, projected<I, P>>(),
+                    CONCEPT_ASSERT_MSG(IndirectRelation<C, projected<I, P>>(),
                         "The comparator passed to action::sort must accept objects returned "
                         "by the projection function, or of the range's value type if no projection "
                         "is specified.");

--- a/include/range/v3/action/split.hpp
+++ b/include/range/v3/action/split.hpp
@@ -93,8 +93,8 @@ namespace ranges
                         "range's value type, "
                         "(3) A Predicate that is callable with one argument of the range's reference "
                         "type, or "
-                        "(4) A Function that is callable with two arguments: the range's iterator "
-                        "and sentinel, and that returns a std::pair<bool, I>, where I is the "
+                        "(4) A Callable that accepts two arguments, the range's iterator "
+                        "and sentinel, and that returns a std::pair<bool, I> where I is the "
                         "input range's difference_type.");
                 }
             #endif

--- a/include/range/v3/action/stable_sort.hpp
+++ b/include/range/v3/action/stable_sort.hpp
@@ -74,10 +74,10 @@ namespace ranges
                         "The object on which action::stable_sort operates must be a model of the "
                         "ForwardRange concept.");
                     using I = range_iterator_t<Rng>;
-                    CONCEPT_ASSERT_MSG(IndirectCallable<P, I>(),
+                    CONCEPT_ASSERT_MSG(IndirectInvocable<P, I>(),
                         "The projection function must accept objects of the iterator's value type, "
                         "reference type, and common reference type.");
-                    CONCEPT_ASSERT_MSG(IndirectCallableRelation<C, projected<I, P>>(),
+                    CONCEPT_ASSERT_MSG(IndirectRelation<C, projected<I, P>>(),
                         "The comparator passed to action::stable_sort must accept objects returned "
                         "by the projection function, or of the range's value type if no projection "
                         "is specified.");

--- a/include/range/v3/action/take_while.hpp
+++ b/include/range/v3/action/take_while.hpp
@@ -53,7 +53,7 @@ namespace ranges
                         concepts::valid_expr(
                             concepts::model_of<concepts::ForwardRange, Rng>(),
                             concepts::model_of<concepts::ErasableRange, Rng, I, S>(),
-                            concepts::is_true(IndirectCallablePredicate<Fun, I>{})
+                            concepts::is_true(IndirectPredicate<Fun, I>{})
                         ));
                 };
 
@@ -82,7 +82,7 @@ namespace ranges
                     CONCEPT_ASSERT_MSG(ErasableRange<Rng, I, S>(),
                         "The object on which action::take_while operates must allow element "
                         "removal.");
-                    CONCEPT_ASSERT_MSG(IndirectCallablePredicate<Fun, I>(),
+                    CONCEPT_ASSERT_MSG(IndirectPredicate<Fun, I>(),
                         "The function passed to action::take_while must be callable with objects "
                         "of the range's common reference type, and it must return something convertible to "
                         "bool.");

--- a/include/range/v3/action/transform.hpp
+++ b/include/range/v3/action/transform.hpp
@@ -74,16 +74,16 @@ namespace ranges
                         "The object on which action::transform operates must be a model of the "
                         "InputRange concept.");
                     using I = range_iterator_t<Rng>;
-                    CONCEPT_ASSERT_MSG(IndirectCallable<P, I>(),
+                    CONCEPT_ASSERT_MSG(IndirectInvocable<P, I>(),
                         "The projection function must accept objects of the iterator's value type, "
                         "reference type, and common reference type.");
-                    CONCEPT_ASSERT_MSG(IndirectCallable<F, projected<I, P>>(),
+                    CONCEPT_ASSERT_MSG(IndirectInvocable<F, projected<I, P>>(),
                         "The function argument to action::transform must be callable with "
                         "the result of the projection argument, or with objects of the range's "
                         "common reference type if no projection is specified.");
                     CONCEPT_ASSERT_MSG(Writable<range_iterator_t<Rng>,
-                            concepts::Callable::result_t<F,
-                                concepts::Callable::result_t<P, range_common_reference_t<Rng>>> &&>(),
+                            concepts::Invocable::result_t<F&,
+                                concepts::Invocable::result_t<P&, range_common_reference_t<Rng>>> &&>(),
                         "The result type of the function passed to action::transform must "
                         "be writable back into the source range.");
                 }

--- a/include/range/v3/action/unique.hpp
+++ b/include/range/v3/action/unique.hpp
@@ -81,10 +81,10 @@ namespace ranges
                     CONCEPT_ASSERT_MSG(ErasableRange<Rng, I, S>(),
                         "The object on which action::unique operates must allow element "
                         "removal.");
-                    CONCEPT_ASSERT_MSG(IndirectCallable<P, I>(),
+                    CONCEPT_ASSERT_MSG(IndirectInvocable<P, I>(),
                         "The projection function must accept objects of the iterator's value type, "
                         "reference type, and common reference type.");
-                    CONCEPT_ASSERT_MSG(IndirectCallableRelation<C, projected<I, P>>(),
+                    CONCEPT_ASSERT_MSG(IndirectRelation<C, projected<I, P>>(),
                         "The comparator passed to action::unique must accept objects returned "
                         "by the projection function, or of the range's value type if no projection "
                         "is specified.");

--- a/include/range/v3/algorithm/adjacent_find.hpp
+++ b/include/range/v3/algorithm/adjacent_find.hpp
@@ -37,17 +37,15 @@ namespace ranges
             /// \pre `C` is a model of the `BinaryPredicate` concept
             template<typename I, typename S, typename C = equal_to, typename P = ident,
                 CONCEPT_REQUIRES_(ForwardIterator<I>() && Sentinel<S, I>() &&
-                    IndirectCallableRelation<C, projected<I, P>>())>
+                    IndirectRelation<C, projected<I, P>>())>
             I
-            operator()(I begin, S end, C pred_ = C{}, P proj_ = P{}) const
+            operator()(I begin, S end, C pred = C{}, P proj = P{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj = as_function(proj_);
                 if(begin == end)
                     return begin;
                 auto next = begin;
                 for(; ++next != end; begin = next)
-                    if(pred(proj(*begin), proj(*next)))
+                    if(invoke(pred, invoke(proj, *begin), invoke(proj, *next)))
                         return begin;
                 return next;
             }
@@ -56,7 +54,7 @@ namespace ranges
             template<typename Rng, typename C = equal_to, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(ForwardRange<Rng>() &&
-                    IndirectCallableRelation<C, projected<I, P>>())>
+                    IndirectRelation<C, projected<I, P>>())>
             range_safe_iterator_t<Rng>
             operator()(Rng &&rng, C pred = C{}, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/all_of.hpp
+++ b/include/range/v3/algorithm/all_of.hpp
@@ -33,21 +33,19 @@ namespace ranges
         {
             template<typename I, typename S, typename F, typename P = ident,
                 CONCEPT_REQUIRES_(InputIterator<I>() && Sentinel<S, I>() &&
-                    IndirectCallablePredicate<F, projected<I, P> >())>
+                    IndirectPredicate<F, projected<I, P> >())>
             bool
             operator()(I first, S last, F pred, P proj = P{}) const
             {
-                auto &&ipred = as_function(pred);
-                auto &&iproj = as_function(proj);
                 for(; first != last; ++first)
-                    if(!ipred(iproj(*first)))
+                    if(!invoke(pred, invoke(proj, *first)))
                         break;
                 return first == last;
             }
 
             template<typename Rng, typename F, typename P = ident,
                 typename I = range_iterator_t<Rng>,
-                CONCEPT_REQUIRES_(InputRange<Rng>() && IndirectCallablePredicate<F, projected<I, P> >())>
+                CONCEPT_REQUIRES_(InputRange<Rng>() && IndirectPredicate<F, projected<I, P> >())>
             bool
             operator()(Rng &&rng, F pred, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/any_of.hpp
+++ b/include/range/v3/algorithm/any_of.hpp
@@ -34,21 +34,19 @@ namespace ranges
         {
             template<typename I, typename S, typename F, typename P = ident,
                 CONCEPT_REQUIRES_(InputIterator<I>() && Sentinel<S, I>() &&
-                    IndirectCallablePredicate<F, projected<I, P> >())>
+                    IndirectPredicate<F, projected<I, P> >())>
             bool
             operator()(I first, S last, F pred, P proj = P{}) const
             {
-                auto &&ipred = as_function(pred);
-                auto &&iproj = as_function(proj);
                 for(; first != last; ++first)
-                    if(ipred(iproj(*first)))
+                    if(invoke(pred, invoke(proj, *first)))
                         return true;
                 return false;
             }
 
             template<typename Rng, typename F, typename P = ident,
                 typename I = range_iterator_t<Rng>,
-                CONCEPT_REQUIRES_(InputRange<Rng>() && IndirectCallablePredicate<F, projected<I, P> >())>
+                CONCEPT_REQUIRES_(InputRange<Rng>() && IndirectPredicate<F, projected<I, P> >())>
             bool
             operator()(Rng &&rng, F pred, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/aux_/equal_range_n.hpp
+++ b/include/range/v3/algorithm/aux_/equal_range_n.hpp
@@ -37,25 +37,23 @@ namespace ranges
                 template<typename I, typename V, typename R = ordered_less, typename P = ident,
                     CONCEPT_REQUIRES_(BinarySearchable<I, V, R, P>())>
                 iterator_range<I>
-                operator()(I begin, iterator_difference_t<I> dist, V const & val, R pred_ = R{},
-                    P proj_ = P{}) const
+                operator()(I begin, iterator_difference_t<I> dist, V const & val, R pred = R{},
+                    P proj = P{}) const
                 {
                     if(0 < dist)
                     {
-                        auto && pred = as_function(pred_);
-                        auto && proj = as_function(proj_);
                         do
                         {
                             auto half = dist / 2;
                             auto middle = next(begin, half);
                             auto && v = *middle;
-                            auto && pv = proj((decltype(v) &&) v);
-                            if(pred(pv, val))
+                            auto && pv = invoke(proj, (decltype(v) &&) v);
+                            if(invoke(pred, pv, val))
                             {
                                 begin = std::move(++middle);
                                 dist -= half + 1;
                             }
-                            else if(pred(val, pv))
+                            else if(invoke(pred, val, pv))
                             {
                                 dist = half;
                             }

--- a/include/range/v3/algorithm/aux_/lower_bound_n.hpp
+++ b/include/range/v3/algorithm/aux_/lower_bound_n.hpp
@@ -27,7 +27,7 @@ namespace ranges
         /// \cond
         namespace detail
         {
-            // [&](auto&& i){ return pred(i, val); }
+            // [&](auto&& i){ return invoke(pred, i, val); }
             template<typename Pred, typename Val>
             struct lower_bound_predicate
             {
@@ -37,7 +37,7 @@ namespace ranges
                 template<typename T>
                 bool operator()(T&& t) const
                 {
-                    return pred_(std::forward<T>(t), val_);
+                    return invoke(pred_, std::forward<T>(t), val_);
                 }
             };
 
@@ -56,10 +56,9 @@ namespace ranges
             {
                 template<typename I, typename V2, typename C = ordered_less, typename P = ident,
                     CONCEPT_REQUIRES_(BinarySearchable<I, V2, C, P>())>
-                I operator()(I begin, iterator_difference_t<I> d, V2 const &val, C pred_ = C{},
+                I operator()(I begin, iterator_difference_t<I> d, V2 const &val, C pred = C{},
                     P proj = P{}) const
                 {
-                    auto&& pred = as_function(pred_);
                     return partition_point_n(std::move(begin), d,
                         detail::make_lower_bound_predicate(pred, val), std::move(proj));
                 }

--- a/include/range/v3/algorithm/aux_/merge_n.hpp
+++ b/include/range/v3/algorithm/aux_/merge_n.hpp
@@ -61,9 +61,6 @@ namespace ranges
                            O out, C r = C{}, P0 p0 = P0{}, P1 p1 = P1{}) const
                 {
                     using T = tagged_tuple<tag::in1(I0), tag::in2(I1), tag::out(O)>;
-                    auto &&ir = as_function(r);
-                    auto &&ip0 = as_function(p0);
-                    auto &&ip1 = as_function(p1);
                     auto n0orig = n0;
                     auto n1orig = n1;
                     auto b0 = uncounted(begin0);
@@ -84,7 +81,7 @@ namespace ranges
                             begin1 = recounted(begin1, b1, n1orig);
                             return T{begin0, begin1, res.second};
                         }
-                        if(ir(ip1(*b1), ip0(*b0)))
+                        if(invoke(r, invoke(p1, *b1), invoke(p0, *b0)))
                         {
                             *out = *b1;
                             ++b1; ++out; --n1;

--- a/include/range/v3/algorithm/aux_/partition_point_n.hpp
+++ b/include/range/v3/algorithm/aux_/partition_point_n.hpp
@@ -24,12 +24,10 @@ namespace ranges
     inline namespace v3
     {
         /// \ingroup group-concepts
-        template<typename I, typename C, typename P = ident,
-            typename V = iterator_common_reference_t<I>,
-            typename = concepts::Callable::result_t<P, V>>
+        template<typename I, typename C, typename P = ident>
         using PartitionPointable = meta::strict_and<
             ForwardIterator<I>,
-            IndirectCallablePredicate<C, projected<I, P>>>;
+            IndirectPredicate<C, projected<I, P>>>;
 
         namespace aux
         {
@@ -37,17 +35,15 @@ namespace ranges
             {
                 template<typename I, typename C, typename P = ident,
                     CONCEPT_REQUIRES_(PartitionPointable<I, C, P>())>
-                I operator()(I begin, iterator_difference_t<I> d, C pred_, P proj_ = P{}) const
+                I operator()(I begin, iterator_difference_t<I> d, C pred, P proj = P{}) const
                 {
                     if(0 < d)
                     {
-                        auto &&pred = as_function(pred_);
-                        auto &&proj = as_function(proj_);
                         do
                         {
                             auto half = d / 2;
                             auto middle = next(uncounted(begin), half);
-                            if(pred(proj(*middle)))
+                            if(invoke(pred, invoke(proj, *middle)))
                             {
                                 begin = recounted(begin, std::move(++middle), half + 1);
                                 d -= half + 1;

--- a/include/range/v3/algorithm/aux_/upper_bound_n.hpp
+++ b/include/range/v3/algorithm/aux_/upper_bound_n.hpp
@@ -27,7 +27,7 @@ namespace ranges
         /// \cond
         namespace detail
         {
-            // [&](auto&& i){ return !pred(val, i); }
+            // [&](auto&& i){ return !invoke(pred, val, i); }
             template<typename Pred, typename Val>
             struct upper_bound_predicate
             {
@@ -37,7 +37,7 @@ namespace ranges
                 template<typename T>
                 bool operator()(T&& t) const
                 {
-                    return !pred_(val_, std::forward<T>(t));
+                    return !invoke(pred_, val_, std::forward<T>(t));
                 }
             };
 
@@ -61,10 +61,9 @@ namespace ranges
                 /// \pre `Rng` is a model of the `Range` concept
                 template<typename I, typename V2, typename C = ordered_less, typename P = ident,
                     CONCEPT_REQUIRES_(BinarySearchable<I, V2, C, P>())>
-                I operator()(I begin, iterator_difference_t<I> d, V2 const &val, C pred_ = C{},
+                I operator()(I begin, iterator_difference_t<I> d, V2 const &val, C pred = C{},
                     P proj = P{}) const
                 {
-                    auto&& pred = as_function(pred_);
                     return partition_point_n(std::move(begin), d,
                         detail::make_upper_bound_predicate(pred, val), std::move(proj));
                 }

--- a/include/range/v3/algorithm/binary_search.hpp
+++ b/include/range/v3/algorithm/binary_search.hpp
@@ -44,10 +44,8 @@ namespace ranges
             bool
             operator()(I begin, S end, V2 const &val, C pred = C{}, P proj = P{}) const
             {
-                begin = lower_bound(std::move(begin), end, val, pred, proj);
-                auto &&ipred = as_function(pred);
-                auto &&iproj = as_function(proj);
-                return begin != end && !ipred(val, iproj(*begin));
+                begin = lower_bound(std::move(begin), end, val, std::ref(pred), std::ref(proj));
+                return begin != end && !invoke(pred, val, invoke(proj, *begin));
             }
 
             /// \overload

--- a/include/range/v3/algorithm/copy.hpp
+++ b/include/range/v3/algorithm/copy.hpp
@@ -19,7 +19,6 @@
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/iterator_traits.hpp>
 #include <range/v3/utility/iterator_concepts.hpp>
 #include <range/v3/utility/copy.hpp>

--- a/include/range/v3/algorithm/copy_backward.hpp
+++ b/include/range/v3/algorithm/copy_backward.hpp
@@ -20,7 +20,6 @@
 #include <range/v3/range_traits.hpp>
 #include <range/v3/utility/iterator_concepts.hpp>
 #include <range/v3/utility/iterator_traits.hpp>
-#include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/static_const.hpp>
 #include <range/v3/utility/tagged_pair.hpp>
 #include <range/v3/algorithm/tagspec.hpp>

--- a/include/range/v3/algorithm/copy_if.hpp
+++ b/include/range/v3/algorithm/copy_if.hpp
@@ -36,17 +36,15 @@ namespace ranges
         {
             template<typename I, typename S, typename O, typename F, typename P = ident,
                 CONCEPT_REQUIRES_(InputIterator<I>() && Sentinel<S, I>() &&
-                    WeaklyIncrementable<O>() && IndirectCallablePredicate<F, projected<I, P> >() &&
+                    WeaklyIncrementable<O>() && IndirectPredicate<F, projected<I, P> >() &&
                     IndirectlyCopyable<I, O>())>
             tagged_pair<tag::in(I), tag::out(O)>
-            operator()(I begin, S end, O out, F pred_, P proj_ = P{}) const
+            operator()(I begin, S end, O out, F pred, P proj = P{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj = as_function(proj_);
                 for(; begin != end; ++begin)
                 {
                     auto &&x = *begin;
-                    if(pred(proj(x)))
+                    if(invoke(pred, invoke(proj, x)))
                     {
                         *out = (decltype(x) &&) x;
                         ++out;
@@ -58,7 +56,7 @@ namespace ranges
             template<typename Rng, typename O, typename F, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(InputRange<Rng>() && WeaklyIncrementable<O>() &&
-                    IndirectCallablePredicate<F, projected<I, P> >() && IndirectlyCopyable<I, O>())>
+                    IndirectPredicate<F, projected<I, P> >() && IndirectlyCopyable<I, O>())>
             tagged_pair<tag::in(range_safe_iterator_t<Rng>), tag::out(O)>
             operator()(Rng &&rng, O out, F pred, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/count.hpp
+++ b/include/range/v3/algorithm/count.hpp
@@ -33,14 +33,13 @@ namespace ranges
         {
             template<typename I, typename S, typename V, typename P = ident,
                 CONCEPT_REQUIRES_(InputIterator<I>() && Sentinel<S, I>() &&
-                    IndirectCallableRelation<equal_to, projected<I, P>, V const *>())>
+                    IndirectRelation<equal_to, projected<I, P>, V const *>())>
             iterator_difference_t<I>
-            operator()(I begin, S end, V const & val, P proj_ = P{}) const
+            operator()(I begin, S end, V const & val, P proj = P{}) const
             {
-                auto &&proj = as_function(proj_);
                 iterator_difference_t<I> n = 0;
                 for(; begin != end; ++begin)
-                    if(proj(*begin) == val)
+                    if(invoke(proj, *begin) == val)
                         ++n;
                 return n;
             }
@@ -48,7 +47,7 @@ namespace ranges
             template<typename Rng, typename V, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(InputRange<Rng>() &&
-                    IndirectCallableRelation<equal_to, projected<I, P>, V const *>())>
+                    IndirectRelation<equal_to, projected<I, P>, V const *>())>
             iterator_difference_t<I>
             operator()(Rng &&rng, V const & val, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/count_if.hpp
+++ b/include/range/v3/algorithm/count_if.hpp
@@ -33,22 +33,20 @@ namespace ranges
         {
             template<typename I, typename S, typename R, typename P = ident,
                 CONCEPT_REQUIRES_(InputIterator<I>() && Sentinel<S, I>() &&
-                    IndirectCallablePredicate<R, projected<I, P> >())>
+                    IndirectPredicate<R, projected<I, P> >())>
             iterator_difference_t<I>
-            operator()(I begin, S end, R pred_, P proj_ = P{}) const
+            operator()(I begin, S end, R pred, P proj = P{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj = as_function(proj_);
                 iterator_difference_t<I> n = 0;
                 for(; begin != end; ++begin)
-                    if(pred(proj(*begin)))
+                    if(invoke(pred, invoke(proj, *begin)))
                         ++n;
                 return n;
             }
 
             template<typename Rng, typename R, typename P = ident,
                 typename I = range_iterator_t<Rng>,
-                CONCEPT_REQUIRES_(InputRange<Rng>() && IndirectCallablePredicate<R, projected<I, P> >())>
+                CONCEPT_REQUIRES_(InputRange<Rng>() && IndirectPredicate<R, projected<I, P> >())>
             iterator_difference_t<I>
             operator()(Rng &&rng, R pred, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/equal.hpp
+++ b/include/range/v3/algorithm/equal.hpp
@@ -35,14 +35,11 @@ namespace ranges
         private:
             template<typename I0, typename S0, typename I1, typename S1,
                 typename C, typename P0, typename P1>
-            bool nocheck(I0 begin0, S0 end0, I1 begin1, S1 end1, C pred_,
-                P0 proj0_, P1 proj1_) const
+            bool nocheck(I0 begin0, S0 end0, I1 begin1, S1 end1, C pred,
+                P0 proj0, P1 proj1) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj0 = as_function(proj0_);
-                auto &&proj1 = as_function(proj1_);
                 for(; begin0 != end0 && begin1 != end1; ++begin0, ++begin1)
-                    if(!pred(proj0(*begin0), proj1(*begin1)))
+                    if(!invoke(pred, invoke(proj0, *begin0), invoke(proj1, *begin1)))
                         return false;
                 return begin0 == end0 && begin1 == end1;
             }
@@ -54,14 +51,11 @@ namespace ranges
                     Sentinel<S0, I0>() &&
                     Comparable<I0, I1, C, P0, P1>()
                 )>
-            bool operator()(I0 begin0, S0 end0, I1 begin1, C pred_ = C{},
-                P0 proj0_ = P0{}, P1 proj1_ = P1{}) const
+            bool operator()(I0 begin0, S0 end0, I1 begin1, C pred = C{},
+                P0 proj0 = P0{}, P1 proj1 = P1{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj0 = as_function(proj0_);
-                auto &&proj1 = as_function(proj1_);
                 for(; begin0 != end0; ++begin0, ++begin1)
-                    if(!pred(proj0(*begin0), proj1(*begin1)))
+                    if(!invoke(pred, invoke(proj0, *begin0), invoke(proj1, *begin1)))
                         return false;
                 return true;
             }
@@ -72,14 +66,14 @@ namespace ranges
                     Sentinel<S0, I0>() && Sentinel<S1, I1>() &&
                     Comparable<I0, I1, C, P0, P1>()
                 )>
-            bool operator()(I0 begin0, S0 end0, I1 begin1, S1 end1, C pred_ = C{},
-                P0 proj0_ = P0{}, P1 proj1_ = P1{}) const
+            bool operator()(I0 begin0, S0 end0, I1 begin1, S1 end1, C pred = C{},
+                P0 proj0 = P0{}, P1 proj1 = P1{}) const
             {
                 if(SizedSentinel<S0, I0>() && SizedSentinel<S1, I1>())
                     if(distance(begin0, end0) != distance(begin1, end1))
                         return false;
                 return this->nocheck(std::move(begin0), std::move(end0), std::move(begin1),
-                    std::move(end1), std::move(pred_), std::move(proj0_), std::move(proj1_));
+                    std::move(end1), std::move(pred), std::move(proj0), std::move(proj1));
             }
 
             template<typename Rng0, typename I1Ref,
@@ -90,11 +84,11 @@ namespace ranges
                     Range<Rng0>() && Iterator<I1>() &&
                     Comparable<I0, I1, C, P0, P1>()
                 )>
-            bool operator()(Rng0 && rng0, I1Ref && begin1, C pred_ = C{}, P0 proj0_ = P0{},
-                P1 proj1_ = P1{}) const
+            bool operator()(Rng0 && rng0, I1Ref && begin1, C pred = C{}, P0 proj0 = P0{},
+                P1 proj1 = P1{}) const
             {
-                return (*this)(begin(rng0), end(rng0), (I1Ref &&) begin1, std::move(pred_),
-                    std::move(proj0_), std::move(proj1_));
+                return (*this)(begin(rng0), end(rng0), (I1Ref &&) begin1, std::move(pred),
+                    std::move(proj0), std::move(proj1));
             }
 
             template<typename Rng0, typename Rng1,
@@ -105,14 +99,14 @@ namespace ranges
                     Range<Rng0>() && Range<Rng1>() &&
                     Comparable<I0, I1, C, P0, P1>()
                 )>
-            bool operator()(Rng0 && rng0, Rng1 && rng1, C pred_ = C{}, P0 proj0_ = P0{},
-                P1 proj1_ = P1{}) const
+            bool operator()(Rng0 && rng0, Rng1 && rng1, C pred = C{}, P0 proj0 = P0{},
+                P1 proj1 = P1{}) const
             {
                 if(SizedRange<Rng0>() && SizedRange<Rng1>())
                     if(distance(rng0) != distance(rng1))
                         return false;
                 return this->nocheck(begin(rng0), end(rng0), begin(rng1), end(rng1),
-                    std::move(pred_), std::move(proj0_), std::move(proj1_));
+                    std::move(pred), std::move(proj0), std::move(proj1));
             }
         };
 

--- a/include/range/v3/algorithm/equal_range.hpp
+++ b/include/range/v3/algorithm/equal_range.hpp
@@ -40,15 +40,12 @@ namespace ranges
                 CONCEPT_REQUIRES_(Sentinel<S, I>() && !SizedSentinel<S, I>() &&
                     BinarySearchable<I, V, C, P>())>
             iterator_range<I>
-            operator()(I begin, S end, V const &val, C pred_ = C{}, P proj_ = P{}) const
+            operator()(I begin, S end, V const &val, C pred = C{}, P proj = P{}) const
             {
                 // Probe exponentially for either end-of-range, an iterator that
                 // is past the equal range (i.e., denotes an element greater
                 // than val), or is in the equal range (denotes an element equal
                 // to val).
-                auto && pred = as_function(pred_);
-                auto && proj = as_function(proj_);
-
                 auto dist = iterator_difference_t<I>{1};
                 while(true)
                 {
@@ -63,13 +60,13 @@ namespace ranges
                     }
                     // if val < *mid, mid is after the target range.
                     auto && v = *mid;
-                    auto && pv = proj((decltype(v)&&) v);
-                    if(pred(val, pv))
+                    auto && pv = invoke(proj, (decltype(v)&&) v);
+                    if(invoke(pred, val, pv))
                     {
                         return aux::equal_range_n(
                             std::move(begin), dist, val, std::ref(pred), std::ref(proj));
                     }
-                    else if(!pred(pv, val))
+                    else if(!invoke(pred, pv, val))
                     {
                         // *mid == val: the lower bound is <= mid, and the upper bound is > mid.
                         return {

--- a/include/range/v3/algorithm/find.hpp
+++ b/include/range/v3/algorithm/find.hpp
@@ -38,16 +38,15 @@ namespace ranges
             /// \pre `Rng` is a model of the `Range` concept
             /// \pre `I` is a model of the `InputIterator` concept
             /// \pre `S` is a model of the `Sentinel<I>` concept
-            /// \pre `P` is a model of the `Callable<iterator_common_reference_t<I>>` concept
+            /// \pre `P` is a model of the `Invocable<iterator_common_reference_t<I>>` concept
             /// \pre The ResultType of `P` is EqualityComparable with V
             template<typename I, typename S, typename V, typename P = ident,
                 CONCEPT_REQUIRES_(InputIterator<I>() && Sentinel<S, I>() &&
-                    IndirectCallableRelation<equal_to, projected<I, P>, V const *>())>
-            I operator()(I begin, S end, V const &val, P proj_ = P{}) const
+                    IndirectRelation<equal_to, projected<I, P>, V const *>())>
+            I operator()(I begin, S end, V const &val, P proj = P{}) const
             {
-                auto &&proj = as_function(proj_);
                 for(; begin != end; ++begin)
-                    if(proj(*begin) == val)
+                    if(invoke(proj, *begin) == val)
                         break;
                 return begin;
             }
@@ -56,7 +55,7 @@ namespace ranges
             template<typename Rng, typename V, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(InputRange<Rng>() &&
-                    IndirectCallableRelation<equal_to, projected<I, P>, V const *>())>
+                    IndirectRelation<equal_to, projected<I, P>, V const *>())>
             range_safe_iterator_t<Rng> operator()(Rng &&rng, V const &val, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), val, std::move(proj));

--- a/include/range/v3/algorithm/find_first_of.hpp
+++ b/include/range/v3/algorithm/find_first_of.hpp
@@ -40,15 +40,12 @@ namespace ranges
                      typename R = equal_to, typename P0 = ident, typename P1 = ident,
                      CONCEPT_REQUIRES_(Sentinel<S0, I0>() && Sentinel<S1, I1>() &&
                         ForwardIterator<I1>() && AsymmetricallyComparable<I0, I1, R, P0, P1>())>
-            I0 operator()(I0 begin0, S0 end0, I1 begin1, S1 end1, R pred_ = R{}, P0 proj0_ = P0{},
-                P1 proj1_ = P1{}) const
+            I0 operator()(I0 begin0, S0 end0, I1 begin1, S1 end1, R pred = R{}, P0 proj0 = P0{},
+                P1 proj1 = P1{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj0 = as_function(proj0_);
-                auto &&proj1 = as_function(proj1_);
                 for(; begin0 != end0; ++begin0)
                     for(auto tmp = begin1; tmp != end1; ++tmp)
-                        if(pred(proj0(*begin0), proj1(*tmp)))
+                        if(invoke(pred, invoke(proj0, *begin0), invoke(proj1, *tmp)))
                             return begin0;
                 return begin0;
             }

--- a/include/range/v3/algorithm/find_if.hpp
+++ b/include/range/v3/algorithm/find_if.hpp
@@ -38,19 +38,17 @@ namespace ranges
             /// \pre `Rng` is a model of the `Range` concept
             /// \pre `I` is a model of the `InputIterator` concept
             /// \pre `S` is a model of the `Sentinel<I>` concept
-            /// \pre `P` is a model of the `Callable<V>` concept, where `V` is the
+            /// \pre `P` is a model of the `Invocable<V>` concept, where `V` is the
             ///      value type of I.
-            /// \pre `F` models `CallablePredicate<X>`, where `X` is the result type
-            ///      of `Callable<P, V>`
+            /// \pre `F` models `Predicate<X>`, where `X` is the result type
+            ///      of `Invocable<P, V>`
             template<typename I, typename S, typename F, typename P = ident,
                 CONCEPT_REQUIRES_(InputIterator<I>() && Sentinel<S, I>() &&
-                    IndirectCallablePredicate<F, projected<I, P> >())>
-            I operator()(I begin, S end, F pred_, P proj_ = P{}) const
+                    IndirectPredicate<F, projected<I, P> >())>
+            I operator()(I begin, S end, F pred, P proj = P{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj = as_function(proj_);
                 for(; begin != end; ++begin)
-                    if(pred(proj(*begin)))
+                    if(invoke(pred, invoke(proj, *begin)))
                         break;
                 return begin;
             }
@@ -59,7 +57,7 @@ namespace ranges
             template<typename Rng, typename F, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(InputRange<Rng>() &&
-                    IndirectCallablePredicate<F, projected<I, P>>())>
+                    IndirectPredicate<F, projected<I, P>>())>
             range_safe_iterator_t<Rng> operator()(Rng &&rng, F pred, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));

--- a/include/range/v3/algorithm/find_if_not.hpp
+++ b/include/range/v3/algorithm/find_if_not.hpp
@@ -38,19 +38,17 @@ namespace ranges
             /// \pre `Rng` is a model of the `Range` concept
             /// \pre `I` is a model of the `InputIterator` concept
             /// \pre `S` is a model of the `Sentinel<I>` concept
-            /// \pre `P` is a model of the `Callable<V>` concept, where `V` is the
+            /// \pre `P` is a model of the `Invocable<V>` concept, where `V` is the
             ///      value type of I.
-            /// \pre `F` models `CallablePredicate<X>`, where `X` is the result type
-            ///      of `Callable<P, V>`
+            /// \pre `F` models `Predicate<X>`, where `X` is the result type
+            ///      of `Invocable<P, V>`
             template<typename I, typename S, typename F, typename P = ident,
                 CONCEPT_REQUIRES_(InputIterator<I>() && Sentinel<S, I>() &&
-                    IndirectCallablePredicate<F, projected<I, P> >())>
-            I operator()(I begin, S end, F pred_, P proj_ = P{}) const
+                    IndirectPredicate<F, projected<I, P> >())>
+            I operator()(I begin, S end, F pred, P proj = P{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj = as_function(proj_);
                 for(; begin != end; ++begin)
-                    if(!pred(proj(*begin)))
+                    if(!invoke(pred, invoke(proj, *begin)))
                         break;
                 return begin;
             }
@@ -59,7 +57,7 @@ namespace ranges
             template<typename Rng, typename F, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(InputRange<Rng>() &&
-                    IndirectCallablePredicate<F, projected<I, P> >())>
+                    IndirectPredicate<F, projected<I, P> >())>
             range_safe_iterator_t<Rng> operator()(Rng &&rng, F pred, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));

--- a/include/range/v3/algorithm/generate_n.hpp
+++ b/include/range/v3/algorithm/generate_n.hpp
@@ -34,8 +34,8 @@ namespace ranges
         struct generate_n_fn
         {
             template<typename O, typename F,
-                CONCEPT_REQUIRES_(Function<F>() &&
-                    OutputIterator<O, concepts::Function::result_t<F> &&>())>
+                CONCEPT_REQUIRES_(Invocable<F&>() &&
+                    OutputIterator<O, result_of_t<F&()> &&>())>
             tagged_pair<tag::out(O), tag::fun(F)>
             operator()(O begin, iterator_difference_t<O> n, F fun) const
             {
@@ -43,8 +43,8 @@ namespace ranges
                 auto norig = n;
                 auto b = uncounted(begin);
                 for(; 0 != n; ++b, --n)
-                    *b = fun();
-                return {recounted(begin, b, norig), fun};
+                    *b = invoke(fun);
+                return {recounted(begin, b, norig), detail::move(fun)};
             }
         };
 

--- a/include/range/v3/algorithm/inplace_merge.hpp
+++ b/include/range/v3/algorithm/inplace_merge.hpp
@@ -88,11 +88,9 @@ namespace ranges
                     CONCEPT_REQUIRES_(BidirectionalIterator<I>() && Sortable<I, C, P>())>
                 void operator()(I begin, I middle, I end, iterator_difference_t<I> len1,
                     iterator_difference_t<I> len2, iterator_value_t<I> *buf,
-                    std::ptrdiff_t buf_size, C pred_ = C{}, P proj_ = P{}) const
+                    std::ptrdiff_t buf_size, C pred = C{}, P proj = P{}) const
                 {
                     using D = iterator_difference_t<I>;
-                    auto &&pred = as_function(pred_);
-                    auto &&proj = as_function(proj_);
                     while(true)
                     {
                         // if middle == end, we're done
@@ -103,7 +101,7 @@ namespace ranges
                         {
                             if(len1 == 0)
                                 return;
-                            if(pred(proj(*middle), proj(*begin)))
+                            if(invoke(pred, invoke(proj, *middle), invoke(proj, *begin)))
                                 break;
                         }
                         if(len1 <= buf_size || len2 <= buf_size)
@@ -129,7 +127,7 @@ namespace ranges
                         {   // len >= 1, len2 >= 2
                             len21 = len2 / 2;
                             m2 = next(middle, len21);
-                            m1 = upper_bound(begin, middle, proj(*m2), std::ref(pred), std::ref(proj));
+                            m1 = upper_bound(begin, middle, invoke(proj, *m2), std::ref(pred), std::ref(proj));
                             len11 = distance(begin, m1);
                         }
                         else
@@ -143,7 +141,7 @@ namespace ranges
                             // len1 >= 2, len2 >= 1
                             len11 = len1 / 2;
                             m1 = next(begin, len11);
-                            m2 = lower_bound(middle, end, proj(*m1), std::ref(pred), std::ref(proj));
+                            m2 = lower_bound(middle, end, invoke(proj, *m1), std::ref(pred), std::ref(proj));
                             len21 = distance(middle, m2);
                         }
                         D len12 = len1 - len11;  // distance(m1, middle)

--- a/include/range/v3/algorithm/is_partitioned.hpp
+++ b/include/range/v3/algorithm/is_partitioned.hpp
@@ -39,7 +39,7 @@ namespace ranges
         template<typename I, typename C, typename P = ident>
         using IsPartitionedable = meta::strict_and<
             InputIterator<I>,
-            IndirectCallablePredicate<C, projected<I, P>>>;
+            IndirectPredicate<C, projected<I, P>>>;
 
         /// \addtogroup group-algorithms
         /// @{
@@ -47,15 +47,13 @@ namespace ranges
         {
             template<typename I, typename S, typename C, typename P = ident,
                 CONCEPT_REQUIRES_(IsPartitionedable<I, C, P>() && Sentinel<S, I>())>
-            bool operator()(I begin, S end, C pred_, P proj_ = P{}) const
+            bool operator()(I begin, S end, C pred, P proj = P{}) const
             {
-                auto && pred = as_function(pred_);
-                auto && proj = as_function(proj_);
                 for(; begin != end; ++begin)
-                    if(!pred(proj(*begin)))
+                    if(!invoke(pred, invoke(proj, *begin)))
                         break;
                 for(; begin != end; ++begin)
-                    if(pred(proj(*begin)))
+                    if(invoke(pred, invoke(proj, *begin)))
                         return false;
                 return true;
             }

--- a/include/range/v3/algorithm/is_sorted.hpp
+++ b/include/range/v3/algorithm/is_sorted.hpp
@@ -32,26 +32,26 @@ namespace ranges
             ///
             /// range-based version of the \c is_sorted std algorithm
             ///
-            /// Works on ForwardViews
+            /// Works on ForwardRanges
             ///
-            /// \pre `Rng` is a model of the `ForwardView` concept
+            /// \pre `Rng` is a model of the `ForwardRange` concept
             /// \pre `I` is a model of the `ForwardIterator` concept
-            /// \pre `S` is a model of the `Sentinel<I>` concept
-            /// \pre `R` is a model of the `Relation<Value_Type<I>>` concept
+            /// \pre `S` and `I` model the `Sentinel<S, I>` concept
+            /// \pre `R` and `projected<I, P>` model the `IndirectRelation<R, projected<I, P>>` concept
             ///
             template<typename I, typename S, typename R = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(ForwardIterator<I>() && Sentinel<S, I>() &&
-                       IndirectCallableRelation<R, projected<I, P>>())>
-            bool operator()(I begin, S end, R rel = R{}, P proj_ = P{}) const
+                       IndirectRelation<R, projected<I, P>>())>
+            bool operator()(I begin, S end, R rel = R{}, P proj = P{}) const
             {
                 return is_sorted_until(std::move(begin), end, std::move(rel),
-                                       std::move(proj_)) == end;
+                                       std::move(proj)) == end;
             }
 
             template<typename Rng, typename R = ordered_less, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(ForwardRange<Rng>() &&
-                    IndirectCallableRelation<R, projected<I, P>>())>
+                    IndirectRelation<R, projected<I, P>>())>
             bool operator()(Rng &&rng, R rel = R{}, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), std::move(rel), std::move(proj));

--- a/include/range/v3/algorithm/is_sorted_until.hpp
+++ b/include/range/v3/algorithm/is_sorted_until.hpp
@@ -34,26 +34,24 @@ namespace ranges
             ///
             /// range-based version of the \c is_sorted_until std algorithm
             ///
-            /// Works on ForwardViews
+            /// Works on ForwardRanges
             ///
-            /// \pre `Rng` is a model of the `ForwardView` concept
+            /// \pre `Rng` is a model of the `ForwardRange` concept
             /// \pre `I` is a model of the `ForwardIterator` concept
-            /// \pre `S` is a model of the `Sentinel<I>` concept
-            /// \pre `R` is a model of the `Relation<Value_Type<I>>` concept
+            /// \pre `S` and `I` model the `Sentinel<S, I>` concept
+            /// \pre `R` and `projected<I, P>` model the `IndirectRelation<R, projected<I, P>>` concept
             ///
             template<typename I, typename S, typename R = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(ForwardIterator<I>() && Sentinel<S, I>() &&
-                    IndirectCallableRelation<R, projected<I, P>>())>
-            I operator()(I begin, S end, R pred_ = R{}, P proj_ = P{}) const
+                    IndirectRelation<R, projected<I, P>>())>
+            I operator()(I begin, S end, R pred = R{}, P proj = P{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj = as_function(proj_);
                 auto i = begin;
                 if(begin != end)
                 {
                     while(++i != end)
                     {
-                        if(pred(proj(*i), proj(*begin)))
+                        if(invoke(pred, invoke(proj, *i), invoke(proj, *begin)))
                             return i;
                         begin = i;
                     }
@@ -64,7 +62,7 @@ namespace ranges
             template<typename Rng, typename R = ordered_less, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(ForwardRange<Rng>() &&
-                    IndirectCallableRelation<R, projected<I, P>>())>
+                    IndirectRelation<R, projected<I, P>>())>
             range_safe_iterator_t<Rng> operator()(Rng &&rng, R pred = R{}, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));

--- a/include/range/v3/algorithm/lexicographical_compare.hpp
+++ b/include/range/v3/algorithm/lexicographical_compare.hpp
@@ -34,17 +34,14 @@ namespace ranges
                 typename C = ordered_less, typename P0 = ident, typename P1 = ident,
                 CONCEPT_REQUIRES_(Sentinel<S0, I0>() && Sentinel<S1, I1>() &&
                     Comparable<I0, I1, C, P0, P1>())>
-            bool operator()(I0 begin0, S0 end0, I1 begin1, S1 end1, C pred_ = C{}, P0 proj0_ = P0{},
-                P1 proj1_ = P1{}) const
+            bool operator()(I0 begin0, S0 end0, I1 begin1, S1 end1, C pred = C{}, P0 proj0 = P0{},
+                P1 proj1 = P1{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj0 = as_function(proj0_);
-                auto &&proj1 = as_function(proj1_);
                 for(; begin1 != end1; ++begin0, ++begin1)
                 {
-                    if(begin0 == end0 || pred(proj0(*begin0), proj1(*begin1)))
+                    if(begin0 == end0 || invoke(pred, invoke(proj0, *begin0), invoke(proj1, *begin1)))
                         return true;
-                    if(pred(proj1(*begin1), proj0(*begin0)))
+                    if(invoke(pred, invoke(proj1, *begin1), invoke(proj0, *begin0)))
                         return false;
                 }
                 return false;

--- a/include/range/v3/algorithm/lower_bound.hpp
+++ b/include/range/v3/algorithm/lower_bound.hpp
@@ -35,9 +35,8 @@ namespace ranges
         {
             template<typename I, typename S, typename V, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(Sentinel<S, I>() && BinarySearchable<I, V, C, P>())>
-            I operator()(I begin, S end, V const &val, C pred_ = C{}, P proj = P{}) const
+            I operator()(I begin, S end, V const &val, C pred = C{}, P proj = P{}) const
             {
-                auto&& pred = as_function(pred_);
                 return partition_point(std::move(begin), std::move(end),
                     detail::make_lower_bound_predicate(pred, val), std::move(proj));
             }
@@ -45,9 +44,8 @@ namespace ranges
             template<typename Rng, typename V, typename C = ordered_less, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(Range<Rng>() && BinarySearchable<I, V, C, P>())>
-            range_safe_iterator_t<Rng> operator()(Rng &&rng, V const &val, C pred_ = C{}, P proj = P{}) const
+            range_safe_iterator_t<Rng> operator()(Rng &&rng, V const &val, C pred = C{}, P proj = P{}) const
             {
-                auto&& pred = as_function(pred_);
                 return partition_point(rng,
                     detail::make_lower_bound_predicate(pred, val), std::move(proj));
             }

--- a/include/range/v3/algorithm/max_element.hpp
+++ b/include/range/v3/algorithm/max_element.hpp
@@ -33,14 +33,12 @@ namespace ranges
         {
             template<typename I, typename S, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(ForwardIterator<I>() && Sentinel<S, I>() &&
-                    IndirectCallableRelation<C, projected<I, P>>())>
-            I operator()(I begin, S end, C pred_ = C{}, P proj_ = P{}) const
+                    IndirectRelation<C, projected<I, P>>())>
+            I operator()(I begin, S end, C pred = C{}, P proj = P{}) const
             {
-                auto && pred = as_function(pred_);
-                auto && proj = as_function(proj_);
                 if(begin != end)
                     for(auto tmp = next(begin); tmp != end; ++tmp)
-                        if(pred(proj(*begin), proj(*tmp)))
+                        if(invoke(pred, invoke(proj, *begin), invoke(proj, *tmp)))
                             begin = tmp;
                 return begin;
             }
@@ -48,7 +46,7 @@ namespace ranges
             template<typename Rng, typename C = ordered_less, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(ForwardRange<Rng>() &&
-                    IndirectCallableRelation<C, projected<I, P>>())>
+                    IndirectRelation<C, projected<I, P>>())>
             range_safe_iterator_t<Rng> operator()(Rng &&rng, C pred = C{}, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));

--- a/include/range/v3/algorithm/merge.hpp
+++ b/include/range/v3/algorithm/merge.hpp
@@ -56,15 +56,12 @@ namespace ranges
                     Mergeable<I0, I1, O, C, P0, P1>()
                 )>
             tagged_tuple<tag::in1(I0), tag::in2(I1), tag::out(O)>
-            operator()(I0 begin0, S0 end0, I1 begin1, S1 end1, O out, C pred_ = C{},
-                P0 proj0_ = P0{}, P1 proj1_ = P1{}) const
+            operator()(I0 begin0, S0 end0, I1 begin1, S1 end1, O out, C pred = C{},
+                P0 proj0 = P0{}, P1 proj1 = P1{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj0 = as_function(proj0_);
-                auto &&proj1 = as_function(proj1_);
                 for(; begin0 != end0 && begin1 != end1; ++out)
                 {
-                    if(pred(proj1(*begin1), proj0(*begin0)))
+                    if(invoke(pred, invoke(proj1, *begin1), invoke(proj0, *begin0)))
                     {
                         *out = *begin1;
                         ++begin1;

--- a/include/range/v3/algorithm/min.hpp
+++ b/include/range/v3/algorithm/min.hpp
@@ -32,22 +32,12 @@ namespace ranges
         /// @{
         struct min_fn
         {
-        private:
-            template<typename T, typename C, typename P>
-            constexpr T const &min2_impl(T const &a, T const &b, C&& pred, P&& proj) const
-            {
-                return pred(proj(b), proj(a)) ? b : a;
-            }
-
-        public:
             template<typename Rng, typename C = ordered_less, typename P = ident,
                 typename I = range_iterator_t<Rng>, typename V = iterator_value_t<I>,
                 CONCEPT_REQUIRES_(InputRange<Rng>() && Copyable<V>() &&
-                    IndirectCallableRelation<C, projected<I, P>>())>
-            RANGES_CXX14_CONSTEXPR V operator()(Rng &&rng, C pred_ = C{}, P proj_ = P{}) const
+                    IndirectRelation<C, projected<I, P>>())>
+            RANGES_CXX14_CONSTEXPR V operator()(Rng &&rng, C pred = C{}, P proj = P{}) const
             {
-                auto && pred = as_function(pred_);
-                auto && proj = as_function(proj_);
                 auto begin = ranges::begin(rng);
                 auto end = ranges::end(rng);
                 RANGES_EXPECT(begin != end);
@@ -55,7 +45,7 @@ namespace ranges
                 while(++begin != end)
                 {
                     auto && tmp = *begin;
-                    if(pred(proj(tmp), proj(result)))
+                    if(invoke(pred, invoke(proj, tmp), invoke(proj, result)))
                         result = (decltype(tmp) &&) tmp;
                 }
                 return result;
@@ -63,10 +53,10 @@ namespace ranges
 
             template<typename T, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(
-                    IndirectCallableRelation<C, projected<const T *, P>>())>
+                    IndirectRelation<C, projected<const T *, P>>())>
             constexpr T const &operator()(T const &a, T const &b, C pred = C{}, P proj = P{}) const
             {
-                return min2_impl(a, b, as_function(pred), as_function(proj));
+                return invoke(pred, invoke(proj, b), invoke(proj, a)) ? b : a;
             }
         };
 

--- a/include/range/v3/algorithm/min_element.hpp
+++ b/include/range/v3/algorithm/min_element.hpp
@@ -33,14 +33,12 @@ namespace ranges
         {
             template<typename I, typename S, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(ForwardIterator<I>() && Sentinel<S, I>() &&
-                    IndirectCallableRelation<C, projected<I, P>>())>
-            I operator()(I begin, S end, C pred_ = C{}, P proj_ = P{}) const
+                    IndirectRelation<C, projected<I, P>>())>
+            I operator()(I begin, S end, C pred = C{}, P proj = P{}) const
             {
-                auto && pred = as_function(pred_);
-                auto && proj = as_function(proj_);
                 if(begin != end)
                     for(auto tmp = next(begin); tmp != end; ++tmp)
-                        if(pred(proj(*tmp), proj(*begin)))
+                        if(invoke(pred, invoke(proj, *tmp), invoke(proj, *begin)))
                             begin = tmp;
                 return begin;
             }
@@ -48,7 +46,7 @@ namespace ranges
             template<typename Rng, typename C = ordered_less, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(ForwardRange<Rng>() &&
-                    IndirectCallableRelation<C, projected<I, P>>())>
+                    IndirectRelation<C, projected<I, P>>())>
             range_safe_iterator_t<Rng> operator()(Rng &&rng, C pred = C{}, P proj = P{}) const
             {
                 return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));

--- a/include/range/v3/algorithm/minmax.hpp
+++ b/include/range/v3/algorithm/minmax.hpp
@@ -34,33 +34,23 @@ namespace ranges
         /// @{
         struct minmax_fn
         {
-        private:
-            template<typename T, typename C, typename P,
-                typename R = tagged_pair<tag::min(T const &), tag::max(T const &)>>
-            constexpr R minmax2_impl(T const &a, T const &b, C&& pred, P&& proj) const
-            {
-                return pred(proj(b), proj(a)) ? R{b, a} : R{a, b};
-            }
-
-        public:
             template<typename Rng, typename C = ordered_less, typename P = ident,
                 typename I = range_iterator_t<Rng>, typename V = iterator_value_t<I>,
                 typename R = tagged_pair<tag::min(V), tag::max(V)>,
                 CONCEPT_REQUIRES_(InputRange<Rng>() && Copyable<V>() &&
-                    IndirectCallableRelation<C, projected<I, P>>())>
+                    IndirectRelation<C, projected<I, P>>())>
             RANGES_CXX14_CONSTEXPR
-            R operator()(Rng &&rng, C pred_ = C{}, P proj_ = P{}) const
+            R operator()(Rng &&rng, C pred = C{}, P proj = P{}) const
             {
                 auto begin = ranges::begin(rng);
                 auto end = ranges::end(rng);
                 RANGES_EXPECT(begin != end);
                 auto result = R{*begin, *begin};
-                if(++begin != end) {
-                    auto && pred = as_function(pred_);
-                    auto && proj = as_function(proj_);
+                if(++begin != end)
+                {
                     {
                         auto && tmp = *begin;
-                        if(pred(proj(tmp), proj(result.first)))
+                        if(invoke(pred, invoke(proj, tmp), invoke(proj, result.first)))
                             result.first = (decltype(tmp) &&) tmp;
                         else
                             result.second = (decltype(tmp) &&) tmp;
@@ -70,26 +60,26 @@ namespace ranges
                         V tmp1 = *begin;
                         if(++begin == end)
                         {
-                            if(pred(proj(tmp1), proj(result.first)))
+                            if(invoke(pred, invoke(proj, tmp1), invoke(proj, result.first)))
                                 result.first = std::move(tmp1);
-                            else if(!pred(proj(tmp1), proj(result.second)))
+                            else if(!invoke(pred, invoke(proj, tmp1), invoke(proj, result.second)))
                                 result.second = std::move(tmp1);
                             break;
                         }
 
                         auto && tmp2 = *begin;
-                        if(pred(proj(tmp2), proj(tmp1)))
+                        if(invoke(pred, invoke(proj, tmp2), invoke(proj, tmp1)))
                         {
-                            if(pred(proj(tmp2), proj(result.first)))
+                            if(invoke(pred, invoke(proj, tmp2), invoke(proj, result.first)))
                                 result.first = (decltype(tmp2) &&) tmp2;
-                            if(!pred(proj(tmp1), proj(result.second)))
+                            if(!invoke(pred, invoke(proj, tmp1), invoke(proj, result.second)))
                                 result.second = std::move(tmp1);
                         }
                         else
                         {
-                            if(pred(proj(tmp1), proj(result.first)))
+                            if(invoke(pred, invoke(proj, tmp1), invoke(proj, result.first)))
                                 result.first = std::move(tmp1);
-                            if(!pred(proj(tmp2), proj(result.second)))
+                            if(!invoke(pred, invoke(proj, tmp2), invoke(proj, result.second)))
                                 result.second = (decltype(tmp2) &&) tmp2;
                         }
                     }
@@ -99,11 +89,12 @@ namespace ranges
 
             template<typename T, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(
-                    IndirectCallableRelation<C, projected<const T *, P>>())>
+                    IndirectRelation<C, projected<const T *, P>>())>
             constexpr tagged_pair<tag::min(T const &), tag::max(T const &)>
             operator()(T const &a, T const &b, C pred = C{}, P proj = P{}) const
             {
-                return minmax2_impl(a, b, as_function(pred), as_function(proj));
+                using R = tagged_pair<tag::min(T const &), tag::max(T const &)>;
+                return invoke(pred, invoke(proj, b), invoke(proj, a)) ? R{b, a} : R{a, b};
             }
         };
 

--- a/include/range/v3/algorithm/minmax_element.hpp
+++ b/include/range/v3/algorithm/minmax_element.hpp
@@ -38,16 +38,14 @@ namespace ranges
         {
             template<typename I, typename S, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(ForwardIterator<I>() && Sentinel<S, I>() &&
-                    IndirectCallableRelation<C, projected<I, P>>())>
+                    IndirectRelation<C, projected<I, P>>())>
             tagged_pair<tag::min(I), tag::max(I)>
-            operator()(I begin, S end, C pred_ = C{}, P proj_ = P{}) const
+            operator()(I begin, S end, C pred = C{}, P proj = P{}) const
             {
-                auto && pred = as_function(pred_);
-                auto && proj = as_function(proj_);
                 tagged_pair<tag::min(I), tag::max(I)> result{begin, begin};
                 if(begin == end || ++begin == end)
                     return result;
-                if(pred(proj(*begin), proj(*result.first)))
+                if(invoke(pred, invoke(proj, *begin), invoke(proj, *result.first)))
                     result.first = begin;
                 else
                     result.second = begin;
@@ -56,26 +54,26 @@ namespace ranges
                     I tmp = begin;
                     if(++begin == end)
                     {
-                        if(pred(proj(*tmp), proj(*result.first)))
+                        if(invoke(pred, invoke(proj, *tmp), invoke(proj, *result.first)))
                             result.first = tmp;
-                        else if(!pred(proj(*tmp), proj(*result.second)))
+                        else if(!invoke(pred, invoke(proj, *tmp), invoke(proj, *result.second)))
                             result.second = tmp;
                         break;
                     }
                     else
                     {
-                        if(pred(proj(*begin), proj(*tmp)))
+                        if(invoke(pred, invoke(proj, *begin), invoke(proj, *tmp)))
                         {
-                            if(pred(proj(*begin), proj(*result.first)))
+                            if(invoke(pred, invoke(proj, *begin), invoke(proj, *result.first)))
                                 result.first = begin;
-                            if(!pred(proj(*tmp), proj(*result.second)))
+                            if(!invoke(pred, invoke(proj, *tmp), invoke(proj, *result.second)))
                                 result.second = tmp;
                         }
                         else
                         {
-                            if(pred(proj(*tmp), proj(*result.first)))
+                            if(invoke(pred, invoke(proj, *tmp), invoke(proj, *result.first)))
                                 result.first = tmp;
-                            if(!pred(proj(*begin), proj(*result.second)))
+                            if(!invoke(pred, invoke(proj, *begin), invoke(proj, *result.second)))
                                 result.second = begin;
                         }
                     }
@@ -86,7 +84,7 @@ namespace ranges
             template<typename Rng, typename C = ordered_less, typename P = ident,
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(ForwardRange<Rng>() &&
-                    IndirectCallableRelation<C, projected<I, P>>())>
+                    IndirectRelation<C, projected<I, P>>())>
             meta::if_<std::is_lvalue_reference<Rng>,
                 tagged_pair<tag::min(I), tag::max(I)>,
                 dangling<tagged_pair<tag::min(I), tag::max(I)>>>

--- a/include/range/v3/algorithm/mismatch.hpp
+++ b/include/range/v3/algorithm/mismatch.hpp
@@ -39,7 +39,7 @@ namespace ranges
         using Mismatchable = meta::strict_and<
             InputIterator<I1>,
             InputIterator<I2>,
-            IndirectCallablePredicate<C, projected<I1, P1>, projected<I2, P2>>>;
+            IndirectPredicate<C, projected<I1, P1>, projected<I2, P2>>>;
 
         /// \addtogroup group-algorithms
         /// @{
@@ -49,14 +49,11 @@ namespace ranges
                 typename P1 = ident, typename P2 = ident,
                 CONCEPT_REQUIRES_(Mismatchable<I1, I2, C, P1, P2>() && Sentinel<S1, I1>())>
             tagged_pair<tag::in1(I1), tag::in2(I2)>
-            operator()(I1 begin1, S1 end1, I2 begin2, C pred_ = C{}, P1 proj1_ = P1{},
-                P2 proj2_ = P2{}) const
+            operator()(I1 begin1, S1 end1, I2 begin2, C pred = C{}, P1 proj1 = P1{},
+                P2 proj2 = P2{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj1 = as_function(proj1_);
-                auto &&proj2 = as_function(proj2_);
                 for(; begin1 != end1; ++begin1, ++begin2)
-                    if(!pred(proj1(*begin1), proj2(*begin2)))
+                    if(!invoke(pred, invoke(proj1, *begin1), invoke(proj2, *begin2)))
                         break;
                 return {begin1, begin2};
             }
@@ -66,14 +63,11 @@ namespace ranges
                 CONCEPT_REQUIRES_(Mismatchable<I1, I2, C, P1, P2>() && Sentinel<S1, I1>() &&
                     Sentinel<S2, I2>())>
             tagged_pair<tag::in1(I1), tag::in2(I2)>
-            operator()(I1 begin1, S1 end1, I2 begin2, S2 end2, C pred_ = C{}, P1 proj1_ = P1{},
-                P2 proj2_ = P2{}) const
+            operator()(I1 begin1, S1 end1, I2 begin2, S2 end2, C pred = C{}, P1 proj1 = P1{},
+                P2 proj2 = P2{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj1 = as_function(proj1_);
-                auto &&proj2 = as_function(proj2_);
                 for(; begin1 != end1 &&  begin2 != end2; ++begin1, ++begin2)
-                    if(!pred(proj1(*begin1), proj2(*begin2)))
+                    if(!invoke(pred, invoke(proj1, *begin1), invoke(proj2, *begin2)))
                         break;
                 return {begin1, begin2};
             }

--- a/include/range/v3/algorithm/none_of.hpp
+++ b/include/range/v3/algorithm/none_of.hpp
@@ -34,21 +34,19 @@ namespace ranges
         {
             template<typename I, typename S, typename F, typename P = ident,
                 CONCEPT_REQUIRES_(InputIterator<I>() && Sentinel<S, I>() &&
-                    IndirectCallablePredicate<F, projected<I, P>>())>
+                    IndirectPredicate<F, projected<I, P>>())>
             bool
             operator()(I first, S last, F pred, P proj = P{}) const
             {
-                auto &&ipred = as_function(pred);
-                auto &&iproj = as_function(proj);
                 for(; first != last; ++first)
-                    if(ipred(iproj(*first)))
+                    if(invoke(pred, invoke(proj, *first)))
                         return false;
                 return true;
             }
 
             template<typename Rng, typename F, typename P = ident,
                 typename I = range_iterator_t<Rng>,
-                CONCEPT_REQUIRES_(InputRange<Rng>() && IndirectCallablePredicate<F, projected<I, P>>())>
+                CONCEPT_REQUIRES_(InputRange<Rng>() && IndirectPredicate<F, projected<I, P>>())>
             bool
             operator()(Rng &&rng, F pred, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/partial_sort.hpp
+++ b/include/range/v3/algorithm/partial_sort.hpp
@@ -35,17 +35,14 @@ namespace ranges
         {
             template<typename I, typename S, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(Sortable<I, C, P>() && RandomAccessIterator<I>() && Sentinel<S, I>())>
-            I operator()(I begin, I middle, S end, C pred_ = C{}, P proj_ = P{}) const
+            I operator()(I begin, I middle, S end, C pred = C{}, P proj = P{}) const
             {
-                auto && pred = as_function(pred_);
-                auto && proj = as_function(proj_);
-
                 make_heap(begin, middle, std::ref(pred), std::ref(proj));
                 auto const len = middle - begin;
                 I i = middle;
                 for(; i != end; ++i)
                 {
-                    if(pred(proj(*i), proj(*begin)))
+                    if(invoke(pred, invoke(proj, *i), invoke(proj, *begin)))
                     {
                         iter_swap(i, begin);
                         detail::sift_down_n(begin, len, begin, std::ref(pred), std::ref(proj));

--- a/include/range/v3/algorithm/partial_sort_copy.hpp
+++ b/include/range/v3/algorithm/partial_sort_copy.hpp
@@ -36,7 +36,7 @@ namespace ranges
             InputIterator<I>,
             RandomAccessIterator<O>,
             IndirectlyCopyable<I, O>,
-            IndirectCallableRelation<C, projected<I, PI>, projected<O, PO>>,
+            IndirectRelation<C, projected<I, PI>, projected<O, PO>>,
             Sortable<O, C, PO>>;
 
         /// \addtogroup group-algorithms
@@ -47,12 +47,9 @@ namespace ranges
                 typename PI = ident, typename PO = ident,
                 CONCEPT_REQUIRES_(PartialSortCopyConcept<I, O, C, PI, PO>() &&
                     Sentinel<SI, I>() && Sentinel<SO, O>())>
-            O operator()(I begin, SI end, O out_begin, SO out_end, C pred_ = C{}, PI in_proj_ = PI{},
-                PO out_proj_ = PO{}) const
+            O operator()(I begin, SI end, O out_begin, SO out_end, C pred = C{}, PI in_proj = PI{},
+                PO out_proj = PO{}) const
             {
-                auto && pred = as_function(pred_);
-                auto && in_proj = as_function(in_proj_);
-                auto && out_proj = as_function(out_proj_);
                 O r = out_begin;
                 if(r != out_end)
                 {
@@ -63,7 +60,7 @@ namespace ranges
                     for(; begin != end; ++begin)
                     {
                         auto &&x = *begin;
-                        if(pred(in_proj(x), out_proj(*out_begin)))
+                        if(invoke(pred, invoke(in_proj, x), invoke(out_proj, *out_begin)))
                         {
                             *out_begin = (decltype(x) &&) x;
                             detail::sift_down_n(out_begin, len, out_begin, std::ref(pred), std::ref(out_proj));

--- a/include/range/v3/algorithm/partition.hpp
+++ b/include/range/v3/algorithm/partition.hpp
@@ -41,7 +41,7 @@ namespace ranges
         using Partitionable = meta::strict_and<
             ForwardIterator<I>,
             Permutable<I>,
-            IndirectCallablePredicate<C, projected<I, P>>>;
+            IndirectPredicate<C, projected<I, P>>>;
 
         /// \addtogroup group-algorithms
         /// @{
@@ -49,21 +49,19 @@ namespace ranges
         {
         private:
             template<typename I, typename S, typename C, typename P>
-            static I impl(I begin, S end, C pred_, P proj_, concepts::ForwardIterator*)
+            static I impl(I begin, S end, C pred, P proj, concepts::ForwardIterator*)
             {
-                auto && pred = as_function(pred_);
-                auto && proj = as_function(proj_);
                 while(true)
                 {
                     if(begin == end)
                         return begin;
-                    if(!pred(proj(*begin)))
+                    if(!invoke(pred, invoke(proj, *begin)))
                         break;
                     ++begin;
                 }
                 for(I p = begin; ++p != end;)
                 {
-                    if(pred(proj(*p)))
+                    if(invoke(pred, invoke(proj, *p)))
                     {
                         ranges::iter_swap(begin, p);
                         ++begin;
@@ -73,10 +71,8 @@ namespace ranges
             }
 
             template<typename I, typename S, typename C, typename P>
-            static I impl(I begin, S end_, C pred_, P proj_, concepts::BidirectionalIterator*)
+            static I impl(I begin, S end_, C pred, P proj, concepts::BidirectionalIterator*)
             {
-                auto && pred = as_function(pred_);
-                auto && proj = as_function(proj_);
                 I end = ranges::next(begin, end_);
                 while(true)
                 {
@@ -84,7 +80,7 @@ namespace ranges
                     {
                         if(begin == end)
                             return begin;
-                        if(!pred(proj(*begin)))
+                        if(!invoke(pred, invoke(proj, *begin)))
                             break;
                         ++begin;
                     }
@@ -92,7 +88,7 @@ namespace ranges
                     {
                         if(begin == --end)
                             return begin;
-                    } while(!pred(proj(*end)));
+                    } while(!invoke(pred, invoke(proj, *end)));
                     ranges::iter_swap(begin, end);
                     ++begin;
                 }

--- a/include/range/v3/algorithm/partition_copy.hpp
+++ b/include/range/v3/algorithm/partition_copy.hpp
@@ -40,7 +40,7 @@ namespace ranges
             WeaklyIncrementable<O1>,
             IndirectlyCopyable<I, O0>,
             IndirectlyCopyable<I, O1>,
-            IndirectCallablePredicate<C, projected<I, P>>>;
+            IndirectPredicate<C, projected<I, P>>>;
 
         /// \addtogroup group-algorithms
         /// @{
@@ -49,14 +49,12 @@ namespace ranges
             template<typename I, typename S, typename O0, typename O1, typename C, typename P = ident,
                 CONCEPT_REQUIRES_(PartitionCopyable<I, O0, O1, C, P>() && Sentinel<S, I>())>
             tagged_tuple<tag::in(I), tag::out1(O0), tag::out2(O1)>
-            operator()(I begin, S end, O0 o0, O1 o1, C pred_, P proj_ = P{}) const
+            operator()(I begin, S end, O0 o0, O1 o1, C pred, P proj = P{}) const
             {
-                auto && pred = as_function(pred_);
-                auto && proj = as_function(proj_);
                 for(; begin != end; ++begin)
                 {
                     auto &&x = *begin;
-                    if(pred(proj(x)))
+                    if(invoke(pred, invoke(proj, x)))
                     {
                         *o0 = (decltype(x) &&) x;
                         ++o0;

--- a/include/range/v3/algorithm/partition_point.hpp
+++ b/include/range/v3/algorithm/partition_point.hpp
@@ -47,19 +47,16 @@ namespace ranges
             template<typename I, typename S, typename C, typename P = ident,
                 CONCEPT_REQUIRES_(PartitionPointable<I, C, P>() &&
                     Sentinel<S, I>() && !SizedSentinel<S, I>())>
-            I operator()(I begin, S end, C pred_, P proj_ = P{}) const
+            I operator()(I begin, S end, C pred, P proj = P{}) const
             {
                 // Probe exponentially for either end-of-range or an iterator
                 // that is past the partition point (i.e., does not satisfy pred).
-                auto && pred = as_function(pred_);
-                auto && proj = as_function(proj_);
-
                 auto len = iterator_difference_t<I>{1};
                 while(true)
                 {
                     auto mid = begin;
                     auto d = advance(mid, len, end);
-                    if(mid == end || !pred(proj(*mid)))
+                    if(mid == end || !invoke(pred, invoke(proj, *mid)))
                     {
                         len -= d;
                         return aux::partition_point_n(

--- a/include/range/v3/algorithm/permutation.hpp
+++ b/include/range/v3/algorithm/permutation.hpp
@@ -54,15 +54,12 @@ namespace ranges
         private:
             template<typename I1, typename S1, typename I2, typename S2, typename C, typename P1,
                 typename P2>
-            static bool four_iter_impl(I1 begin1, S1 end1, I2 begin2, S2 end2, C pred_, P1 proj1_,
-                P2 proj2_)
+            static bool four_iter_impl(I1 begin1, S1 end1, I2 begin2, S2 end2, C pred, P1 proj1,
+                P2 proj2)
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj1 = as_function(proj1_);
-                auto &&proj2 = as_function(proj2_);
                 // shorten sequences as much as possible by lopping off any equal parts
                 for(; begin1 != end1 && begin2 != end2; ++begin1, ++begin2)
-                    if(!pred(proj1(*begin1), proj2(*begin2)))
+                    if(!invoke(pred, invoke(proj1, *begin1), invoke(proj2, *begin2)))
                         goto not_done;
                 return begin1 == end1 && begin2 == end2;
             not_done:
@@ -78,20 +75,20 @@ namespace ranges
                 {
                     // Have we already counted the number of *i in [f1, l1)?
                     for(I1 j = begin1; j != i; ++j)
-                        if(pred(proj1(*j), proj1(*i)))
+                        if(invoke(pred, invoke(proj1, *j), invoke(proj1, *i)))
                             goto next_iter;
                     {
                         // Count number of *i in [f2, l2)
                         iterator_difference_t<I2> c2 = 0;
                         for(I2 j = begin2; j != end2; ++j)
-                            if(pred(proj1(*i), proj2(*j)))
+                            if(invoke(pred, invoke(proj1, *i), invoke(proj2, *j)))
                                 ++c2;
                         if(c2 == 0)
                             return false;
                         // Count number of *i in [i, l1) (we can start with 1)
                         iterator_difference_t<I1> c1 = 1;
                         for(I1 j = next(i); j != end1; ++j)
-                            if(pred(proj1(*i), proj1(*j)))
+                            if(invoke(pred, invoke(proj1, *i), invoke(proj1, *j)))
                                 ++c1;
                         if(c1 != c2)
                             return false;
@@ -105,15 +102,12 @@ namespace ranges
             template<typename I1, typename S1, typename I2, typename C = equal_to,
                 typename P1 = ident, typename P2 = ident,
                 CONCEPT_REQUIRES_(Sentinel<S1, I1>() && IsPermutationable<I1, I2, C, P1, P2>())>
-            bool operator()(I1 begin1, S1 end1, I2 begin2, C pred_ = C{}, P1 proj1_ = P1{},
-                P2 proj2_ = P2{}) const
+            bool operator()(I1 begin1, S1 end1, I2 begin2, C pred = C{}, P1 proj1 = P1{},
+                P2 proj2 = P2{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj1 = as_function(proj1_);
-                auto &&proj2 = as_function(proj2_);
                 // shorten sequences as much as possible by lopping off any equal parts
                 for(; begin1 != end1; ++begin1, ++begin2)
-                    if(!pred(proj1(*begin1), proj2(*begin2)))
+                    if(!invoke(pred, invoke(proj1, *begin1), invoke(proj2, *begin2)))
                         goto not_done;
                 return true;
             not_done:
@@ -128,20 +122,20 @@ namespace ranges
                 {
                     // Have we already counted the number of *i in [f1, l1)?
                     for(I1 j = begin1; j != i; ++j)
-                        if(pred(proj1(*j), proj1(*i)))
+                        if(invoke(pred, invoke(proj1, *j), invoke(proj1, *i)))
                             goto next_iter;
                     {
                         // Count number of *i in [f2, l2)
                         iterator_difference_t<I2> c2 = 0;
                         for(I2 j = begin2; j != end2; ++j)
-                            if(pred(proj1(*i), proj2(*j)))
+                            if(invoke(pred, invoke(proj1, *i), invoke(proj2, *j)))
                                 ++c2;
                         if(c2 == 0)
                             return false;
                         // Count number of *i in [i, l1) (we can start with 1)
                         iterator_difference_t<I1> c1 = 1;
                         for(I1 j = next(i); j != end1; ++j)
-                            if(pred(proj1(*i), proj1(*j)))
+                            if(invoke(pred, invoke(proj1, *i), invoke(proj1, *j)))
                                 ++c1;
                         if(c1 != c2)
                             return false;
@@ -205,10 +199,8 @@ namespace ranges
         {
             template<typename I, typename S, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(BidirectionalIterator<I>() && Sentinel<S, I>() && Sortable<I, C, P>())>
-            bool operator()(I begin, S end_, C pred_ = C{}, P proj_ = P{}) const
+            bool operator()(I begin, S end_, C pred = C{}, P proj = P{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj = as_function(proj_);
                 if(begin == end_)
                     return false;
                 I end = ranges::next(begin, end_), i = end;
@@ -217,10 +209,10 @@ namespace ranges
                 while(true)
                 {
                     I ip1 = i;
-                    if(pred(proj(*--i), proj(*ip1)))
+                    if(invoke(pred, invoke(proj, *--i), invoke(proj, *ip1)))
                     {
                         I j = end;
-                        while(!pred(proj(*i), proj(*--j)))
+                        while(!invoke(pred, invoke(proj, *i), invoke(proj, *--j)))
                             ;
                         ranges::iter_swap(i, j);
                         ranges::reverse(ip1, end);
@@ -252,10 +244,8 @@ namespace ranges
         {
             template<typename I, typename S, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(BidirectionalIterator<I>() && Sentinel<S, I>() && Sortable<I, C, P>())>
-            bool operator()(I begin, S end_, C pred_ = C{}, P proj_ = P{}) const
+            bool operator()(I begin, S end_, C pred = C{}, P proj = P{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj = as_function(proj_);
                 if(begin == end_)
                     return false;
                 I end = ranges::next(begin, end_), i = end;
@@ -264,10 +254,10 @@ namespace ranges
                 while(true)
                 {
                     I ip1 = i;
-                    if(pred(proj(*ip1), proj(*--i)))
+                    if(invoke(pred, invoke(proj, *ip1), invoke(proj, *--i)))
                     {
                         I j = end;
-                        while(!pred(proj(*--j), proj(*i)))
+                        while(!invoke(pred, invoke(proj, *--j), invoke(proj, *i)))
                             ;
                         ranges::iter_swap(i, j);
                         ranges::reverse(ip1, end);

--- a/include/range/v3/algorithm/remove.hpp
+++ b/include/range/v3/algorithm/remove.hpp
@@ -33,7 +33,7 @@ namespace ranges
         template<typename I, typename T, typename P = ident>
         using Removable = meta::strict_and<
             ForwardIterator<I>,
-            IndirectCallableRelation<equal_to, projected<I, P>, T const *>,
+            IndirectRelation<equal_to, projected<I, P>, T const *>,
             Permutable<I>>;
 
         /// \addtogroup group-algorithms
@@ -42,15 +42,14 @@ namespace ranges
         {
             template<typename I, typename S, typename T, typename P = ident,
                 CONCEPT_REQUIRES_(Removable<I, T, P>() && Sentinel<S, I>())>
-            I operator()(I begin, S end, T const &val, P proj_ = P{}) const
+            I operator()(I begin, S end, T const &val, P proj = P{}) const
             {
-                auto &&proj = as_function(proj_);
                 begin = find(std::move(begin), end, val, std::ref(proj));
                 if(begin != end)
                 {
                     for(I i = next(begin); i != end; ++i)
                     {
-                        if(!(proj(*i) == val))
+                        if(!(invoke(proj, *i) == val))
                         {
                             *begin = iter_move(i);
                             ++begin;

--- a/include/range/v3/algorithm/remove_copy.hpp
+++ b/include/range/v3/algorithm/remove_copy.hpp
@@ -34,7 +34,7 @@ namespace ranges
         using RemoveCopyable = meta::strict_and<
             InputIterator<I>,
             WeaklyIncrementable<O>,
-            IndirectCallableRelation<equal_to, projected<I, P>, T const *>,
+            IndirectRelation<equal_to, projected<I, P>, T const *>,
             IndirectlyCopyable<I, O>>;
 
         /// \addtogroup group-algorithms
@@ -43,13 +43,12 @@ namespace ranges
         {
             template<typename I, typename S, typename O, typename T, typename P = ident,
                 CONCEPT_REQUIRES_(RemoveCopyable<I, O, T, P>() && Sentinel<S, I>())>
-            tagged_pair<tag::in(I), tag::out(O)> operator()(I begin, S end, O out, T const &val, P proj_ = P{}) const
+            tagged_pair<tag::in(I), tag::out(O)> operator()(I begin, S end, O out, T const &val, P proj = P{}) const
             {
-                auto &&proj = as_function(proj_);
                 for(; begin != end; ++begin)
                 {
                     auto &&x = *begin;
-                    if(!(proj(x) == val))
+                    if(!(invoke(proj, x) == val))
                     {
                         *out = (decltype(x) &&) x;
                         ++out;

--- a/include/range/v3/algorithm/remove_copy_if.hpp
+++ b/include/range/v3/algorithm/remove_copy_if.hpp
@@ -34,7 +34,7 @@ namespace ranges
         using RemoveCopyableIf = meta::strict_and<
             InputIterator<I>,
             WeaklyIncrementable<O>,
-            IndirectCallablePredicate<C, projected<I, P>>,
+            IndirectPredicate<C, projected<I, P>>,
             IndirectlyCopyable<I, O>>;
 
         /// \addtogroup group-algorithms
@@ -43,14 +43,12 @@ namespace ranges
         {
             template<typename I, typename S, typename O, typename C, typename P = ident,
                 CONCEPT_REQUIRES_(RemoveCopyableIf<I, O, C, P>() && Sentinel<S, I>())>
-            tagged_pair<tag::in(I), tag::out(O)> operator()(I begin, S end, O out, C pred_, P proj_ = P{}) const
+            tagged_pair<tag::in(I), tag::out(O)> operator()(I begin, S end, O out, C pred, P proj = P{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj = as_function(proj_);
                 for(; begin != end; ++begin)
                 {
                     auto &&x = *begin;
-                    if(!(pred(proj(x))))
+                    if(!(invoke(pred, invoke(proj, x))))
                     {
                         *out = (decltype(x) &&) x;
                         ++out;

--- a/include/range/v3/algorithm/remove_if.hpp
+++ b/include/range/v3/algorithm/remove_if.hpp
@@ -33,7 +33,7 @@ namespace ranges
         template<typename I, typename C, typename P = ident>
         using RemovableIf = meta::strict_and<
             ForwardIterator<I>,
-            IndirectCallablePredicate<C, projected<I, P>>,
+            IndirectPredicate<C, projected<I, P>>,
             Permutable<I>>;
 
         /// \addtogroup group-algorithms
@@ -42,16 +42,14 @@ namespace ranges
         {
             template<typename I, typename S, typename C, typename P = ident,
                 CONCEPT_REQUIRES_(RemovableIf<I, C, P>() && Sentinel<S, I>())>
-            I operator()(I begin, S end, C pred_, P proj_ = P{}) const
+            I operator()(I begin, S end, C pred, P proj = P{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj = as_function(proj_);
                 begin = find_if(std::move(begin), end, std::ref(pred), std::ref(proj));
                 if(begin != end)
                 {
                     for(I i = next(begin); i != end; ++i)
                     {
-                        if(!(pred(proj(*i))))
+                        if(!(invoke(pred, invoke(proj, *i))))
                         {
                             *begin = iter_move(i);
                             ++begin;

--- a/include/range/v3/algorithm/replace.hpp
+++ b/include/range/v3/algorithm/replace.hpp
@@ -31,7 +31,7 @@ namespace ranges
         template<typename I, typename T0, typename T1, typename P = ident>
         using Replaceable = meta::strict_and<
             InputIterator<I>,
-            IndirectCallableRelation<equal_to, projected<I, P>, T0 const *>,
+            IndirectRelation<equal_to, projected<I, P>, T0 const *>,
             Writable<I, T1 const &>>;
 
         /// \addtogroup group-algorithms
@@ -40,11 +40,10 @@ namespace ranges
         {
             template<typename I, typename S, typename T0, typename T1, typename P = ident,
                 CONCEPT_REQUIRES_(Replaceable<I, T0, T1, P>() && Sentinel<S, I>())>
-            I operator()(I begin, S end, T0 const & old_value, T1 const & new_value, P proj_ = {}) const
+            I operator()(I begin, S end, T0 const & old_value, T1 const & new_value, P proj = {}) const
             {
-                auto &&proj = as_function(proj_);
                 for(; begin != end; ++begin)
-                    if(proj(*begin) == old_value)
+                    if(invoke(proj, *begin) == old_value)
                         *begin = new_value;
                 return begin;
             }

--- a/include/range/v3/algorithm/replace_copy.hpp
+++ b/include/range/v3/algorithm/replace_copy.hpp
@@ -35,7 +35,7 @@ namespace ranges
             InputIterator<I>,
             OutputIterator<O, T1 const &>,
             IndirectlyCopyable<I, O>,
-            IndirectCallableRelation<equal_to, projected<I, P>, T0 const *>>;
+            IndirectRelation<equal_to, projected<I, P>, T0 const *>>;
 
         /// \addtogroup group-algorithms
         /// @{
@@ -43,13 +43,12 @@ namespace ranges
         {
             template<typename I, typename S, typename O, typename T0, typename T1, typename P = ident,
                 CONCEPT_REQUIRES_(ReplaceCopyable<I, O, T0, T1, P>() && Sentinel<S, I>())>
-            tagged_pair<tag::in(I), tag::out(O)> operator()(I begin, S end, O out, T0 const & old_value, T1 const & new_value, P proj_ = {}) const
+            tagged_pair<tag::in(I), tag::out(O)> operator()(I begin, S end, O out, T0 const & old_value, T1 const & new_value, P proj = {}) const
             {
-                auto &&proj = as_function(proj_);
                 for(; begin != end; ++begin, ++out)
                 {
                     auto &&x = *begin;
-                    if(proj(x) == old_value)
+                    if(invoke(proj, x) == old_value)
                         *out = new_value;
                     else
                         *out = (decltype(x) &&) x;

--- a/include/range/v3/algorithm/replace_copy_if.hpp
+++ b/include/range/v3/algorithm/replace_copy_if.hpp
@@ -35,7 +35,7 @@ namespace ranges
             InputIterator<I>,
             OutputIterator<O, T const &>,
             IndirectlyCopyable<I, O>,
-            IndirectCallablePredicate<C, projected<I, P>>>;
+            IndirectPredicate<C, projected<I, P>>>;
 
         /// \addtogroup group-algorithms
         /// @{
@@ -43,14 +43,12 @@ namespace ranges
         {
             template<typename I, typename S, typename O, typename C, typename T, typename P = ident,
                 CONCEPT_REQUIRES_(ReplaceCopyIfable<I, O, C, T, P>() && Sentinel<S, I>())>
-            tagged_pair<tag::in(I), tag::out(O)> operator()(I begin, S end, O out, C pred_, T const & new_value, P proj_ = {}) const
+            tagged_pair<tag::in(I), tag::out(O)> operator()(I begin, S end, O out, C pred, T const & new_value, P proj = {}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj = as_function(proj_);
                 for(; begin != end; ++begin, ++out)
                 {
                     auto &&x = *begin;
-                    if(pred(proj(x)))
+                    if(invoke(pred, invoke(proj, x)))
                         *out = new_value;
                     else
                         *out = (decltype(x) &&) x;

--- a/include/range/v3/algorithm/replace_if.hpp
+++ b/include/range/v3/algorithm/replace_if.hpp
@@ -31,7 +31,7 @@ namespace ranges
         template<typename I, typename C, typename T, typename P = ident>
         using ReplaceIfable = meta::strict_and<
             InputIterator<I>,
-            IndirectCallablePredicate<C, projected<I, P>>,
+            IndirectPredicate<C, projected<I, P>>,
             Writable<I, T const &>>;
 
         /// \addtogroup group-algorithms
@@ -40,12 +40,10 @@ namespace ranges
         {
             template<typename I, typename S, typename C, typename T, typename P = ident,
                 CONCEPT_REQUIRES_(ReplaceIfable<I, C, T, P>() && Sentinel<S, I>())>
-            I operator()(I begin, S end, C pred_, T const & new_value, P proj_ = P{}) const
+            I operator()(I begin, S end, C pred, T const & new_value, P proj = P{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj = as_function(proj_);
                 for(; begin != end; ++begin)
-                    if(pred(proj(*begin)))
+                    if(invoke(pred, invoke(proj, *begin)))
                         *begin = new_value;
                 return begin;
             }

--- a/include/range/v3/algorithm/search.hpp
+++ b/include/range/v3/algorithm/search.hpp
@@ -65,7 +65,7 @@ namespace ranges
                     {
                         if(d1 < d2)  // return the end if we've run out of room
                             return ranges::next(recounted(begin1_, std::move(begin1), d1_ - d1), std::move(end1));
-                        if(pred(proj1(*begin1), proj2(*begin2)))
+                        if(invoke(pred, invoke(proj1, *begin1), invoke(proj2, *begin2)))
                             break;
                         ++begin1;
                         --d1;
@@ -78,7 +78,7 @@ namespace ranges
                         if(++m2 == end2)  // If pattern exhausted, begin1 is the answer (works for 1 element pattern)
                             return recounted(begin1_, std::move(begin1), d1_ - d1);
                         ++m1;  // No need to check, we know we have room to match successfully
-                        if(!pred(proj1(*m1), proj2(*m2)))  // if there is a mismatch, restart with a new begin1
+                        if(!invoke(pred, invoke(proj1, *m1), invoke(proj2, *m2)))  // if there is a mismatch, restart with a new begin1
                         {
                             ++begin1;
                             --d1;
@@ -98,7 +98,7 @@ namespace ranges
                     {
                         if(begin1 == end1)  // return end1 if no element matches *begin2
                             return begin1;
-                        if(pred(proj1(*begin1), proj2(*begin2)))
+                        if(invoke(pred, invoke(proj1, *begin1), invoke(proj2, *begin2)))
                             break;
                         ++begin1;
                     }
@@ -111,7 +111,7 @@ namespace ranges
                             return begin1;
                         if(++m1 == end1)  // Otherwise if source exhausted, pattern not found
                             return m1;
-                        if(!pred(proj1(*m1), proj2(*m2)))  // if there is a mismatch, restart with a new begin1
+                        if(!invoke(pred, invoke(proj1, *m1), invoke(proj2, *m2)))  // if there is a mismatch, restart with a new begin1
                         {
                             ++begin1;
                             break;
@@ -128,13 +128,10 @@ namespace ranges
                     Sentinel<S2, I2>()
                 )>
             I1 operator()(I1 begin1, S1 end1, I2 begin2, S2 end2,
-                C pred_ = C{}, P1 proj1_ = P1{}, P2 proj2_ = P2{}) const
+                C pred = C{}, P1 proj1 = P1{}, P2 proj2 = P2{}) const
             {
                 if(begin2 == end2)
                     return begin1;
-                auto &&pred = as_function(pred_);
-                auto &&proj1 = as_function(proj1_);
-                auto &&proj2 = as_function(proj2_);
                 if(SizedSentinel<S1, I1>() && SizedSentinel<S2, I2>())
                     return search_fn::sized_impl(std::move(begin1), std::move(end1),
                         distance(begin1, end1), std::move(begin2), std::move(end2),
@@ -154,14 +151,11 @@ namespace ranges
                     Range<Rng2>()
                 )>
             range_safe_iterator_t<Rng1>
-            operator()(Rng1 &&rng1, Rng2 &&rng2, C pred_ = C{}, P1 proj1_ = P1{},
-                P2 proj2_ = P2{}) const
+            operator()(Rng1 &&rng1, Rng2 &&rng2, C pred = C{}, P1 proj1 = P1{},
+                P2 proj2 = P2{}) const
             {
                 if(empty(rng2))
                     return begin(rng1);
-                auto &&pred = as_function(pred_);
-                auto &&proj1 = as_function(proj1_);
-                auto &&proj2 = as_function(proj2_);
                 if(SizedRange<Rng1>() && SizedRange<Rng2>())
                     return search_fn::sized_impl(begin(rng1), end(rng1), distance(rng1),
                         begin(rng2), end(rng2), distance(rng2), pred, proj1, proj2);

--- a/include/range/v3/algorithm/search_n.hpp
+++ b/include/range/v3/algorithm/search_n.hpp
@@ -42,7 +42,7 @@ namespace ranges
         template<typename I, typename V, typename C = equal_to, typename P = ident>
         using Searchnable = meta::strict_and<
             ForwardIterator<I>,
-            IndirectCallableRelation<C, projected<I, P>, V const *>>;
+            IndirectRelation<C, projected<I, P>, V const *>>;
 
         /// \addtogroup group-algorithms
         /// @{
@@ -62,7 +62,7 @@ namespace ranges
                     {
                         if(d < count)  // return the end if we've run out of room
                             return ranges::next(recounted(begin_, std::move(begin), d_ - d), std::move(end));
-                        if(pred(proj(*begin), val))
+                        if(invoke(pred, invoke(proj, *begin), val))
                             break;
                         ++begin;
                         --d;
@@ -75,7 +75,7 @@ namespace ranges
                         if(++c == count)  // If pattern exhausted, begin is the answer (works for 1 element pattern)
                             return recounted(begin_, std::move(begin), d_ - d);
                         ++m;  // No need to check, we know we have room to match successfully
-                        if(!pred(proj(*m), val))  // if there is a mismatch, restart with a new begin
+                        if(!invoke(pred, invoke(proj, *m), val))  // if there is a mismatch, restart with a new begin
                         {
                             begin = next(std::move(m));
                             d -= (c+1);
@@ -95,7 +95,7 @@ namespace ranges
                     {
                         if(begin == end)  // return end if no element matches val
                             return begin;
-                        if(pred(proj(*begin), val))
+                        if(invoke(pred, invoke(proj, *begin), val))
                             break;
                         ++begin;
                     }
@@ -108,7 +108,7 @@ namespace ranges
                             return begin;
                         if(++m == end)  // Otherwise if source exhausted, pattern not found
                             return m;
-                        if(!pred(proj(*m), val))  // if there is a mismatch, restart with a new begin
+                        if(!invoke(pred, invoke(proj, *m), val))  // if there is a mismatch, restart with a new begin
                         {
                             begin = next(std::move(m));
                             break;
@@ -120,12 +120,10 @@ namespace ranges
             template<typename I, typename S, typename V, typename C = equal_to, typename P = ident,
                 CONCEPT_REQUIRES_(Searchnable<I, V, C, P>() && Sentinel<S, I>())>
             I operator()(I begin, S end, iterator_difference_t<I> count, V const &val,
-                C pred_ = C{}, P proj_ = P{}) const
+                C pred = C{}, P proj = P{}) const
             {
                 if(count <= 0)
                     return begin;
-                auto &&pred = as_function(pred_);
-                auto &&proj = as_function(proj_);
                 if(SizedSentinel<S, I>())
                     return search_n_fn::sized_impl(std::move(begin), std::move(end),
                         distance(begin, end), count, val, pred, proj);
@@ -138,13 +136,11 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(Searchnable<I, V, C, P>() && Range<Rng>())>
             range_safe_iterator_t<Rng>
-            operator()(Rng &&rng, iterator_difference_t<I> count, V const &val, C pred_ = C{},
-                P proj_ = P{}) const
+            operator()(Rng &&rng, iterator_difference_t<I> count, V const &val, C pred = C{},
+                P proj = P{}) const
             {
                 if(count <= 0)
                     return begin(rng);
-                auto &&pred = as_function(pred_);
-                auto &&proj = as_function(proj_);
                 if(SizedRange<Rng>())
                     return search_n_fn::sized_impl(begin(rng), end(rng), distance(rng), count, val,
                         pred, proj);

--- a/include/range/v3/algorithm/set_algorithm.hpp
+++ b/include/range/v3/algorithm/set_algorithm.hpp
@@ -49,16 +49,13 @@ namespace ranges
                 CONCEPT_REQUIRES_(Comparable<I1, I2, C, P1, P2>() &&
                     Sentinel<S1, I1>() && Sentinel<S2, I2>())>
             bool operator()(I1 begin1, S1 end1, I2 begin2, S2 end2,
-                C pred_ = C{}, P1 proj1_ = P1{}, P2 proj2_ = P2{}) const
+                C pred = C{}, P1 proj1 = P1{}, P2 proj2 = P2{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj1 = as_function(proj1_);
-                auto &&proj2 = as_function(proj2_);
                 for(; begin2 != end2; ++begin1)
                 {
-                    if(begin1 == end1 || pred(proj2(*begin2), proj1(*begin1)))
+                    if(begin1 == end1 || invoke(pred, invoke(proj2, *begin2), invoke(proj1, *begin1)))
                         return false;
-                    if(!pred(proj1(*begin1), proj2(*begin2)))
+                    if(!invoke(pred, invoke(proj1, *begin1), invoke(proj2, *begin2)))
                         ++begin2;
                 }
                 return true;
@@ -90,11 +87,8 @@ namespace ranges
                     Sentinel<S1, I1>() && Sentinel<S2, I2>())>
             tagged_tuple<tag::in1(I1), tag::in2(I2), tag::out(O)>
             operator()(I1 begin1, S1 end1, I2 begin2, S2 end2, O out,
-                C pred_ = C{}, P1 proj1_ = P1{}, P2 proj2_ = P2{}) const
+                C pred = C{}, P1 proj1 = P1{}, P2 proj2 = P2{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj1 = as_function(proj1_);
-                auto &&proj2 = as_function(proj2_);
                 for(; begin1 != end1; ++out)
                 {
                     if(begin2 == end2)
@@ -103,7 +97,7 @@ namespace ranges
                         return make_tagged_tuple<tag::in1, tag::in2, tag::out>(tmp.first, begin2,
                             tmp.second);
                     }
-                    if(pred(proj2(*begin2), proj1(*begin1)))
+                    if(invoke(pred, invoke(proj2, *begin2), invoke(proj1, *begin1)))
                     {
                         *out = *begin2;
                         ++begin2;
@@ -111,7 +105,7 @@ namespace ranges
                     else
                     {
                         *out = *begin1;
-                        if(!pred(proj1(*begin1), proj2(*begin2)))
+                        if(!invoke(pred, invoke(proj1, *begin1), invoke(proj2, *begin2)))
                             ++begin2;
                         ++begin1;
                     }
@@ -147,18 +141,15 @@ namespace ranges
                 CONCEPT_REQUIRES_(Mergeable<I1, I2, O, C, P1, P2>() &&
                     Sentinel<S1, I1>() && Sentinel<S2, I2>())>
             O operator()(I1 begin1, S1 end1, I2 begin2, S2 end2, O out,
-                C pred_ = C{}, P1 proj1_ = P1{}, P2 proj2_ = P2{}) const
+                C pred = C{}, P1 proj1 = P1{}, P2 proj2 = P2{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj1 = as_function(proj1_);
-                auto &&proj2 = as_function(proj2_);
                 while(begin1 != end1 && begin2 != end2)
                 {
-                    if(pred(proj1(*begin1), proj2(*begin2)))
+                    if(invoke(pred, invoke(proj1, *begin1), invoke(proj2, *begin2)))
                         ++begin1;
                     else
                     {
-                        if(!pred(proj2(*begin2), proj1(*begin1)))
+                        if(!invoke(pred, invoke(proj2, *begin2), invoke(proj1, *begin1)))
                         {
                             *out = *begin1;
                             ++out;
@@ -196,16 +187,13 @@ namespace ranges
                 CONCEPT_REQUIRES_(Mergeable<I1, I2, O, C, P1, P2>() &&
                     Sentinel<S1, I1>() && Sentinel<S2, I2>())>
             tagged_pair<tag::in1(I1), tag::out(O)> operator()(I1 begin1, S1 end1, I2 begin2, S2 end2, O out,
-                C pred_ = C{}, P1 proj1_ = P1{}, P2 proj2_ = P2{}) const
+                C pred = C{}, P1 proj1 = P1{}, P2 proj2 = P2{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj1 = as_function(proj1_);
-                auto &&proj2 = as_function(proj2_);
                 while(begin1 != end1)
                 {
                     if(begin2 == end2)
                         return copy(begin1, end1, out);
-                    if(pred(proj1(*begin1), proj2(*begin2)))
+                    if(invoke(pred, invoke(proj1, *begin1), invoke(proj2, *begin2)))
                     {
                         *out = *begin1;
                         ++out;
@@ -213,7 +201,7 @@ namespace ranges
                     }
                     else
                     {
-                        if(!pred(proj2(*begin2), proj1(*begin1)))
+                        if(!invoke(pred, invoke(proj2, *begin2), invoke(proj1, *begin1)))
                             ++begin1;
                         ++begin2;
                     }
@@ -247,11 +235,8 @@ namespace ranges
                 CONCEPT_REQUIRES_(Mergeable<I1, I2, O, C, P1, P2>() &&
                     Sentinel<S1, I1>() && Sentinel<S2, I2>())>
             tagged_tuple<tag::in1(I1), tag::in2(I2), tag::out(O)> operator()(I1 begin1, S1 end1, I2 begin2, S2 end2, O out,
-                C pred_ = C{}, P1 proj1_ = P1{}, P2 proj2_ = P2{}) const
+                C pred = C{}, P1 proj1 = P1{}, P2 proj2 = P2{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj1 = as_function(proj1_);
-                auto &&proj2 = as_function(proj2_);
                 while(begin1 != end1)
                 {
                     if(begin2 == end2)
@@ -259,7 +244,7 @@ namespace ranges
                         auto tmp = copy(begin1, end1, out);
                         return tagged_tuple<tag::in1(I1), tag::in2(I2), tag::out(O)>{tmp.first, begin2, tmp.second};
                     }
-                    if(pred(proj1(*begin1), proj2(*begin2)))
+                    if(invoke(pred, invoke(proj1, *begin1), invoke(proj2, *begin2)))
                     {
                         *out = *begin1;
                         ++out;
@@ -267,7 +252,7 @@ namespace ranges
                     }
                     else
                     {
-                        if(pred(proj2(*begin2), proj1(*begin1)))
+                        if(invoke(pred, invoke(proj2, *begin2), invoke(proj1, *begin1)))
                         {
                             *out = *begin2;
                             ++out;

--- a/include/range/v3/algorithm/stable_partition.hpp
+++ b/include/range/v3/algorithm/stable_partition.hpp
@@ -48,7 +48,7 @@ namespace ranges
         using StablePartitionable = meta::strict_and<
             ForwardIterator<I>,
             Permutable<I>,
-            IndirectCallablePredicate<C, projected<I, P>>>;
+            IndirectPredicate<C, projected<I, P>>>;
 
         /// \addtogroup group-algorithms
         /// @{
@@ -65,7 +65,7 @@ namespace ranges
                 if(len == 2)
                 {
                     I tmp = begin;
-                    if(pred(proj(*++tmp)))
+                    if(invoke(pred, invoke(proj, *++tmp)))
                     {
                         ranges::iter_swap(begin, tmp);
                         return tmp;
@@ -102,7 +102,7 @@ namespace ranges
                 // recurse on [middle, end], except increase middle until *(middle) is false, *end know to be true
                 I m1 = middle;
                 D len_half = len - half;
-                while(pred(proj(*m1)))
+                while(invoke(pred, invoke(proj, *m1)))
                 {
                     if(++m1 == end)
                         return ranges::rotate(begin_false, middle, end).begin();
@@ -128,7 +128,7 @@ namespace ranges
                 {
                     if(begin == end)
                         return begin;
-                    if(!pred(proj(*begin)))
+                    if(!invoke(pred, invoke(proj, *begin)))
                         break;
                     ++begin;
                 }
@@ -156,7 +156,7 @@ namespace ranges
                 if(len == 3)
                 {
                     I tmp = begin;
-                    if(pred(proj(*++tmp)))
+                    if(invoke(pred, invoke(proj, *++tmp)))
                     {
                         ranges::iter_swap(begin, tmp);
                         ranges::iter_swap(tmp, end);
@@ -198,7 +198,7 @@ namespace ranges
                 I m1 = middle;
                 I begin_false = begin;
                 D len_half = half;
-                while(!pred(proj(*--m1)))
+                while(!invoke(pred, invoke(proj, *--m1)))
                 {
                     if(m1 == begin)
                         goto first_half_done;
@@ -213,7 +213,7 @@ namespace ranges
                 // recurse on [middle, end], except increase middle until *(middle) is false, *end know to be true
                 m1 = middle;
                 len_half = len - half;
-                while(pred(proj(*m1)))
+                while(invoke(pred, invoke(proj, *m1)))
                 {
                     if(++m1 == end)
                         return ranges::rotate(begin_false, middle, ++end).begin();
@@ -240,7 +240,7 @@ namespace ranges
                 {
                     if(begin == end_)
                         return begin;
-                    if(!pred(proj(*begin)))
+                    if(!invoke(pred, invoke(proj, *begin)))
                         break;
                     ++begin;
                 }
@@ -251,7 +251,7 @@ namespace ranges
                 {
                     if(begin == --end)
                         return begin;
-                } while(!pred(proj(*end)));
+                } while(!invoke(pred, invoke(proj, *end)));
                 // We now have a reduced range [begin, end]
                 // *begin is known to be false
                 // *end is known to be true
@@ -266,10 +266,8 @@ namespace ranges
         public:
             template<typename I, typename S, typename C, typename P = ident,
                 CONCEPT_REQUIRES_(StablePartitionable<I, C, P>() && Sentinel<S, I>())>
-            I operator()(I begin, S end, C pred_, P proj_ = P{}) const
+            I operator()(I begin, S end, C pred, P proj = P{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj = as_function(proj_);
                 return stable_partition_fn::impl(std::move(begin), std::move(end), std::ref(pred),
                     std::ref(proj), iterator_concept<I>());
             }

--- a/include/range/v3/algorithm/stable_sort.hpp
+++ b/include/range/v3/algorithm/stable_sort.hpp
@@ -157,10 +157,8 @@ namespace ranges
             template<typename I, typename S, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(Sortable<I, C, P>() && RandomAccessIterator<I>() &&
                     Sentinel<S, I>())>
-            I operator()(I begin, S end_, C pred_ = C{}, P proj_ = P{}) const
+            I operator()(I begin, S end_, C pred = C{}, P proj = P{}) const
             {
-                auto && pred = as_function(pred_);
-                auto && proj = as_function(proj_);
                 I end = ranges::next(begin, end_);
                 using D = iterator_difference_t<I>;
                 using V = iterator_value_t<I>;

--- a/include/range/v3/algorithm/unique.hpp
+++ b/include/range/v3/algorithm/unique.hpp
@@ -39,21 +39,18 @@ namespace ranges
             /// \pre `Rng` is a model of the `ForwardView` concept
             /// \pre `I` is a model of the `ForwardIterator` concept
             /// \pre `S` is a model of the `Sentinel` concept
-            /// \pre `C` is a model of the `CallableRelation` concept
+            /// \pre `C` is a model of the `Relation` concept
             ///
             template<typename I, typename S, typename C = equal_to, typename P = ident,
                 CONCEPT_REQUIRES_(Sortable<I, C, P>() && Sentinel<S, I>())>
-            I operator()(I begin, S end, C pred_ = C{}, P proj_ = P{}) const
+            I operator()(I begin, S end, C pred = C{}, P proj = P{}) const
             {
-                auto &&pred = as_function(pred_);
-                auto &&proj = as_function(proj_);
-
                 begin = adjacent_find(std::move(begin), end, std::ref(pred), std::ref(proj));
 
                 if(begin != end)
                 {
                     for(I i = next(begin); ++i != end;)
-                        if(!pred(proj(*begin), proj(*i)))
+                        if(!invoke(pred, invoke(proj, *begin), invoke(proj, *i)))
                             *++begin = iter_move(i);
                     ++begin;
                 }

--- a/include/range/v3/algorithm/upper_bound.hpp
+++ b/include/range/v3/algorithm/upper_bound.hpp
@@ -33,9 +33,8 @@ namespace ranges
         {
             template<typename I, typename S, typename V2, typename C = ordered_less, typename P = ident,
                 CONCEPT_REQUIRES_(Sentinel<S, I>() && BinarySearchable<I, V2, C, P>())>
-            I operator()(I begin, S end, V2 const &val, C pred_ = C{}, P proj = P{}) const
+            I operator()(I begin, S end, V2 const &val, C pred = C{}, P proj = P{}) const
             {
-                auto&& pred = as_function(pred_);
                 return partition_point(std::move(begin), std::move(end),
                     detail::make_upper_bound_predicate(pred, val), std::move(proj));
             }
@@ -45,9 +44,8 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(Range<Rng>() && BinarySearchable<I, V2, C, P>())>
             range_safe_iterator_t<Rng>
-            operator()(Rng &&rng, V2 const &val, C pred_ = C{}, P proj = P{}) const
+            operator()(Rng &&rng, V2 const &val, C pred = C{}, P proj = P{}) const
             {
-                auto&& pred = as_function(pred_);
                 return partition_point(rng,
                     detail::make_upper_bound_predicate(pred, val), std::move(proj));
             }

--- a/include/range/v3/numeric/inner_product.hpp
+++ b/include/range/v3/numeric/inner_product.hpp
@@ -32,17 +32,17 @@ namespace ranges
                 typename P1 = ident, typename P2 = ident,
                 typename V1 = iterator_value_t<I1>,
                 typename V2 = iterator_value_t<I2>,
-                typename X1 = concepts::Callable::result_t<P1, V1>,
-                typename X2 = concepts::Callable::result_t<P2, V2>,
-                typename Y2 = concepts::Callable::result_t<BOp2, X1, X2>,
-                typename Y1 = concepts::Callable::result_t<BOp1, T, Y2>>
+                typename X1 = concepts::Invocable::result_t<P1&, V1>,
+                typename X2 = concepts::Invocable::result_t<P2&, V2>,
+                typename Y2 = concepts::Invocable::result_t<BOp2&, X1, X2>,
+                typename Y1 = concepts::Invocable::result_t<BOp1&, T, Y2>>
         using InnerProductable = meta::strict_and<
             InputIterator<I1>,
             InputIterator<I2>,
-            Callable<P1, V1>,
-            Callable<P2, V2>,
-            Callable<BOp2, X1, X2>,
-            Callable<BOp1, T, Y2>,
+            Invocable<P1&, V1>,
+            Invocable<P2&, V2>,
+            Invocable<BOp2&, X1, X2>,
+            Invocable<BOp1&, T, Y2>,
             Assignable<T&, Y2>>;
 
         struct inner_product_fn
@@ -54,16 +54,11 @@ namespace ranges
                     Sentinel<S1, I1>() &&
                     InnerProductable<I1, I2, T, BOp1, BOp2, P1, P2>()
                 )>
-            T operator()(I1 begin1, S1 end1, I2 begin2, T init, BOp1 bop1_ = BOp1{},
-                BOp2 bop2_ = BOp2{}, P1 proj1_ = P1{}, P2 proj2_ = P2{}) const
+            T operator()(I1 begin1, S1 end1, I2 begin2, T init, BOp1 bop1 = BOp1{},
+                BOp2 bop2 = BOp2{}, P1 proj1 = P1{}, P2 proj2 = P2{}) const
             {
-                auto &&bop1 = as_function(bop1_);
-                auto &&bop2 = as_function(bop2_);
-                auto &&proj1 = as_function(proj1_);
-                auto &&proj2 = as_function(proj2_);
-
                 for (; begin1 != end1; ++begin1, ++begin2)
-                  init = bop1(init, bop2(proj1(*begin1), proj2(*begin2)));
+                  init = invoke(bop1, init, invoke(bop2, invoke(proj1, *begin1), invoke(proj2, *begin2)));
                 return init;
             }
 
@@ -75,16 +70,11 @@ namespace ranges
                     Sentinel<S2, I2>() &&
                     InnerProductable<I1, I2, T, BOp1, BOp2, P1, P2>()
                 )>
-            T operator()(I1 begin1, S1 end1, I2 begin2, S2 end2, T init, BOp1 bop1_ = BOp1{},
-                BOp2 bop2_ = BOp2{}, P1 proj1_ = P1{}, P2 proj2_ = P2{}) const
+            T operator()(I1 begin1, S1 end1, I2 begin2, S2 end2, T init, BOp1 bop1 = BOp1{},
+                BOp2 bop2 = BOp2{}, P1 proj1 = P1{}, P2 proj2 = P2{}) const
             {
-                auto &&bop1 = as_function(bop1_);
-                auto &&bop2 = as_function(bop2_);
-                auto &&proj1 = as_function(proj1_);
-                auto &&proj2 = as_function(proj2_);
-
                 for (; begin1 != end1 && begin2 != end2; ++begin1, ++begin2)
-                  init = bop1(init, bop2(proj1(*begin1), proj2(*begin2)));
+                  init = invoke(bop1, init, invoke(bop2, invoke(proj1, *begin1), invoke(proj2, *begin2)));
                 return init;
             }
 

--- a/include/range/v3/numeric/iota.hpp
+++ b/include/range/v3/numeric/iota.hpp
@@ -35,11 +35,11 @@ namespace ranges
                 return begin;
             }
 
-            template<typename Rng, class T, typename O = range_iterator_t<Rng>,
-                CONCEPT_REQUIRES_(OutputRange<Rng &, T const &>() && WeaklyIncrementable<T>())>
-            O operator()(Rng &rng, T val) const
+            template<typename Rng, class T,
+                CONCEPT_REQUIRES_(OutputRange<Rng, T const &>() && WeaklyIncrementable<T>())>
+            range_safe_iterator_t<Rng> operator()(Rng && rng, T val) const
             {
-                return (*this)(begin(rng), end(rng), std::move(val));
+                return (*this)(begin(rng), end(rng), detail::move(val));
             }
         };
 

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -115,8 +115,10 @@ namespace ranges
         template<typename ...Ts>
         using common_reference_t = meta::_t<common_reference<Ts...>>;
 
+        template<typename, typename = void>
+        struct result_of;
         template<typename Sig>
-        using result_of_t = meta::_t<std::result_of<Sig>>;
+        using result_of_t = meta::_t<result_of<Sig>>;
 
         struct make_pipeable_fn;
 
@@ -408,8 +410,6 @@ namespace ranges
 
         template<typename T>
         using bind_element_t = meta::_t<bind_element<T>>;
-
-        struct as_function_fn;
 
         template<typename Derived, cardinality = finite>
         struct view_interface;

--- a/include/range/v3/utility/concepts.hpp
+++ b/include/range/v3/utility/concepts.hpp
@@ -691,69 +691,6 @@ RANGES_DIAGNOSTIC_POP
             struct Regular
               : refines<SemiRegular, EqualityComparable>
             {};
-
-            ////////////////////////////////////////////////////////////////////////////////////////////
-            // Function concepts
-            ////////////////////////////////////////////////////////////////////////////////////////////
-
-            struct Function
-            {
-                template<typename Fun, typename ...Args>
-                using result_t = decltype(val<Fun>()(val<Args>()...));
-
-                template<typename Fun, typename ...Args>
-                auto requires_(Fun&& fun, Args&&... args) -> decltype(
-                    concepts::valid_expr(
-                        concepts::model_of<CopyConstructible, uncvref_t<Fun>>(),
-                        ((void)val<Fun>()(val<Args>()...), 42)
-                    ));
-            };
-
-            struct RegularFunction
-              : refines<Function>
-            {
-                // Axiom: equality_preserving(f(args...))
-            };
-
-            struct Predicate
-              : refines<RegularFunction>
-            {
-                template<typename Fun, typename ...Args>
-                auto requires_(Fun&& fun, Args&&... args) -> decltype(
-                    concepts::valid_expr(
-                        concepts::convertible_to<bool>(val<Fun>()(val<Args>()...))
-                    ));
-            };
-
-            struct Relation
-              : refines<RegularFunction>
-            {
-                template<typename Fun, typename T>
-                auto requires_(Fun&&, T &&) -> decltype(
-                    concepts::valid_expr(
-                        concepts::model_of<Predicate>(val<Fun>(), val<T>(), val<T>())
-                    ));
-
-                template<typename Fun, typename T, typename U,
-                    meta::if_<std::is_same<T, U>, int> = 0>
-                auto requires_(Fun&&, T &&, T &&) -> decltype(
-                    concepts::valid_expr(
-                        concepts::model_of<Predicate>(val<Fun>(), val<T>(), val<U>())
-                    ));
-
-                template<typename Fun, typename T, typename U,
-                    meta::if_c<!std::is_same<T, U>::value, int> = 0,
-                    typename C = CommonReference::reference_t<T const &, U const &>>
-                auto requires_(Fun &&, T &&, U &&) -> decltype(
-                    concepts::valid_expr(
-                        concepts::model_of<Relation, Fun, T, T>(),
-                        concepts::model_of<Relation, Fun, U, U>(),
-                        concepts::model_of<CommonReference, T const &, U const &>(),
-                        concepts::model_of<Relation, Fun, C, C>(),
-                        concepts::model_of<Predicate, Fun, T, U>(),
-                        concepts::model_of<Predicate, Fun, U, T>()
-                    ));
-            };
         }
 
         template<typename ...Ts>
@@ -840,18 +777,6 @@ RANGES_DIAGNOSTIC_POP
 
         template<typename T, typename U = T>
         using Swappable = concepts::models<concepts::Swappable, T, U>;
-
-        template<typename Fun, typename ...Args>
-        using Function = concepts::models<concepts::Function, Fun, Args...>;
-
-        template<typename Fun, typename ...Args>
-        using RegularFunction = concepts::models<concepts::RegularFunction, Fun, Args...>;
-
-        template<typename Fun, typename ...Args>
-        using Predicate = concepts::models<concepts::Predicate, Fun, Args...>;
-
-        template<typename Fun, typename T, typename U = T>
-        using Relation = concepts::models<concepts::Relation, Fun, T, U>;
     }
 }
 

--- a/include/range/v3/utility/invoke.hpp
+++ b/include/range/v3/utility/invoke.hpp
@@ -1,0 +1,177 @@
+/// \file
+// Range v3 library
+//
+//  Copyright Eric Niebler 2013-2014
+//  Copyright Casey Carter 2016
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+#ifndef RANGES_V3_UTILITY_INVOKE_HPP
+#define RANGES_V3_UTILITY_INVOKE_HPP
+
+#include <functional>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <meta/meta.hpp>
+#include <range/v3/detail/config.hpp>
+#include <range/v3/utility/static_const.hpp>
+
+RANGES_DISABLE_WARNINGS
+
+namespace ranges
+{
+    inline namespace v3
+    {
+        /// \addtogroup group-utility
+        /// @{
+        template<typename T>
+        struct is_reference_wrapper
+          : meta::if_<
+                std::is_same<uncvref_t<T>, T>,
+                std::false_type,
+                is_reference_wrapper<uncvref_t<T>>>
+        {};
+
+        template<typename T, bool RValue>
+        struct is_reference_wrapper<reference_wrapper<T, RValue>>
+          : std::true_type
+        {};
+
+        template<typename T>
+        struct is_reference_wrapper<std::reference_wrapper<T>>
+          : std::true_type
+        {};
+
+        template<typename T>
+        using is_reference_wrapper_t = meta::_t<is_reference_wrapper<T>>;
+
+        struct invoke_fn
+        {
+        private:
+            template<typename MemberFunctionPtr, typename First, typename... Rest>
+            static constexpr auto invoke_member_fn(
+                std::true_type, detail::any, MemberFunctionPtr fn, First && first, Rest &&... rest)
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+            (
+                (detail::forward<First>(first).*fn)(detail::forward<Rest>(rest)...)
+            )
+            template<typename MemberFunctionPtr, typename First, typename... Rest>
+            static constexpr auto invoke_member_fn(
+                std::false_type, std::true_type, MemberFunctionPtr fn, First && first, Rest &&... rest)
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+            (
+                (detail::forward<First>(first).get().*fn)(detail::forward<Rest>(rest)...)
+            )
+            template<typename MemberFunctionPtr, typename First, typename... Rest>
+            static constexpr auto invoke_member_fn(
+                std::false_type, std::false_type, MemberFunctionPtr fn, First && first, Rest &&... rest)
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+            (
+                ((*detail::forward<First>(first)).*fn)(detail::forward<Rest>(rest)...)
+            )
+
+            template<typename MemberDataPtr, typename First>
+            static constexpr auto invoke_member_data(
+                std::true_type, detail::any, MemberDataPtr ptr, First && first)
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+            (
+                detail::forward<First>(first).*ptr
+            )
+            template<typename MemberDataPtr, typename First>
+            static constexpr auto invoke_member_data(
+                std::false_type, std::true_type, MemberDataPtr ptr, First && first)
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+            (
+                detail::forward<First>(first).get().*ptr
+            )
+            template<typename MemberDataPtr, typename First>
+            static constexpr auto invoke_member_data(
+                std::false_type, std::false_type, MemberDataPtr ptr, First && first)
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+            (
+                (*detail::forward<First>(first)).*ptr
+            )
+        public:
+            template<typename F, typename Obj, typename First, typename... Rest,
+                meta::if_c<std::is_function<F>::value, int> = 0>
+            constexpr auto operator()(F (Obj::*ptr), First && first, Rest &&... rest) const
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+            (
+                invoke_member_fn(std::is_base_of<Obj, detail::decay_t<First>>{},
+                    is_reference_wrapper_t<detail::decay_t<First>>{},
+                    ptr, detail::forward<First>(first), detail::forward<Rest>(rest)...)
+            )
+            template<typename Data, typename Obj, typename First,
+                meta::if_c<!std::is_function<Data>::value, int> = 0>
+            constexpr auto operator()(Data (Obj::*ptr), First && first) const
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+            (
+                invoke_member_data(std::is_base_of<Obj, detail::decay_t<First>>{},
+                    is_reference_wrapper_t<detail::decay_t<First>>{},
+                    ptr, detail::forward<First>(first))
+            )
+            template<typename F, typename... Args,
+                meta::if_c<!std::is_member_pointer<uncvref_t<F>>::value, int> = 0>
+            constexpr auto operator()(F && fn, Args &&... args) const
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+            (
+                detail::forward<F>(fn)(detail::forward<Args>(args)...)
+            )
+        };
+        RANGES_INLINE_VARIABLE(invoke_fn, invoke)
+
+        template<typename T, bool RValue /* = false*/>
+        struct reference_wrapper
+        {
+        private:
+            T *t_;
+        public:
+            using type = T;
+            using reference = meta::if_c<RValue, T &&, T &>;
+            constexpr reference_wrapper() = default;
+            constexpr reference_wrapper(reference t) noexcept
+              : t_(std::addressof(t))
+            {}
+            reference_wrapper(meta::if_c<RValue, T &, T &&>) = delete;
+            constexpr reference get() const noexcept
+            {
+                return static_cast<reference>(*t_);
+            }
+            constexpr operator reference() const noexcept
+            {
+                return get();
+            }
+            CONCEPT_REQUIRES(!RValue)
+            operator std::reference_wrapper<T> () const noexcept
+            {
+                return {get()};
+            }
+            template<typename ...Args>
+            constexpr auto operator()(Args &&...args) const
+            RANGES_DECLTYPE_NOEXCEPT(
+                invoke(std::declval<reference>(), std::declval<Args>()...))
+            {
+                return invoke(get(), detail::forward<Args>(args)...);
+            }
+        };
+
+        template<typename Sig, typename Enable /*= void*/>
+        struct result_of {};
+        template<typename Fun, typename...Args>
+        struct result_of<Fun(Args...), meta::void_<
+            decltype(invoke(std::declval<Fun>(), std::declval<Args>()...))>>
+        {
+            using type = decltype(invoke(std::declval<Fun>(), std::declval<Args>()...));
+        };
+    } // namespace v3
+} // namespace ranges
+
+RANGES_RE_ENABLE_WARNINGS
+
+#endif // RANGES_V3_UTILITY_INVOKE_HPP

--- a/include/range/v3/utility/tuple_algorithm.hpp
+++ b/include/range/v3/utility/tuple_algorithm.hpp
@@ -41,7 +41,7 @@ namespace ranges
             static auto impl(Fun &&fun, Tup &&tup, meta::index_sequence<Is...>)
             RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
-                std::forward<Fun>(fun)(std::get<Is>(std::forward<Tup>(tup))...)
+                invoke(std::forward<Fun>(fun), std::get<Is>(std::forward<Tup>(tup))...)
             )
         public:
             template<typename Fun, typename Tup>

--- a/include/range/v3/view/adjacent_filter.hpp
+++ b/include/range/v3/view/adjacent_filter.hpp
@@ -43,7 +43,7 @@ namespace ranges
         {
         private:
             friend range_access;
-            semiregular_t<function_type<Pred>> pred_;
+            semiregular_t<Pred> pred_;
 
             struct adaptor : adaptor_base
             {
@@ -57,10 +57,10 @@ namespace ranges
                 void next(range_iterator_t<Rng> &it) const
                 {
                     auto const end = ranges::end(rng_->mutable_base());
-                    auto &&pred = rng_->pred_;
+                    auto &pred = rng_->pred_;
                     RANGES_EXPECT(it != end);
                     for(auto prev = it; ++it != end; prev = it)
-                        if(pred(*prev, *it))
+                        if(invoke(pred, *prev, *it))
                             break;
                 }
                 void prev() = delete;
@@ -78,7 +78,7 @@ namespace ranges
             adjacent_filter_view() = default;
             adjacent_filter_view(Rng rng, Pred pred)
               : adjacent_filter_view::view_adaptor{std::move(rng)}
-              , pred_(as_function(std::move(pred)))
+              , pred_(std::move(pred))
             {}
        };
 
@@ -99,7 +99,7 @@ namespace ranges
                 template<typename Rng, typename Pred>
                 using Concept = meta::and_<
                     ForwardRange<Rng>,
-                    IndirectCallablePredicate<Pred, range_iterator_t<Rng>,
+                    IndirectPredicate<Pred, range_iterator_t<Rng>,
                         range_iterator_t<Rng>>>;
 
                 template<typename Rng, typename Pred,
@@ -115,9 +115,9 @@ namespace ranges
                 {
                     CONCEPT_ASSERT_MSG(ForwardRange<Rng>(),
                         "Rng must model the ForwardRange concept");
-                    CONCEPT_ASSERT_MSG(IndirectCallablePredicate<Pred, range_iterator_t<Rng>,
+                    CONCEPT_ASSERT_MSG(IndirectPredicate<Pred, range_iterator_t<Rng>,
                         range_iterator_t<Rng>>(),
-                        "Function Pred must be callable with two arguments of the range's common "
+                        "Pred must be callable with two arguments of the range's common "
                         "reference type, and it must return something convertible to bool.");
                 }
             #endif

--- a/include/range/v3/view/adjacent_remove_if.hpp
+++ b/include/range/v3/view/adjacent_remove_if.hpp
@@ -42,7 +42,7 @@ namespace ranges
         {
         private:
             friend range_access;
-            semiregular_t<function_type<Pred>> pred_;
+            semiregular_t<Pred> pred_;
             detail::non_propagating_cache<range_iterator_t<Rng>> begin_;
 
             struct adaptor : adaptor_base
@@ -52,12 +52,12 @@ namespace ranges
                 void satisfy(range_iterator_t<Rng> &it) const
                 {
                     auto const end = ranges::end(rng_->mutable_base());
-                    auto &&pred = rng_->pred_;
+                    auto &pred = rng_->pred_;
                     if(it == end)
                         return;
                     auto next = it;
                     for(; ++next != end; it = next)
-                        if(!pred(*it, *next))
+                        if(!invoke(pred, *it, *next))
                             return;
                 }
             public:
@@ -95,7 +95,7 @@ namespace ranges
             adjacent_remove_if_view() = default;
             adjacent_remove_if_view(Rng rng, Pred pred)
               : adjacent_remove_if_view::view_adaptor{std::move(rng)}
-              , pred_(as_function(std::move(pred)))
+              , pred_(std::move(pred))
             {}
        };
 
@@ -116,7 +116,7 @@ namespace ranges
                 template<typename Rng, typename Pred>
                 using Concept = meta::and_<
                     ForwardRange<Rng>,
-                    IndirectCallablePredicate<Pred, range_iterator_t<Rng>,
+                    IndirectPredicate<Pred, range_iterator_t<Rng>,
                         range_iterator_t<Rng>>>;
 
                 template<typename Rng, typename Pred,
@@ -132,9 +132,9 @@ namespace ranges
                 {
                     CONCEPT_ASSERT_MSG(ForwardRange<Rng>(),
                         "Rng must model the ForwardRange concept");
-                    CONCEPT_ASSERT_MSG(IndirectCallablePredicate<Pred, range_iterator_t<Rng>,
+                    CONCEPT_ASSERT_MSG(IndirectPredicate<Pred, range_iterator_t<Rng>,
                         range_iterator_t<Rng>>(),
-                        "Function Pred must be callable with two arguments of the range's common "
+                        "Pred must be callable with two arguments of the range's common "
                         "reference type, and it must return something convertible to bool.");
                 }
             #endif

--- a/include/range/v3/view/concat.hpp
+++ b/include/range/v3/view/concat.hpp
@@ -127,9 +127,11 @@ namespace ranges
                 struct next_fun
                 {
                     cursor *pos;
-                    template<typename I, std::size_t N>
+                    template<typename I, std::size_t N,
+                        CONCEPT_REQUIRES_(Iterator<I>())>
                     void operator()(indexed_element<I, N> it) const
                     {
+                        RANGES_ASSERT(it.get() != end(std::get<N>(pos->rng_->rngs_)));
                         ++it.get();
                         pos->satisfy(meta::size_t<N>{});
                     }
@@ -137,13 +139,15 @@ namespace ranges
                 struct prev_fun
                 {
                     cursor *pos;
-                    template<typename I>
+                    template<typename I,
+                        CONCEPT_REQUIRES_(BidirectionalIterator<I>())>
                     void operator()(indexed_element<I, 0> it) const
                     {
                         RANGES_ASSERT(it.get() != begin(std::get<0>(pos->rng_->rngs_)));
                         --it.get();
                     }
-                    template<typename I, std::size_t N>
+                    template<typename I, std::size_t N,
+                        CONCEPT_REQUIRES_(N != 0 && BidirectionalIterator<I>())>
                     void operator()(indexed_element<I, N> it) const
                     {
                         if(it.get() == begin(std::get<N>(pos->rng_->rngs_)))
@@ -161,12 +165,14 @@ namespace ranges
                 {
                     cursor *pos;
                     difference_type n;
-                    template<typename I>
+                    template<typename I,
+                        CONCEPT_REQUIRES_(RandomAccessIterator<I>())>
                     void operator()(indexed_element<I, cranges - 1> it) const
                     {
                         ranges::advance(it.get(), n);
                     }
-                    template<typename I, std::size_t N>
+                    template<typename I, std::size_t N,
+                        CONCEPT_REQUIRES_(RandomAccessIterator<I>())>
                     void operator()(indexed_element<I, N> it) const
                     {
                         auto end = ranges::end(std::get<N>(pos->rng_->rngs_));
@@ -184,12 +190,14 @@ namespace ranges
                 {
                     cursor *pos;
                     difference_type n;
-                    template<typename I>
+                    template<typename I,
+                        CONCEPT_REQUIRES_(RandomAccessIterator<I>())>
                     void operator()(indexed_element<I, 0> it) const
                     {
                         ranges::advance(it.get(), n);
                     }
-                    template<typename I, std::size_t N>
+                    template<typename I, std::size_t N,
+                        CONCEPT_REQUIRES_(RandomAccessIterator<I>())>
                     void operator()(indexed_element<I, N> it) const
                     {
                         auto begin = ranges::begin(std::get<N>(pos->rng_->rngs_));
@@ -210,7 +218,7 @@ namespace ranges
                 };
                 [[noreturn]] static difference_type distance_to_(meta::size_t<cranges>, cursor const &, cursor const &)
                 {
-                    RANGES_ENSURE(false);
+                    RANGES_EXPECT(false);
                 }
                 template<std::size_t N>
                 static difference_type distance_to_(meta::size_t<N>, cursor const &from, cursor const &to)

--- a/include/range/v3/view/drop_while.hpp
+++ b/include/range/v3/view/drop_while.hpp
@@ -43,7 +43,7 @@ namespace ranges
         private:
             friend range_access;
             Rng rng_;
-            semiregular_t<function_type<Pred>> pred_;
+            semiregular_t<Pred> pred_;
             detail::non_propagating_cache<range_iterator_t<Rng>> begin_;
 
             range_iterator_t<Rng> get_begin_()
@@ -55,7 +55,7 @@ namespace ranges
         public:
             drop_while_view() = default;
             drop_while_view(Rng rng, Pred pred)
-              : rng_(std::move(rng)), pred_(as_function(std::move(pred)))
+              : rng_(std::move(rng)), pred_(std::move(pred))
             {}
             range_iterator_t<Rng> begin()
             {
@@ -91,7 +91,7 @@ namespace ranges
                 template<typename Rng, typename Pred>
                 using Concept = meta::and_<
                     InputRange<Rng>,
-                    IndirectCallablePredicate<Pred, range_iterator_t<Rng>>>;
+                    IndirectPredicate<Pred, range_iterator_t<Rng>>>;
 
                 template<typename Rng, typename Pred,
                     CONCEPT_REQUIRES_(Concept<Rng, Pred>())>
@@ -108,7 +108,7 @@ namespace ranges
                     CONCEPT_ASSERT_MSG(InputRange<Rng>(),
                         "The first argument to view::drop_while must be a model of the "
                         "InputRange concept");
-                    CONCEPT_ASSERT_MSG(IndirectCallablePredicate<Pred, range_iterator_t<Rng>>(),
+                    CONCEPT_ASSERT_MSG(IndirectPredicate<Pred, range_iterator_t<Rng>>(),
                         "The second argument to view::drop_while must be callable with "
                         "an argument of the range's common reference type, and its return value "
                         "must be convertible to bool");

--- a/include/range/v3/view/filter.hpp
+++ b/include/range/v3/view/filter.hpp
@@ -32,7 +32,7 @@ namespace ranges
                 operator()(Rng && rng, Pred pred) const
                 {
                     CONCEPT_ASSERT(Range<Rng>());
-                    CONCEPT_ASSERT(IndirectCallablePredicate<Pred, range_iterator_t<Rng>>());
+                    CONCEPT_ASSERT(IndirectPredicate<Pred, range_iterator_t<Rng>>());
                     return {all(std::forward<Rng>(rng)), not_fn(std::move(pred))};
                 }
                 template<typename Pred>

--- a/include/range/v3/view/for_each.hpp
+++ b/include/range/v3/view/for_each.hpp
@@ -60,8 +60,8 @@ namespace ranges
                 template<typename Rng, typename F>
                 using Concept = meta::and_<
                     Range<Rng>,
-                    IndirectCallable<F, range_iterator_t<Rng>>,
-                    Range<concepts::Callable::result_t<F, range_common_reference_t<Rng>>>>;
+                    IndirectInvocable<F, range_iterator_t<Rng>>,
+                    Range<concepts::Invocable::result_t<F&, range_common_reference_t<Rng>>>>;
 
                 template<typename Rng, typename F,
                     CONCEPT_REQUIRES_(Concept<Rng, F>())>
@@ -78,10 +78,10 @@ namespace ranges
                 {
                     CONCEPT_ASSERT_MSG(Range<Rng>(),
                         "Rng is not a model of the Range concept.");
-                    CONCEPT_ASSERT_MSG(IndirectCallable<F, range_iterator_t<Rng>>(),
+                    CONCEPT_ASSERT_MSG(IndirectInvocable<F, range_iterator_t<Rng>>(),
                         "The function F is not callable with arguments of the type of the range's "
                         "common reference type.");
-                    CONCEPT_ASSERT_MSG(Range<concepts::Callable::result_t<F,
+                    CONCEPT_ASSERT_MSG(Range<concepts::Invocable::result_t<F&,
                         range_common_reference_t<Rng>>>(),
                         "To use view::for_each, the function F must return a model of the Range "
                         "concept.");
@@ -154,7 +154,7 @@ namespace ranges
             template<typename F>
             generate_n_view<F> operator()(bool b, F f) const
             {
-                CONCEPT_ASSERT(Function<F>());
+                CONCEPT_ASSERT(Invocable<F&>());
                 return view::generate_n(std::move(f), b ? 1 : 0);
             }
         };
@@ -166,10 +166,9 @@ namespace ranges
 
         /// \cond
         template<typename Rng, typename Fun,
-            typename Result = concepts::Function::result_t<Fun, range_common_reference_t<Rng>>,
-            CONCEPT_REQUIRES_(Range<Rng>() &&
-                              Function<Fun, range_common_reference_t<Rng>>() &&
-                              Range<Result>())>
+            CONCEPT_REQUIRES_(Range<Rng>() && CopyConstructible<Fun>() &&
+                Invocable<Fun&, range_common_reference_t<Rng>>() &&
+                Range<result_of_t<Fun&(range_common_reference_t<Rng>)>>())>
         auto operator >>= (Rng && rng, Fun fun) ->
             decltype(view::for_each(std::forward<Rng>(rng), std::move(fun)))
         {

--- a/include/range/v3/view/map.hpp
+++ b/include/range/v3/view/map.hpp
@@ -74,7 +74,8 @@ namespace ranges
             };
 
             template<typename T>
-            using PairLike = meta::and_<Function<get_first, T>, Function<get_second, T>>;
+            using PairLike = meta::and_<
+                Invocable<get_first const&, T>, Invocable<get_second const&, T>>;
         }
         /// \endcond
 
@@ -87,7 +88,7 @@ namespace ranges
                 template<typename Rng>
                 using Concept = meta::and_<
                     InputRange<Rng>,
-                    detail::PairLike<range_value_t<Rng>>>;
+                    detail::PairLike<range_reference_t<Rng>>>;
 
                 template<typename Rng,
                     CONCEPT_REQUIRES_(Concept<Rng>())>
@@ -102,7 +103,7 @@ namespace ranges
                 {
                     CONCEPT_ASSERT_MSG(InputRange<Rng>(),
                         "The argument of view::keys must be a model of the InputRange concept.");
-                    CONCEPT_ASSERT_MSG(detail::PairLike<range_value_t<Rng>>(),
+                    CONCEPT_ASSERT_MSG(detail::PairLike<range_reference_t<Rng>>(),
                         "The value type of the range passed to view::keys must look like a std::pair; "
                         "That is, it must have first and second data members.");
                 }
@@ -114,7 +115,7 @@ namespace ranges
                 template<typename Rng>
                 using Concept = meta::and_<
                     InputRange<Rng>,
-                    detail::PairLike<range_value_t<Rng>>>;
+                    detail::PairLike<range_reference_t<Rng>>>;
 
                 template<typename Rng,
                     CONCEPT_REQUIRES_(Concept<Rng>())>
@@ -129,7 +130,7 @@ namespace ranges
                 {
                     CONCEPT_ASSERT_MSG(InputRange<Rng>(),
                         "The argument of view::values must be a model of the InputRange concept.");
-                    CONCEPT_ASSERT_MSG(detail::PairLike<range_value_t<Rng>>(),
+                    CONCEPT_ASSERT_MSG(detail::PairLike<range_reference_t<Rng>>(),
                         "The value type of the range passed to view::values must look like a std::pair; "
                         "That is, it must have first and second data members.");
                 }

--- a/include/range/v3/view/remove_if.hpp
+++ b/include/range/v3/view/remove_if.hpp
@@ -47,7 +47,7 @@ namespace ranges
         {
         private:
             friend range_access;
-            semiregular_t<function_type<Pred>> pred_;
+            semiregular_t<Pred> pred_;
             detail::non_propagating_cache<range_iterator_t<Rng>> begin_;
 
             struct adaptor
@@ -82,8 +82,8 @@ namespace ranges
                 CONCEPT_REQUIRES(BidirectionalRange<Rng>())
                 void prev(range_iterator_t<Rng> &it) const
                 {
-                    auto &&pred = rng_->pred_;
-                    do --it; while(pred(*it));
+                    auto &pred = rng_->pred_;
+                    do --it; while(invoke(pred, *it));
                 }
                 void advance() = delete;
                 void distance_to() = delete;
@@ -102,7 +102,7 @@ namespace ranges
             remove_if_view() = default;
             remove_if_view(Rng rng, Pred pred)
               : remove_if_view::view_adaptor{std::move(rng)}
-              , pred_(as_function(std::move(pred)))
+              , pred_(std::move(pred))
             {}
         };
 
@@ -122,7 +122,7 @@ namespace ranges
                 template<typename Rng, typename Pred>
                 using Concept = meta::and_<
                     InputRange<Rng>,
-                    IndirectCallablePredicate<Pred, range_iterator_t<Rng>>>;
+                    IndirectPredicate<Pred, range_iterator_t<Rng>>>;
 
                 template<typename Rng, typename Pred,
                     CONCEPT_REQUIRES_(Concept<Rng, Pred>())>
@@ -139,7 +139,7 @@ namespace ranges
                     CONCEPT_ASSERT_MSG(InputRange<Rng>(),
                         "The first argument to view::remove_if must be a model of the "
                         "InputRange concept");
-                    CONCEPT_ASSERT_MSG(IndirectCallablePredicate<Pred, range_iterator_t<Rng>>(),
+                    CONCEPT_ASSERT_MSG(IndirectPredicate<Pred, range_iterator_t<Rng>>(),
                         "The second argument to view::remove_if must be callable with "
                         "a value of the range, and the return type must be convertible "
                         "to bool");

--- a/include/range/v3/view/replace.hpp
+++ b/include/range/v3/view/replace.hpp
@@ -48,8 +48,12 @@ namespace ranges
                 {}
 
                 template<typename I>
+                [[noreturn]]
                 common_type_t<decay_t<unwrap_reference_t<Val2 const &>>, iterator_value_t<I>> &
-                operator()(copy_tag, I const &i) const;
+                operator()(copy_tag, I const &) const
+                {
+                    RANGES_EXPECT(false);
+                }
 
                 template<typename I>
                 common_reference_t<unwrap_reference_t<Val2 const &>, iterator_reference_t<I>>

--- a/include/range/v3/view/view.hpp
+++ b/include/range/v3/view/view.hpp
@@ -83,7 +83,7 @@ namespace ranges
                 friend pipeable_access;
 
                 template<typename Rng, typename ...Rest>
-                using ViewConcept = meta::and_<ViewableRange<Rng>, Function<View, Rng, Rest...>>;
+                using ViewConcept = meta::and_<ViewableRange<Rng>, Invocable<View&, Rng, Rest...>>;
 
                 // Pipeing requires range arguments or lvalue containers.
                 template<typename Rng, typename Vw,
@@ -103,7 +103,7 @@ namespace ranges
                         "The type Rng must be a model of the Range concept.");
                     // BUGBUG This isn't a very helpful message. This is probably the wrong place
                     // to put this check:
-                    CONCEPT_ASSERT_MSG(Function<View, Rng>(),
+                    CONCEPT_ASSERT_MSG(Invocable<View&, Rng>(),
                         "This view is not callable with this range type.");
                     static_assert(ranges::View<Rng>() || std::is_lvalue_reference<Rng>(),
                         "You can't pipe an rvalue container into a view. First, save the container into "

--- a/include/range/v3/view/zip.hpp
+++ b/include/range/v3/view/zip.hpp
@@ -39,8 +39,11 @@ namespace ranges
                 // tuple value
                 template<typename ...Its,
                     CONCEPT_REQUIRES_(meta::and_<Readable<Its>...>() && sizeof...(Its) != 2)>
-                auto operator()(copy_tag, Its...) const ->
-                    std::tuple<iterator_value_t<Its>...>;
+                [[noreturn]] auto operator()(copy_tag, Its...) const ->
+                    std::tuple<iterator_value_t<Its>...>
+                {
+                    RANGES_EXPECT(false);
+                }
 
                 // tuple reference
                 template<typename ...Its,
@@ -66,8 +69,11 @@ namespace ranges
                 // pair value
                 template<typename It1, typename It2,
                     CONCEPT_REQUIRES_(Readable<It1>() && Readable<It2>())>
-                auto operator()(copy_tag, It1, It2) const ->
-                    std::pair<iterator_value_t<It1>, iterator_value_t<It2>>;
+                [[noreturn]] auto operator()(copy_tag, It1, It2) const ->
+                    std::pair<iterator_value_t<It1>, iterator_value_t<It2>>
+                {
+                    RANGES_EXPECT(false);
+                }
 
                 // pair reference
                 template<typename It1, typename It2,

--- a/test/algorithm/equal_range.cpp
+++ b/test/algorithm/equal_range.cpp
@@ -56,26 +56,25 @@ test(Iter first, Sent last, const T& value, Proj proj = Proj{})
 {
     ranges::iterator_range<Iter, Iter> i =
         ranges::equal_range(first, last, value, ranges::ordered_less{}, proj);
-    auto p = ranges::as_function(proj);
     for (Iter j = first; j != i.begin(); ++j)
-        CHECK(p(*j) < value);
+        CHECK(ranges::invoke(proj, *j) < value);
     for (Iter j = i.begin(); j != last; ++j)
-        CHECK(!(p(*j) < value));
+        CHECK(!(ranges::invoke(proj, *j) < value));
     for (Iter j = first; j != i.end(); ++j)
-        CHECK(!(value < p(*j)));
+        CHECK(!(value < ranges::invoke(proj, *j)));
     for (Iter j = i.end(); j != last; ++j)
-        CHECK(value < p(*j));
+        CHECK(value < ranges::invoke(proj, *j));
 
     auto res = ranges::equal_range(
         ranges::make_iterator_range(first, last), value, ranges::ordered_less{}, proj);
     for (Iter j = first; j != res.get_unsafe().begin(); ++j)
-        CHECK(p(*j) < value);
+        CHECK(ranges::invoke(proj, *j) < value);
     for (Iter j = res.get_unsafe().begin(); j != last; ++j)
-        CHECK(!(p(*j) < value));
+        CHECK(!(ranges::invoke(proj, *j) < value));
     for (Iter j = first; j != res.get_unsafe().end(); ++j)
-        CHECK(!(value < p(*j)));
+        CHECK(!(value < ranges::invoke(proj, *j)));
     for (Iter j = res.get_unsafe().end(); j != last; ++j)
-        CHECK(value < p(*j));
+        CHECK(value < ranges::invoke(proj, *j));
 }
 
 template <class Iter, class Sent = Iter>

--- a/test/algorithm/for_each.cpp
+++ b/test/algorithm/for_each.cpp
@@ -26,24 +26,24 @@ int main()
     int sum = 0;
     auto fun = [&](int i){sum += i; };
     std::vector<int> v1 { 0, 2, 4, 6 };
-    CHECK(ranges::for_each(v1.begin(), v1.end(), fun) == v1.end());
-    CHECK(ranges::for_each(v1, fun) == v1.end());
+    CHECK(ranges::for_each(v1.begin(), v1.end(), fun).in() == v1.end());
+    CHECK(ranges::for_each(v1, fun).in() == v1.end());
     CHECK(sum == 24);
 
     sum = 0;
     auto rfun = [&](int & i){sum += i; };
-    CHECK(ranges::for_each(v1.begin(), v1.end(), rfun) == v1.end());
-    CHECK(ranges::for_each(v1, rfun) == v1.end());
+    CHECK(ranges::for_each(v1.begin(), v1.end(), rfun).in() == v1.end());
+    CHECK(ranges::for_each(v1, rfun).in() == v1.end());
     CHECK(sum == 24);
 
     sum = 0;
     std::vector<S> v2{{&sum, 0}, {&sum, 2}, {&sum, 4}, {&sum, 6}};
-    CHECK(ranges::for_each(v2.begin(), v2.end(), &S::p) == v2.end());
-    CHECK(ranges::for_each(v2, &S::p) == v2.end());
+    CHECK(ranges::for_each(v2.begin(), v2.end(), &S::p).in() == v2.end());
+    CHECK(ranges::for_each(v2, &S::p).in() == v2.end());
     CHECK(sum == 24);
 
     sum = 0;
-    CHECK(ranges::for_each(ranges::make_iterator_range(v1.begin(), v1.end()), fun).get_unsafe() == v1.end());
+    CHECK(ranges::for_each(ranges::make_iterator_range(v1.begin(), v1.end()), fun).in().get_unsafe() == v1.end());
     CHECK(sum == 12);
 
     return ::test_result();

--- a/test/utility/functional.cpp
+++ b/test/utility/functional.cpp
@@ -20,6 +20,11 @@
 #define GCC_4_8_WORKAROUND 1
 #endif
 
+CONCEPT_ASSERT(ranges::Constructible<ranges::reference_wrapper<int>, int&>());
+CONCEPT_ASSERT(!ranges::Constructible<ranges::reference_wrapper<int>, int&&>());
+CONCEPT_ASSERT(!ranges::Constructible<ranges::reference_wrapper<int, true>, int&>());
+CONCEPT_ASSERT(ranges::Constructible<ranges::reference_wrapper<int, true>, int&&>());
+
 namespace
 {
     struct Integer
@@ -135,12 +140,12 @@ int main()
 
 #ifdef _WIN32
     {
-        // Ensure that Callable accepts pointers to functions with non-default calling conventions.
-        CONCEPT_ASSERT(ranges::Callable<void(__cdecl*)()>());
-        CONCEPT_ASSERT(ranges::Callable<void(__stdcall*)()>());
-        CONCEPT_ASSERT(ranges::Callable<void(__fastcall*)()>());
-        CONCEPT_ASSERT(ranges::Callable<void(__thiscall*)()>());
-        CONCEPT_ASSERT(ranges::Callable<void(__vectorcall*)()>());
+        // Ensure that Invocable accepts pointers to functions with non-default calling conventions.
+        CONCEPT_ASSERT(ranges::Invocable<void(__cdecl*)()>());
+        CONCEPT_ASSERT(ranges::Invocable<void(__stdcall*)()>());
+        CONCEPT_ASSERT(ranges::Invocable<void(__fastcall*)()>());
+        CONCEPT_ASSERT(ranges::Invocable<void(__thiscall*)()>());
+        CONCEPT_ASSERT(ranges::Invocable<void(__vectorcall*)()>());
     }
 #endif // _WIN32
 


### PR DESCRIPTION
* Implement `invoke`, use it instead of `as_function` and `function_type`. Implement `result_of` in terms of `invoke`, use it in place of `std::result_of`. (Put `invoke`, `result_of`, and `reference_wrapper` in a separate invoke.hpp since functional.hpp is getting a bit enormous.)

* Make `Callable` & `IndirectCallable` concepts independent of `Function` concepts.

* Replace uses of `Function` family concepts with `Callable` family concepts.

* `reference_wrapper` updates:
  * Delete constructor from "wrong" value category
  * Use `invoke` in `operator()`

* Properly constrain `variant`'s `visit` and `emplace` functions.

* Remove (unused) stuff from functional.hpp:
  * `reference_of`
  * `function_type`
  * `as_function`
  * `Function` concept family

* Great `Callable` renaming:
  * Rename `Callable` => `Invocable`
  * `RegularCallable` => `RegularInvocable`
  * `CallablePredicate` => `Predicate`
  * `CallableRelation` => `Relation`
  * `IndirectCallable` => `IndirectInvocable`
  * `IndirectRegularCallable` => `IndirectRegularInvocable`
  * `IndirectCallablePredicate` => `IndirectPredicate`
  * `IndirectCallableRelation` => `IndirectRelation`

* Update `Callable` concepts to use perfect forwarding, and update uses correspondingly.

* Correct some algorithm return types:
  * `for_each`: return `tagged_pair` of `{end, fun}`
  * `adjacent_difference` and `partial_sum`: return `tagged_pair` instead of plain `std::pair`.
  * `iota`: return `range_safe_iterator_t<Rng`>

* `generate_view`:
  * Use `unreachable` instead of `default_sentinel`. (Seems a bit more idiomatic for an infinite range.)
  * Try to fully constrain all usage of the generator function's return type.
  * Reuse the `Concept` and "bad" overload of `operator()` in `generate_n_view`.
* `generate_n_view`:
  * Don't store the count in the iterators, instead update the count in the range.
