### PR TITLE
Implement coroutine generator support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,17 @@ endif()
 range_v3_append_flag(RANGE_V3_HAS_MARCH_NATIVE "-march=native")
 range_v3_append_flag(RANGE_V3_HAS_MTUNE_NATIVE "-mtune=native")
 
+# Test for coroutine TS support
+include(CheckCXXSourceCompiles)
+
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/cmake/coro_test_code.cpp" RANGE_V3_CORO_TEST_CODE)
+set(CMAKE_REQUIRED_FLAGS "-fcoroutines-ts")
+check_cxx_source_compiles("${RANGE_V3_CORO_TEST_CODE}" RANGE_V3_HAS_FCOROUTINES_TS)
+
+if (RANGE_V3_HAS_FCOROUTINES_TS)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcoroutines-ts")
+endif()
+
 # Test all headers
 file(GLOB_RECURSE RANGE_V3_PUBLIC_HEADERS
                   RELATIVE "${CMAKE_SOURCE_DIR}/include"

--- a/cmake/coro_test_code.cpp
+++ b/cmake/coro_test_code.cpp
@@ -1,0 +1,36 @@
+#include <experimental/coroutine>
+
+namespace coro = std::experimental::coroutines_v1;
+
+struct present
+{
+    struct promise_type
+    {
+        int result;
+
+        present get_return_object() { return {*this}; }
+        coro::suspend_never initial_suspend() { return {}; }
+        coro::suspend_never final_suspend() { return {}; }
+        void return_value(int i) { result = i; }
+        void unhandled_exception() {}
+    };
+
+    promise_type& promise;
+
+    bool await_ready() const { return true; }
+    void await_suspend(coro::coroutine_handle<>) const {}
+    int await_resume() const { return promise.result; }
+};
+
+present f(int n)
+{
+    if (n < 2)
+        co_return 1;
+    else
+        co_return n * co_await f(n - 1);
+}
+
+int main()
+{
+    return f(5).promise.result != 120;
+}

--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -141,6 +141,10 @@ namespace ranges
 #define RANGES_CXX_INLINE_VARIABLES_11 0
 #define RANGES_CXX_INLINE_VARIABLES_14 0
 #define RANGES_CXX_INLINE_VARIABLES_17 201606
+#define RANGES_CXX_COROUTINES_11 0
+#define RANGES_CXX_COROUTINES_14 0
+#define RANGES_CXX_COROUTINES_17 0
+#define RANGES_CXX_COROUTINES_TS1 201703
 
 #if defined(_MSC_VER) && !defined(__clang__)
 #if _MSC_VER >= 1900
@@ -332,6 +336,14 @@ namespace ranges
 #endif
 #else
 #define RANGES_DEPRECATED(MSG)
+#endif
+
+#ifndef RANGES_CXX_COROUTINES
+#ifdef __cpp_coroutines
+#define RANGES_CXX_COROUTINES __cpp_coroutines
+#else
+#define RANGES_CXX_COROUTINES RANGES_CXX_FEATURE(COROUTINES)
+#endif
 #endif
 
 // RANGES_CXX14_CONSTEXPR macro (see also BOOST_CXX14_CONSTEXPR)

--- a/include/range/v3/experimental/utility/generator.hpp
+++ b/include/range/v3/experimental/utility/generator.hpp
@@ -1,0 +1,353 @@
+// Range v3 library
+//
+//  Copyright Casey Carter 2017
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+#ifndef RANGES_V3_EXPERIMENTAL_UTILITY_GENERATOR_HPP
+#define RANGES_V3_EXPERIMENTAL_UTILITY_GENERATOR_HPP
+
+#include <range/v3/detail/config.hpp>
+#if RANGES_CXX_COROUTINES >= RANGES_CXX_COROUTINES_TS1
+#include <cstddef>
+#include <exception>
+#include <utility>
+#include <experimental/coroutine>
+#include <meta/meta.hpp>
+#include <range/v3/range_traits.hpp>
+#include <range/v3/view_facade.hpp>
+#include <range/v3/detail/optional.hpp>
+#include <range/v3/utility/box.hpp>
+#include <range/v3/utility/concepts.hpp>
+#include <range/v3/utility/swap.hpp>
+#include <range/v3/view/all.hpp>
+
+namespace ranges
+{
+    inline namespace v3
+    {
+        /// \addtogroup group-utility
+        /// @{
+        namespace experimental
+        {
+            // The type of size() for a sized_generator
+            using generator_size_t = std::size_t;
+
+            // Type upon which to co_await to set the size of a sized_generator
+            enum struct generator_size : generator_size_t { invalid = ~generator_size_t(0) };
+
+            template<typename Promise = void>
+            struct coroutine_owner;
+        } // namespace experimental
+
+        /// \cond
+        namespace detail
+        {
+            inline void resume(std::experimental::coroutine_handle<> coro)
+            {
+                // Pre: coro refers to a suspended coroutine.
+                RANGES_EXPECT(coro);
+                RANGES_EXPECT(!coro.done());
+                coro.resume();
+            }
+
+            namespace coroutine_owner_
+            {
+                struct adl_hook {};
+
+                template<typename Promise>
+                void swap(experimental::coroutine_owner<Promise> &x,
+                          experimental::coroutine_owner<Promise> &y) noexcept
+                {
+                    ranges::swap(x.base(), y.base());
+                }
+            } // namespace coroutine_owner_
+        } // namespace detail
+        /// \endcond
+
+        namespace experimental
+        {
+            // An owning coroutine_handle
+            template<typename Promise>
+            struct coroutine_owner
+              : std::experimental::coroutine_handle<Promise>
+              , private detail::coroutine_owner_::adl_hook
+            {
+                using base_t = std::experimental::coroutine_handle<Promise>;
+
+                using base_t::operator bool;
+                using base_t::done;
+                using base_t::promise;
+
+                constexpr coroutine_owner() noexcept = default;
+                explicit constexpr coroutine_owner(base_t coro) noexcept
+                  : base_t(coro)
+                {}
+                RANGES_CXX14_CONSTEXPR coroutine_owner(coroutine_owner &&that) noexcept
+                  : base_t(ranges::exchange(that.base(), {}))
+                {}
+
+                ~coroutine_owner() { if (*this) base().destroy(); }
+
+                coroutine_owner &operator=(coroutine_owner &&that) noexcept
+                {
+                    coroutine_owner{ranges::exchange(base(), ranges::exchange(that.base(), {}))};
+                    return *this;
+                }
+
+                void resume() { detail::resume(base()); }
+                void operator()() { detail::resume(base()); }
+
+                base_t &base() noexcept { return *this; }
+                base_t const &base() const noexcept { return *this; }
+
+                base_t release() noexcept
+                {
+                    return ranges::exchange(base(), {});
+                }
+            };
+        } // namespace experimental
+
+        /// \cond
+        namespace detail
+        {
+            // storage for the reference to the current element
+            template<typename Reference, typename = void>
+            struct generator_promise_storage
+            {
+                CONCEPT_ASSERT(CopyConstructible<Reference>());
+
+                Reference const &read() const noexcept
+                {
+                    RANGES_EXPECT(opt_);
+                    return *opt_;
+                }
+                template<typename Arg,
+                    CONCEPT_REQUIRES_(Assignable<Reference &, Arg>())>
+                void store(Arg &&arg)
+                {
+                    // ranges::optional is weird. For std::optional this would be:
+                    //   opt_ = std::forward<Arg>(arg);
+                    if (opt_) *opt_ = std::forward<Arg>(arg);
+                    else opt_ = std::forward<Arg>(arg);
+                }
+                template<typename Arg,
+                    CONCEPT_REQUIRES_(!Assignable<Reference &, Arg>() &&
+                        Constructible<Reference, Arg>())>
+                void store(Arg &&arg)
+                {
+                    // ranges::optional is weird. For std::optional this would be:
+                    //   opt_.emplace(std::forward<Arg>(arg));
+                    opt_ = std::forward<Arg>(arg);
+                }
+            private:
+                optional<Reference> opt_;
+            };
+
+            template<typename Reference>
+            struct generator_promise_storage<Reference, meta::if_<std::is_reference<Reference>>>
+            {
+                Reference read() const noexcept
+                {
+                    RANGES_EXPECT(ptr_);
+                    return static_cast<Reference>(*ptr_);
+                }
+                template<typename Arg>
+                void store(Arg &&arg) noexcept
+                {
+                    ptr_ = std::addressof(arg);
+                }
+            private:
+                meta::_t<std::remove_reference<Reference>> *ptr_ = nullptr;
+            };
+
+            template<typename Reference>
+            struct generator_promise_storage<Reference, meta::if_<SemiRegular<Reference>>>
+              : private box<Reference, generator_promise_storage<Reference>>
+            {
+                Reference const &read() const noexcept
+                {
+                    return get();
+                }
+                template<typename Arg>
+                void store(Arg &&arg)
+                {
+                    get() = std::forward<Arg>(arg);
+                }
+            private:
+                using box<Reference, generator_promise_storage<Reference>>::get;
+            };
+
+            template<typename Reference>
+            struct generator_promise
+              : private generator_promise_storage<Reference>
+            {
+            private:
+                using base_t = generator_promise_storage<Reference>;
+            public:
+                std::exception_ptr except_ = nullptr;
+
+                using base_t::read;
+                generator_promise *get_return_object() noexcept
+                {
+                    return this;
+                }
+                std::experimental::suspend_always initial_suspend() const noexcept
+                {
+                    return {};
+                }
+                std::experimental::suspend_always final_suspend() const noexcept
+                {
+                    return {};
+                }
+                void return_void() const noexcept
+                {}
+                void unhandled_exception() noexcept
+                {
+                    except_ = std::current_exception();
+                    RANGES_EXPECT(except_);
+                }
+                template<typename Arg, CONCEPT_REQUIRES_(ConvertibleTo<Arg, Reference>())>
+                std::experimental::suspend_always yield_value(Arg &&arg)
+                    noexcept(noexcept(std::declval<base_t &>().store(std::declval<Arg>())))
+                {
+                    base_t::store(std::forward<Arg>(arg));
+                    return {};
+                }
+                std::experimental::suspend_never
+                await_transform(experimental::generator_size) const noexcept
+                {
+                    RANGES_ENSURE_MSG(false, "Invalid size request for a non-sized generator");
+                    return {};
+                }
+            };
+
+            template<typename Reference>
+            struct sized_generator_promise
+              : generator_promise<Reference>
+            {
+                sized_generator_promise *get_return_object() noexcept
+                {
+                    return this;
+                }
+                std::experimental::suspend_never initial_suspend() const noexcept
+                {
+                    // sized_generator doesn't suspend at its initial suspend point because...
+                    return {};
+                }
+                std::experimental::suspend_always
+                await_transform(experimental::generator_size size) noexcept
+                {
+                    // ...we need the coroutine set the size of the range first by
+                    // co_awaiting on a generator_size.
+                    size_ = size;
+                    return {};
+                }
+                experimental::generator_size_t size() const noexcept
+                {
+                    RANGES_EXPECT(size_ != experimental::generator_size::invalid);
+                    return static_cast<experimental::generator_size_t>(size_);
+                }
+            private:
+                experimental::generator_size size_ = experimental::generator_size::invalid;
+            };
+        } // namespace detail
+        /// \endcond
+
+        namespace experimental
+        {
+            template<typename Reference, typename Value = uncvref_t<Reference>>
+            struct generator
+              : view_facade<generator<Reference, Value>>
+            {
+                using promise_type = detail::generator_promise<Reference>;
+
+                constexpr generator() noexcept = default;
+                generator(promise_type *p)
+                  : coro_{handle::from_promise(*p)}
+                {
+                    RANGES_EXPECT(coro_);
+                }
+
+            protected:
+                coroutine_owner<promise_type> coro_;
+            private:
+                friend range_access;
+                using handle = std::experimental::coroutine_handle<promise_type>;
+
+                struct cursor
+                {
+                    using value_type = Value;
+
+                    cursor() = default;
+                    constexpr explicit cursor(handle coro) noexcept
+                      : coro_{coro}
+                    {}
+                    bool equal(default_sentinel) const
+                    {
+                        RANGES_EXPECT(coro_);
+                        if (coro_.done())
+                        {
+                            auto &e = coro_.promise().except_;
+                            if (e) std::rethrow_exception(std::move(e));
+                            return true;
+                        }
+                        return false;
+                    }
+                    void next()
+                    {
+                        detail::resume(coro_);
+                    }
+                    Reference read() const
+                    {
+                        RANGES_EXPECT(coro_);
+                        return coro_.promise().read();
+                    }
+                private:
+                    handle coro_ = nullptr;
+                };
+
+                cursor begin_cursor()
+                {
+                    detail::resume(coro_);
+                    return cursor{coro_};
+                }
+            };
+
+            template<typename Reference, typename Value = uncvref_t<Reference>>
+            struct sized_generator
+              : generator<Reference, Value>
+            {
+                using promise_type = detail::sized_generator_promise<Reference>;
+                using handle = std::experimental::coroutine_handle<promise_type>;
+
+                constexpr sized_generator() noexcept = default;
+                sized_generator(promise_type *p)
+                  : generator<Reference, Value>{p}
+                {}
+                generator_size_t size() const noexcept
+                {
+                    return promise().size();
+                }
+            private:
+                using generator<Reference, Value>::coro_;
+
+                promise_type const &promise() const noexcept
+                {
+                    RANGES_EXPECT(coro_);
+                    return static_cast<promise_type const &>(coro_.promise());
+                }
+            };
+        } // namespace experimental
+
+        /// @}
+    } // inline namespace v3
+} // namespace ranges
+#endif // RANGES_CXX_COROUTINES >= RANGES_CXX_COROUTINES_TS1
+
+#endif // RANGES_V3_EXPERIMENTAL_UTILITY_GENERATOR_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,19 +32,22 @@ add_executable(distance distance.cpp)
 add_test(test.distance distance)
 
 add_executable(to_container to_container.cpp)
-add_test(test.to_container, to_container)
+add_test(test.to_container to_container)
 
 add_executable(getlines getlines.cpp)
-add_test(test.getlines, getlines)
+add_test(test.getlines getlines)
 
 add_executable(istream_range istream_range.cpp)
-add_test(test.istream_range, istream_range)
+add_test(test.istream_range istream_range)
 
 add_executable(bug474 bug474.cpp)
-add_test(test.bug474, bug474)
+add_test(test.bug474 bug474)
 
 add_executable(bug566 bug566.cpp)
-add_test(test.bug566, bug566)
+add_test(test.bug566 bug566)
 
 add_executable(span span.cpp)
-add_test(test.span, span)
+add_test(test.span span)
+
+add_executable(generator generator.cpp)
+add_test(test.generator generator)

--- a/test/generator.cpp
+++ b/test/generator.cpp
@@ -1,0 +1,283 @@
+// Range v3 library
+//
+//  Copyright Casey Carter 2017
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+#include <range/v3/detail/config.hpp>
+#if RANGES_CXX_COROUTINES >= RANGES_CXX_COROUTINES_TS1
+#include <iostream>
+#include <vector>
+#include <range/v3/begin_end.hpp>
+#include <range/v3/range_for.hpp>
+#include <range/v3/algorithm/copy.hpp>
+#include <range/v3/algorithm/count.hpp>
+#include <range/v3/algorithm/equal.hpp>
+#include <range/v3/utility/swap.hpp>
+#include <range/v3/view/filter.hpp>
+#include <range/v3/view/iota.hpp>
+#include <range/v3/view/move.hpp>
+#include <range/v3/view/take_exactly.hpp>
+#include <range/v3/view/transform.hpp>
+#include <range/v3/experimental/utility/generator.hpp>
+#include "simple_test.hpp"
+#include "test_utils.hpp"
+
+template<bool Condition>
+using maybe_sized_generator = meta::if_c<Condition,
+    meta::quote<ranges::experimental::sized_generator>,
+    meta::quote<ranges::experimental::generator>>;
+
+struct coro_fn
+{
+private:
+    template<typename Rng>
+    using Constraint = meta::and_<ranges::InputRange<Rng>,
+        meta::or_<std::is_reference<ranges::range_reference_t<Rng>>,
+            ranges::CopyConstructible<ranges::range_reference_t<Rng>>>>;
+
+    template<typename V>
+    using generator_for = meta::invoke<
+        maybe_sized_generator<(bool) ranges::SizedRange<V>()>,
+        ranges::range_reference_t<V>,
+        ranges::range_value_type_t<V>>;
+
+    template<typename V,
+        CONCEPT_REQUIRES_(Constraint<V>() && ranges::View<V>())>
+    static generator_for<V> impl(V v)
+    {
+        if /* constexpr */ (ranges::SizedRange<V>())
+            co_await static_cast<ranges::experimental::generator_size>(ranges::distance(v));
+        auto first = ranges::begin(v);
+        auto const last = ranges::end(v);
+        for (; first != last; ++first)
+            co_yield *first;
+    }
+public:
+    template<typename Rng,
+        CONCEPT_REQUIRES_(meta::and_<
+            meta::not_<meta::is<ranges::uncvref_t<Rng>, ranges::experimental::generator>>,
+            meta::not_<meta::is<ranges::uncvref_t<Rng>, ranges::experimental::sized_generator>>,
+            Constraint<Rng>>::value)>
+    generator_for<ranges::view::all_t<Rng>> operator()(Rng &&rng) const
+    {
+        return impl(ranges::view::all(static_cast<Rng &&>(rng)));
+    }
+    template<typename R, typename V>
+    ranges::experimental::generator<R, V>
+    operator()(ranges::experimental::generator<R, V> g) const noexcept
+    {
+        return g;
+    }
+    template<typename R, typename V>
+    ranges::experimental::sized_generator<R, V>
+    operator()(ranges::experimental::sized_generator<R, V> g) const noexcept
+    {
+        return g;
+    }
+};
+
+RANGES_INLINE_VARIABLE(coro_fn, coro)
+
+auto f(int const n)
+RANGES_DECLTYPE_AUTO_RETURN
+(
+    ::coro(ranges::view::iota(0, n))
+)
+
+ranges::experimental::sized_generator<int> g(int const n)
+{
+    co_await static_cast<ranges::experimental::generator_size>(n > 0 ? n : 0);
+    for (int i = 0; i < n; ++i)
+        co_yield i;
+}
+
+ranges::experimental::sized_generator<int &> h(int const n)
+{
+    co_await static_cast<ranges::experimental::generator_size>(n > 0 ? n : 0);
+    for (int i = 0; i < n; ++i)
+        co_yield i;
+}
+
+template<class T, CONCEPT_REQUIRES_(ranges::WeaklyIncrementable<T>())>
+ranges::experimental::generator<T> iota_generator(T t)
+{
+    for (;; ++t)
+        co_yield t;
+}
+
+template<class T, class S,
+    CONCEPT_REQUIRES_(ranges::WeaklyIncrementable<T>() &&
+        ranges::WeaklyEqualityComparable<T, S>() &&
+        !ranges::SizedIncrementableSentinel<S, T>())>
+ranges::experimental::generator<T> iota_generator(T t, S const s)
+{
+    for (; t != s; ++t)
+        co_yield t;
+}
+
+template<class T, class S,
+    CONCEPT_REQUIRES_(ranges::SizedIncrementableSentinel<S, T>())>
+ranges::experimental::sized_generator<T> iota_generator(T t, S const s)
+{
+    co_await static_cast<ranges::experimental::generator_size>(s - t);
+    for (; t != s; ++t)
+        co_yield t;
+}
+
+template<class V, class F,
+    CONCEPT_REQUIRES_(ranges::InputView<V>() &&
+        ranges::IndirectPredicate<F, ranges::iterator_t<V>>())>
+ranges::experimental::generator<ranges::range_reference_t<V>, ranges::range_value_type_t<V>>
+filter(V view, F f)
+{
+    RANGES_FOR(auto &&i, view)
+    {
+        if (ranges::invoke(f, i))
+            co_yield i;
+    }
+}
+
+template<class V, class F,
+    CONCEPT_REQUIRES_(ranges::InputView<V>() &&
+        ranges::IndirectInvocable<F, ranges::iterator_t<V>>())>
+meta::invoke<
+    maybe_sized_generator<(bool) ranges::SizedRange<V>()>,
+    ranges::indirect_result_of_t<F &(ranges::iterator_t<V>)>>
+transform(V view, F f)
+{
+    if /* constexpr */ (ranges::SizedRange<V>())
+        co_await static_cast<ranges::experimental::generator_size>(ranges::distance(view));
+    RANGES_FOR(auto &&i, view)
+        co_yield ranges::invoke(f, i);
+}
+
+struct MoveInt
+{
+    int i_;
+
+    MoveInt(int i = 42) : i_{i}
+    {}
+    MoveInt(MoveInt &&that) noexcept
+      : i_{ranges::exchange(that.i_, 0)}
+    {}
+    MoveInt &operator=(MoveInt &&that) noexcept
+    {
+        i_ = ranges::exchange(that.i_, 0);
+        return *this;
+    }
+
+    friend bool operator==(MoveInt const &x, MoveInt const &y)
+    {
+        return x.i_ == y.i_;
+    }
+    friend bool operator!=(MoveInt const &x, MoveInt const &y)
+    {
+        return !(x == y);
+    }
+
+    friend std::ostream &operator<<(std::ostream &os, MoveInt const &mi)
+    {
+        return os << mi.i_;
+    }
+};
+
+int main()
+{
+    using namespace ranges;
+
+    {
+        auto rng = ::iota_generator(0, 10);
+        ::models<concepts::SizedRange>(rng);
+        CHECK(size(rng) == 10u);
+        CHECK(equal(rng, {0,1,2,3,4,5,6,7,8,9}));
+    }
+    {
+        auto rng = ::coro(::coro(::coro(::iota_generator(0, 10))));
+        ::has_type<decltype(::iota_generator(0, 10)) &>(rng);
+        ::models<concepts::SizedRange>(rng);
+        CHECK(size(rng) == 10u);
+        CHECK(equal(rng, {0,1,2,3,4,5,6,7,8,9}));
+    }
+    {
+        auto even = [](int i){ return i % 2 == 0; };
+        auto rng = ::coro(view::ints | view::filter(even) | view::take_exactly(10));
+        ::models<concepts::SizedRange>(rng);
+        CHECK(size(rng) == 10u);
+        CHECK(equal(rng, {0,2,4,6,8,10,12,14,16,18}));
+    }
+    {
+        auto const control = {1, 2, 3};
+        MoveInt a[] = {{1}, {2}, {3}};
+        MoveInt b[3];
+        CHECK(equal(a, control, std::equal_to<int>{}, &MoveInt::i_));
+        CHECK(count(b, 42, &MoveInt::i_) == 3);
+        auto rng = ::coro(view::move(a));
+        ::models<concepts::SizedRange>(rng);
+        CHECK(size(rng) == 3u);
+        copy(rng, b);
+        CHECK(equal(b, control, std::equal_to<int>{}, &MoveInt::i_));
+        CHECK(count(a, 0, &MoveInt::i_) == 3);
+    }
+    {
+        int some_ints[] = {0,1,2};
+        auto rng = ::coro(some_ints);
+        ::models<concepts::SizedRange>(rng);
+        CHECK(size(rng) == 3u);
+        auto i = begin(rng);
+        auto e = end(rng);
+        CHECK(i != e);
+        CHECK(&*i == &some_ints[0]);
+        ++i;
+        CHECK(i != e);
+        CHECK(&*i == &some_ints[1]);
+        ++i;
+        CHECK(i != e);
+        CHECK(&*i == &some_ints[2]);
+        ++i;
+        CHECK(i == e);
+    }
+    {
+        std::vector<bool> vec(3, false);
+        auto rng = ::coro(vec);
+        ::models<concepts::SizedRange>(rng);
+        CHECK(size(rng) == 3u);
+        CHECK(equal(rng, {false,false,false}));
+    }
+    CHECK(equal(f(42), g(42)));
+    CHECK(equal(f(42), h(42)));
+
+    // Since generator is a range, but not a view, it must be an lvalue to
+    // participate in view composition.
+    {
+#if 0
+        auto rng = h(20) | view::transform([](int &x) { return ++x; });
+#else
+        auto gen = h(20);
+        auto rng = gen | view::transform([](int &x) { return ++x; });
+#endif
+        ::check_equal(rng, {1,3,5,7,9,11,13,15,17,19});
+    }
+
+    {
+        auto even = [](int i) { return i % 2 == 0; };
+        auto square = [](int i) { return i * i; };
+
+        int const some_ints[] = {0,1,2,3,4,5,6,7};
+        auto rng1 = ::filter(view::all(some_ints), even);
+        auto rng2 = ::transform(view::all(rng1), square);
+        ::check_equal(rng2, {0,4,16,36});
+    }
+
+    std::cout << f(8) << '\n';
+
+    return ::test_result();
+}
+#else // RANGES_CXX_COROUTINES >= RANGES_CXX_COROUTINES_TS1
+int main() {}
+#endif // RANGES_CXX_COROUTINES >= RANGES_CXX_COROUTINES_TS1


### PR DESCRIPTION
* Cmake support for detecting `-fcoroutines-ts` compiler flag and library support in `<experimental/coroutine>`
* Config system support for `RANGES_CXX_COROUTINES`
* Implement coroutine Range generator `ranges::experimental::generator`, and SizedRange generator `ranges::experimental::sized_generator`