### PR TITLE
Use ranges::detail::assert on MinGW

### DIFF
--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -16,9 +16,10 @@
 #define RANGES_V3_DETAIL_CONFIG_HPP
 
 #include <iosfwd>
-#if(defined(NDEBUG) && !defined(RANGES_ENSURE_MSG)) || \
+#if (defined(NDEBUG) && !defined(RANGES_ENSURE_MSG)) || \
     (!defined(NDEBUG) && !defined(RANGES_ASSERT) && \
-     defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5)
+     defined(__GNUC__) && !defined(__clang__) && \
+     (__GNUC__ < 5 || defined(__MINGW32__)))
 #include <cstdio>
 #include <cstdlib>
 
@@ -40,7 +41,8 @@ namespace ranges
 #endif
 
 #ifndef RANGES_ASSERT
-#if !defined(NDEBUG) && defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5
+#if !defined(NDEBUG) && defined(__GNUC__) && !defined(__clang__) && \
+    (__GNUC__ < 5 || defined(__MINGW32__))
 #define RANGES_ASSERT(...) \
     static_cast<void>((__VA_ARGS__) ? void(0) : \
         ::ranges::detail::assert_failure(__FILE__, __LINE__, "assertion failed: " #__VA_ARGS__))


### PR DESCRIPTION
Fixes #654.

MinGW's `assert` is not `[[noreturn]]`.