### PR TITLE
Allow move-only single-pass Views

### DIFF
--- a/include/range/v3/istream_range.hpp
+++ b/include/range/v3/istream_range.hpp
@@ -33,7 +33,7 @@ namespace ranges
         private:
             friend range_access;
             std::istream *sin_;
-            semiregular_t<Val> obj_;
+            movesemiregular_t<Val> obj_;
             struct cursor
             {
             private:

--- a/include/range/v3/range_concepts.hpp
+++ b/include/range/v3/range_concepts.hpp
@@ -204,12 +204,11 @@ namespace ranges
             ///
 
             struct View
-              : refines<Range>
+              : refines<Range, Movable, DefaultConstructible>
             {
                 template<typename T>
                 auto requires_() -> decltype(
                     concepts::valid_expr(
-                        concepts::model_of<SemiRegular, T>(),
                         concepts::is_true(detail::view_predicate_<T>())
                     ));
             };
@@ -223,7 +222,7 @@ namespace ranges
             {};
 
             struct ForwardView
-              : refines<InputView, ForwardRange>
+              : refines<InputView, ForwardRange, Copyable>
             {};
 
             struct BidirectionalView

--- a/include/range/v3/utility/memory.hpp
+++ b/include/range/v3/utility/memory.hpp
@@ -23,10 +23,11 @@
 
 #include <memory>
 #include <type_traits>
-#include <range/v3/range_fwd.hpp>
 #include <meta/meta.hpp>
+#include <range/v3/detail/config.hpp>
 #include <range/v3/utility/iterator_concepts.hpp>
 #include <range/v3/utility/iterator_traits.hpp>
+#include <range/v3/utility/polymorphic_cast.hpp>
 
 namespace ranges
 {
@@ -44,6 +45,13 @@ namespace ranges
                         std::return_temporary_buffer(p);
                 }
             };
+
+            template<typename T, typename... Args,
+                CONCEPT_REQUIRES_(!std::is_array<T>::value)>
+            std::unique_ptr<T> make_unique(Args &&... args)
+            {
+                return std::unique_ptr<T>{new T(static_cast<Args &&>(args)...)};
+            }
         }
         /// \endcond
 

--- a/include/range/v3/utility/polymorphic_cast.hpp
+++ b/include/range/v3/utility/polymorphic_cast.hpp
@@ -5,6 +5,10 @@
 
 #ifndef RANGES_V3_UTILITY_POLYMORPHIC_CAST_HPP
 #define RANGES_V3_UTILITY_POLYMORPHIC_CAST_HPP
+
+#include <memory>
+#include <type_traits>
+#include <meta/meta.hpp>
 #include <range/v3/detail/config.hpp>
 
 namespace ranges
@@ -12,10 +16,19 @@ namespace ranges
     inline namespace v3
     {
         template<typename Target, typename Source>
-        inline Target polymorphic_downcast(Source* x)
+        meta::if_<std::is_pointer<Target>, Target>
+        polymorphic_downcast(Source *x) noexcept
         {
             RANGES_ASSERT(dynamic_cast<Target>(x) == x);
             return static_cast<Target>(x);
+        }
+        template<typename Target, typename Source>
+        meta::if_<std::is_reference<Target>, Target>
+        polymorphic_downcast(Source &&x) noexcept
+        {
+            using PTarget = meta::_t<std::add_pointer<Target>>;
+            auto ptr = polymorphic_downcast<PTarget>(std::addressof(x));
+            return static_cast<Target>(*ptr);
         }
     }
 }

--- a/include/range/v3/utility/semiregular.hpp
+++ b/include/range/v3/utility/semiregular.hpp
@@ -195,6 +195,13 @@ namespace ranges
         using semiregular_t =
             meta::if_<SemiRegular<T>, T, semiregular<T>>;
 
+        template<typename T>
+        using movesemiregular_t =
+            meta::if_c<
+                Movable<T>() && DefaultConstructible<T>(),
+                T,
+                semiregular<T>>;
+
         template<typename T, bool IsConst = false>
         using semiregular_ref_or_val_t =
             meta::if_<

