### PR TITLE
Default the default constructor of overloaded

### DIFF
--- a/include/range/v3/utility/functional.hpp
+++ b/include/range/v3/utility/functional.hpp
@@ -450,13 +450,7 @@ namespace ranges
             using base_t::first;
             using base_t::second;
         public:
-            CONCEPT_REQUIRES(meta::and_<
-                DefaultConstructible<First>, DefaultConstructible<Rest>...>())
-            constexpr overloaded()
-                noexcept(meta::strict_and<
-                    std::is_nothrow_default_constructible<First>,
-                    std::is_nothrow_default_constructible<Rest>...>::value)
-            {}
+            overloaded() = default;
             constexpr overloaded(First first, Rest... rest)
               : overloaded::compressed_pair{
                     detail::move(first),


### PR DESCRIPTION
Avoids some nasty interaction between defaulted and inherited default constructors that manifests with g++-4.9 in utility.variant and view.transform.