### PR TITLE
[breaking change] view::ints(N) returns [0, N) instead of [N, ...)

### DIFF
--- a/include/range/v3/view/iota.hpp
+++ b/include/range/v3/view/iota.hpp
@@ -488,17 +488,23 @@ namespace ranges
             {
                 ints_fn() = default;
 
-                template<typename Val,
-                    CONCEPT_REQUIRES_(Integral<Val>())>
-                iota_view<Val> operator()(Val value) const
-                {
-                    return iota_view<Val>{value};
-                }
                 template<typename Val>
                 meta::if_c<
                     (bool)Integral<Val>(),
                     detail::take_exactly_view_<iota_view<Val>, true>>
-                operator()(Val from, Val to) const;
+                operator()(Val from, Val to) const
+                {
+                    return {iota_view<Val>{from}, detail::iota_minus_(to, from)};
+                }
+
+                template<typename Val,
+                    CONCEPT_REQUIRES_(Integral<Val>())>
+                auto operator()(Val to) const
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                (
+                    (*this)(Val(), to)
+                )
+
 
             #ifndef RANGES_DOXYGEN_INVOKED
                 template<typename Val,
@@ -518,15 +524,6 @@ namespace ranges
             #endif
             };
 
-            template<typename Val>
-            meta::if_c<
-                (bool)Integral<Val>(),
-                detail::take_exactly_view_<iota_view<Val>, true>>
-            ints_fn::operator()(Val from, Val to) const
-            {
-                return {iota_view<Val>{from}, detail::iota_minus_(to, from)};
-            }
-
             struct closed_ints_fn
             {
                 template<typename Val,
@@ -535,10 +532,26 @@ namespace ranges
                 {
                     return {iota_view<Val>{from}, detail::iota_minus_(to, from) + 1};
                 }
+
+                template<typename Val,
+                    CONCEPT_REQUIRES_(Integral<Val>())>
+                auto operator()(Val to) const
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                (
+                    (*this)(Val(), to)
+                )
+
             #ifndef RANGES_DOXYGEN_INVOKED
                 template<typename Val,
                     CONCEPT_REQUIRES_(!Integral<Val>())>
                 void operator()(Val, Val) const
+                {
+                    CONCEPT_ASSERT_MSG(Integral<Val>(),
+                        "The object passed to view::closed_ints must be Integral");
+                }
+                template<typename Val,
+                    CONCEPT_REQUIRES_(!Integral<Val>())>
+                void operator()(Val) const
                 {
                     CONCEPT_ASSERT_MSG(Integral<Val>(),
                         "The object passed to view::closed_ints must be Integral");

--- a/test/action/push_back.cpp
+++ b/test/action/push_back.cpp
@@ -26,10 +26,10 @@ int main()
         push_back(v, {1,2,3});
         ::check_equal(v, {1,2,3});
 
-        push_back(v, view::ints(10) | view::take(3));
+        push_back(v, view::iota(10) | view::take(3));
         ::check_equal(v, {1,2,3,10,11,12});
 
-        push_back(v, view::ints(10) | view::take(3));
+        push_back(v, view::iota(10) | view::take(3));
         ::check_equal(v, {1,2,3,10,11,12,10,11,12});
 
         int rg[] = {9,8,7};
@@ -51,10 +51,10 @@ int main()
         v = std::move(v) | push_back({1,2,3});
         ::check_equal(v, {1,2,3});
 
-        v = std::move(v) | push_back(view::ints(10) | view::take(3));
+        v = std::move(v) | push_back(view::iota(10) | view::take(3));
         ::check_equal(v, {1,2,3,10,11,12});
 
-        v = std::move(v) | push_back(view::ints(10) | view::take(3));
+        v = std::move(v) | push_back(view::iota(10) | view::take(3));
         ::check_equal(v, {1,2,3,10,11,12,10,11,12});
 
         int rg[] = {9,8,7};
@@ -76,10 +76,10 @@ int main()
         v |= push_back({1,2,3});
         ::check_equal(v, {1,2,3});
 
-        v |= push_back(view::ints(10) | view::take(3));
+        v |= push_back(view::iota(10) | view::take(3));
         ::check_equal(v, {1,2,3,10,11,12});
 
-        v |= push_back(view::ints(10) | view::take(3));
+        v |= push_back(view::iota(10) | view::take(3));
         ::check_equal(v, {1,2,3,10,11,12,10,11,12});
 
         int rg[] = {9,8,7};

--- a/test/action/push_front.cpp
+++ b/test/action/push_front.cpp
@@ -26,10 +26,10 @@ int main()
         push_front(v, {1,2,3});
         ::check_equal(v, {1,2,3});
 
-        push_front(v, view::ints(10) | view::take(3));
+        push_front(v, view::iota(10) | view::take(3));
         ::check_equal(v, {10,11,12,1,2,3});
 
-        push_front(v, view::ints(10) | view::take(3));
+        push_front(v, view::iota(10) | view::take(3));
         ::check_equal(v, {10,11,12,10,11,12,1,2,3});
 
         int rg[] = {9,8,7};
@@ -51,10 +51,10 @@ int main()
         v = std::move(v) | push_front({1,2,3});
         ::check_equal(v, {1,2,3});
 
-        v = std::move(v) | push_front(view::ints(10) | view::take(3));
+        v = std::move(v) | push_front(view::iota(10) | view::take(3));
         ::check_equal(v, {10,11,12,1,2,3});
 
-        v = std::move(v) | push_front(view::ints(10) | view::take(3));
+        v = std::move(v) | push_front(view::iota(10) | view::take(3));
         ::check_equal(v, {10,11,12,10,11,12,1,2,3});
 
         int rg[] = {9,8,7};
@@ -76,10 +76,10 @@ int main()
         v |= push_front({1,2,3});
         ::check_equal(v, {1,2,3});
 
-        v |= push_front(view::ints(10) | view::take(3));
+        v |= push_front(view::iota(10) | view::take(3));
         ::check_equal(v, {10,11,12,1,2,3});
 
-        v |= push_front(view::ints(10) | view::take(3));
+        v |= push_front(view::iota(10) | view::take(3));
         ::check_equal(v, {10,11,12,10,11,12,1,2,3});
 
         int rg[] = {9,8,7};

--- a/test/container_conversion.cpp
+++ b/test/container_conversion.cpp
@@ -31,13 +31,13 @@ int main()
     std::vector<int> v = view::ints | view::take(10);
     ::check_equal(v, {0,1,2,3,4,5,6,7,8,9});
 
-    v = view::ints(10) | view::take(10) | view::reverse;
+    v = view::iota(10) | view::take(10) | view::reverse;
     ::check_equal(v, {19,18,17,16,15,14,13,12,11,10});
 
     std::list<int> l = view::ints | view::take(10);
     ::check_equal(l, {0,1,2,3,4,5,6,7,8,9});
 
-    l = view::ints(10) | view::take(10) | view::reverse;
+    l = view::iota(10) | view::take(10) | view::reverse;
     ::check_equal(l, {19,18,17,16,15,14,13,12,11,10});
 
     auto to_string = [](int i){ std::stringstream str; str << i; return str.str();};

--- a/test/distance.cpp
+++ b/test/distance.cpp
@@ -110,11 +110,11 @@ int main()
     }
 
     {
-        test_range(view::ints(0) | view::take_while([](int i) { return i < 4; }), 4);
+        test_range(view::iota(0) | view::take_while([](int i) { return i < 4; }), 4);
     }
 
     {
-        test_infinite_range(view::ints(0u));
+        test_infinite_range(view::iota(0u));
     }
 
     return ::test_result();

--- a/test/view/iota.cpp
+++ b/test/view/iota.cpp
@@ -59,11 +59,13 @@ int main()
         {'h','e','l','l','o',' ','w','o','r','l'});
 
     ::check_equal(view::ints | view::take(10), {0,1,2,3,4,5,6,7,8,9});