--- a/include/range/v3/view/generate.hpp
+++ b/include/range/v3/view/generate.hpp
@@ -39,18 +39,17 @@ namespace ranges
           : view_facade<generate_view<G>, infinite>
         {
         private:
-            friend struct ranges::range_access;
+            friend range_access;
             using result_t = result_of_t<G&()>;
-            semiregular_t<G> gen_;
-            semiregular_t<result_t> val_;
+            movesemiregular_t<G> gen_;
+            movesemiregular_t<result_t> val_;
             struct cursor
             {
             private:
                 generate_view *view_;
             public:
-                using single_pass = std::true_type;
                 cursor() = default;
-                cursor(generate_view &view)
+                explicit cursor(generate_view &view)
                   : view_(&view)
                 {}
                 result_t read() const
@@ -68,7 +67,7 @@ namespace ranges
             }
             cursor begin_cursor()
             {
-                return {*this};
+                return cursor{*this};
             }
             unreachable end_cursor() const
             {
@@ -92,7 +91,7 @@ namespace ranges
                 template<typename G>
                 using Concept = meta::and_<
                     Invocable<G&>,
-                    CopyConstructible<G>,
+                    MoveConstructible<G>,
                     std::is_object<detail::decay_t<result_of_t<G&()>>>,
                     Constructible<detail::decay_t<result_of_t<G&()>>, result_of_t<G&()>>,
                     Assignable<detail::decay_t<result_of_t<G&()>>&, result_of_t<G&()>>>;
@@ -115,8 +114,8 @@ namespace ranges
                 {
                     CONCEPT_ASSERT_MSG(Invocable<G&>(),
                         "The function object G must be callable with no arguments.");
-                    CONCEPT_ASSERT_MSG(CopyConstructible<G>(),
-                        "The function object G must be CopyConstructible.");
+                    CONCEPT_ASSERT_MSG(MoveConstructible<G>(),
+                        "The function object G must be MoveConstructible.");
                     using T = result_of_t<G&()>;
                     using D = detail::decay_t<T>;
                     CONCEPT_ASSERT_MSG(std::is_object<D>(),

--- a/include/range/v3/view/generate_n.hpp
+++ b/include/range/v3/view/generate_n.hpp
@@ -38,19 +38,18 @@ namespace ranges
           : view_facade<generate_n_view<G>, finite>
         {
         private:
-            friend struct ranges::range_access;
+            friend range_access;
             using result_t = result_of_t<G&()>;
-            semiregular_t<G> gen_;
-            semiregular_t<result_t> val_;
+            movesemiregular_t<G> gen_;
+            movesemiregular_t<result_t> val_;
             std::size_t n_;
             struct cursor
             {
             private:
                 generate_n_view *rng_;
             public:
-                using single_pass = std::true_type;
                 cursor() = default;
-                cursor(generate_n_view &rng)
+                explicit cursor(generate_n_view &rng)
                   : rng_(&rng)
                 {}
                 bool equal(default_sentinel) const
@@ -74,7 +73,7 @@ namespace ranges
             }
             cursor begin_cursor()
             {
-                return {*this};
+                return cursor{*this};
             }
         public:
             generate_n_view() = default;

--- a/include/range/v3/view_interface.hpp
+++ b/include/range/v3/view_interface.hpp
@@ -170,7 +170,7 @@ namespace ranges
             //      rng[{4,6}]
             template<typename D = Derived, typename Slice = view::slice_fn,
                 CONCEPT_REQUIRES_(Same<D, Derived>())>
-            auto operator[](detail::slice_bounds<range_difference_type_t<D>> offs) ->
+            auto operator[](detail::slice_bounds<range_difference_type_t<D>> offs) & ->
                 decltype(std::declval<Slice>()(std::declval<D &>(), offs.from, offs.to))
             {
                 return Slice{}(derived(), offs.from, offs.to);
@@ -178,17 +178,25 @@ namespace ranges
             /// \overload
             template<typename D = Derived, typename Slice = view::slice_fn,
                 CONCEPT_REQUIRES_(Same<D, Derived>())>
-            auto operator[](detail::slice_bounds<range_difference_type_t<D>> offs) const ->
+            auto operator[](detail::slice_bounds<range_difference_type_t<D>> offs) const & ->
                 decltype(std::declval<Slice>()(std::declval<D const &>(), offs.from, offs.to))
             {
                 return Slice{}(derived(), offs.from, offs.to);
+            }
+            /// \overload
+            template<typename D = Derived, typename Slice = view::slice_fn,
+                CONCEPT_REQUIRES_(Same<D, Derived>())>
+            auto operator[](detail::slice_bounds<range_difference_type_t<D>> offs) && ->
+                decltype(std::declval<Slice>()(std::declval<D>(), offs.from, offs.to))
+            {
+                return Slice{}(detail::move(derived()), offs.from, offs.to);
             }
             //      rng[{4,end-2}]
             /// \overload
             template<typename D = Derived, typename Slice = view::slice_fn,
                 CONCEPT_REQUIRES_(Same<D, Derived>())>
             auto operator[](detail::slice_bounds<range_difference_type_t<D>,
-                detail::from_end_<range_difference_type_t<D>>> offs) ->
+                detail::from_end_<range_difference_type_t<D>>> offs) & ->
                 decltype(std::declval<Slice>()(std::declval<D &>(), offs.from, offs.to))
             {
                 return Slice{}(derived(), offs.from, offs.to);
@@ -197,17 +205,26 @@ namespace ranges
             template<typename D = Derived, typename Slice = view::slice_fn,
                 CONCEPT_REQUIRES_(Same<D, Derived>())>
             auto operator[](detail::slice_bounds<range_difference_type_t<D>,
-                detail::from_end_<range_difference_type_t<D>>> offs) const ->
+                detail::from_end_<range_difference_type_t<D>>> offs) const & ->
                 decltype(std::declval<Slice>()(std::declval<D const &>(), offs.from, offs.to))
             {
                 return Slice{}(derived(), offs.from, offs.to);
+            }
+            /// \overload
+            template<typename D = Derived, typename Slice = view::slice_fn,
+                CONCEPT_REQUIRES_(Same<D, Derived>())>
+            auto operator[](detail::slice_bounds<range_difference_type_t<D>,
+                detail::from_end_<range_difference_type_t<D>>> offs) && ->
+                decltype(std::declval<Slice>()(std::declval<D>(), offs.from, offs.to))
+            {
+                return Slice{}(detail::move(derived()), offs.from, offs.to);
             }
             //      rng[{end-4,end-2}]
             /// \overload
             template<typename D = Derived, typename Slice = view::slice_fn,
                 CONCEPT_REQUIRES_(Same<D, Derived>())>
             auto operator[](detail::slice_bounds<detail::from_end_<range_difference_type_t<D>>,
-                detail::from_end_<range_difference_type_t<D>>> offs) ->
+                detail::from_end_<range_difference_type_t<D>>> offs) & ->
                 decltype(std::declval<Slice>()(std::declval<D &>(), offs.from, offs.to))
             {
                 return Slice{}(derived(), offs.from, offs.to);
@@ -216,16 +233,25 @@ namespace ranges
             template<typename D = Derived, typename Slice = view::slice_fn,
                 CONCEPT_REQUIRES_(Same<D, Derived>())>
             auto operator[](detail::slice_bounds<detail::from_end_<range_difference_type_t<D>>,
-                detail::from_end_<range_difference_type_t<D>>> offs) const ->
+                detail::from_end_<range_difference_type_t<D>>> offs) const & ->
                 decltype(std::declval<Slice>()(std::declval<D const &>(), offs.from, offs.to))
             {
                 return Slice{}(derived(), offs.from, offs.to);
+            }
+            /// \overload
+            template<typename D = Derived, typename Slice = view::slice_fn,
+                CONCEPT_REQUIRES_(Same<D, Derived>())>
+            auto operator[](detail::slice_bounds<detail::from_end_<range_difference_type_t<D>>,
+                detail::from_end_<range_difference_type_t<D>>> offs) && ->
+                decltype(std::declval<Slice>()(std::declval<D>(), offs.from, offs.to))
+            {
+                return Slice{}(detail::move(derived()), offs.from, offs.to);
             }
             //      rng[{4,end}]
             /// \overload
             template<typename D = Derived, typename Slice = view::slice_fn,
                 CONCEPT_REQUIRES_(Same<D, Derived>())>
-            auto operator[](detail::slice_bounds<range_difference_type_t<D>, end_fn> offs) ->
+            auto operator[](detail::slice_bounds<range_difference_type_t<D>, end_fn> offs) & ->
                 decltype(std::declval<Slice>()(std::declval<D &>(), offs.from, offs.to))
             {
                 return Slice{}(derived(), offs.from, offs.to);
@@ -233,16 +259,24 @@ namespace ranges
             /// \overload
             template<typename D = Derived, typename Slice = view::slice_fn,
                 CONCEPT_REQUIRES_(Same<D, Derived>())>
-            auto operator[](detail::slice_bounds<range_difference_type_t<D>, end_fn> offs) const ->
+            auto operator[](detail::slice_bounds<range_difference_type_t<D>, end_fn> offs) const & ->
                 decltype(std::declval<Slice>()(std::declval<D const &>(), offs.from, offs.to))
             {
                 return Slice{}(derived(), offs.from, offs.to);
+            }
+            /// \overload
+            template<typename D = Derived, typename Slice = view::slice_fn,
+                CONCEPT_REQUIRES_(Same<D, Derived>())>
+            auto operator[](detail::slice_bounds<range_difference_type_t<D>, end_fn> offs) && ->
+                decltype(std::declval<Slice>()(std::declval<D>(), offs.from, offs.to))
+            {
+                return Slice{}(detail::move(derived()), offs.from, offs.to);
             }
             //      rng[{end-4,end}]
             /// \overload
             template<typename D = Derived, typename Slice = view::slice_fn,
                 CONCEPT_REQUIRES_(Same<D, Derived>())>
-            auto operator[](detail::slice_bounds<detail::from_end_<range_difference_type_t<D>>, end_fn> offs) ->
+            auto operator[](detail::slice_bounds<detail::from_end_<range_difference_type_t<D>>, end_fn> offs) & ->
                 decltype(std::declval<Slice>()(std::declval<D &>(), offs.from, offs.to))
             {
                 return Slice{}(derived(), offs.from, offs.to);
@@ -250,10 +284,18 @@ namespace ranges
             /// \overload
             template<typename D = Derived, typename Slice = view::slice_fn,
                 CONCEPT_REQUIRES_(Same<D, Derived>())>
-            auto operator[](detail::slice_bounds<detail::from_end_<range_difference_type_t<D>>, end_fn> offs) const ->
+            auto operator[](detail::slice_bounds<detail::from_end_<range_difference_type_t<D>>, end_fn> offs) const & ->
                 decltype(std::declval<Slice>()(std::declval<D const &>(), offs.from, offs.to))
             {
                 return Slice{}(derived(), offs.from, offs.to);
+            }
+            /// \overload
+            template<typename D = Derived, typename Slice = view::slice_fn,
+                CONCEPT_REQUIRES_(Same<D, Derived>())>
+            auto operator[](detail::slice_bounds<detail::from_end_<range_difference_type_t<D>>, end_fn> offs) && ->
+                decltype(std::declval<Slice>()(std::declval<D>(), offs.from, offs.to))
+            {
+                return Slice{}(detail::move(derived()), offs.from, offs.to);
             }
             /// Implicit conversion to something that looks like a container.
             template<typename Container, typename D = Derived,

--- a/test/debug_view.hpp
+++ b/test/debug_view.hpp
@@ -1,0 +1,187 @@
+// Range v3 library
+//
+//  Copyright Casey Carter 2017
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+#ifndef RANGES_TEST_DEBUG_VIEW_HPP
+#define RANGES_TEST_DEBUG_VIEW_HPP
+
+#include <cstddef>
+#include <range/v3/utility/iterator.hpp>
+#include <range/v3/utility/swap.hpp>
+
+template<typename T, bool Sized = true>
+struct debug_input_view
+{
+    CONCEPT_ASSERT(std::is_object<T>::value);
+
+    using index_t = std::ptrdiff_t;
+    using version_t = unsigned long;
+
+    T *data_ = nullptr;
+    T *last_ = nullptr;
+    version_t version_ = 0;
+    bool valid_ = false;
+    bool begin_called_ = false;
+
+    debug_input_view() = default;
+    constexpr debug_input_view(T* data, index_t size) noexcept
+      : data_{data}
+      , last_{(RANGES_ENSURE(data || !size), data + size)}
+      , valid_{true}
+    {}
+    template<index_t N>
+    constexpr debug_input_view(T (&data)[N]) noexcept
+      : debug_input_view{data, N}
+    {}
+    RANGES_CXX14_CONSTEXPR
+    debug_input_view(debug_input_view &&that) noexcept
+      : data_{ranges::exchange(that.data_, nullptr)}
+      , last_{ranges::exchange(that.last_, nullptr)}
+      , valid_{ranges::exchange(that.valid_, false)}
+    {
+        ++that.version_;
+        if (that.begin_called_)
+        {
+            data_ = last_ = nullptr;
+            valid_ = false;
+        }
+    }
+    RANGES_CXX14_CONSTEXPR
+    debug_input_view &operator=(debug_input_view &&that) noexcept
+    {
+        ++that.version_;
+        data_ = ranges::exchange(that.data_, nullptr);
+        last_ = ranges::exchange(that.last_, nullptr);
+        valid_ = ranges::exchange(that.valid_, false);
+        begin_called_ = false;
+        if (that.begin_called_)
+        {
+            data_ = last_ = nullptr;
+            valid_ = false;
+        }
+        ++version_;
+        return *this;
+    }
+
+    struct sentinel
+    {
+        debug_input_view *view_ = nullptr;
+
+        sentinel() = default;
+        explicit constexpr sentinel(debug_input_view &view) noexcept
+          : view_{&view}
+        {}
+    };
+    struct iterator
+    {
+        using iterator_category = std::input_iterator_tag;
+        using value_type = meta::_t<std::remove_cv<T>>;
+        using difference_type = index_t;
+        using reference = T &;
+        using pointer = T *;
+
+        debug_input_view *view_ = nullptr;
+        version_t version_ = 0;
+
+        iterator() = default;
+        explicit constexpr iterator(debug_input_view &view) noexcept
+          : view_{&view}, version_{view.version_}
+        {}
+
+        RANGES_CXX14_CONSTEXPR void check_current() const noexcept
+        {
+            RANGES_ENSURE(view_), RANGES_ENSURE(view_->version_ == version_);
+        }
+
+        RANGES_CXX14_CONSTEXPR void check_dereferenceable() const noexcept
+        {
+            check_current(), RANGES_ENSURE(view_->data_ < view_->last_);
+        }
+
+        RANGES_CXX14_CONSTEXPR
+        reference operator*() const noexcept
+        {
+            check_dereferenceable();
+            return *view_->data_;
+        }
+        RANGES_CXX14_CONSTEXPR
+        iterator &operator++() noexcept
+        {
+            check_dereferenceable();
+            ++view_->data_;
+            version_ = ++view_->version_;
+            return *this;
+        }
+        RANGES_CXX14_CONSTEXPR
+        void operator++(int) noexcept
+        {
+            ++*this;
+        }
+
+        RANGES_CXX14_CONSTEXPR
+        friend bool operator==(iterator const &i, sentinel const &s)
+        {
+            RANGES_ENSURE(i.view_ == s.view_);
+            i.check_current();
+            return i.view_->data_ == i.view_->last_;
+        }
+        RANGES_CXX14_CONSTEXPR
+        friend bool operator==(sentinel const &s, iterator const &i)
+        {
+            return i == s;
+        }
+        RANGES_CXX14_CONSTEXPR
+        friend bool operator!=(iterator const &i, sentinel const &s)
+        {
+            return !(i == s);
+        }
+        RANGES_CXX14_CONSTEXPR
+        friend bool operator!=(sentinel const &s, iterator const &i)
+        {
+            return !(i == s);
+        }
+        CONCEPT_REQUIRES(Sized)
+        RANGES_CXX14_CONSTEXPR
+        friend difference_type operator-(sentinel const& s, iterator const& i)
+        {
+            RANGES_ENSURE(i.view_ == s.view_);
+            i.check_current();
+            return i.view_->last_ - i.view_->data_;
+        }
+        CONCEPT_REQUIRES(Sized)
+        RANGES_CXX14_CONSTEXPR
+        friend difference_type operator-(iterator const& i, sentinel const& s)
+        {
+            return -(s - i);
+        }
+    };
+    RANGES_CXX14_CONSTEXPR iterator begin() noexcept
+    {
+        RANGES_ENSURE(valid_);
+        RANGES_ENSURE(!begin_called_);
+        begin_called_ = true;
+        return iterator{*this};
+    }
+    RANGES_CXX14_CONSTEXPR sentinel end() noexcept
+    {
+        RANGES_ENSURE(valid_);
+        return sentinel{*this};
+    }
+    CONCEPT_REQUIRES(Sized)
+    RANGES_CXX14_CONSTEXPR
+    std::size_t size() const noexcept
+    {
+        RANGES_ENSURE(valid_);
+        RANGES_ENSURE(!begin_called_);
+        return static_cast<std::size_t>(last_ - data_);
+    }
+};
+
+#endif

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -23,6 +23,7 @@
 #include <range/v3/utility/iterator_traits.hpp>
 #include <range/v3/range_concepts.hpp>
 #include <range/v3/range_traits.hpp>
+#include "./debug_view.hpp"
 #include "./simple_test.hpp"
 #include "./test_iterators.hpp"
 

--- a/test/view/all.cpp
+++ b/test/view/all.cpp
@@ -41,5 +41,16 @@ int main()
     rrgi = view::all(stdref);
     rrgi = view::all(static_cast<std::reference_wrapper<int[7]> const &>(stdref));
 
+    {
+        auto v = view::all(debug_input_view<int const>{rgi});
+        CHECK(v.size() == size(rgi));
+        CHECK(v.data_ == rgi);
+        auto v2 = view::all(view::all(view::all(std::move(v))));
+        CONCEPT_ASSERT(Same<decltype(v), decltype(v2)>());
+        CHECK(!v.valid_);
+        CHECK(v2.size() == size(rgi));
+        CHECK(v2.data_ == rgi);
+    }
+
     return test_result();
 }

--- a/test/view/any_view.cpp
+++ b/test/view/any_view.cpp
@@ -26,15 +26,12 @@ int main()
 
     {
         any_view<int> ints = view::ints;
-        ::models<concepts::InputView>(aux::copy(ints));
-        ::models_not<concepts::ForwardView>(aux::copy(ints));
-        ::check_equal(ints | view::take(10), ten_ints);
-        ::check_equal(ints | view::take(10), ten_ints);
+        CONCEPT_ASSERT(InputView<decltype(ints)>());
+        CONCEPT_ASSERT(!ForwardView<decltype(ints)>());
+        ::check_equal(std::move(ints) | view::take(10), ten_ints);
     }
     {
         any_view<int> ints2 = view::ints | view::take(10);
-        ::models<concepts::InputView>(aux::copy(ints2));
-        ::models_not<concepts::ForwardView>(aux::copy(ints2));
         ::check_equal(ints2, ten_ints);
         ::check_equal(ints2, ten_ints);
     }
@@ -65,7 +62,8 @@ int main()
         ::check_equal(any_view<int>{vec}, ten_ints);
         ::check_equal(any_view<int>{ranges::detail::as_const(vec)}, ten_ints);
 
-        struct Int {
+        struct Int
+        {
             int i_;
 
             Int(int i) : i_{i} {}
@@ -73,6 +71,13 @@ int main()
         };
         auto vec2 = std::vector<Int>{begin(ten_ints), end(ten_ints)};
         ::check_equal(any_view<int>{vec2}, ten_ints);
+    }
+
+    {
+        auto v = unique_any_view<int>{debug_input_view<int const>{
+            ten_ints.begin(), std::ptrdiff_t(ten_ints.size())
+        }};
+        ::check_equal(v, ten_ints);
     }
 
     return test_result();

--- a/test/view/any_view.cpp
+++ b/test/view/any_view.cpp
@@ -74,7 +74,7 @@ int main()
     }
 
     {
-        auto v = unique_any_view<int>{debug_input_view<int const>{
+        auto v = any_view<int>{debug_input_view<int const>{
             ten_ints.begin(), std::ptrdiff_t(ten_ints.size())
         }};
         ::check_equal(v, ten_ints);

--- a/test/view/bounded.cpp
+++ b/test/view/bounded.cpp
@@ -105,5 +105,15 @@ int main()
         ::check_equal(rng2, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
     }
 
+    {
+        int const data[] = {1,2,3,4};
+        auto rng = debug_input_view<int const>{data} | view::bounded;
+        using Rng = decltype(rng);
+        CONCEPT_ASSERT(InputView<Rng>());
+        CONCEPT_ASSERT(!ForwardRange<Rng>());
+        CONCEPT_ASSERT(BoundedRange<Rng>());
+        ::check_equal(rng, {1,2,3,4});
+    }
+
     return ::test_result();
 }

--- a/test/view/chunk.cpp
+++ b/test/view/chunk.cpp
@@ -34,16 +34,10 @@ namespace
         int const ints[] = {0,1,2,3,4};
         constexpr auto N = ranges::size(ints);
         constexpr auto K = 2;
-        auto base = [&]
-        {
-            auto first = input_iterator<int const*, true>(ranges::begin(ints));
-            auto last = input_iterator<int const*, true>(ranges::end(ints));
-            return make_iterator_range(first, last, N);
-        }();
-        auto make_range = [&]{ return view::chunk(decltype(base)(base), +K); };
+        auto make_range = [&]{ return debug_input_view<int const>{ints} | view::chunk(K); };
         auto rng = make_range();
         using Rng = decltype(rng);
-        CONCEPT_ASSERT(InputRange<Rng>());
+        CONCEPT_ASSERT(InputView<Rng>());
         CONCEPT_ASSERT(!ForwardRange<Rng>());
         CONCEPT_ASSERT(SizedRange<Rng>());
         CHECK(ranges::size(rng) == (N + K - 1) / K);

--- a/test/view/concat.cpp
+++ b/test/view/concat.cpp
@@ -94,5 +94,12 @@ int main()
         CHECK(ranges::distance(ranges::begin(rng), ranges::end(rng)) == 30);
     }
 
+    {
+        int const data[] = {0,1,2,3};
+        auto dv = [&]{ return debug_input_view<int const>{data}; };
+        auto rng = view::concat(dv(), dv(), dv());
+        ::check_equal(rng, {0,1,2,3,0,1,2,3,0,1,2,3});
+    }
+
     return test_result();
 }

--- a/test/view/const.cpp
+++ b/test/view/const.cpp
@@ -77,5 +77,11 @@ int main()
     CHECK(&(*begin(rng4)).first == &rgi[0]);
     CHECK(rng4.size() == 4u);
 
+    {
+        auto rng = debug_input_view<int>{rgi} | view::const_;
+        CONCEPT_ASSERT(Same<int const&, range_reference_t<decltype(rng)>>());
+        ::check_equal(rng, rgi);
+    }
+
     return test_result();
 }

--- a/test/view/delimit.cpp
+++ b/test/view/delimit.cpp
@@ -36,5 +36,11 @@ int main()
     auto rng2 = view::delimit(vi.begin(), 8);
     ::check_equal(rng2, {0, 1, 2, 3, 4, 5, 6, 7});
 
+    {
+        int const some_ints[] = {1,2,3,0,4,5,6};
+        auto rng = debug_input_view<const int>{some_ints} | view::delimit(0);
+        ::check_equal(rng, {1,2,3});
+    }
+
     return test_result();
 }

--- a/test/view/drop.cpp
+++ b/test/view/drop.cpp
@@ -109,5 +109,16 @@ int main()
             ::check_equal(skipped[7], {8});
         }
     }
