### PR TITLE
[travis-ci] build the calendar example with clang-trunk on linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 ﻿# Copyright Louis Dionne 2013-2016
-# Copyright Gonzalo BG 2014-2016
+# Copyright Gonzalo BG 2014-2017
 # Copyright Julian Becker 2015
 # Copyright Manu Sánchez 2015
 # Copyright Casey Carter 2015-2017
 # Copyright Eric Niebler 2015-2016
 # Copyright Paul Fultz II 2015-2016
+# Copyright Jakub Szuppe 2016.
 
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE.txt or copy at http://boost.org/LICENSE_1_0.txt)
@@ -15,13 +16,19 @@
 language: cpp
 script: cmake
 
+env:
+  global:
+    - DEPS_DIR=${TRAVIS_BUILD_DIR}/deps
+    - BOOST_URL="http://sourceforge.net/projects/boost/files/boost/1.63.0/boost_1_63_0.tar.gz"
+    - BOOST_VERSION="1_63_0"
+
 cache:
   directories:
     - ${TRAVIS_BUILD_DIR}/deps/cmake
 
 matrix:
   include:
-    - env: BUILD_TYPE=Release CPP=11 ASAN=Off SYSTEM_LIBCXX=On
+    - env: BUILD_TYPE=Release CPP=11 ASAN=Off SYSTEM_LIBCXX=On BOOST=Off
       os: osx
       compiler: clang
 
@@ -29,7 +36,7 @@ matrix:
     #  https://llvm.org/bugs/show_bug.cgi?id=22757
 
     # clang 3.6 C++11/14 Release libc++
-    - env: CLANG_VERSION=3.6 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
+    - env: CLANG_VERSION=3.6 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On BOOST=Off
       os: linux
       addons: &clang36
         apt:
@@ -41,12 +48,12 @@ matrix:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.6
 
-    - env: CLANG_VERSION=3.6 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On HEADERS=On
+    - env: CLANG_VERSION=3.6 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On HEADERS=On BOOST=Off
       os: linux
       addons: *clang36
 
     # clang 3.7 C++11/14 Release libc++
-    - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On CLANG_MODULES=On
+    - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On CLANG_MODULES=On BOOST=Off
       os: linux
       addons: &clang37
         apt:
@@ -59,12 +66,12 @@ matrix:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.7
 
-    - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On HEADERS=On CLANG_MODULES=On
+    - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On HEADERS=On CLANG_MODULES=On BOOST=Off
       os: linux
       addons: *clang37
 
     # clang 3.8 C++11/14 Release ASAN libc++
-    - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On CLANG_MODULES=On
+    - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On CLANG_MODULES=On BOOST=Off
       os: linux
       addons: &clang38
         apt:
@@ -77,12 +84,12 @@ matrix:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.8
 
-    - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On HEADERS=On CLANG_MODULES=On
+    - env: CLANG_VERSION=3.8 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On HEADERS=On CLANG_MODULES=On BOOST=Off
       os: linux
       addons: *clang38
 
     # clang 3.9 C++11/14 Release ASAN libc++
-    - env: CLANG_VERSION=3.9 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On CLANG_MODULES=On
+    - env: CLANG_VERSION=3.9 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On CLANG_MODULES=On BOOST=Off
       os: linux
       addons: &clang39
         apt:
@@ -95,12 +102,12 @@ matrix:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.9
 
-    - env: CLANG_VERSION=3.9 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On HEADERS=On CLANG_MODULES=On
+    - env: CLANG_VERSION=3.9 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On HEADERS=On CLANG_MODULES=On BOOST=Off
       os: linux
       addons: *clang39
 
     # clang 5 C++11/14/1z Debug/Release-ASAN libc++, 11 Debug libstdc++
-    - env: CLANG_VERSION=5.0 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On CLANG_MODULES=On
+    - env: CLANG_VERSION=5.0 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On CLANG_MODULES=On BOOST=Off
       os: linux
       addons: &clang5
         apt:
@@ -113,32 +120,32 @@ matrix:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-precise
 
-    - env: CLANG_VERSION=5.0 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On CLANG_MODULES=On
+    - env: CLANG_VERSION=5.0 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On CLANG_MODULES=On BOOST=Off
       os: linux
       addons: *clang5
 
-    - env: CLANG_VERSION=5.0 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On CLANG_MODULES=On
+    - env: CLANG_VERSION=5.0 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On CLANG_MODULES=On BOOST=Off
       os: linux
       addons: *clang5
 
-    - env: CLANG_VERSION=5.0 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On CLANG_MODULES=On
+    - env: CLANG_VERSION=5.0 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On CLANG_MODULES=On BOOST=Off
       os: linux
       addons: *clang5
 