-    ::check_equal(view::ints(0) | view::take(10), {0,1,2,3,4,5,6,7,8,9});
+    ::check_equal(view::iota(0) | view::take(10), {0,1,2,3,4,5,6,7,8,9});
+    ::check_equal(view::ints(10) | view::take(10), {0,1,2,3,4,5,6,7,8,9});
     ::check_equal(view::ints(0,9), {0,1,2,3,4,5,6,7,8});
     ::check_equal(view::closed_ints(0,9), {0,1,2,3,4,5,6,7,8,9});
     ::check_equal(view::ints(1,10), {1,2,3,4,5,6,7,8,9});
     ::check_equal(view::closed_ints(1,10), {1,2,3,4,5,6,7,8,9,10});
+    ::check_equal(view::closed_ints(10), {0, 1,2,3,4,5,6,7,8,9,10});
 
     auto chars = view::ints(std::numeric_limits<char>::min(),
                             std::numeric_limits<char>::max());

--- a/test/view/slice.cpp
+++ b/test/view/slice.cpp
@@ -99,8 +99,11 @@ int main()
     models_not<concepts::RandomAccessIterator>(begin(rng8));
     ::check_equal(rng8, {6, 7, 8});
 
-    auto rng9 = view::ints(0)[{0,end}];
+    auto rng9 = view::iota(0)[{0,end}];
     static_assert(is_infinite<decltype(rng9)>::value, "should be infinite");
+
+    auto rng10 = view::ints(0)[{0,end}];
+    static_assert(!is_infinite<decltype(rng10)>::value, "should not be infinite");
 
     {
         std::string str{"0 1 2 3 4 5 6 7 8 9"};


### PR DESCRIPTION
**This is a breaking change**

- Change the behavior of single argument `view::ints(N)` to return the half-open range `[0, N)` instead of the infinite range `[N, ...)`. This makes `view::ints` behave like Python's `range(N)`.
- Add single argument version of `view::closed_ints(N)` to return the closed-range `[0, N]`.

Closes #277.