+
+    {
+        static int const some_ints[] = {0,1,2,3};
+        auto rng = debug_input_view<int const>{some_ints} | view::drop(2);
+        using R = decltype(rng);
+        CONCEPT_ASSERT(InputView<R>());
+        CONCEPT_ASSERT(!ForwardRange<R>());
+        CONCEPT_ASSERT(Same<int const&, range_reference_t<R>>());
+        ::check_equal(rng, {2,3});
+    }
+
     return test_result();
 }

--- a/test/view/drop_exactly.cpp
+++ b/test/view/drop_exactly.cpp
@@ -86,5 +86,13 @@ int main()
         (void)odds;
     }
 
+    {
+        auto rng = debug_input_view<int const>{rgi} | view::drop_exactly(5);
+        using Rng = decltype(rng);
+        CONCEPT_ASSERT(InputView<Rng>());
+        CONCEPT_ASSERT(SizedRange<Rng>());
+        ::check_equal(rng, {5,6,7,8,9,10});
+    }
+
     return test_result();
 }

--- a/test/view/generate.cpp
+++ b/test/view/generate.cpp
@@ -11,11 +11,23 @@
 
 #include <range/v3/core.hpp>
 #include <range/v3/view/generate.hpp>
-#include <range/v3/view/take.hpp>
+#include <range/v3/view/take_exactly.hpp>
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 
 namespace view = ranges::view;
