### PR TITLE
Clang/C2 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Supported Compilers
 
 The code is known to work on the following compilers:
 
-- clang 3.5.2
-- GCC 4.9.4 (C++14 support requires GCC 5.2; C++14 "extended constexpr" support is poor before 6.1.)
-- VS2015 Update 3 "Clang with Microsoft CodeGen" (Clang/C2)
+- clang 3.6.2 (or later)
+- GCC 4.9.4 (or later) (C++14 support requires GCC 5.2; C++14 "extended constexpr" support is poor before 6.1.)
+- "Clang with Microsoft CodeGen" (Clang/C2) VS2015 Update 3 (or later)
 
 **Development Status:** This code is fairly stable, well-tested, and suitable for casual use, although currently lacking documentation. No promise is made about support or long-term stability. This code *will* evolve without regard to backwards compatibility.
 
@@ -87,7 +87,7 @@ Release Notes:
     | `range_sentinel_t`            | `sentinel_t`              |
   - `common_iterator` now requires that its two types (`Iterator` and `Sentinel`)
     are different. Use `common_iterator_t<I, S>` to get the old behavior (i.e., if the two types are the same, it is an alias for `I`; otherwise, it is
-    `common_iterator<I, S>`). 
+    `common_iterator<I, S>`).
   - The following iterator adaptors now work with iterators that return proxies
     from their dereference operator (i.e., `operator*`):
     * `common_iterator`
@@ -120,7 +120,7 @@ Release Notes:
 * **0.1.1**
   Small tweak to `Writable` concept to fix #537.
 * **0.1.0**
-  March 8, 2017, Begin semantic versioning 
+  March 8, 2017, Begin semantic versioning
 
 Say Thanks!
 -----------

--- a/include/range/v3/utility/swap.hpp
+++ b/include/range/v3/utility/swap.hpp
@@ -188,7 +188,8 @@ namespace ranges
 
             template<typename T, typename U>
             struct is_nothrow_swappable_with_
-              : meta::bool_<noexcept(swap_fn{}(std::declval<T>(), std::declval<U>()))>
+              : meta::bool_<noexcept(swap_fn{}(std::declval<T>(), std::declval<U>())) &&
+                            noexcept(swap_fn{}(std::declval<U>(), std::declval<T>()))>
             {};
 
             // Q: Should std::reference_wrapper be considered a proxy wrt swapping rvalues?

--- a/include/range/v3/utility/tagged_pair.hpp
+++ b/include/range/v3/utility/tagged_pair.hpp
@@ -121,17 +121,17 @@ namespace ranges
                     static_cast<Base &>(*this) = std::forward<U>(u);
                     return *this;
                 }
-                template<int dummy_ = 42>
-                RANGES_CXX14_CONSTEXPR meta::if_c<dummy_ == 43 || is_swappable<Base>::value>
+                template<typename B = Base>
+                RANGES_CXX14_CONSTEXPR meta::if_c<is_swappable<B>::value>
                 swap(tagged &that)
-                    noexcept(is_nothrow_swappable<Base>::value)
+                    noexcept(is_nothrow_swappable<B>::value)
                 {
                     ranges::swap(static_cast<Base &>(*this), static_cast<Base &>(that));
                 }
-                template<int dummy_ = 42>
-                friend RANGES_CXX14_CONSTEXPR meta::if_c<dummy_ == 43 || is_swappable<Base>::value>
+                template<typename B = Base>
+                friend RANGES_CXX14_CONSTEXPR meta::if_c<is_swappable<B>::value>
                 swap(tagged &x, tagged &y)
-                    noexcept(is_nothrow_swappable<Base>::value)
+                    noexcept(is_nothrow_swappable<B>::value)
                 {
                     x.swap(y);
                 }

--- a/test/utility/concepts.cpp
+++ b/test/utility/concepts.cpp
@@ -78,8 +78,6 @@ struct IntSwappable
     friend void swap(IntSwappable, IntSwappable);
 };
 
-struct incomplete;
-
 static_assert(ranges::Destructible<int>(), "");
 static_assert(ranges::Destructible<const int>(), "");
 static_assert(!ranges::Destructible<void>(), "");
@@ -94,7 +92,6 @@ static_assert(ranges::Destructible<int(&)[2]>(), "");
 static_assert(ranges::Destructible<moveonly>(), "");
 static_assert(ranges::Destructible<nonmovable>(), "");
 static_assert(!ranges::Destructible<NotDestructible>(), "");
-static_assert(!ranges::Destructible<incomplete>(), "");
 
 static_assert(ranges::Constructible<int>(), "");
 static_assert(ranges::Constructible<int const>(), "");

--- a/test/utility/scope_exit.cpp
+++ b/test/utility/scope_exit.cpp
@@ -13,10 +13,7 @@
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 
-#ifdef __GNUC__
-RANGES_DIAGNOSTIC_IGNORE_PRAGMAS
-#pragma GCC diagnostic ignored "-Wunneeded-member-function"
-#endif
+RANGES_DIAGNOSTIC_IGNORE_UNNEEDED_MEMBER
 
 namespace
 {


### PR DESCRIPTION
Clang/C2 warns on unneeded members - as do all clangs - and doesn't define `__GNUC__`; use `RANGES_DIAGNOSTIC_IGNORE_UNNEEDED_MEMBER` to disable the warning.

Don't check `is_nothrow_destructible` with an incomplete type.

Drive-by: `is_nothrow_swappable` is specified to symmetrically check both `noexcept(swap(a, b)) and noexcept(swap(b, a))`

Don't instantiation `is_swappable<Base>` in `tagged` when the class is instantiated. (VC++ apparently doesn't constrain `pair`'s assignment operator.)