### PR TITLE
Fix swap_ranges:

### DIFF
--- a/include/range/v3/algorithm/swap_ranges.hpp
+++ b/include/range/v3/algorithm/swap_ranges.hpp
@@ -31,12 +31,11 @@ namespace ranges
         /// @{
         struct swap_ranges_fn
         {
-            template<typename I1Ref, typename S1, typename I2,
-                typename I1 = uncvref_t<I1Ref>,
+            template<typename I1, typename S1, typename I2,
                 CONCEPT_REQUIRES_(InputIterator<I1>() && Sentinel<S1, I1>() &&
-                                  InputIterator<I2>() &&
-                                  IndirectlySwappable<I1, I2>())>
-            tagged_pair<tag::in1(I1), tag::in2(I2)> operator()(I1Ref&& begin1, S1 end1, I2 begin2) const
+                    InputIterator<I2>() && IndirectlySwappable<I1, I2>())>
+            tagged_pair<tag::in1(I1), tag::in2(I2)>
+            operator()(I1 begin1, S1 end1, I2 begin2) const
             {
                 for(; begin1 != end1; ++begin1, ++begin2)
                     ranges::iter_swap(begin1, begin2);
@@ -45,33 +44,36 @@ namespace ranges
 
             template<typename I1, typename S1, typename I2, typename S2,
                 CONCEPT_REQUIRES_(InputIterator<I1>() && Sentinel<S1, I1>() &&
-                                  InputIterator<I2>() && Sentinel<S2, I2>() &&
-                                  IndirectlySwappable<I1, I2>())>
-            tagged_pair<tag::in1(I1), tag::in2(I2)> operator()(I1 begin1, S1 end1, I2 begin2, S2 end2) const
+                    InputIterator<I2>() && Sentinel<S2, I2>() &&
+                    IndirectlySwappable<I1, I2>())>
+            tagged_pair<tag::in1(I1), tag::in2(I2)>
+            operator()(I1 begin1, S1 end1, I2 begin2, S2 end2) const
             {
                 for(; begin1 != end1 && begin2 != end2; ++begin1, ++begin2)
                     ranges::iter_swap(begin1, begin2);
                 return {begin1, begin2};
             }
 
-            template<typename Rng1, typename I2,
+            template<typename Rng1, typename I2_,
                 typename I1 = range_iterator_t<Rng1>,
-                CONCEPT_REQUIRES_(InputRange<Rng1>() &&
-                                  InputIterator<I2>() &&
-                                  IndirectlySwappable<I1, I2>())>
-            tagged_pair<tag::in1(I1), tag::in2(I2)> operator()(Rng1 & rng1, I2 begin2) const
+                typename I2 = uncvref_t<I2_>,
+                CONCEPT_REQUIRES_(InputRange<Rng1>() && InputIterator<I2>() &&
+                    IndirectlySwappable<I1, I2>())>
+            tagged_pair<tag::in1(I1), tag::in2(I2)>
+            operator()(Rng1 && rng1, I2_ && begin2) const
             {
-                return (*this)(begin(rng1), end(rng1), std::move(begin2));
+                return (*this)(begin(rng1), end(rng1), (I2_ &&)begin2);
             }
 
             template<typename Rng1, typename Rng2,
                 typename I1 = range_iterator_t<Rng1>,
                 typename I2 = range_iterator_t<Rng2>,
-                CONCEPT_REQUIRES_(InputRange<Rng1>() &&
-                                  InputRange<Rng2>() &&
-                                  IndirectlySwappable<I1, I2>())>
-            tagged_pair<tag::in1(range_safe_iterator_t<Rng1>), tag::in2(range_safe_iterator_t<Rng2>)>
-            operator()(Rng1 &&rng1, Rng2 &&rng2) const
+                CONCEPT_REQUIRES_(InputRange<Rng1>() && InputRange<Rng2>() &&
+                    IndirectlySwappable<I1, I2>())>
+            tagged_pair<
+                tag::in1(range_safe_iterator_t<Rng1>),
+                tag::in2(range_safe_iterator_t<Rng2>)>
+            operator()(Rng1 && rng1, Rng2 && rng2) const
             {
                 return (*this)(begin(rng1), end(rng1), begin(rng2), end(rng2));
             }

--- a/test/algorithm/swap_ranges.cpp
+++ b/test/algorithm/swap_ranges.cpp
@@ -18,6 +18,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <array>
 #include <memory>
 #include <algorithm>
 #include <range/v3/core.hpp>
@@ -227,6 +228,16 @@ int main()
     test_move_only<std::unique_ptr<int>*, bidirectional_iterator<std::unique_ptr<int>*> >();
     test_move_only<std::unique_ptr<int>*, random_access_iterator<std::unique_ptr<int>*> >();
     test_move_only<std::unique_ptr<int>*, std::unique_ptr<int>*>();
+
+    {
+        int a[4] = {1, 2, 3, 4};
+        int b[4] = {5, 6, 7, 8};
+        ranges::swap_ranges(a, a + 4, b);
+        ::check_equal(a, {5, 6, 7, 8});
+        ::check_equal(b, {1, 2, 3, 4});
+        ranges::swap_ranges(std::array<int, 2>{{3,4}}, a+2);
+        ::check_equal(a, {5, 6, 3, 4});
+    }
 
     return ::test_result();
 }


### PR DESCRIPTION
* `swap_ranges(a, a+n, b)` should work for array `a` & `b`
* `swap_ranges(a, b)` should work for rvalue `a` and iterator `b`
