### PR TITLE
Batch of bugfixes

### DIFF
--- a/include/meta/meta.hpp
+++ b/include/meta/meta.hpp
@@ -693,7 +693,7 @@ namespace meta
         /// we express it using \c defer as follows:
         ///
         /// \code
-        /// template<typename List>
+        /// template <typename List>
         /// using reverse = reverse_fold<List, list<>, lambda<_a, _b, defer<push_back,
         /// _a, _b>>>;
         /// \endcode
@@ -3204,7 +3204,7 @@ namespace meta
         /// A lexically scoped expression with local variables.
         ///
         /// \code
-        /// template<typename T, typename List>
+        /// template <typename T, typename List>
         /// using find_index_ = let<
         ///     var<_a, List>,
         ///     var<_b, lazy::find<_a, T>>,
@@ -3292,11 +3292,34 @@ namespace meta
         /// \cond
         ///////////////////////////////////////////////////////////////////////////////////////////
         // add_const_if
-        template <typename If>
-        using add_const_if = if_<If, quote_trait<std::add_const>, quote_trait<id>>;
-
+        namespace detail
+        {
+            template <bool>
+            struct add_const_if
+            {
+                template <typename T>
+                using invoke = T const;
+            };
+            template <>
+            struct add_const_if<false>
+            {
+                template <typename T>
+                using invoke = T;
+            };
+        } // namespace detail
         template <bool If>
-        using add_const_if_c = if_c<If, quote_trait<std::add_const>, quote_trait<id>>;
+        using add_const_if_c = detail::add_const_if<If>;
+        template <typename If>
+        using add_const_if = add_const_if_c<If::type::value>;
+        /// \endcond
+
+        /// \cond
+        ///////////////////////////////////////////////////////////////////////////////////////////
+        // const_if
+        template <bool If, typename T>
+        using const_if_c = invoke<add_const_if_c<If>, T>;
+        template <typename If, typename T>
+        using const_if = invoke<add_const_if<If>, T>;
         /// \endcond
 
         /// \cond

--- a/include/range/v3/action/action.hpp
+++ b/include/range/v3/action/action.hpp
@@ -75,7 +75,7 @@ namespace ranges
                     Range<Rng>,
                     meta::not_<std::is_reference<Rng>>>;
 
-                // Pipeing requires things are passed by value.
+                // Piping requires things are passed by value.
                 template<typename Rng, typename Act,
                     CONCEPT_REQUIRES_(ActionPipeConcept<Rng>())>
                 static auto pipe(Rng && rng, Act && act)

--- a/include/range/v3/front.hpp
+++ b/include/range/v3/front.hpp
@@ -18,7 +18,6 @@
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/range_traits.hpp>
-#include <range/v3/utility/iterator.hpp>
 #include <range/v3/utility/static_const.hpp>
 
 namespace ranges
@@ -30,9 +29,8 @@ namespace ranges
         {
             /// \return `*begin(rng)`
             template<typename Rng,
-                CONCEPT_REQUIRES_(Range<Rng>())>
-            RANGES_CXX14_CONSTEXPR
-            range_reference_t<Rng> operator()(Rng &&rng) const
+                CONCEPT_REQUIRES_(ForwardRange<Rng>())>
+            constexpr range_reference_t<Rng> operator()(Rng &&rng) const
             {
                 return *begin(rng);
             }

--- a/include/range/v3/getlines.hpp
+++ b/include/range/v3/getlines.hpp
@@ -55,10 +55,6 @@ namespace ranges
                 {
                     return !*rng_->sin_;
                 }
-                std::string && move() const noexcept
-                {
-                    return detail::move(rng_->str_);
-                }
             };
             void next()
             {

--- a/include/range/v3/istream_range.hpp
+++ b/include/range/v3/istream_range.hpp
@@ -55,11 +55,6 @@ namespace ranges
                 {
                     return !*rng_->sin_;
                 }
-                Val && move() const noexcept
-                {
-                    return detail::move(rng_->cached());
-                }
-
             };
             void next()
             {
@@ -95,7 +90,7 @@ namespace ranges
         {
             CONCEPT_ASSERT_MSG(DefaultConstructible<Val>(),
                "Only DefaultConstructible types are extractable from streams.");
-            return istream_range<Val>{sin};
+            return {sin};
         }
     #else
         template<typename Val, CONCEPT_REQUIRES_(DefaultConstructible<Val>())>
@@ -103,7 +98,7 @@ namespace ranges
         {
             istream_range<Val> operator()(std::istream & sin) const
             {
-                return istream_range<Val>{sin};
+                return {sin};
             }
         };
 

--- a/include/range/v3/iterator_range.hpp
+++ b/include/range/v3/iterator_range.hpp
@@ -78,6 +78,10 @@ namespace ranges
             {
                 return {begin(), end()};
             }
+            constexpr bool empty() const
+            {
+                return begin() == end();
+            }
         };
 
         // Like iterator_range, but with a known size. The first and second members

