### PR TITLE
Eradicate concepts::val and concepts::val_t

### DIFF
--- a/include/range/v3/action/erase.hpp
+++ b/include/range/v3/action/erase.hpp
@@ -82,13 +82,11 @@ namespace ranges
               : refines<Range(_1)>
             {
                 template<typename Rng, typename...Rest>
-                using result_t = decltype(ranges::erase(val<Rng>(), val<Rest>()...));
+                using result_t = decltype(ranges::erase(std::declval<Rng&>(), std::declval<Rest>()...));
 
                 template<typename Rng, typename...Rest>
-                auto requires_(Rng&&, Rest&&...) -> decltype(
-                    concepts::valid_expr(
-                        ((void)ranges::erase(val<Rng>(), val<Rest>()...), 42)
-                    ));
+                auto requires_(Rng &&, Rest &&...) ->
+                    meta::void_<result_t<Rng, Rest...>>;
             };
         }
 

--- a/include/range/v3/action/push_back.hpp
+++ b/include/range/v3/action/push_back.hpp
@@ -59,13 +59,13 @@ namespace ranges
                 struct ConceptImpl
                 {
                     template<typename Rng, typename T>
-                    auto requires_(Rng&& rng, T&&) -> decltype(
+                    auto requires_(Rng && rng, T &&) -> decltype(
                         concepts::valid_expr(
                             concepts::model_of<concepts::InputRange, Rng>(),
                             concepts::is_true(meta::or_<
-                                Constructible<range_value_t<Rng>, T &&>,
-                                Range<T &&>>()),
-                            ((void)push_back(rng, concepts::val<T>()), 42)
+                                Constructible<range_value_t<Rng>, T>,
+                                Range<T>>()),
+                            ((void)push_back(rng, std::declval<T>()), 42)
                         ));
                 };
 
@@ -89,8 +89,8 @@ namespace ranges
                         "The object on which action::push_back operates must be a model of the "
                         "InputRange concept.");
                     CONCEPT_ASSERT_MSG(meta::or_<
-                        Constructible<range_value_t<Rng>, T &&>,
-                        Range<T &&>>(),
+                        Constructible<range_value_t<Rng>, T>,
+                        Range<T>>(),
                         "The object to be inserted with action::push_back must either be "
                         "convertible to the range's value type, or else it must be a range "
                         "of elements that are convertible to the range's value type.");

--- a/include/range/v3/action/push_front.hpp
+++ b/include/range/v3/action/push_front.hpp
@@ -59,13 +59,13 @@ namespace ranges
                 struct ConceptImpl
                 {
                     template<typename Rng, typename T>
-                    auto requires_(Rng&& rng, T&&) -> decltype(
+                    auto requires_(Rng && rng, T &&) -> decltype(
                         concepts::valid_expr(
                             concepts::model_of<concepts::InputRange, Rng>(),
                             concepts::is_true(meta::or_<
-                                Constructible<range_value_t<Rng>, T &&>,
-                                Range<T &&>>()),
-                            ((void)push_front(rng, concepts::val<T>()), 42)
+                                Constructible<range_value_t<Rng>, T>,
+                                Range<T>>()),
+                            ((void)push_front(rng, std::declval<T>()), 42)
                         ));
                 };
 
@@ -89,8 +89,8 @@ namespace ranges
                         "The object on which action::push_front operates must be a model of the "
                         "InputRange concept.");
                     CONCEPT_ASSERT_MSG(meta::or_<
-                        Constructible<range_value_t<Rng>, T &&>,
-                        Range<T &&>>(),
+                        Constructible<range_value_t<Rng>, T>,
+                        Range<T>>(),
                         "The object to be inserted with action::push_front must either be "
                         "convertible to the range's value type, or else it must be a range "
                         "of elements that are convertible to the range's value type.");