+
+
+struct MoveOnlyFunction
+{
+    MoveOnlyString str_;
+    int i_;
+
+    char operator()()
+    {
+        return str_.sz_[i_++];
+    }
+};
 
 int main()
 {
@@ -24,7 +36,7 @@ int main()
         int i = 0, j = 1;
         auto fib = view::generate([&]()->int{int tmp = i; i += j; std::swap(i, j); return tmp;});
         CONCEPT_ASSERT(ranges::InputView<decltype(fib)>());
-        check_equal(fib | view::take(10), {0,1,1,2,3,5,8,13,21,34});
+        check_equal(fib | view::take_exactly(10), {0,1,1,2,3,5,8,13,21,34});
     }
 
     // Test for mutable-only generator functions
@@ -32,10 +44,17 @@ int main()
         int i = 0, j = 1;
         auto fib = view::generate([=]()mutable->int{int tmp = i; i += j; std::swap(i, j); return tmp;});
         CONCEPT_ASSERT(ranges::InputView<decltype(fib)>());
-        check_equal(fib | view::take(10), {0,1,1,2,3,5,8,13,21,34});
+        check_equal(fib | view::take_exactly(10), {0,1,1,2,3,5,8,13,21,34});
         // The generator cannot be called when it's const-qualified, so "fib const"
         // does not model View.
         CONCEPT_ASSERT(!ranges::View<decltype(fib) const>());
+    }
+
+    // Test for move-only generator functions
+    {
+        auto rng = view::generate(MoveOnlyFunction{"Hello, world!", 0}) | view::take_exactly(5);
+        CONCEPT_ASSERT(ranges::InputView<decltype(rng)>());
+        check_equal(rng, {'H', 'e', 'l', 'l', 'o'});
     }
 
     return test_result();

--- a/test/view/generate_n.cpp
+++ b/test/view/generate_n.cpp
@@ -16,6 +16,17 @@
 
 namespace view = ranges::view;
 
+struct MoveOnlyFunction
+{
+    MoveOnlyString str_;
+    int i_;
+
+    char operator()()
+    {
+        return str_.sz_[i_++];
+    }
+};
+
 int main()
 {
     // Test for constant generator functions
@@ -35,6 +46,13 @@ int main()
         // The generator cannot be called when it's const-qualified, so "fib const"
         // does not model View.
         CONCEPT_ASSERT(!ranges::View<decltype(fib) const>());
+    }
+
+    // Test for move-only generator functions
+    {
+        auto rng = view::generate_n(MoveOnlyFunction{"Hello, world!", 0}, 5);
+        CONCEPT_ASSERT(ranges::InputView<decltype(rng)>());
+        check_equal(rng, {'H', 'e', 'l', 'l', 'o'});
     }
 
     return test_result();

--- a/test/view/indirect.cpp
+++ b/test/view/indirect.cpp
@@ -26,5 +26,19 @@ int main()
     CHECK(&*begin(rng) == vp[0].get());
     ::check_equal(rng, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
 
+    {
+        int const some_ints[] = {0,1,2,3};
+        int const *some_int_pointers[] = {
+            some_ints + 0, some_ints + 1, some_ints + 2, some_ints + 3
+        };
+        auto make_range = [&]{
+            return debug_input_view<int const *>{some_int_pointers} | view::indirect;
+        };
+        auto rng = make_range();
+        ::check_equal(rng, some_ints);
+        rng = make_range();
+        CHECK(&*begin(rng) == some_ints + 0);
+    }
+
     return test_result();
 }

--- a/test/view/intersperse.cpp
+++ b/test/view/intersperse.cpp
@@ -148,5 +148,11 @@ int main()
         check_equal(r0, {1,42,2,42,3,42,4,42,5});
     }
 
+    {
+        int const some_ints[] = {1,2,3,4,5};
+        auto rng = debug_input_view<int const>{some_ints} | view::intersperse(42);
+        check_equal(rng, {1,42,2,42,3,42,4,42,5});
+    }
+
     return test_result();
 }

--- a/test/view/join.cpp
+++ b/test/view/join.cpp
@@ -142,5 +142,11 @@ int main()
         models_not<concepts::SizedRange>(some_strings | view::join);
     }
 
+    {
+        int const some_int_pairs[3][2] = {{0,1},{2,3},{4,5}};
+        auto rng = debug_input_view<int const[2]>{some_int_pairs} | view::join;
+        check_equal(rng, {0,1,2,3,4,5});
+    }
+
     return ::test_result();
 }

--- a/test/view/keys_value.cpp
+++ b/test/view/keys_value.cpp
@@ -58,5 +58,13 @@ int main()
         ::check_equal(view::keys(exs), {0, 1, 2});
     }
 
+    {
+        std::pair<int, int> const data[] = {{0, 2}, {1, 1}, {2, 0}};
+        auto key_range = debug_input_view<std::pair<int, int> const>{data} | view::keys;
+        check_equal(key_range, {0,1,2});
+        auto value_range = debug_input_view<std::pair<int, int> const>{data} | view::values;
+        check_equal(value_range, {2,1,0});
+    }
+
     return test_result();
 }

--- a/test/view/move.cpp
+++ b/test/view/move.cpp
@@ -23,10 +23,8 @@
 int main()
 {
     using namespace ranges;
-    std::vector<MoveOnlyString> vs;
-    vs.emplace_back("'allo");
-    vs.emplace_back("'allo");
-    vs.emplace_back("???");
+    static const char * const data[] = {"'allo", "'allo", "???"};
+    std::vector<MoveOnlyString> vs(begin(data), end(data));
 
     auto x = vs | view::move;
     CONCEPT_ASSERT(Same<bounded_view_concept_t<decltype(x)>, concepts::BoundedView>());
@@ -44,6 +42,15 @@ int main()
     static_assert(std::is_same<MoveOnlyString&&, decltype(*x.begin())>::value, "");
     ::check_equal(vs2, {"'allo", "'allo", "???"});
     ::check_equal(vs, {"", "", ""});
+
+    {
+        MoveOnlyString data[] = {"can", "you", "hear", "me", "now?"};
+        auto rng = debug_input_view<MoveOnlyString>{data} | view::move;
+        MoveOnlyString target[sizeof(data) / sizeof(data[0])];
+        copy(rng, target);
+        ::check_equal(data, {"", "", "", "", ""});
+        ::check_equal(target, {"can", "you", "hear", "me", "now?"});
+    }
 
     return test_result();
 }

--- a/test/view/partial_sum.cpp
+++ b/test/view/partial_sum.cpp
@@ -19,14 +19,6 @@
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 
-struct is_odd
-{
-    bool operator()(int i) const
-    {
-        return (i % 2) == 1;
-    }
-};
-
 int main()
 {
     using namespace ranges;
@@ -58,6 +50,11 @@ int main()
     CHECK(cnt == 0);
     CONCEPT_ASSERT(View<decltype(mutable_rng)>());
     CONCEPT_ASSERT(!View<decltype(mutable_rng) const>());
+
+    {
+        auto rng = debug_input_view<int const>{rgi} | view::partial_sum();
+        ::check_equal(rng, {1, 3, 6, 10, 15, 21, 28, 36, 45, 55});
+    }
 
     return test_result();
 }

--- a/test/view/remove_if.cpp
+++ b/test/view/remove_if.cpp
@@ -93,5 +93,10 @@ int main()
         ::check_equal(r2, {1,5});
     }
 
+    {
+        auto rng = debug_input_view<int const>{rgi} | view::remove_if(is_even{});
+        ::check_equal(rng, {1,3,5,7,9});
+    }
+
     return test_result();
 }

--- a/test/view/replace.cpp
+++ b/test/view/replace.cpp
@@ -80,5 +80,11 @@ int main()
     models<concepts::RandomAccessIterator>(begin(rng4));
     ::check_equal(rng4, {0,1,2,3,4,42,6,7,8,9});
 
+    {
+        int const some_ints[] = {1,2,3,4,5,6,7,8,9,1,2,3,4,5,6,7,8,9,1,2,3,4,5,6,7,8,9};
+        auto rng = debug_input_view<int const>{some_ints} | view::replace(1, 42);
+        ::check_equal(rng, {42,2,3,4,5,6,7,8,9,42,2,3,4,5,6,7,8,9,42,2,3,4,5,6,7,8,9});
+    }
+
     return test_result();
 }

--- a/test/view/replace_if.cpp
+++ b/test/view/replace_if.cpp
@@ -94,5 +94,13 @@ int main()
     CONCEPT_ASSERT(View<decltype(mutable_only)>());
     CONCEPT_ASSERT(!View<decltype(mutable_only) const>());
 
