### PR TITLE
Fix some size + single-pass bugs:

### DIFF
--- a/include/range/v3/size.hpp
+++ b/include/range/v3/size.hpp
@@ -65,7 +65,8 @@ namespace ranges
                     size(r)
                 )
 
-                template<typename R>
+                template<typename R, typename I = decltype(ranges::cbegin(std::declval<R const&>())),
+                    CONCEPT_REQUIRES_(ForwardIterator<I>())>
                 static RANGES_CXX14_CONSTEXPR auto impl_(R const &r, ...)
                 RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
                 (

--- a/include/range/v3/utility/iterator.hpp
+++ b/include/range/v3/utility/iterator.hpp
@@ -391,9 +391,9 @@ namespace ranges
         struct iter_size_fn
         {
             template<typename I, typename S,
-                CONCEPT_REQUIRES_(SizedSentinel<S, I>() && ForwardIterator<I>())>
+                CONCEPT_REQUIRES_(SizedSentinel<S, I>())>
             RANGES_CXX14_CONSTEXPR
-            size_type_t<I> operator()(I begin, S end) const
+            size_type_t<I> operator()(I const& begin, S end) const
             {
                 difference_type_t<I> n = end - begin;
                 RANGES_EXPECT(0 <= n);

--- a/include/range/v3/view_interface.hpp
+++ b/include/range/v3/view_interface.hpp
@@ -103,7 +103,8 @@ namespace ranges
             }
             template<typename D = Derived,
                 CONCEPT_REQUIRES_(Same<D, Derived>() && Cardinality < 0 &&
-                    SizedSentinel<sentinel_t<const D>, iterator_t<const D>>())>
+                    SizedSentinel<sentinel_t<const D>, iterator_t<const D>>() &&
+                    ForwardIterator<iterator_t<const D>>())>
             constexpr range_size_type_t<D> size() const
             {
                 return iter_size(derived().begin(), derived().end());


### PR DESCRIPTION
* `iter_size` can work fine with *references* to single-pass iterators

* `view_interface` should not trash single-pass ranges by calling `iter_size(begin(), end())`

* `size` should not trash single-pass ranges by calling `iter_size(begin(), end())`
