### PR TITLE
Build on GCC 7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,8 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.0")
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-field-initializers")
     endif()
+  elseif(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "7.0")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-noexcept-type")
   endif()
   set(CMAKE_CXX_FLAGS_DEBUG "-O0 -fno-inline -g3 -fstack-protector-all")
   set(CMAKE_CXX_FLAGS_RELEASE "-Ofast -g0 -DNDEBUG")
@@ -87,7 +89,7 @@ range_v3_append_flag(RANGE_V3_HAS_MTUNE_NATIVE "-mtune=native")
 file(GLOB_RECURSE RANGE_V3_PUBLIC_HEADERS
                   RELATIVE "${CMAKE_SOURCE_DIR}/include"
                   "${CMAKE_SOURCE_DIR}/include/*.hpp")
-				  
+
 # Add header files as sources to fix MSVS 2017 not finding source during debugging
 file(GLOB_RECURSE RANGE_V3_PUBLIC_HEADERS_ABSOLUTE
                   "${CMAKE_SOURCE_DIR}/include/*.hpp")

--- a/test/getlines.cpp
+++ b/test/getlines.cpp
@@ -27,9 +27,10 @@ good men
 )";
 
     std::stringstream sin{text};
-    ::check_equal(getlines(sin), {"Now is", "the time", "for all", "good men"});
+    auto rng = getlines(sin);
+    ::check_equal(rng, {"Now is", "the time", "for all", "good men"});
 
-    using Rng = decltype(getlines(sin));
+    using Rng = decltype(rng);
     CONCEPT_ASSERT(InputView<Rng>());
     CONCEPT_ASSERT(!ForwardView<Rng>());
     CONCEPT_ASSERT(Same<range_rvalue_reference_t<Rng>, std::string &&>());

--- a/test/view/replace_if.cpp
+++ b/test/view/replace_if.cpp
@@ -9,6 +9,14 @@
 //
 // Project home: https://github.com/ericniebler/range-v3
 
+// HACKHACKHACK silence false positive:
+//   error: ‘<anonymous>.ranges::v3::istream_range<int>::cursor::rng_’ may be used uninitialized in this function
+// triggered on line 39.
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 7
+#include <range/v3/detail/config.hpp>
+RANGES_DIAGNOSTIC_IGNORE("-Wmaybe-uninitialized")
+#endif
+
 #include <string>
 #include <sstream>
 #include <vector>


### PR DESCRIPTION
Partially addresses #659

* Disable `-Wnoexcept-type` globally

* Perma-workaround `-Wstrict-aliasing` false positive in getlines.cpp ([GCC PR 80633](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80633))

* Disable `-Wmaybe-uninitialized` in view/replace_if.cpp (I *think* this is a false positive, but it needs proper investigation.)
