### PR TITLE
add view::indices, deprecate closed_ints

### DIFF
--- a/include/range/v3/view.hpp
+++ b/include/range/v3/view.hpp
@@ -38,6 +38,7 @@ RANGES_DISABLE_WARNINGS
 #include <range/v3/view/generate.hpp>
 #include <range/v3/view/generate_n.hpp>
 #include <range/v3/view/group_by.hpp>
+#include <range/v3/view/indices.hpp>
 #include <range/v3/view/indirect.hpp>
 #include <range/v3/view/intersperse.hpp>
 #include <range/v3/view/iota.hpp>

--- a/include/range/v3/view/indices.hpp
+++ b/include/range/v3/view/indices.hpp
@@ -1,0 +1,119 @@
+/// \file
+// Range v3 library
+//
+//  Copyright Eric Niebler 2013-2014
+//  Copyright Gonzalo Brito Gadeschi
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#ifndef RANGES_V3_VIEW_INDICES_HPP
+#define RANGES_V3_VIEW_INDICES_HPP
+
+#include <meta/meta.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
+#include <range/v3/range_fwd.hpp>
+#include <range/v3/range_concepts.hpp>
+#include <range/v3/utility/static_const.hpp>
+#include <range/v3/view/take_exactly.hpp>
+#include <range/v3/view/iota.hpp>
+
+namespace ranges
+{
+    inline namespace v3
+    {
+
+        namespace view
+        {
+            /// Half-open range of indices: [from, to).
+            struct indices_fn
+              : iota_view<std::ptrdiff_t>
+            {
+                indices_fn() = default;
+
+                template<typename Val, CONCEPT_REQUIRES_(Integral<Val>())>
+                auto operator()(Val from, Val to) const
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                (
+                    detail::take_exactly_view_<iota_view<Val>, true>
+                        {iota_view<Val>{from}, detail::ints_open_distance_(from, to)}
+                )
+
+                template<typename Val, typename Self = indices_fn,
+                    CONCEPT_REQUIRES_(Integral<Val>())>
+                auto operator()(Val to) const
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                (
+                    Self{}(Val(), to)
+                )
+
+            #ifndef RANGES_DOXYGEN_INVOKED
+                template<typename Val, CONCEPT_REQUIRES_(!Integral<Val>())>
+                void operator()(Val) const
+                {
+                    CONCEPT_ASSERT_MSG(Integral<Val>(),
+                        "The object passed to view::indices must be Integral");
+                }
+                template<typename Val, CONCEPT_REQUIRES_(!Integral<Val>())>
+                void operator()(Val, Val) const
+                {
+                    CONCEPT_ASSERT_MSG(Integral<Val>(),
+                        "The object passed to view::indices must be Integral");
+                }
+            #endif
+            };
+
+            /// Inclusive range of indices: [from, to].
+            struct closed_indices_fn
+              : iota_view<std::ptrdiff_t>
+            {
+                template<typename Val, CONCEPT_REQUIRES_(Integral<Val>())>
+                auto operator()(Val from, Val to) const
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                (
+                    detail::take_exactly_view_<iota_view<Val>, true>
+                        {iota_view<Val>{from}, detail::ints_closed_distance_(from, to)}
+                )
+
+                template<typename Val, typename Self = closed_indices_fn,
+                    CONCEPT_REQUIRES_(Integral<Val>())>
+                auto operator()(Val to) const
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                (
+                    Self{}(Val(), to)
+                )
+
+            #ifndef RANGES_DOXYGEN_INVOKED
+                template<typename Val, CONCEPT_REQUIRES_(!Integral<Val>())>
+                void operator()(Val) const
+                {
+                    CONCEPT_ASSERT_MSG(Integral<Val>(),
+                        "The object passed to view::closed_indices must be Integral");
+                }
+                template<typename Val, CONCEPT_REQUIRES_(!Integral<Val>())>
+                void operator()(Val, Val) const
+                {
+                    CONCEPT_ASSERT_MSG(Integral<Val>(),
+                        "The object passed to view::closed_indices must be Integral");
+                }
+            #endif
+            };
+
+            /// \relates indices_fn
+            /// \ingroup group-views
+            RANGES_INLINE_VARIABLE(indices_fn, indices)
+
+            /// \relates closed_indices_fn
+            /// \ingroup group-views
+            RANGES_INLINE_VARIABLE(closed_indices_fn, closed_indices)
+
+        }  // namespace view
+    }
+}
+
+#endif  // RANGES_V3_VIEW_INDICES_HPP


### PR DESCRIPTION
- Deprecate `closed_ints`. 
- add `view::indices/inclusive_indices`
- [bugfix]: fix unsigned integer wrap around which caused weird behavior like a range of size of `0` that can be iterated for`ints`/`closed_ints`/`indices`/`inclusive_indices` :
- assert on signed integer overflow by requiring `to - from < std::numeric_limits<T>::max()` for`ints`/`closed_ints`/`indices`/`inclusive_indices`

Closes #470 (at least the "bug" part of it. @CaseyCarter: it might be worth it to move your ideas for infinite ranges to its own issue to pursue them further).

Closes #277 .

Supersedes #592 .