### PR TITLE
Fix assertion in view::cycle

### DIFF
--- a/include/range/v3/view/cycle.hpp
+++ b/include/range/v3/view/cycle.hpp
@@ -160,7 +160,7 @@ namespace ranges
             explicit cycled_view(Rng rng)
               : rng_(std::move(rng))
             {
-                RANGES_EXPECT(!ranges::empty(rng));
+                RANGES_EXPECT(!ranges::empty(rng_));
             }
         };
 


### PR DESCRIPTION
Fix constructor in view::cycle, which uses a moved-from variable