-    - env: CLANG_VERSION=5.0 BUILD_TYPE=Debug CPP=1z ASAN=Off LIBCXX=On HEADERS=On CLANG_MODULES=On
+    - env: CLANG_VERSION=5.0 BUILD_TYPE=Debug CPP=1z ASAN=Off LIBCXX=On HEADERS=On CLANG_MODULES=On BOOST=On
       os: linux
       addons: *clang5
 
-    - env: CLANG_VERSION=5.0 BUILD_TYPE=Release CPP=1z ASAN=On LIBCXX=On CLANG_MODULES=On
+    - env: CLANG_VERSION=5.0 BUILD_TYPE=Release CPP=1z ASAN=On LIBCXX=On CLANG_MODULES=On BOOST=Off
       os: linux
       addons: *clang5
 
-    - env: CLANG_VERSION=5.0 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off CLANG_MODULES=On
+    - env: CLANG_VERSION=5.0 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off CLANG_MODULES=On BOOST=Off
       os: linux
       addons: *clang5
 
     #   # gcc-4.8 C++11 Debug/Release
-    # - env: GCC_VERSION=4.8 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=Off HEADERS=On
+    # - env: GCC_VERSION=4.8 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=Off HEADERS=On BOOST=Off
     #   os: linux
     #   addons: &gcc48
     #     apt:
@@ -148,12 +155,12 @@ matrix:
     #       sources:
     #         - ubuntu-toolchain-r-test
 
-    # - env: GCC_VERSION=4.8 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off
+    # - env: GCC_VERSION=4.8 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off BOOST=Off
     #   os: linux
     #   addons: *gcc48
 
       # gcc-4.9 C++11/C++14 Release
-    - env: GCC_VERSION=4.9 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off
+    - env: GCC_VERSION=4.9 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off BOOST=Off
       os: linux
       addons: &gcc49
         apt:
@@ -163,12 +170,12 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: GCC_VERSION=4.9 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=Off HEADERS=On
+    - env: GCC_VERSION=4.9 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=Off HEADERS=On BOOST=Off
       os: linux
       addons: *gcc49
 
       # gcc-5 C++11/C++14 Release
-    - env: GCC_VERSION=5 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off
+    - env: GCC_VERSION=5 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off BOOST=Off
       os: linux
       addons: &gcc5
         apt:
@@ -178,12 +185,12 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: GCC_VERSION=5 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=Off HEADERS=On
+    - env: GCC_VERSION=5 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=Off HEADERS=On BOOST=Off
       os: linux
       addons: *gcc5
 
     # gcc-6 C++11/14/1z Debug/Release
-    - env: GCC_VERSION=6 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=Off
+    - env: GCC_VERSION=6 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=Off BOOST=Off
       os: linux
       addons: &gcc6
         apt:
@@ -193,23 +200,23 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - env: GCC_VERSION=6 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off
+    - env: GCC_VERSION=6 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off BOOST=Off
       os: linux
       addons: *gcc6
 
-    - env: GCC_VERSION=6 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=Off
+    - env: GCC_VERSION=6 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=Off BOOST=Off
       os: linux
       addons: *gcc6
 
-    - env: GCC_VERSION=6 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=Off
+    - env: GCC_VERSION=6 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=Off BOOST=Off
       os: linux
       addons: *gcc6
 
-    - env: GCC_VERSION=6 BUILD_TYPE=Debug CPP=1z ASAN=Off LIBCXX=Off HEADERS=On
+    - env: GCC_VERSION=6 BUILD_TYPE=Debug CPP=1z ASAN=Off LIBCXX=Off HEADERS=On BOOST=Off
       os: linux
       addons: *gcc6
 
-    - env: GCC_VERSION=6 BUILD_TYPE=Release CPP=1z ASAN=Off LIBCXX=Off
+    - env: GCC_VERSION=6 BUILD_TYPE=Release CPP=1z ASAN=Off LIBCXX=Off BOOST=Off
       os: linux
       addons: *gcc6
 
@@ -242,6 +249,29 @@ before_install:
   - if [ "$ASAN" == "On" ]; then export SANITIZER=Address; fi
   - if [ -n "$CLANG_VERSION" ]; then sudo PATH="${PATH}" CXX="$CXX" CC="$CC" ./install_libcxx.sh; fi
 
