### PR TITLE
Get range-v3 to compile with gcc-5.2 (fixes #614)

### DIFF
--- a/include/range/v3/utility/concepts.hpp
+++ b/include/range/v3/utility/concepts.hpp
@@ -100,12 +100,15 @@ namespace ranges
             template<typename Concept>
             using base_concepts_of_t = meta::_t<base_concepts_of<Concept>>;
 
+            template<typename T>
+            T gcc_bugs_bugs_bugs(T);
+
             template<typename...Ts>
             auto models_(any) ->
                 std::false_type;
 
             template<typename...Ts, typename Concept,
-                typename = decltype(&Concept::template requires_<Ts...>)>
+                typename = decltype(gcc_bugs_bugs_bugs(&Concept::template requires_<Ts...>))>
             auto models_(Concept *) ->
                 meta::apply<
                     meta::quote<meta::lazy::strict_and>,
@@ -485,13 +488,10 @@ namespace ranges
 
             struct Destructible
             {
-                template<typename T,
-                    typename UnRefT = meta::_t<std::remove_reference<T>>>
-                auto requires_(T &t, UnRefT const &ct) -> decltype(
+                template<typename T>
+                auto requires_() -> decltype(
                     concepts::valid_expr(
-                        concepts::is_true(std::is_nothrow_destructible<T>()),
-                        concepts::has_type<UnRefT *>(&t),
-                        concepts::has_type<UnRefT const *>(&ct)
+                        concepts::is_true(std::is_nothrow_destructible<T>())
                     ));
             };
 


### PR DESCRIPTION
Also, `Destructible` doesn't check for sane address-of operator (refs ericniebler/stl2#382)