+    {
+        int const some_ints[] = {1,2,3,4,5,6,7,8,9,1,2,3,4,5,6,7,8,9,1,2,3,4,5,6,7,8,9};
+
+        auto rng = debug_input_view<int const>{some_ints} |
+            view::replace_if([](int i){ return i == 1; }, 42);
+        ::check_equal(rng, {42,2,3,4,5,6,7,8,9,42,2,3,4,5,6,7,8,9,42,2,3,4,5,6,7,8,9});
+    }
+
     return test_result();
 }

--- a/test/view/sample.cpp
+++ b/test/view/sample.cpp
@@ -10,21 +10,32 @@ using namespace ranges;
 
 int main ()
 {
+    std::mt19937 engine;
+
     std::vector<int> pop(100);
     std::iota(std::begin(pop), std::end(pop), 0);
     {
         constexpr std::size_t N = 32;
         std::array<int, N> tmp;
-        std::mt19937 engine;
         auto rng = pop | view::sample(N, engine);
-        CONCEPT_ASSERT(InputRange<decltype(rng)>());
-        CONCEPT_ASSERT(View<decltype(rng)>());
+        using Rng = decltype(rng);
+        CONCEPT_ASSERT(InputView<Rng>());
+        CONCEPT_ASSERT(!ForwardRange<Rng>());
         ranges::copy(rng, tmp.begin());
         rng = pop | view::sample(N, engine);
         CHECK(!ranges::equal(rng, tmp));
         engine = decltype(engine){};
         rng = pop | view::sample(N, engine);
         CHECK(ranges::equal(rng, tmp));
+    }
+
+    {
+        int const some_ints[] = {0,1,2,3,4,5,6,7,8};
+        auto rng = debug_input_view<int const>{some_ints} | view::sample(4, engine);
+        using Rng = decltype(rng);
+        CONCEPT_ASSERT(InputView<Rng>());
+        CONCEPT_ASSERT(!ForwardRange<Rng>());
+        CHECK(ranges::distance(rng) == 4);
     }
 
     return ::test_result();

--- a/test/view/set_difference.cpp
+++ b/test/view/set_difference.cpp
@@ -32,8 +32,6 @@
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 
-
-
 int main()
 {
     using namespace ranges;
@@ -47,7 +45,6 @@ int main()
         return x * x;
     });
 
-
     // difference between two finite ranges/sets
     {
         auto res = view::set_difference(i1_finite, i2_finite);
@@ -55,7 +52,7 @@ int main()
         models<concepts::ForwardView>(aux::copy(res));
         models_not<concepts::RandomAccessView>(aux::copy(res));
         models_not<concepts::BoundedView>(aux::copy(res));
-        
+
         using R = decltype(res);
 
         CONCEPT_ASSERT(Same<range_value_type_t<R>, int>());
@@ -65,15 +62,14 @@ int main()
         static_assert(range_cardinality<R>::value == ranges::finite, "Cardinality of difference between two finite ranges should be finite!");
 
         ::check_equal(res, {1, 2, 3, 3, 3, 4, 4});
-        
+
         // check if the final result agrees with the greedy algorithm
         std::vector<int> diff;
         set_difference(i1_finite, i2_finite, back_inserter(diff));
         ::check_equal(res, diff);
-        
+
         CHECK(&*begin(res) == &*(begin(i1_finite)));
     }
-
 
     // difference between two infinite ranges
     {
@@ -82,7 +78,7 @@ int main()
         models<concepts::ForwardView>(aux::copy(res));
         models_not<concepts::RandomAccessView>(aux::copy(res));
         models_not<concepts::BoundedView>(aux::copy(res));
-        
+
         using R = decltype(res);
 
         CONCEPT_ASSERT(Same<range_value_type_t<R>, int>());
@@ -100,7 +96,6 @@ int main()
 
     }
 
-
     // difference between a finite and an infinite range
     {
         auto res = view::set_difference(i1_finite, i2_infinite);
@@ -108,7 +103,7 @@ int main()
         models<concepts::ForwardView>(aux::copy(res));
         models_not<concepts::RandomAccessView>(aux::copy(res));
         models_not<concepts::BoundedView>(aux::copy(res));
-        
+
         using R = decltype(res);
 
         CONCEPT_ASSERT(Same<range_value_type_t<R>, int>());
@@ -127,7 +122,7 @@ int main()
         models<concepts::ForwardView>(aux::copy(res));
         models_not<concepts::RandomAccessView>(aux::copy(res));
         models_not<concepts::BoundedView>(aux::copy(res));
-        
+
         using R = decltype(res);
 
         CONCEPT_ASSERT(Same<range_value_type_t<R>, int>());
@@ -139,7 +134,6 @@ int main()
         ::check_equal(res | view::take(5), {0, 3, 12, 15, 18});
     }
 
-
     // differences involving unknown cardinalities
     {
         auto rng0 = view::iota(10) | view::drop_while([](int i)
@@ -150,18 +144,17 @@ int main()
 
         auto res1 = view::set_difference(i2_finite, rng0);
         static_assert(range_cardinality<decltype(res1)>::value == ranges::finite, "Difference between a finite and unknown cardinality set should have finite cardinality!");
-        
+
         auto res2 = view::set_difference(rng0, i2_finite);
         static_assert(range_cardinality<decltype(res2)>::value == ranges::unknown, "Difference between an unknown cardinality and finite set should have unknown cardinality!");
-        
+
         auto res3 = view::set_difference(i1_infinite, rng0);
         static_assert(range_cardinality<decltype(res3)>::value == ranges::unknown, "Difference between an unknown cardinality and finite set should have unknown cardinality!");
-    
+
         auto res4 = view::set_difference(rng0, i1_infinite);
         static_assert(range_cardinality<decltype(res4)>::value == ranges::unknown, "Difference between an unknown and infinite cardinality set should have unknown cardinality!");
-        
-    }
 
+    }
 
     // test const ranges
     {
@@ -170,14 +163,13 @@ int main()
         CONCEPT_ASSERT(Same<range_value_type_t<R1>, int>());
         CONCEPT_ASSERT(Same<range_reference_t<R1>, const int&>());
         CONCEPT_ASSERT(Same<range_rvalue_reference_t<R1>, const int&&> ());
-        
+
         auto res2 = view::set_difference(view::const_(i1_finite), i2_finite);
         using R2 = decltype(res2);
         CONCEPT_ASSERT(Same<range_value_type_t<R2>, int>());
         CONCEPT_ASSERT(Same<range_reference_t<R2>, const int&>());
         CONCEPT_ASSERT(Same<range_rvalue_reference_t<R2>, const int&&> ());
     }
-
 
     // test different orderings
     {
@@ -187,7 +179,6 @@ int main()
         });
         ::check_equal(res, {4, 4, 3, 3, 3, 2, 1});
     }
-
 
     // test projections and sets with different element types
     struct S
@@ -200,7 +191,7 @@ int main()
     };
 
     S s_finite[] = {S{-20}, S{-10}, S{1}, S{3}, S{3}, S{6}, S{8}, S{20}};
-    
+
     {
         auto res1 = view::set_difference(s_finite, view::ints(-2, 10),
                                          ordered_less(),
@@ -213,7 +204,6 @@ int main()
         CONCEPT_ASSERT(Same<range_rvalue_reference_t<R1>, S&&> ());
         ::check_equal(res1, {S{-20}, S{-10}, S{3}, S{20}});
 
-
         auto res2 = view::set_difference(view::ints(-2, 10), s_finite,
                                          ordered_less(),
                                          ident(),
@@ -225,8 +215,7 @@ int main()
         CONCEPT_ASSERT(Same<range_rvalue_reference_t<R2>, int> ());
         ::check_equal(res2, {-2, -1, 0, 2, 4, 5, 7, 9});
     }
-    
-    
+
     // move
     {
         auto v0 = to_<std::vector<MoveOnlyString>>({"a","b","b","c","x","x"});
@@ -240,7 +229,6 @@ int main()
         ::check_equal(v1, {"b","x","y","z"});
         ::check_equal(v0, {"","b","","","x",""});
 
-        
         auto v0_greedy = to_<std::vector<MoveOnlyString>>({"a","b","b","c","x","x"});
         auto v1_greedy = to_<std::vector<MoveOnlyString>>({"b","x","y","z"});
         std::vector<MoveOnlyString> expected_greedy;
@@ -251,19 +239,26 @@ int main()
         ::check_equal(v0_greedy, v0);
         ::check_equal(v1_greedy, v1);
 
- 
         using R = decltype(res);
 
         CONCEPT_ASSERT(Same<range_value_type_t<R>, MoveOnlyString>());
         CONCEPT_ASSERT(Same<range_reference_t<R>, MoveOnlyString &>());
         CONCEPT_ASSERT(Same<range_rvalue_reference_t<R>, MoveOnlyString &&>());
     }
-    
+
     // WARNING: set_difference between two infinite ranges can create infinite loops!
     // {
     //     auto empty_range = view::set_difference(view::ints, view::ints);
     //     begin(empty_range); // infinite loop!
     // }
+
+    {
+        auto rng = view::set_difference(
+            debug_input_view<int const>{i1_finite},
+            debug_input_view<int const>{i2_finite}
+        );
+        ::check_equal(rng, {1, 2, 3, 3, 3, 4, 4});
+    }
 
     return test_result();
 }

--- a/test/view/set_intersection.cpp
+++ b/test/view/set_intersection.cpp
@@ -31,8 +31,6 @@
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 
-
-
 int main()
 {
     using namespace ranges;
@@ -46,17 +44,16 @@ int main()
         return x * x;
     });
 
