### PR TITLE
Implement view::cartesian_product

### DIFF
--- a/include/range/v3/to_container.hpp
+++ b/include/range/v3/to_container.hpp
@@ -42,7 +42,7 @@ namespace ranges
             using ConvertibleToContainer = meta::strict_and<
                 Range<Cont>,
                 meta::not_<View<Cont>>,
-                Movable<Cont>,
+                MoveConstructible<Cont>,
                 ConvertibleTo<range_value_type_t<Rng>, range_value_type_t<Cont>>,
                 Constructible<Cont, I, I>>;
 
@@ -59,7 +59,7 @@ namespace ranges
 
                 template<typename Rng,
                     typename Cont = meta::invoke<ContainerMetafunctionClass, range_value_type_t<Rng>>,
-                    CONCEPT_REQUIRES_(Range<Rng>() && detail::ConvertibleToContainer<Rng, Cont>())>
+                    CONCEPT_REQUIRES_(InputRange<Rng>() && detail::ConvertibleToContainer<Rng, Cont>())>
                 Cont impl(Rng && rng, std::false_type) const
                 {
                     using I = range_common_iterator_t<Rng>;
@@ -68,7 +68,7 @@ namespace ranges
 
                 template<typename Rng,
                     typename Cont = meta::invoke<ContainerMetafunctionClass, range_value_type_t<Rng>>,
-                    CONCEPT_REQUIRES_(Range<Rng>() && detail::ConvertibleToContainer<Rng, Cont>() &&
+                    CONCEPT_REQUIRES_(InputRange<Rng>() && detail::ConvertibleToContainer<Rng, Cont>() &&
                                       ReserveConcept<Cont, Rng>())>
                 Cont impl(Rng && rng, std::true_type) const
                 {
@@ -83,7 +83,7 @@ namespace ranges
             public:
                 template<typename Rng,
                     typename Cont = meta::invoke<ContainerMetafunctionClass, range_value_type_t<Rng>>,
-                    CONCEPT_REQUIRES_(Range<Rng>() && detail::ConvertibleToContainer<Rng, Cont>())>
+                    CONCEPT_REQUIRES_(InputRange<Rng>() && detail::ConvertibleToContainer<Rng, Cont>())>
                 Cont operator()(Rng && rng) const
                 {
                     static_assert(!is_infinite<Rng>::value,

--- a/include/range/v3/utility/common_tuple.hpp
+++ b/include/range/v3/utility/common_tuple.hpp
@@ -45,14 +45,6 @@ namespace ranges
             common_tuple(That && that, meta::index_sequence<Is...>)
               : std::tuple<Ts...>{std::get<Is>(std::forward<That>(that))...}
             {}
-            std::tuple<Ts...> & base() noexcept
-            {
-                return *this;
-            }
-            std::tuple<Ts...> const & base() const noexcept
-            {
-                return *this;
-            }
             struct element_assign_
             {
                 template<typename T, typename U>
@@ -93,6 +85,15 @@ namespace ranges
                 noexcept(meta::and_c<std::is_nothrow_constructible<Ts, Us>::value...>::value)
               : common_tuple(std::move(that), meta::make_index_sequence<sizeof...(Ts)>{})
             {}
+
+            std::tuple<Ts...> & base() noexcept
+            {
+                return *this;
+            }
+            std::tuple<Ts...> const & base() const noexcept
+            {
+                return *this;
+            }
 
             // Assignment
             template<typename...Us,

--- a/include/range/v3/utility/functional.hpp
+++ b/include/range/v3/utility/functional.hpp
@@ -181,6 +181,17 @@ namespace ranges
           : coerce<T>
         {};
 
+        struct dereference_fn
+        {
+            template<typename I>
+            constexpr auto operator()(I &i) const
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+            (
+                *i
+            )
+        };
+        RANGES_INLINE_VARIABLE(dereference_fn, dereference)
+
         /// \addtogroup group-concepts
         /// @{
         namespace concepts

--- a/include/range/v3/utility/tuple_algorithm.hpp
+++ b/include/range/v3/utility/tuple_algorithm.hpp
@@ -62,14 +62,14 @@ namespace ranges
         {
         private:
             template<typename Tup, typename Fun, std::size_t...Is>
-            static auto impl1(Tup && tup, Fun fun, meta::index_sequence<Is...>)
+            static auto impl1(Tup && tup, Fun &fun, meta::index_sequence<Is...>)
             RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
                 std::tuple<decltype(fun(std::get<Is>(std::forward<Tup>(tup))))...>{
                     fun(std::get<Is>(std::forward<Tup>(tup)))...}
             )
             template<typename Tup0, typename Tup1, typename Fun, std::size_t...Is>
-            static auto impl2(Tup0 && tup0, Tup1 && tup1, Fun fun, meta::index_sequence<Is...>)
+            static auto impl2(Tup0 && tup0, Tup1 && tup1, Fun &fun, meta::index_sequence<Is...>)
             RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
                 std::tuple<decltype(fun(std::get<Is>(std::forward<Tup0>(tup0)),
@@ -82,15 +82,14 @@ namespace ranges
             auto operator()(Tup && tup, Fun fun) const
             RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
-                tuple_transform_fn::impl1(std::forward<Tup>(tup), std::move(fun),
-                    tuple_indices_t<Tup>{})
+                tuple_transform_fn::impl1(std::forward<Tup>(tup), fun, tuple_indices_t<Tup>{})
             )
             template<typename Tup0, typename Tup1, typename Fun>
             auto operator()(Tup0 && tup0, Tup1 && tup1, Fun fun) const
             RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
                 tuple_transform_fn::impl2(std::forward<Tup0>(tup0), std::forward<Tup1>(tup1),
-                    std::move(fun), tuple_indices_t<Tup0>{})
+                    fun, tuple_indices_t<Tup0>{})
             )
         };
 
@@ -102,32 +101,30 @@ namespace ranges
         {
         private:
             template<typename Tup, typename Val, typename Fun>
-            static Val impl(Tup &&, Val val, Fun)
+            static Val impl(Tup &&, Val val, Fun &)
             {
                 return val;
             }
             template<std::size_t I0, std::size_t...Is, typename Tup, typename Val, typename Fun,
                 typename Impl = tuple_foldl_fn>
-            static auto impl(Tup && tup, Val val, Fun fun)
+            static auto impl(Tup && tup, Val val, Fun &fun)
             RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
                 Impl::template impl<Is...>(std::forward<Tup>(tup),
-                    fun(std::move(val), std::get<I0>(std::forward<Tup>(tup))),
-                    std::move(fun))
+                    fun(std::move(val), std::get<I0>(std::forward<Tup>(tup))), fun)
             )
             template<typename Tup, typename Val, typename Fun, std::size_t...Is>
-            static auto impl2(Tup && tup, Val val, Fun fun, meta::index_sequence<Is...>)
+            static auto impl2(Tup && tup, Val val, Fun &fun, meta::index_sequence<Is...>)
             RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
-                tuple_foldl_fn::impl<Is...>(std::forward<Tup>(tup), std::move(val),
-                    std::move(fun))
+                tuple_foldl_fn::impl<Is...>(std::forward<Tup>(tup), std::move(val), fun)
             )
         public:
             template<typename Tup, typename Val, typename Fun>
             auto operator()(Tup && tup, Val val, Fun fun) const
             RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
-                tuple_foldl_fn::impl2(std::forward<Tup>(tup), std::move(val), std::move(fun),
+                tuple_foldl_fn::impl2(std::forward<Tup>(tup), std::move(val), fun,
                     tuple_indices_t<Tup>{})
             )
         };
@@ -140,7 +137,7 @@ namespace ranges
         {
         private:
             template<typename Tup, typename Fun, std::size_t...Is>
-            static void impl(Tup && tup, Fun fun, meta::index_sequence<Is...>)
+            static void impl(Tup && tup, Fun &fun, meta::index_sequence<Is...>)
             {
                 (void)std::initializer_list<int>{
                     ((void)fun(std::get<Is>(std::forward<Tup>(tup))), 42)...};
@@ -149,8 +146,7 @@ namespace ranges
             template<typename Tup, typename Fun>
             Fun operator()(Tup && tup, Fun fun) const
             {
-                tuple_for_each_fn::impl(std::forward<Tup>(tup), std::ref(fun),
-                    tuple_indices_t<Tup>{});
+                tuple_for_each_fn::impl(std::forward<Tup>(tup), fun, tuple_indices_t<Tup>{});
                 return fun;
             }
         };

--- a/include/range/v3/view.hpp
+++ b/include/range/v3/view.hpp
@@ -23,10 +23,11 @@ RANGES_DISABLE_WARNINGS
 #include <range/v3/view/any_view.hpp>
 #include <range/v3/view/bounded.hpp>
 #include <range/v3/view/c_str.hpp>
+#include <range/v3/view/cartesian_product.hpp>
+#include <range/v3/view/chunk.hpp>
 #include <range/v3/view/concat.hpp>
 #include <range/v3/view/const.hpp>
 #include <range/v3/view/counted.hpp>
-#include <range/v3/view/chunk.hpp>
 #include <range/v3/view/cycle.hpp>
 #include <range/v3/view/delimit.hpp>
 #include <range/v3/view/drop.hpp>
@@ -45,9 +46,9 @@ RANGES_DISABLE_WARNINGS
 #include <range/v3/view/map.hpp>
 #include <range/v3/view/move.hpp>
 #include <range/v3/view/partial_sum.hpp>
+#include <range/v3/view/remove_if.hpp>
 #include <range/v3/view/repeat.hpp>
 #include <range/v3/view/repeat_n.hpp>
-#include <range/v3/view/remove_if.hpp>
 #include <range/v3/view/replace.hpp>
 #include <range/v3/view/replace_if.hpp>
 #include <range/v3/view/reverse.hpp>
@@ -62,12 +63,12 @@ RANGES_DISABLE_WARNINGS
 #include <range/v3/view/take.hpp>
 #include <range/v3/view/take_exactly.hpp>
 #include <range/v3/view/take_while.hpp>
-#include <range/v3/view/transform.hpp>
 #include <range/v3/view/tokenize.hpp>
+#include <range/v3/view/transform.hpp>
 #include <range/v3/view/unbounded.hpp>
 #include <range/v3/view/unique.hpp>
-#include <range/v3/view/zip_with.hpp>
 #include <range/v3/view/zip.hpp>
+#include <range/v3/view/zip_with.hpp>
 
 RANGES_RE_ENABLE_WARNINGS
 

--- a/include/range/v3/view/cartesian_product.hpp
+++ b/include/range/v3/view/cartesian_product.hpp
@@ -1,0 +1,377 @@
+/// \file
+// Range v3 library
+//
+//  Copyright Eric Niebler 2013-2014.
+//  Copyright Casey Carter 2017.
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#ifndef RANGES_V3_VIEW_CARTESIAN_PRODUCT_HPP
+#define RANGES_V3_VIEW_CARTESIAN_PRODUCT_HPP
+
+#include <range/v3/begin_end.hpp>
+#include <range/v3/range_access.hpp>
+#include <range/v3/range_concepts.hpp>
+#include <range/v3/range_fwd.hpp>
+#include <range/v3/range_traits.hpp>
+#include <range/v3/size.hpp>
+#include <range/v3/view_facade.hpp>
+#include <range/v3/utility/concepts.hpp>
+#include <range/v3/utility/static_const.hpp>
+#include <range/v3/utility/tuple_algorithm.hpp>
+#include <range/v3/view/all.hpp>
+
+namespace ranges
+{
+    inline namespace v3
+    {
+        namespace detail
+        {
+            template<typename State, typename Value>
+            using product_cardinality =
+                std::integral_constant<cardinality,
+                    State::value == 0 || Value::value == 0 ?
+                        static_cast<cardinality>(0) :
+                        State::value == unknown || Value::value == unknown ?
+                            unknown :
+                            State::value == infinite || Value::value == infinite ?
+                                infinite :
+                                State::value == finite || Value::value == finite ?
+                                    finite :
+                                    static_cast<cardinality>(State::value * Value::value)>;
+
+            struct cartesian_size_fn
+            {
+                template<typename Rng, CONCEPT_REQUIRES_(SizedRange<Rng>())>
+                auto operator()(std::size_t s, Rng && rng)
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                (
+                    s * static_cast<std::size_t>(ranges::size(rng))
+                )
+            };
+
+            template<typename View,
+                CONCEPT_REQUIRES_(BoundedRange<View>())>
+            static iterator_t<View> last_iter(View& v)
+            {
+                return ranges::end(v);
+            }
+            template<typename View,
+                CONCEPT_REQUIRES_(!BoundedRange<View>() &&
+                    RandomAccessRange<View>() && SizedRange<View>())>
+            static iterator_t<View> last_iter(View& v)
+            {
+                return ranges::begin(v) + ranges::size(v);
+            }
+        } // namespace detail
+
+        template<typename...Views>
+        class cartesian_product_view
+          : public view_facade<cartesian_product_view<Views...>,
+                meta::fold<
+                    meta::list<range_cardinality<Views>...>,
+                    std::integral_constant<cardinality,
+                        static_cast<cardinality>((sizeof...(Views) > 0))>,
+                    meta::quote<detail::product_cardinality>>::value>
+        {
+            friend range_access;
+            CONCEPT_ASSERT(meta::strict_and<ForwardView<Views>...>::value);
+            using CanConst = meta::strict_and<
+                Range<Views const>...>;
+            template<bool IsConst>
+            using CanSize = meta::strict_and<
+                SizedRange<meta::if_c<IsConst, Views const, Views>>...>;
+            template<bool IsConst>
+            using CanDistance = meta::strict_and<
+                CanSize<IsConst>,
+                SizedSentinel<
+                    iterator_t<meta::if_c<IsConst, Views const, Views>>,
+                    iterator_t<meta::if_c<IsConst, Views const, Views>>>...>;
+            template<bool IsConst>
+            using CanRandom = meta::strict_and<
+                CanDistance<IsConst>,
+                RandomAccessIterator<iterator_t<
+                    meta::if_c<IsConst, Views const, Views>>>...>;
+            template<bool IsConst>
+            using CanBidi = meta::strict_or<
+                CanRandom<IsConst>,
+                meta::strict_and<
+                    BoundedRange<meta::if_c<IsConst, Views const, Views>>...,
+                    BidirectionalIterator<iterator_t<
+                        meta::if_c<IsConst, Views const, Views>>>...>>;
+
+            std::tuple<Views...> views_;
+
+            template<bool IsConst>
+            class cursor
+            {
+                template<typename T>
+                using constify_if = meta::invoke<meta::add_const_if_c<IsConst>, T>;
+                using pos_t = std::tuple<iterator_t<constify_if<Views>>...>;
+                constify_if<cartesian_product_view> *view_;
+                pos_t its_;
+
+                void next_(meta::size_t<0>)
+                {
+                    RANGES_EXPECT(false);
+                }
+                void next_(meta::size_t<1>)
+                {
+                    auto& v = std::get<0>(view_->views_);
+                    auto& i = std::get<0>(its_);
+                    auto const last = ranges::end(v);
+                    RANGES_EXPECT(i != last);
+                    ++i;
+                }
+                template<std::size_t N>
+                void next_(meta::size_t<N>)
+                {
+                    auto& v = std::get<N - 1>(view_->views_);
+                    auto& i = std::get<N - 1>(its_);
+                    auto const last = ranges::end(v);
+                    RANGES_EXPECT(i != last);
+                    if (++i == last)
+                    {
+                        i = ranges::begin(v);
+                        next_(meta::size_t<N - 1>{});
+                    }
+                }
+                void prev_(meta::size_t<0>)
+                {
+                    RANGES_EXPECT(false);
+                }
+                template<std::size_t N>
+                void prev_(meta::size_t<N>)
+                {
+                    auto& v = std::get<N - 1>(view_->views_);
+                    auto& i = std::get<N - 1>(its_);
+                    if (i == ranges::begin(v))
+                    {
+                        i = detail::last_iter(v);
+                        prev_(meta::size_t<N - 1>{});
+                    }
+                    --i;
+                }
+                bool equal_(cursor const&, meta::size_t<sizeof...(Views)>) const
+                {
+                    return true;
+                }
+                template<std::size_t N>
+                bool equal_(cursor const &that, meta::size_t<N>) const
+                {
+                    return std::get<N>(its_) == std::get<N>(that.its_) &&
+                        equal_(that, meta::size_t<N + 1>{});
+                }
+                struct dist_info {
+                    std::ptrdiff_t distance;
+                    std::ptrdiff_t size_product;
+
+                    dist_info(std::ptrdiff_t d = 0, std::ptrdiff_t s = 1)
+                      : distance{d}, size_product{s}
+                    {}
+                };
+                std::ptrdiff_t distance_(
+                    cursor const &, meta::size_t<0>, dist_info) const
+                {
+                    CONCEPT_ASSERT(sizeof...(Views) == 0);
+                    return 0;
+                }
+                std::ptrdiff_t distance_(
+                    cursor const &that, meta::size_t<1>, dist_info const inf) const
+                {
+                    auto const my_distance = std::get<0>(that.its_) - std::get<0>(its_);
+                    return my_distance * inf.size_product + inf.distance;
+                }
+                template<std::size_t N>
+                std::ptrdiff_t distance_(
+                    cursor const &that, meta::size_t<N>, dist_info const inf) const
+                {
+                    auto const my_size = ranges::size(std::get<N - 1>(view_->views_));
+                    auto const my_distance = std::get<N - 1>(that.its_) - std::get<N - 1>(its_);
+                    return distance_(that, meta::size_t<N - 1>{}, dist_info{
+                        static_cast<std::ptrdiff_t>(my_distance * inf.size_product + inf.distance),
+                        static_cast<std::ptrdiff_t>(my_size) * inf.size_product
+                    });
+                }
+                void advance_(meta::size_t<0>, dist_info const inf)
+                {
+                    RANGES_EXPECT(inf.distance == 0);
+                }
+                template<std::size_t N>
+                void advance_(meta::size_t<N>, dist_info const inf)
+                {
+                    auto &i = std::get<N - 1>(its_);
+                    auto const my_size = ranges::size(std::get<N - 1>(view_->views_));
+                    auto const first = ranges::begin(std::get<N - 1>(view_->views_));
+                    auto const idx = i - first;
+                    auto d = inf.distance;
+                    if (static_cast<std::ptrdiff_t>(my_size) - idx < d || d < -idx)
+                    {
+                        auto const new_size = inf.size_product * static_cast<std::ptrdiff_t>(my_size);
+                        auto div = d / new_size;
+                        d %= new_size;
+                        if (static_cast<std::ptrdiff_t>(my_size) - idx < d)
+                        {
+                            i = first;
+                            d -= static_cast<std::ptrdiff_t>(my_size) - idx;
+                            ++div;
+                            RANGES_EXPECT(0 <= d && d < static_cast<std::ptrdiff_t>(my_size));
+                        }
+                        else if (d < -idx)
+                        {
+                            i = first + static_cast<std::ptrdiff_t>(my_size);
+                            d += idx;
+                            --div;
+                            RANGES_EXPECT(0 > d && -d <= static_cast<std::ptrdiff_t>(my_size));
+                        }
+                        advance_(meta::size_t<N - 1>{}, { div, new_size });
+                    }
+                    i += d;
+                }
+                void check_at_end_(meta::size_t<0>, bool = false)
+                {}
+                void check_at_end_(meta::size_t<1>, bool at_end = false)
+                {
+                    if (at_end)
+                    {
+                        ranges::advance(std::get<0>(its_), ranges::end(std::get<0>(view_->views_)));
+                    }
+                }
+                template<std::size_t N>
+                void check_at_end_(meta::size_t<N>, bool at_end = false)
+                {
+                    return check_at_end_(meta::size_t<N - 1>{}, at_end ||
+                        std::get<N - 1>(its_) == ranges::end(std::get<N - 1>(view_->views_)));
+                }
+            public:
+                using value_type = std::tuple<range_value_type_t<Views>...>;
+                cursor() = default;
+                explicit cursor(begin_tag, constify_if<cartesian_product_view>& view)
+                  : view_(&view)
+                  , its_(tuple_transform(view.views_, ranges::begin))
+                {
+                    check_at_end_(meta::size_t<sizeof...(Views)>{});
+                }
+                explicit cursor(end_tag, constify_if<cartesian_product_view>& view)
+                  : cursor(begin_tag{}, view)
+                {
+                    std::get<0>(its_) = ranges::end(std::get<0>(view.views_));
+                }
+                ranges::common_tuple<range_reference_t<Views>...> read() const
+                {
+                    return tuple_transform(its_, ranges::dereference);
+                }
+                void next()
+                {
+                    next_(meta::size_t<sizeof...(Views)>{});
+                }
+                bool equal(default_sentinel) const
+                {
+                    return std::get<0>(its_) == ranges::end(std::get<0>(view_->views_));
+                }
+                bool equal(cursor const &that) const
+                {
+                    return equal_(that, meta::size_t<0>{});
+                }
+                CONCEPT_REQUIRES(CanBidi<IsConst>())
+                void prev()
+                {
+                    prev_(meta::size_t<sizeof...(Views)>{});
+                }
+                CONCEPT_REQUIRES(CanDistance<IsConst>())
+                std::ptrdiff_t distance_to(cursor const &that) const
+                {
+                    return distance_(that, meta::size_t<sizeof...(Views)>{}, {});
+                }
+                CONCEPT_REQUIRES(CanRandom<IsConst>())
+                void advance(std::ptrdiff_t n)
+                {
+                    return advance_(meta::size_t<sizeof...(Views)>{}, { n });
+                }
+            };
+            CONCEPT_REQUIRES(CanConst())
+            cursor<true> begin_cursor() const
+            {
+                return cursor<true>{begin_tag{}, *this};
+            }
+            CONCEPT_REQUIRES(!CanConst())
+            cursor<false> begin_cursor()
+            {
+                return cursor<false>{begin_tag{}, *this};
+            }
+            CONCEPT_REQUIRES(sizeof...(Views) == 0)
+            cursor<true> end_cursor() const
+            {
+                return cursor<true>{begin_tag{}, *this};
+            }
+            CONCEPT_REQUIRES(CanBidi<true>() && sizeof...(Views) > 0)
+            cursor<true> end_cursor() const
+            {
+                return cursor<true>{end_tag{}, *this};
+            }
+            CONCEPT_REQUIRES(CanBidi<false>() && !CanBidi<true>())
+            cursor<false> end_cursor()
+            {
+                return cursor<false>{end_tag{}, *this};
+            }
+            CONCEPT_REQUIRES(!CanBidi<true>())
+            default_sentinel end_cursor() const
+            {
+                return {};
+            }
+        public:
+            cartesian_product_view() = default;
+            CONCEPT_REQUIRES(sizeof...(Views) > 0)
+            constexpr cartesian_product_view(Views... views)
+              : views_{detail::move(views)...}
+            {}
+            CONCEPT_REQUIRES(CanSize<true>())
+            std::size_t size() const
+            {
+                if (sizeof...(Views) == 0) return 0;
+                return tuple_foldl(views_, std::size_t{1},
+                    detail::cartesian_size_fn{});
+            }
+            CONCEPT_REQUIRES(CanSize<false>() && !CanSize<true>())
+            std::size_t size()
+            {
+                return tuple_foldl(views_, std::size_t{1},
+                    detail::cartesian_size_fn{});
+            }
+        };
+
+        namespace view {
+            struct cartesian_product_fn
+            {
+                template<typename... Rngs>
+                using Constraint = meta::strict_and<ForwardRange<Rngs>...>;
+
+                template<typename... Rngs,
+                    CONCEPT_REQUIRES_(Constraint<Rngs...>())>
+                constexpr cartesian_product_view<all_t<Rngs>...> operator()(Rngs &&... rngs) const
+                {
+                    return cartesian_product_view<all_t<Rngs>...>{all((Rngs &&) rngs)...};
+                }
+
+                template<typename... Rngs,
+                    CONCEPT_REQUIRES_(!Constraint<Rngs...>())>
+                void operator()(Rngs &&...) const
+                {
+                    static_assert(meta::strict_and<ForwardRange<Rngs>...>(),
+                        "All of the ranges passed to view::cartesian_product must model the "
+                        "ForwardRange concept.");
+                }
+            };
+
+            RANGES_INLINE_VARIABLE(cartesian_product_fn, cartesian_product)
+        }
+    } // namespace v3
+} // namespace ranges
+
+#endif

--- a/include/range/v3/view/concat.hpp
+++ b/include/range/v3/view/concat.hpp
@@ -39,17 +39,6 @@ namespace ranges
         /// \cond
         namespace detail
         {
-            // Dereference the iterator and coerce the return type
-            template<typename Reference>
-            struct deref_fun
-            {
-                template<typename I>
-                Reference operator()(I const &it) const
-                {
-                    return *it;
-                }
-            };
-
             template<typename State, typename Value>
             using concat_cardinality =
                 std::integral_constant<cardinality,
@@ -254,7 +243,8 @@ namespace ranges
                 reference read() const
                 {
                     // Kind of a dumb implementation. Surely there's a better way.
-                    return ranges::get<0>(unique_variant(its_.visit(detail::deref_fun<reference>{})));
+                    return ranges::get<0>(unique_variant(its_.visit(
+                        compose(convert_to<reference>{}, dereference_fn{}))));
                 }
                 void next()
                 {

--- a/test/view/CMakeLists.txt
+++ b/test/view/CMakeLists.txt
@@ -10,6 +10,9 @@ add_test(test.view.any_view, view.any_view)
 add_executable(view.bounded bounded.cpp)
 add_test(test.view.bounded, view.bounded)
 
+add_executable(view.cartesian_product cartesian_product.cpp)
+add_test(test.view.cartesian_product, view.cartesian_product)
+
 add_executable(view.chunk chunk.cpp)
 add_test(test.view.chunk, view.chunk)
 

--- a/test/view/cartesian_product.cpp
+++ b/test/view/cartesian_product.cpp
@@ -1,0 +1,183 @@
+/// \file
+// Range v3 library
+//
+//  Copyright Eric Niebler 2013-2014.
+//  Copyright Casey Carter 2017.
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#include <iostream>
+#include <range/v3/begin_end.hpp>
+#include <range/v3/empty.hpp>
+#include <range/v3/size.hpp>
+#include <range/v3/span.hpp>
+#include <range/v3/utility/tuple_algorithm.hpp>
+#include <range/v3/view/cartesian_product.hpp>
+#include <range/v3/view/empty.hpp>
+#include <range/v3/view/reverse.hpp>
+#include "../simple_test.hpp"
+#include "../test_utils.hpp"
+
+using namespace ranges;
+
+struct printer {
+    std::ostream &os_;
+    bool &first_;
+
+    template<typename T>
+    void operator()(T const &t) const
+    {
+        if (first_) first_ = false;
+        else os_ << ',';
+        os_ << t;
+    }
+};
+
+namespace ranges {
+    template<typename... Ts>
+    std::ostream &operator<<(std::ostream &os, std::tuple<Ts...> const &t)
+    {
+        os << '(';
+        auto first = true;
+        tuple_for_each(t, printer{os, first});
+        os << ')';
+        return os;
+    }
+}
+
+void test_empty_set()
+{
+    auto rng = view::cartesian_product();
+    using Rng = decltype(rng);
+    CONCEPT_ASSERT(range_cardinality<Rng>::value ==
+        static_cast<cardinality>(0));
+
+    CONCEPT_ASSERT(RandomAccessView<Rng>());
+    CONCEPT_ASSERT(BoundedRange<Rng>());
+    CONCEPT_ASSERT(SizedRange<Rng>());
+    CHECK(size(rng) == 0u);
+    CHECK(empty(rng));
+
+    CONCEPT_ASSERT(std::is_same<
+        range_value_type_t<Rng>,
+        std::tuple<>>());
+    CONCEPT_ASSERT(std::is_same<
+        range_reference_t<Rng>,
+        common_tuple<>>());
+
+    std::initializer_list<common_tuple<>> control{};
+    ::check_equal(rng, control);
+    ::check_equal(view::reverse(rng), view::reverse(control));
+
+    auto const first = begin(rng);
+    auto const last = end(rng);
+    CHECK((last - first) == static_cast<std::ptrdiff_t>(size(rng)));
+    for(auto i = 0; i <= distance(rng); ++i)
+    {
+        for(auto j = 0; j <= distance(rng); ++j)
+        {
+            CHECK((next(first, i) - next(first, j)) == i - j);
+        }
+    }
+}
+
+void test_empty_range()
+{
+    int some_ints[] = {0,1,2,3};
+    auto e = view::empty<char>();
+    auto rng = view::cartesian_product(
+        span<int, size(some_ints)>{some_ints},
+        e
+    );
+    using Rng = decltype(rng);
+    CONCEPT_ASSERT(range_cardinality<Rng>::value ==
+        static_cast<cardinality>(0));
+
+    CONCEPT_ASSERT(RandomAccessView<Rng>());
+    CONCEPT_ASSERT(BoundedRange<Rng>());
+    CONCEPT_ASSERT(SizedRange<Rng>());
+    CHECK(size(rng) == 0u);
+
+    CONCEPT_ASSERT(std::is_same<
+        range_value_type_t<Rng>,
+        std::tuple<int, char>>());
+    CONCEPT_ASSERT(std::is_same<
+        range_reference_t<Rng>,
+        common_tuple<int &, char const &>>());
+
+    using CT = common_tuple<int, char>;
+    std::initializer_list<CT> control = {};
+
+    ::check_equal(rng, control);
+    ::check_equal(view::reverse(rng), view::reverse(control));
+
+    auto const first = begin(rng);
+    auto const last = end(rng);
+    CHECK((last - first) == static_cast<std::ptrdiff_t>(size(rng)));
+    for(auto i = 0; i <= distance(rng); ++i)
+    {
+        for(auto j = 0; j <= distance(rng); ++j)
+        {
+            CHECK((next(first, i) - next(first, j)) == i - j);
+        }
+    }
+}
+
+int main()
+{
+    int some_ints[] = {0,1,2,3};
+    char const * some_strings[] = {"John", "Paul", "George", "Ringo"};
+    auto rng = view::cartesian_product(
+        span<int, size(some_ints)>{some_ints},
+        span<char const*, size(some_strings)>{some_strings}
+    );
+    using Rng = decltype(rng);
+    CONCEPT_ASSERT(range_cardinality<Rng>::value ==
+        range_cardinality<decltype(some_ints)>::value *
+        range_cardinality<decltype(some_strings)>::value);
+
+    CONCEPT_ASSERT(RandomAccessView<Rng>());
+    CONCEPT_ASSERT(BoundedRange<Rng>());
+    CONCEPT_ASSERT(SizedRange<Rng>());
+    CHECK(size(rng) == size(some_ints) * size(some_strings));
+
+    CONCEPT_ASSERT(std::is_same<
+        range_value_type_t<Rng>,
+        std::tuple<int, char const *>>());
+    CONCEPT_ASSERT(std::is_same<
+        range_reference_t<Rng>,
+        common_tuple<int &, char const * &>>());
+
+    using CT = common_tuple<int, char const *>;
+    std::initializer_list<CT> control = {
+        CT{0, "John"}, CT{0, "Paul"}, CT{0, "George"}, CT{0, "Ringo"},
+        CT{1, "John"}, CT{1, "Paul"}, CT{1, "George"}, CT{1, "Ringo"},
+        CT{2, "John"}, CT{2, "Paul"}, CT{2, "George"}, CT{2, "Ringo"},
+        CT{3, "John"}, CT{3, "Paul"}, CT{3, "George"}, CT{3, "Ringo"}
+    };
+
+    ::check_equal(rng, control);
+    ::check_equal(view::reverse(rng), view::reverse(control));
+
+    auto const first = begin(rng);
+    auto const last = end(rng);
+    CHECK((last - first) == static_cast<std::ptrdiff_t>(size(rng)));
+    for(auto i = 0; i <= distance(rng); ++i)
+    {
+        for(auto j = 0; j <= distance(rng); ++j)
+        {
+            CHECK((next(first, i) - next(first, j)) == i - j);
+        }
+    }
+
+    test_empty_set();
+    test_empty_range();
+
+    return test_result();
+}


### PR DESCRIPTION
* Expose `common_tuple::base`

* Move `detail:deref_fun` into functional.hpp and rename to `dereference` so `cartesian_product can reuse it

* Drive-by:
  * Polish constraints in `to_container`
  * sort view.hpp
  * Pass function objects by reference internally in the tuple algorithms