--- a/include/range/v3/range_concepts.hpp
+++ b/include/range/v3/range_concepts.hpp
@@ -175,13 +175,13 @@ namespace ranges
               : refines<Range>
             {
                 template<typename T>
-                using size_t = decltype(size(val<T>()));
+                using size_t = decltype(size(std::declval<T&>()));
 
                 template<typename T>
-                auto requires_(T&& t) -> decltype(
+                auto requires_(T && t) -> decltype(
                     concepts::valid_expr(
                         concepts::is_false(disable_sized_range<uncvref_t<T>>()),
-                        size(t)
+                        concepts::model_of<Integral>(size(t))
                     ));
             };
 

--- a/include/range/v3/utility/concepts.hpp
+++ b/include/range/v3/utility/concepts.hpp
@@ -47,11 +47,6 @@ namespace ranges
             {
                 template<typename ...T>
                 void operator()(T &&...) const;
-
-            #if defined(__GNUC__) && !defined(__clang__)
-                template<typename ...T>
-                void operator()(T const &...) const;
-            #endif
             } valid_expr {};
 
             constexpr struct same_type_t
@@ -171,12 +166,6 @@ namespace ranges
             using _7 = std::integral_constant<int, 6>;
             using _8 = std::integral_constant<int, 7>;
             using _9 = std::integral_constant<int, 8>;
-
-            template<typename T>
-            using val_t = meta::if_<std::is_rvalue_reference<T>, T, T &>;
-
-            template<typename T>
-            val_t<T> val();
 
             template<typename Ret, typename T>
             Ret returns_(T const &);
@@ -304,8 +293,8 @@ namespace ranges
                 auto requires_(T &&, U &&) -> decltype(
                     concepts::valid_expr(
                         concepts::model_of<Same, C, reference_t<U, T>>(),
-                        C(val<T>()),
-                        C(val<U>())
+                        ((void)C(std::declval<T>()), 42),
+                        ((void)C(std::declval<U>()), 42)
                     ));
 
                 template<typename T, typename U, typename...Rest,
@@ -335,8 +324,8 @@ namespace ranges
                 auto requires_(T &&, U &&) -> decltype(
                     concepts::valid_expr(
                         concepts::model_of<Same, C, value_t<U, T>>(),
-                        C(val<T &&>()),
-                        C(val<U &&>()),
+                        ((void)C(std::declval<T>()), 42),
+                        ((void)C(std::declval<U>()), 42),
                         concepts::model_of<CommonReference, T const &, U const &>(),
                         concepts::model_of<CommonReference, C &, R &&>()
                     ));
@@ -490,8 +479,8 @@ namespace ranges
                 template<typename T, typename U>
                 auto requires_(T &&, U &&) -> decltype(
                     concepts::valid_expr(
-                        concepts::model_of<TotallyOrdered>(val<T>()),
-                        concepts::model_of<TotallyOrdered>(val<U>())
+                        concepts::model_of<TotallyOrdered, T>(),
+                        concepts::model_of<TotallyOrdered, U>()
                     ));
             };
 
@@ -522,7 +511,7 @@ namespace ranges
                     meta::if_<detail::avoid_empty_braces<T>, int> = 0>
                 auto requires_(T &&) -> decltype(
                     concepts::valid_expr(
-                        T(),
+                        ((void)T(), 42),
                         new T()
                     ));
 
@@ -530,7 +519,7 @@ namespace ranges
                     meta::if_c<!detail::avoid_empty_braces<T>::value, int> = 0>
                 auto requires_(T &&) -> decltype(
                     concepts::valid_expr(
-                        T{},
+                        ((void)T{}, 42),
                         new T{}
                     ));
 
@@ -551,7 +540,7 @@ namespace ranges
                     meta::if_<DR1467<T, U>, int> = 0>
                 auto requires_(T &&, U &&) -> decltype(
                     concepts::valid_expr(
-                        T(std::declval<U>()),
+                        ((void)T(std::declval<U>()), 42),
                         new T(std::declval<U>())
                     ));
 
@@ -559,14 +548,14 @@ namespace ranges
                     meta::if_c<!DR1467<T, U>::value, int> = 0>
                 auto requires_(T &&, U &&) -> decltype(
                     concepts::valid_expr(
-                        T{std::declval<U>()},
+                        ((void)T{std::declval<U>()}, 42),
                         new T{std::declval<U>()}
                     ));
 
                 template<typename T, typename U, typename V, typename... Args>
                 auto requires_(T &&, U &&, V &&, meta::id_t<Args> &&...) -> decltype(
                     concepts::valid_expr(
-                        T{std::declval<U>(), std::declval<V>(), std::declval<Args>()...},
+                        ((void)T{std::declval<U>(), std::declval<V>(), std::declval<Args>()...}, 42),
                         new T{std::declval<U>(), std::declval<V>(), std::declval<Args>()...}
                     ));
             };

--- a/include/range/v3/utility/iterator_concepts.hpp
+++ b/include/range/v3/utility/iterator_concepts.hpp
@@ -169,9 +169,9 @@ namespace ranges
               : refines<Movable(_1), DefaultConstructible(_1)>
             {
                 template<typename Out, typename T>
-                auto requires_(Out&& o, T&&) -> decltype(
+                auto requires_(Out && o, T && t) -> decltype(
                     concepts::valid_expr(
-                        *o = val<T>()
+                        ((void)(*(Out &&)o = (T &&)t), 42)
                     ));
             };
 
@@ -233,10 +233,10 @@ namespace ranges
                     concepts::valid_expr(
                         concepts::model_of<Readable, I1>(),
                         concepts::model_of<Readable, I2>(),
-                        (ranges::indirect_swap(i1, i2), 42),
-                        (ranges::indirect_swap(i1, i1), 42),
-                        (ranges::indirect_swap(i2, i2), 42),
-                        (ranges::indirect_swap(i2, i1), 42)
+                        ((void)ranges::indirect_swap(i1, i2), 42),
+                        ((void)ranges::indirect_swap(i1, i1), 42),
+                        ((void)ranges::indirect_swap(i2, i2), 42),
+                        ((void)ranges::indirect_swap(i2, i1), 42)
                     ));
             };
 
@@ -272,7 +272,7 @@ namespace ranges
                 template<typename I>
                 auto requires_(I&& i) -> decltype(
                     concepts::valid_expr(
-                        *i
+                        ((void)*i, 42)
                     ));
             };
 


### PR DESCRIPTION
Also turn some instances of `<expression>` into `((void)(<expression>), 42)` in concept definitions when `<expression>` has user-defined type and could hijack the comma operator.