--- a/include/range/v3/range_concepts.hpp
+++ b/include/range/v3/range_concepts.hpp
@@ -424,11 +424,6 @@ namespace ranges
             struct view_predicate_<std::unordered_multiset<Key, Hash, Pred, Alloc>>
               : std::false_type
             {};
-
-            template<typename T, std::size_t N>
-            struct view_predicate_<T[N]>
-              : std::false_type
-            {};
         }
         /// \endcond
 

--- a/include/range/v3/view/cartesian_product.hpp
+++ b/include/range/v3/view/cartesian_product.hpp
@@ -98,7 +98,7 @@ namespace ranges
             class cursor
             {
                 template<typename T>
-                using constify_if = meta::invoke<meta::add_const_if_c<IsConst>, T>;
+                using constify_if = meta::const_if_c<IsConst, T>;
                 using pos_t = std::tuple<iterator_t<constify_if<Views>>...>;
                 constify_if<cartesian_product_view> *view_;
                 pos_t its_;

--- a/include/range/v3/view/concat.hpp
+++ b/include/range/v3/view/concat.hpp
@@ -81,7 +81,7 @@ namespace ranges
             private:
                 friend struct cursor<IsConst>;
                 template<typename T>
-                using constify_if = meta::invoke<meta::add_const_if_c<IsConst>, T>;
+                using constify_if = meta::const_if_c<IsConst, T>;
                 using concat_view_t = constify_if<concat_view>;
                 sentinel_t<constify_if<meta::back<meta::list<Rngs...>>>> end_;
             public:
@@ -97,7 +97,7 @@ namespace ranges
                 using difference_type = common_type_t<range_difference_type_t<Rngs>...>;
             private:
                 template<typename T>
-                using constify_if = meta::invoke<meta::add_const_if_c<IsConst>, T>;
+                using constify_if = meta::const_if_c<IsConst, T>;
                 using concat_view_t = constify_if<concat_view>;
                 concat_view_t *rng_;
                 variant<iterator_t<constify_if<Rngs>>...> its_;

--- a/include/range/v3/view/const.hpp
+++ b/include/range/v3/view/const.hpp
@@ -55,10 +55,10 @@ namespace ranges
                     return *it;
                 }
                 rvalue_reference_ iter_move(iterator_t<Rng> const &it) const