-
     // intersection of two finite ranges
     {
         auto res = view::set_intersection(i1_finite, i2_finite);
-        
+
         models<concepts::ForwardView>(aux::copy(res));
         models_not<concepts::RandomAccessView>(aux::copy(res));
         models_not<concepts::BoundedView>(aux::copy(res));
 
         using R = decltype(res);
-        
+
         CONCEPT_ASSERT(Same<range_value_type_t<R>, int>());
         CONCEPT_ASSERT(Same<range_reference_t<R>, int&>());
         CONCEPT_ASSERT(Same<decltype(iter_move(begin(res))), int &&> ());
@@ -64,10 +61,9 @@ int main()
         static_assert(range_cardinality<R>::value == ranges::finite, "Cardinality of intersection with a finite range should be finite!");
 
         ::check_equal(res, {2, 4, 4});
-        
+
         CHECK(&*begin(res) == &*(begin(i1_finite) + 1));
     }
-
 
     // intersection of two infinite ranges
     {
@@ -78,7 +74,7 @@ int main()
         models_not<concepts::BoundedView>(aux::copy(res));
 
         using R = decltype(res);
-        
+
         CONCEPT_ASSERT(Same<range_value_type_t<R>, int>());
         CONCEPT_ASSERT(Same<range_reference_t<R>, range_reference_t<decltype(i1_infinite)>>());
         CONCEPT_ASSERT(Same<decltype(iter_move(begin(res))), range_rvalue_reference_t<decltype(i1_infinite)>>());
@@ -88,7 +84,6 @@ int main()
         ::check_equal(res | view::take(5), {0, 9, 36, 81, 144});
     }
 
-
     // intersection of a finite and infinite range
     {
         auto res = view::set_intersection(i1_finite, i2_infinite);
@@ -96,7 +91,7 @@ int main()
         models<concepts::ForwardView>(aux::copy(res));
         models_not<concepts::RandomAccessView>(aux::copy(res));
         models_not<concepts::BoundedView>(aux::copy(res));
-        
+
         using R = decltype(res);
 
         CONCEPT_ASSERT(Same<range_value_type_t<R>, int>());
@@ -107,14 +102,12 @@ int main()
 
         ::check_equal(res | view::take(500), {1, 4});
 
-
-
         auto res2 = view::set_intersection(i1_infinite, i2_finite);
 
         models<concepts::ForwardView>(aux::copy(res2));
         models_not<concepts::RandomAccessView>(aux::copy(res2));
         models_not<concepts::BoundedView>(aux::copy(res2));
-        
+
         using R2 = decltype(res2);
 
         CONCEPT_ASSERT(Same<range_value_type_t<R2>, int>());
@@ -125,7 +118,6 @@ int main()
 
         ::check_equal(res2 | view::take(500), {6, 9});
     }
-
 
     // intersection of a set of unknown cardinality
     {
@@ -139,7 +131,6 @@ int main()
         static_assert(range_cardinality<decltype(res)>::value == ranges::unknown, "Intersection with a set of unknown cardinality should have unknown cardinality!");
     }
 
-
     // test const ranges
     {
         auto res1 = view::set_intersection(view::const_(i1_finite), view::const_(i2_finite));
@@ -147,14 +138,13 @@ int main()
         CONCEPT_ASSERT(Same<range_value_type_t<R1>, int>());
         CONCEPT_ASSERT(Same<range_reference_t<R1>, const int&>());
         CONCEPT_ASSERT(Same<range_rvalue_reference_t<R1>, const int&&> ());
-        
+
         auto res2 = view::set_intersection(view::const_(i1_finite), i2_finite);
         using R2 = decltype(res2);
         CONCEPT_ASSERT(Same<range_value_type_t<R2>, int>());
         CONCEPT_ASSERT(Same<range_reference_t<R2>, const int&>());
         CONCEPT_ASSERT(Same<range_rvalue_reference_t<R2>, const int&&> ());
     }
-
 
     // test different orderings
     {
@@ -164,7 +154,6 @@ int main()
         });
         ::check_equal(res, {4, 4, 2});
     }
-
 
     // test projections and sets with different element types
     struct S
@@ -177,7 +166,7 @@ int main()
     };
 
     S s_finite[] = {S{-20}, S{-10}, S{1}, S{3}, S{3}, S{6}, S{8}, S{20}};
-    
+
     {
         auto res1 = view::set_intersection(s_finite, view::ints(-2, 10),
                                            ordered_less(),
@@ -189,7 +178,6 @@ int main()
         CONCEPT_ASSERT(Same<range_reference_t<R1>, S&>());
         CONCEPT_ASSERT(Same<range_rvalue_reference_t<R1>, S&&> ());
         ::check_equal(res1, {S{1}, S{3}, S{6}, S{8}});
-
 
         auto res2 = view::set_intersection(view::ints(-2, 10), s_finite,
                                            ordered_less(),
@@ -203,7 +191,6 @@ int main()
         ::check_equal(res2, {1, 3, 6, 8});
     }
 
-    
     // move
     {
         auto v0 = to_<std::vector<MoveOnlyString>>({"a","b","b","c","x","x"});
@@ -216,7 +203,7 @@ int main()
         ::check_equal(expected, {"b","x"});
         ::check_equal(v0, {"a","","b","c","","x"});
         ::check_equal(v1, {"b","x","y","z"});
- 
+
         using R = decltype(res);
 
         CONCEPT_ASSERT(Same<range_value_type_t<R>, MoveOnlyString>());
@@ -224,6 +211,13 @@ int main()
         CONCEPT_ASSERT(Same<range_rvalue_reference_t<R>, MoveOnlyString &&>());
     }
 
+    {
+        auto rng = view::set_intersection(
+            debug_input_view<int const>{i1_finite},
+            debug_input_view<int const>{i2_finite}
+        );
+        ::check_equal(rng, {2, 4, 4});
+    }
 
     return test_result();
 }

--- a/test/view/set_symmetric_difference.cpp
+++ b/test/view/set_symmetric_difference.cpp
@@ -47,7 +47,6 @@ int main()
         return x * x;
     });
 
-
     // symmetric difference between two finite ranges/sets
     {
         auto res = view::set_symmetric_difference(i1_finite, i2_finite);
@@ -55,7 +54,7 @@ int main()
         models<concepts::ForwardView>(aux::copy(res));
         models_not<concepts::RandomAccessView>(aux::copy(res));
         models_not<concepts::BoundedView>(aux::copy(res));
-        
+
         using R = decltype(res);
 
         CONCEPT_ASSERT(Same<range_value_type_t<R>, int>());
@@ -65,18 +64,17 @@ int main()
         static_assert(range_cardinality<R>::value == ranges::finite, "Cardinality of symmetric difference of finite ranges should be finite!");
 
         ::check_equal(res, {-3, 1, 2, 3, 3, 3, 4, 4, 6, 9});
-        
+
         // check if the final result agrees with the greedy algorithm
         std::vector<int> greedy_sd;
         set_symmetric_difference(i1_finite, i2_finite, back_inserter(greedy_sd));
         ::check_equal(res, greedy_sd);
-        
+
         auto it = begin(res);
         CHECK(&*it == &*(begin(i2_finite)));
         ++it;
         CHECK(&*it == &*(begin(i1_finite)));
     }