+  # Download and install Boost
+  # Adapted from Boost.Compute (under the Boost License)
+  # Copyright Jakub Szuppe 2016.
+  - |
+    if [[ ${TRAVIS_OS_NAME} == "linux" && ${BOOST} == "On" ]]; then
+      if [ ! -f "${DEPS_DIR}/boost/${BOOST_VERSION}_cached" ]; then
+        # create dirs for source and install
+        mkdir -p ${DEPS_DIR}/boost${BOOST_VERSION}
+        mkdir -p ${DEPS_DIR}/boost
+        rm -rf ${DEPS_DIR}/boost/*
+        # download
+        travis_retry wget --no-check-certificate --quiet -O - ${BOOST_URL} | tar --strip-components=1 -xz -C ${DEPS_DIR}/boost${BOOST_VERSION}
+        pushd ${DEPS_DIR}/boost${BOOST_VERSION}
+        # configure and install
+        ./bootstrap.sh --prefix=${DEPS_DIR}/boost/ --with-libraries=program_options,date_time
+        ./b2 toolset=clang cxxflags="-stdlib=libc++ -nostdinc++ -cxx-isystem /usr/include/c++/v1/" linkflags="-stdlib=libc++"
+        ./b2 -d0 install
+        popd
+        touch ${DEPS_DIR}/boost/${BOOST_VERSION}_cached
+      else
+        echo 'Using cached Boost ${BOOST_VERSION} libraries.'
+      fi
+    fi
 
 install:
   - cd $CHECKOUT_PATH
@@ -259,6 +289,7 @@ install:
   - if [ "$LIBCXX" == "On" ]; then CXX_FLAGS="${CXX_FLAGS} -stdlib=libc++ -nostdinc++ -cxx-isystem /usr/include/c++/v1/ -Wno-unused-command-line-argument"; fi
   - if [ "$HEADERS" == "On" ]; then HEADER_CHECK=1; else HEADER_CHECK=0; fi
   - cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" -DCMAKE_EXE_LINKER_FLAGS="${CXX_LINKER_FLAGS}" -DRANGES_CXX_STD=$CPP -DRANGE_V3_NO_HEADER_CHECK=$HEADER_CHECK
+  - if [ "$BOOST" == "On" ]; then cmake .. -DRANGES_BUILD_CALENDAR_EXAMPLE=On -DBOOST_ROOT=${DEPS_DIR}/boost; fi
   - if [ "$CLANG_MODULES" == "On" ] && [ "$LIBCXX" == "On" ]; then cmake .. -DRANGES_MODULES=On -DRANGES_LIBCXX_MODULE="/usr/include/c++/v1/module.modulemap"; fi
   - make -j2 VERBOSE=1
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -9,7 +9,7 @@ if(RANGES_BUILD_CALENDAR_EXAMPLE)
     set(Boost_USE_STATIC_LIBS        ON)
     set(Boost_USE_MULTITHREADED     OFF)
     set(Boost_USE_STATIC_RUNTIME    OFF)
-    find_package(Boost 1.59 COMPONENTS date_time program_options)
+    find_package(Boost 1.59.0 COMPONENTS date_time program_options)
 
     if (Boost_FOUND)
         include_directories(SYSTEM ${Boost_INCLUDE_DIRS})

--- a/example/calendar.cpp
+++ b/example/calendar.cpp
@@ -153,6 +153,8 @@ auto layout_months() {
     });
 }
 
+namespace cal_example {
+
 // In:  Range<T>
 // Out: Range<Range<T>>, where each inner range has $n$ elements.
 //                       The last range may have fewer.
@@ -191,13 +193,15 @@ public:
     void distance_to() = delete;
 };
 
+}  // namespace cal_example
+
 // In:  Range<T>
 // Out: Range<Range<T>>, where each inner range has $n$ elements.
 //                       The last range may have fewer.
 auto chunk(std::size_t n) {
     return make_pipeable([=](auto&& rng) {
         using Rng = decltype(rng);
-        return chunk_view<view::all_t<Rng>>{
+        return cal_example::chunk_view<view::all_t<Rng>>{
             view::all(std::forward<Rng>(rng)),
             static_cast<ranges::range_difference_type_t<Rng>>(n)};
     });


### PR DESCRIPTION
- The `.travis.yml` file now: 
  - has boost_url/boost_version as global flags
  - the jobs have a boost=on/off environment flag
  - the script fetches and builds boost from source for clang when boost=on
  - builds the calendar example when boost=on for clang trunk -std=c++1z without sanitizers 
- The `chunk_view` in the calendar example is scoped inside a namespace to prevent it from clashing against `ranges::chunk_view` which is in scope if modules are used because the example uses `using namespace ranges;`. 

TODO:
- get a gcc build bot building the calendar example as well (issue #596) . 

Closes #223 (now the calendar example builds on clang-trunk on linux automatically).