-                    noexcept(noexcept(ranges::iter_move(it)))
-                {
-                    return ranges::iter_move(it);
-                }
+                RANGES_AUTO_RETURN_NOEXCEPT
+                (
+                    ranges::iter_move(it)
+                )
             };
             adaptor begin_adaptor() const
             {

--- a/include/range/v3/view/cycle.hpp
+++ b/include/range/v3/view/cycle.hpp
@@ -60,7 +60,7 @@ namespace ranges
             {
             private:
                 template<typename T>
-                using constify_if = meta::invoke<meta::add_const_if_c<IsConst>, T>;
+                using constify_if = meta::const_if_c<IsConst, T>;
                 using cycled_view_t = constify_if<cycled_view>;
                 using difference_type_ = range_difference_type_t<Rng>;
                 using iterator = iterator_t<constify_if<Rng>>;

--- a/include/range/v3/view/indirect.hpp
+++ b/include/range/v3/view/indirect.hpp
@@ -81,8 +81,6 @@ namespace ranges
                 template<typename Rng>
                 using Concept = meta::and_<
                     InputRange<Rng>,
-                    // Stricter than necessary because of the SemiRegular requirement,
-                    // but maybe that's ok?
                     Readable<range_value_type_t<Rng>>>;
 
                 template<typename Rng,

--- a/include/range/v3/view/reverse.hpp
+++ b/include/range/v3/view/reverse.hpp
@@ -70,7 +70,7 @@ namespace ranges
             struct adaptor : adaptor_base
             {
             private:
-                using reverse_view_t = meta::invoke<meta::add_const_if_c<IsConst>, reverse_view>;
+                using reverse_view_t = meta::const_if_c<IsConst, reverse_view>;
                 reverse_view_t *rng_;
             public:
                 adaptor() = default;

--- a/include/range/v3/view/take.hpp
+++ b/include/range/v3/view/take.hpp
@@ -39,17 +39,15 @@ namespace ranges
             friend struct ranges::range_access;
             range_difference_type_t<Rng> n_ = 0;
 
-            template<bool IsConst, typename T>
-            using add_const_if = meta::if_c<IsConst, T const, T>;
             template<bool IsConst>
-            using CI = counted_iterator<iterator_t<add_const_if<IsConst, Rng>>>;
+            using CI = counted_iterator<iterator_t<meta::const_if_c<IsConst, Rng>>>;
             template<bool IsConst>
-            using S = sentinel_t<add_const_if<IsConst, Rng>>;
+            using S = sentinel_t<meta::const_if_c<IsConst, Rng>>;
 
             template<bool IsConst>
             struct adaptor : adaptor_base
             {
-                CI<IsConst> begin(add_const_if<IsConst, take_view> &rng) const
+                CI<IsConst> begin(meta::const_if_c<IsConst, take_view> &rng) const
                 {
                     return {ranges::begin(rng.base()), rng.n_};
                 }

--- a/include/range/v3/view/take_exactly.hpp
+++ b/include/range/v3/view/take_exactly.hpp
@@ -102,6 +102,7 @@ namespace ranges
                   : rng_(std::move(rng)), n_(n)
                 {
                     RANGES_EXPECT(n >= 0);
+                    RANGES_EXPECT(!SizedRange<Rng>() || n <= ranges::distance(rng_));
                 }
                 iterator_t<Rng> begin()
                 {

--- a/include/range/v3/view/tokenize.hpp
+++ b/include/range/v3/view/tokenize.hpp
@@ -41,6 +41,10 @@ namespace ranges
                 is_finite<Rng>::value ? finite : range_cardinality<Rng>::value>
         {
         private:
+            CONCEPT_ASSERT(BidirectionalView<Rng>() && BoundedRange<Rng>());
+            CONCEPT_ASSERT(SemiRegular<Regex>());
+            CONCEPT_ASSERT(SemiRegular<SubMatchRange>());
+
             Rng rng_;
             Regex rex_;
             SubMatchRange subs_;
@@ -50,10 +54,10 @@ namespace ranges
                 std::regex_token_iterator<iterator_t<Rng>>;
 
             tokenize_view() = default;
-            tokenize_view(Rng rng, Regex && rex, SubMatchRange subs,
+            tokenize_view(Rng rng, Regex rex, SubMatchRange subs,
                 std::regex_constants::match_flag_type flags)
               : rng_(std::move(rng))
-              , rex_(static_cast<Regex&&>(rex))
+              , rex_(std::move(rex))
               , subs_(std::move(subs))
               , flags_(flags)
             {}
@@ -85,7 +89,7 @@ namespace ranges
             struct tokenizer_impl_fn
             {
                 template<typename Rng, typename Regex>
-                tokenize_view<all_t<Rng>, Regex, int>
+                tokenize_view<all_t<Rng>, detail::decay_t<Regex>, int>
                 operator()(Rng && rng, Regex && rex, int sub = 0,
                     std::regex_constants::match_flag_type flags =
                         std::regex_constants::match_default) const
@@ -93,14 +97,14 @@ namespace ranges
                     CONCEPT_ASSERT(BidirectionalRange<Rng>());
                     CONCEPT_ASSERT(BoundedRange<Rng>());
                     static_assert(std::is_same<range_value_type_t<Rng>,
-                        typename std::remove_reference<Regex>::type::value_type>::value,
+                        typename detail::decay_t<Regex>::value_type>::value,
                         "The character range and the regex have different character types");
                     return {all(static_cast<Rng&&>(rng)), static_cast<Regex&&>(rex), sub,
                             flags};
                 }
 
                 template<typename Rng, typename Regex>
-                tokenize_view<all_t<Rng>, Regex, std::vector<int>>
+                tokenize_view<all_t<Rng>, detail::decay_t<Regex>, std::vector<int>>
                 operator()(Rng && rng, Regex && rex, std::vector<int> subs,
                     std::regex_constants::match_flag_type flags =
                         std::regex_constants::match_default) const
@@ -108,14 +112,14 @@ namespace ranges
                     CONCEPT_ASSERT(BidirectionalRange<Rng>());
                     CONCEPT_ASSERT(BoundedRange<Rng>());
                     static_assert(std::is_same<range_value_type_t<Rng>,
-                        typename std::remove_reference<Regex>::type::value_type>::value,
+                        typename detail::decay_t<Regex>::value_type>::value,
                         "The character range and the regex have different character types");
                     return {all(static_cast<Rng&&>(rng)), static_cast<Regex&&>(rex),
                             std::move(subs), flags};
                 }
 
                 template<typename Rng, typename Regex>
-                tokenize_view<all_t<Rng>, Regex, std::initializer_list<int>>
+                tokenize_view<all_t<Rng>, detail::decay_t<Regex>, std::initializer_list<int>>
                 operator()(Rng && rng, Regex && rex,
                     std::initializer_list<int> subs, std::regex_constants::match_flag_type flags =
                         std::regex_constants::match_default) const
@@ -123,7 +127,7 @@ namespace ranges
                     CONCEPT_ASSERT(BidirectionalRange<Rng>());
                     CONCEPT_ASSERT(BoundedRange<Rng>());
                     static_assert(std::is_same<range_value_type_t<Rng>,
-                        typename std::remove_reference<Regex>::type::value_type>::value,
+                        typename detail::decay_t<Regex>::value_type>::value,
                         "The character range and the regex have different character types");
                     return {all(static_cast<Rng&&>(rng)), static_cast<Regex&&>(rex),
                             std::move(subs), flags};

--- a/include/range/v3/view/view.hpp
+++ b/include/range/v3/view/view.hpp
@@ -85,7 +85,7 @@ namespace ranges
                 template<typename Rng, typename ...Rest>
                 using ViewConcept = meta::and_<ViewableRange<Rng>, Invocable<View&, Rng, Rest...>>;
 
-                // Pipeing requires range arguments or lvalue containers.
+                // Piping requires range arguments or lvalue containers.
                 template<typename Rng, typename Vw,
                     CONCEPT_REQUIRES_(ViewConcept<Rng>())>
                 static auto pipe(Rng && rng, Vw && v)

--- a/include/range/v3/view_interface.hpp
+++ b/include/range/v3/view_interface.hpp
@@ -67,11 +67,13 @@ namespace ranges
         protected:
             Derived & derived()
             {
+                CONCEPT_ASSERT(DerivedFrom<Derived, view_interface>());
                 return static_cast<Derived &>(*this);
             }
             /// \overload
             Derived const & derived() const
             {
+                CONCEPT_ASSERT(DerivedFrom<Derived, view_interface>());
                 return static_cast<Derived const &>(*this);
             }
             ~view_interface() = default;
@@ -82,14 +84,25 @@ namespace ranges
             view_interface &operator=(view_interface &&) = default;
             view_interface &operator=(view_interface const &) = default;
             // A few ways of testing whether a range can be empty:
+            CONCEPT_REQUIRES(Cardinality >= 0)
             constexpr bool empty() const
             {
-                return Cardinality == 0 ? true : derived().begin() == derived().end();
+                return Cardinality == 0;
             }
+            template<class D = Derived,
+                CONCEPT_REQUIRES_(Same<D, Derived>() && Cardinality < 0 && ForwardRange<D const>())>
+            constexpr bool empty() const
+            {
+                return derived().begin() == derived().end();
+            }
+            template<class D = Derived,
+                CONCEPT_REQUIRES_(Same<D, Derived>() && (Cardinality >= 0 || ForwardRange<D const>()))>
             constexpr bool operator!() const
             {
                 return empty();
             }
+            template<class D = Derived,
+                CONCEPT_REQUIRES_(Same<D, Derived>() && (Cardinality >= 0 || ForwardRange<D const>()))>
             constexpr explicit operator bool() const
             {
                 return !empty();
@@ -103,43 +116,43 @@ namespace ranges
             }
             template<typename D = Derived,
                 CONCEPT_REQUIRES_(Same<D, Derived>() && Cardinality < 0 &&
-                    SizedSentinel<sentinel_t<const D>, iterator_t<const D>>() &&
-                    ForwardIterator<iterator_t<const D>>())>
+                    SizedSentinel<sentinel_t<D const>, iterator_t<D const>>() &&
+                    ForwardRange<D const>())>
             constexpr range_size_type_t<D> size() const
             {
                 return iter_size(derived().begin(), derived().end());
             }
             /// Access the first element in a range:
             template<typename D = Derived,
-                CONCEPT_REQUIRES_(Same<D, Derived>())>
+                CONCEPT_REQUIRES_(Same<D, Derived>() && ForwardRange<D>())>
             range_reference_t<D> front()
             {
                 return *derived().begin();
             }
             /// \overload
             template<typename D = Derived,
-                CONCEPT_REQUIRES_(Same<D, Derived>())>
+                CONCEPT_REQUIRES_(Same<D, Derived>() && ForwardRange<D const>())>
             range_reference_t<D const> front() const
             {
                 return *derived().begin();
             }
             /// Access the last element in a range:
             template<typename D = Derived,
-                CONCEPT_REQUIRES_(Same<D, Derived>() && BoundedRange<D &>() && BidirectionalRange<D &>())>
+                CONCEPT_REQUIRES_(Same<D, Derived>() && BoundedRange<D>() && BidirectionalRange<D>())>
             range_reference_t<D> back()
             {
                 return *prev(derived().end());
             }
             /// \overload
             template<typename D = Derived,
-                CONCEPT_REQUIRES_(Same<D, Derived>() && BoundedRange<D const &>() && BidirectionalRange<D const &>())>
+                CONCEPT_REQUIRES_(Same<D, Derived>() && BoundedRange<D const>() && BidirectionalRange<D const>())>
             range_reference_t<D const> back() const
             {
                 return *prev(derived().end());
             }
             /// Simple indexing:
             template<typename D = Derived,
-                CONCEPT_REQUIRES_(Same<D, Derived>() && RandomAccessRange<D &>())>
+                CONCEPT_REQUIRES_(Same<D, Derived>() && RandomAccessRange<D>())>
             auto operator[](range_difference_type_t<D> n) ->
                 decltype(std::declval<D &>().begin()[n])
             {
@@ -147,7 +160,7 @@ namespace ranges
             }
             /// \overload
             template<typename D = Derived,
-                CONCEPT_REQUIRES_(Same<D, Derived>() && RandomAccessRange<D const &>())>
+                CONCEPT_REQUIRES_(Same<D, Derived>() && RandomAccessRange<D const>())>
             auto operator[](range_difference_type_t<D> n) const ->
                 decltype(std::declval<D const &>().begin()[n])
             {
@@ -244,7 +257,7 @@ namespace ranges
             }
             /// Implicit conversion to something that looks like a container.
             template<typename Container, typename D = Derived,
-                typename Alloc = typename Container::allocator_type, // HACKHACK
+                typename = typename Container::allocator_type, // HACKHACK
                 CONCEPT_REQUIRES_(detail::ConvertibleToContainer<D, Container>())>
             operator Container ()
             {
@@ -252,7 +265,7 @@ namespace ranges
             }
             /// \overload
             template<typename Container, typename D = Derived,
-                typename Alloc = typename Container::allocator_type, // HACKHACK
+                typename = typename Container::allocator_type, // HACKHACK
                 CONCEPT_REQUIRES_(detail::ConvertibleToContainer<D const, Container>())>
             operator Container () const
             {
@@ -274,7 +287,7 @@ namespace ranges
             }
             /// \overload
             template<bool B = true, typename Stream = meta::if_c<B, std::ostream>,
-                typename D = Derived, CONCEPT_REQUIRES_(InputRange<D const &>())>
+                typename D = Derived, CONCEPT_REQUIRES_(InputRange<D const>())>
             friend Stream &operator<<(Stream &sout, Derived const &rng)
             {
                 auto it = ranges::begin(rng);

--- a/test/istream_range.cpp
+++ b/test/istream_range.cpp
@@ -1,3 +1,14 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+
 #include <range/v3/istream_range.hpp>
 #include <range/v3/iterator_range.hpp>
 #include <sstream>

--- a/test/view/tokenize.cpp
+++ b/test/view/tokenize.cpp
@@ -12,7 +12,7 @@ int main()
 #if !defined(__GNUC__) || defined(__clang__) || __GNUC__ > 4 || __GNUC_MINOR__ > 8
     std::string txt{"abc\ndef\tghi"};
     const std::regex rx{R"delim(([\w]+))delim"};
-    auto&& rng = txt | view::tokenize(rx,1);
+    auto rng = txt | view::tokenize(rx,1);
     const auto& crng = txt | view::tokenize(rx,1);
 
     ::check_equal(rng, {"abc","def","ghi"});
@@ -33,8 +33,8 @@ int main()
     ::models_not<concepts::SizedRange>(crng);
     ::models_not<concepts::OutputRange>(crng);
 
-    // ::models<concepts::View>(aux::copy(rng));
-    // ::models<concepts::View>(aux::copy(crng));
+    ::models<concepts::View>(aux::copy(rng));
+    ::models<concepts::View>(aux::copy(crng));
 #endif
 
     return test_result();


### PR DESCRIPTION
Things I found while investigating move-only input views.

* Implement `meta::add_const_if` directly to avoid defer overhead. Add friendlier `meta::const_if` front-end for `add_const_if`. (Not a bugfix)

* Implement `empty` per the Ranges TS spec.

* `front` now requires a forward range. It's not technically *wrong* on input ranges, but all the uses in the library are bugs.

* `getline_` and `istream_range` can use the default `iter_move`; don't implement `move()` in their cursors. (Not a bugfix)

* `istream_range<T>` doesn't require `T` to be `MoveConstructible`, so `istream()` needs to construct its return object in-place.

* Implement `empty` for `iterator_range` since the default implementation in `view_interface` no longer works for input ranges (see below)

* remove unnecessary specialization of `view_predicate_<T[N]>`; array types don't model `View` since they're not `SemiRegular` (Not a bugfix)

`view_interface`:
* Implement distinct overload of `empty` for ranges with fixed cardinality
* Disable `operator bool`, `operator!`, and `empty` overloads that call `begin()` for `!ForwardView`
* `front()` requires `ForwardView`
* (minor syntax cleanups)

* Fix constraints for sizing `chunk_view`s that adapt input views

* `Readable` is no longer overconstraining for `indirect_fn` because it no longer requires `SemiRegular` (Not a bugfix)

* Don't call `empty` on input views in `intersperse_view`!

* Don't call `empty` and `front` on input views in `partial_sum_view`! (also, store the accumulator in a `semiregular_t` instead of `optional` while I'm in here.)

* `sample_view` should properly adapt mutable-only views

* simplify some flow control in `set_union_cursor` (Not a bugfix)

* Store `decay_t<Regex>` in `tokenize_view`, so it's actually a `View`