-
 
     // symmetric difference between two infinite ranges
     {
@@ -85,7 +83,7 @@ int main()
         models<concepts::ForwardView>(aux::copy(res));
         models_not<concepts::RandomAccessView>(aux::copy(res));
         models_not<concepts::BoundedView>(aux::copy(res));
-        
+
         using R = decltype(res);
 
         CONCEPT_ASSERT(Same<range_value_type_t<R>,
@@ -110,7 +108,6 @@ int main()
         ::check_equal(res | view::take(6), greedy_sd | view::take(6));
     }
 
-
     // symmetric difference between a finite and an infinite range
     {
         auto res1 = view::set_symmetric_difference(i1_finite, i2_infinite);
@@ -118,7 +115,7 @@ int main()
         models<concepts::ForwardView>(aux::copy(res1));
         models_not<concepts::RandomAccessView>(aux::copy(res1));
         models_not<concepts::BoundedView>(aux::copy(res1));
-        
+
         using R1 = decltype(res1);
 
         CONCEPT_ASSERT(Same<range_value_type_t<R1>, int>());
@@ -128,15 +125,14 @@ int main()
         static_assert(range_cardinality<R1>::value == ranges::infinite, "Cardinality of symmetric difference between a finite and an infinite range should be infinite!");
 
         ::check_equal(res1 | view::take(10), {0, 2, 2, 3, 3, 3, 4, 4, 4, 9});
-        
-        
+
         // now swap the operands:
         auto res2 = view::set_symmetric_difference(i2_infinite, i1_finite);
 
         models<concepts::ForwardView>(aux::copy(res2));
         models_not<concepts::RandomAccessView>(aux::copy(res2));
         models_not<concepts::BoundedView>(aux::copy(res2));
-        
+
         using R2 = decltype(res2);
 
         CONCEPT_ASSERT(Same<range_value_type_t<R2>, int>());
@@ -148,7 +144,6 @@ int main()
         ::check_equal(res1 | view::take(10), res2 | view::take(10));
     }
 
-
     // symmetric differences involving unknown cardinalities
     {
         auto rng0 = view::iota(10) | view::drop_while([](int i)
@@ -159,20 +154,19 @@ int main()
 
         auto res1 = view::set_symmetric_difference(i2_finite, rng0);
         static_assert(range_cardinality<decltype(res1)>::value == ranges::unknown, "Symmetric difference between a finite and unknown cardinality set should have unknown cardinality!");
-        
+
         auto res2 = view::set_symmetric_difference(rng0, i2_finite);
         static_assert(range_cardinality<decltype(res2)>::value == ranges::unknown, "Symmetric difference between an unknown and finite cardinality set should have unknown cardinality!");
-        
+
         auto res3 = view::set_symmetric_difference(i1_infinite, rng0);
         static_assert(range_cardinality<decltype(res3)>::value == ranges::unknown, "Symmetric difference between an infinite and unknown cardinality set should have unknown cardinality!");
-    
+
         auto res4 = view::set_symmetric_difference(rng0, i1_infinite);
         static_assert(range_cardinality<decltype(res4)>::value == ranges::unknown, "Symmetric difference between an unknown and infinite cardinality set should have infinite cardinality!");
-        
+
         auto res5 = view::set_symmetric_difference(rng0, rng0);
         static_assert(range_cardinality<decltype(res5)>::value == ranges::unknown, "Symmetric difference between two unknown cardinality sets should have unknown cardinality!");
     }
-
 
     // test const ranges
     {
@@ -181,14 +175,13 @@ int main()
         CONCEPT_ASSERT(Same<range_value_type_t<R1>, int>());
         CONCEPT_ASSERT(Same<range_reference_t<R1>, const int&>());
         CONCEPT_ASSERT(Same<range_rvalue_reference_t<R1>, const int&&>());
-        
+
         auto res2 = view::set_symmetric_difference(view::const_(i1_finite), i2_finite);
         using R2 = decltype(res2);
         CONCEPT_ASSERT(Same<range_value_type_t<R2>, int>());
         CONCEPT_ASSERT(Same<range_reference_t<R2>, const int&>());
         CONCEPT_ASSERT(Same<range_rvalue_reference_t<R2>, const int&&>());
     }
-
 
     // test different orderings
     {
@@ -200,7 +193,6 @@ int main()
         CHECK(&*begin(res) == &*(begin(i2_finite) + 5));
     }
 
-
     struct B
     {
         int val;
@@ -210,18 +202,18 @@ int main()
             return val == other.val;
         }
     };
-    
+
     struct D: public B
     {
         D(int i): B{i} {}
         D(B b): B{std::move(b)} {}
     };
-    
+
     B b_finite[] = {B{-20}, B{-10}, B{1}, B{3}, B{3}, B{6}, B{8}, B{20}};
     D d_finite[] = {D{0}, D{2}, D{4}, D{6}};
-    
+
     // sets with different element types, custom orderings
-    {        
+    {
         auto res = view::set_symmetric_difference(b_finite, d_finite, [](const B& a, const D& b){ return a.val < b.val; });
         CONCEPT_ASSERT(Same<range_value_type_t<decltype(res)>, B>());
         CONCEPT_ASSERT(Same<range_reference_t<decltype(res)>, B&>());
@@ -232,9 +224,9 @@ int main()
         advance(it, 2);
         CHECK(&*it == &*begin(d_finite));
     }
-    
+
     // projections
-    {        
+    {
         auto res1 = view::set_symmetric_difference(b_finite, d_finite,
                                                    ordered_less(),
                                                    &B::val,
@@ -255,8 +247,7 @@ int main()
         CONCEPT_ASSERT(Same<range_rvalue_reference_t<decltype(res2)>, B>());
         ::check_equal(res2, {B{-20}, B{-10}, B{-2}, B{-1}, B{0}, B{2}, B{3}, B{4}, B{5}, B{7}, B{9}, B{20}});
     }
-    
-    
+
     // move
     {
         auto v0 = to_<std::vector<MoveOnlyString>>({"a","b","b","c","x","x"});
@@ -269,8 +260,7 @@ int main()
         ::check_equal(expected, {"a","b","c","x","y","z"});
         ::check_equal(v1, {"b","x","",""});
         ::check_equal(v0, {"","b","","","x",""});
-        
-        
+
         auto v0_greedy = to_<std::vector<MoveOnlyString>>({"a","b","b","c","x","x"});
         auto v1_greedy = to_<std::vector<MoveOnlyString>>({"b","x","y","z"});
         std::vector<MoveOnlyString> expected_greedy;
@@ -281,7 +271,6 @@ int main()
         ::check_equal(v0_greedy, v0);
         ::check_equal(v1_greedy, v1);
 
- 
         using R = decltype(res);
 
         CONCEPT_ASSERT(Same<range_value_type_t<R>, MoveOnlyString>());
@@ -289,35 +278,41 @@ int main()
         CONCEPT_ASSERT(Same<range_rvalue_reference_t<R>, MoveOnlyString &&>());
     }
 
-
     // WARNING: set_symmetric_difference between two infinite ranges can create infinite loops!
     // {
     //     auto empty_range = view::set_symmetric_difference(view::ints, view::ints);
     //     begin(empty_range); // infinite loop!
     // }
-    
+
     // iterator (in)equality
     {
         int r1[] = {1, 2, 3};
         int r2[] = {   2, 3, 4, 5};
         auto res = view::set_symmetric_difference(r1, r2); // 1, 4, 5
-        
+
         auto it1 = ranges::next(res.begin()); // *it1 == 4, member iterator into r1 points to r1.end()
         auto it2 = ranges::next(it1);         // *it2 == 5, member iterator into r1 also points to r1.end()
         auto sentinel = res.end();
-        
+
         CHECK(*it1 == 4);
         CHECK(*it2 == 5);
-        
+
         CHECK(it1 != it2); // should be different even though member iterators into r1 are the same
-        
+
         CHECK(it1 != sentinel);
         CHECK(ranges::next(it1, 2) == sentinel);
-        
+
         CHECK(it2 != sentinel);
         CHECK(ranges::next(it2, 1) == sentinel);
     }
-    
-    
+
+    {
+        auto rng = view::set_symmetric_difference(
+            debug_input_view<int const>{i1_finite},
+            debug_input_view<int const>{i2_finite}
+        );
+        ::check_equal(rng, {-3, 1, 2, 3, 3, 3, 4, 4, 6, 9});
+    }
+
     return test_result();
 }

--- a/test/view/set_union.cpp
+++ b/test/view/set_union.cpp
@@ -45,13 +45,11 @@ int main()
     {
         return x * x;
     });
-    
-    
+
     // simple identity check
     {
         ::check_equal(view::set_union(i1_infinite, i1_infinite) | view::take(100), i1_infinite | view::take(100));
     }
-
 
     // union of two finite ranges/sets
     {
@@ -60,7 +58,7 @@ int main()
         models<concepts::ForwardView>(aux::copy(res));
         models_not<concepts::RandomAccessView>(aux::copy(res));
         models_not<concepts::BoundedView>(aux::copy(res));
-        
+
         using R = decltype(res);
 
         CONCEPT_ASSERT(Same<range_value_type_t<R>, int>());
@@ -70,18 +68,17 @@ int main()
         static_assert(range_cardinality<R>::value == ranges::finite, "Cardinality of union of finite ranges should be finite!");
 
         ::check_equal(res, {-3, 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 6, 9});
-        
+
         // check if the final result agrees with the greedy algorithm
         std::vector<int> greedy_union;
         set_union(i1_finite, i2_finite, back_inserter(greedy_union));
         ::check_equal(res, greedy_union);
-        
+
         auto it = begin(res);
         CHECK(&*it == &*(begin(i2_finite)));
         ++it;
         CHECK(&*it == &*(begin(i1_finite)));
     }
-
 
     // union of two infinite ranges
     {
@@ -90,7 +87,7 @@ int main()
         models<concepts::ForwardView>(aux::copy(res));
         models_not<concepts::RandomAccessView>(aux::copy(res));
         models_not<concepts::BoundedView>(aux::copy(res));
-        
+
         using R = decltype(res);
 
         CONCEPT_ASSERT(Same<range_value_type_t<R>,
@@ -115,7 +112,6 @@ int main()
         ::check_equal(res | view::take(6), greedy_union | view::take(6));
     }
 
-
     // union of a finite and an infinite range
     {
         auto res = view::set_union(i1_finite, i2_infinite);
@@ -123,7 +119,7 @@ int main()
         models<concepts::ForwardView>(aux::copy(res));
         models_not<concepts::RandomAccessView>(aux::copy(res));
         models_not<concepts::BoundedView>(aux::copy(res));
-        
+
         using R = decltype(res);
 
         CONCEPT_ASSERT(Same<range_value_type_t<R>, int>());
@@ -142,7 +138,7 @@ int main()
         models<concepts::ForwardView>(aux::copy(res));
         models_not<concepts::RandomAccessView>(aux::copy(res));
         models_not<concepts::BoundedView>(aux::copy(res));
-        
+
         using R = decltype(res);
 
         CONCEPT_ASSERT(Same<range_value_type_t<R>, int>());
@@ -154,7 +150,6 @@ int main()
         ::check_equal(res | view::take(7), {-3, 0, 2, 3, 4, 4, 6});
     }
 
-
     // unions involving unknown cardinalities
     {
         auto rng0 = view::iota(10) | view::drop_while([](int i)
@@ -165,21 +160,20 @@ int main()
 
         auto res1 = view::set_union(i2_finite, rng0);
         static_assert(range_cardinality<decltype(res1)>::value == ranges::unknown, "Union of a finite and unknown cardinality set should have unknown cardinality!");
-        
+
         auto res2 = view::set_union(rng0, i2_finite);
         static_assert(range_cardinality<decltype(res2)>::value == ranges::unknown, "Union of an unknown and finite cardinality set should have unknown cardinality!");
-        
+
         auto res3 = view::set_union(i1_infinite, rng0);
         static_assert(range_cardinality<decltype(res3)>::value == ranges::infinite, "Union of an infinite and unknown cardinality set should have infinite cardinality!");
-    
+
         auto res4 = view::set_union(rng0, i1_infinite);
         static_assert(range_cardinality<decltype(res4)>::value == ranges::infinite, "Union of an unknown and infinite cardinality set should have infinite cardinality!");
-        
+
         auto res5 = view::set_union(rng0, rng0);
         static_assert(range_cardinality<decltype(res5)>::value == ranges::unknown, "Union of two unknown cardinality sets should have unknown cardinality!");
         ::check_equal(res5 | view::take(100), rng0 | view::take(100));
     }
-
 
     // test const ranges
     {
@@ -188,14 +182,13 @@ int main()
         CONCEPT_ASSERT(Same<range_value_type_t<R1>, int>());
         CONCEPT_ASSERT(Same<range_reference_t<R1>, const int&>());
         CONCEPT_ASSERT(Same<range_rvalue_reference_t<R1>, const int&&>());
-        
+
         auto res2 = view::set_union(view::const_(i1_finite), i2_finite);
         using R2 = decltype(res2);
         CONCEPT_ASSERT(Same<range_value_type_t<R2>, int>());
         CONCEPT_ASSERT(Same<range_reference_t<R2>, const int&>());
         CONCEPT_ASSERT(Same<range_rvalue_reference_t<R2>, const int&&>());
     }
-
 
     // test different orderings
     {
@@ -206,7 +199,6 @@ int main()
         ::check_equal(res, {9, 6, 4, 4, 4, 4, 3, 3, 3, 2, 2, 1, -3});
     }
 
-
     struct B
     {
         int val;
@@ -216,18 +208,18 @@ int main()
             return val == other.val;
         }
     };
-    
+
     struct D: public B
     {
         D(int i): B{i} {}
         D(B b): B{std::move(b)} {}
     };
-    
+
     B b_finite[] = {B{-20}, B{-10}, B{1}, B{3}, B{3}, B{6}, B{8}, B{20}};
     D d_finite[] = {D{0}, D{2}, D{4}, D{6}};
-    
+
     // sets with different element types, custom orderings
-    {        
+    {
         auto res = view::set_union(b_finite, d_finite, [](const B& a, const D& b){ return a.val < b.val; });
         using R = decltype(res);
         CONCEPT_ASSERT(Same<range_value_type_t<R>, B>());
@@ -239,9 +231,9 @@ int main()
         advance(it, 2);
         CHECK(&*it == &*begin(d_finite));
     }
-    
+
     // projections
-    {        
+    {
         auto res1 = view::set_union(b_finite, d_finite,
                                     ordered_less(),
                                     &B::val,
@@ -252,7 +244,6 @@ int main()
         CONCEPT_ASSERT(Same<range_reference_t<R1>, B&>());
         CONCEPT_ASSERT(Same<range_rvalue_reference_t<R1>, B&&>());
         ::check_equal(res1, {B{-20}, B{-10}, B{0}, B{1}, B{2}, B{3}, B{3}, B{4}, B{6}, B{8}, B{20}});
-
 
         auto res2 = view::set_union(view::ints(-2, 10), b_finite,
                                     ordered_less(),
@@ -266,49 +257,55 @@ int main()
         ::check_equal(res2, {B{-20}, B{-10}, B{-2}, B{-1}, B{0}, B{1}, B{2}, B{3}, B{3}, B{4}, B{5}, B{6}, B{7}, B{8}, B{9}, B{20}});
     }
 
-    
     // move
     {
         auto v0 = to_<std::vector<MoveOnlyString>>({"a","b","c","x"});
         auto v1 = to_<std::vector<MoveOnlyString>>({"b","x","y","z"});
         auto res = view::set_union(v0, v1, [](const MoveOnlyString& a, const MoveOnlyString& b){return a<b;});
-        
+
         std::vector<MoveOnlyString> expected;
         move(res, back_inserter(expected));
 
         ::check_equal(expected, {"a","b","c","x","y","z"});
         ::check_equal(v0, {"","","",""});
         ::check_equal(v1, {"b","x","",""});
- 
+
         using R = decltype(res);
 
         CONCEPT_ASSERT(Same<range_value_type_t<R>, MoveOnlyString>());
         CONCEPT_ASSERT(Same<range_reference_t<R>, MoveOnlyString &>());
         CONCEPT_ASSERT(Same<range_rvalue_reference_t<R>, MoveOnlyString &&>());
     }
-    
+
     // iterator (in)equality
     {
         int r1[] = {1, 2, 3};
         int r2[] = {   2, 3, 4, 5};
         auto res = view::set_union(r1, r2); // 1, 2, 3, 4, 5
-        
+
         auto it1 = ranges::next(res.begin(), 3); // *it1 == 4, member iterator into r1 points to r1.end()
         auto it2 = ranges::next(it1);            // *it2 == 5, member iterator into r1 also points to r1.end()
         auto sentinel = res.end();
-        
+
         CHECK(*it1 == 4);
         CHECK(*it2 == 5);
-        
+
         CHECK(it1 != it2); // should be different even though member iterators into r1 are the same
-        
+
         CHECK(it1 != sentinel);
         CHECK(ranges::next(it1, 2) == sentinel);
-        
+
         CHECK(it2 != sentinel);
         CHECK(ranges::next(it2, 1) == sentinel);
     }
-    
+
+    {
+        auto rng = view::set_union(
+            debug_input_view<int const>{i1_finite},
+            debug_input_view<int const>{i2_finite}
+        );
+        ::check_equal(rng, {-3, 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 6, 9});
+    }
 
     return test_result();
 }

--- a/test/view/slice.cpp
+++ b/test/view/slice.cpp
@@ -123,5 +123,11 @@ int main()
         ::check_equal(letters[{2,end-2}], {'c','d','e'});
     }
 
+    {
+        int const some_ints[] = {0,1,2,3,4,5,6,7,8,9};
+        auto rng = debug_input_view<int const>{some_ints} | view::slice(3,10);
+        ::check_equal(rng, {3, 4, 5, 6, 7, 8, 9});
+    }
+
     return test_result();
 }

--- a/test/view/stride.cpp
+++ b/test/view/stride.cpp
@@ -80,5 +80,11 @@ int main()
         (void)ranges::view::stride(n);
     }
 
+    {
+        int const some_ints[] = {0,1,2,3,4,5,6,7};
+        auto rng = debug_input_view<int const>{some_ints} | view::stride(2);
+        ::check_equal(rng, {0,2,4,6});
+    }
+
     return ::test_result();
 }

--- a/test/view/take.cpp
+++ b/test/view/take.cpp
@@ -122,5 +122,10 @@ int main()
     ::models_not<concepts::SizedView>(aux::copy(rng9));
     check_equal(rng9, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
 
+    {
+        auto rng = debug_input_view<int const>{rgi} | view::take(6);
+        ::check_equal(rng, {0, 1, 2, 3, 4, 5});
+    }
+
     return test_result();
 }

--- a/test/view/take_exactly.cpp
+++ b/test/view/take_exactly.cpp
@@ -72,5 +72,10 @@ int main()
     ::check_equal(rng5, {19, 18, 17, 16, 15, 14, 13, 12, 11, 10});
     CHECK(size(rng5) == 10u);
 
+    {
+        auto rng = debug_input_view<int const>{rgi} | view::take_exactly(6);
+        ::check_equal(rng, {0, 1, 2, 3, 4, 5});
+    }
+
     return test_result();
 }

--- a/test/view/take_while.cpp
+++ b/test/view/take_while.cpp
@@ -58,5 +58,12 @@ int main()
         ::check_equal(rng, {1,2,3,4});
     }
 
+    {
+        auto rng = debug_input_view<int const>{rgi} | view::take_while([](int i) {
+            return i != 5;
+        });
+        ::check_equal(rng, {0,1,2,3,4});
+    }
+
     return test_result();
 }

--- a/test/view/zip.cpp
+++ b/test/view/zip.cpp
@@ -224,5 +224,16 @@ int main()
         ranges::distance(view::zip(view::ints(0), rng) | view::bounded);
     }
 
+    {
+        int const i1[] = {0,1,2,3};
+        int const i2[] = {4,5,6,7};
+        auto rng = view::zip(
+            debug_input_view<int const>{i1},
+            debug_input_view<int const>{i2}
+        );
+        using P = std::pair<int, int>;
+        ::check_equal(rng, {P{0,4},P{1,5}, P{2,6}, P{3,7}});
+    }
+
     return test_result();
 }


### PR DESCRIPTION
* Concept changes:
  * relax `View<T>` from `Range<T> && Semiregular<T>` to `Range<T> && Movable<T> && DefaultConstructible<T>`
  * add `Copyable<T>` requirement back into `ForwardView<T>` so that it is unchanged

* add `movesemiregular_t` type alias a la `semiregular_t`
  * does not wrap `T` if `Movable<T> && DefaultConstructible<T>` is satisfied
  * use in `istream_range`, `generate_view`, and `generate_n_view` to allow them to be move-only when `T` is not fully `Semiregular`

* `any_view<T, category::input>` is move-only:
  * `any_view_interface<T, category::input>` has no `clone()` member
  * `any_view_impl::clone` is not an `override` - and may have an ill-formed definition - for `category::input`. (Comment out all uses of `override` to avoid triggering Clang's "inconsistent override" warning.)

* In `view_interface`, perfect-forward `*this` into `operator[]` so that move-only views can use Pythonic slicing.

* Implement a move-only input view test tool: `debug_input_view`
  * catches repeated calls to `begin`, calls to `begin`/`end` on an invalidated view, and iterator operations after invalidation of the view or the iterator.
  * found most of the bugs fixed in my bugs_bugs_bugs PR.
  * Add test cases for each view adaptor that accepts input views
