### PR TITLE
Travis: cmake version churn: libc++ needs a newer cmake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -233,7 +233,7 @@ before_install:
   - |
     if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
       if [ -z "$(ls -A ${TRAVIS_BUILD_DIR}/deps/cmake/bin)" ]; then
-        CMAKE_URL="https://cmake.org/files/v3.0/cmake-3.0.2-Linux-i386.tar.gz"
+        CMAKE_URL="https://cmake.org/files/v3.8/cmake-3.8.2-Linux-x86_64.tar.gz"
         mkdir -p ${TRAVIS_BUILD_DIR}/deps/cmake && travis_retry wget --no-check-certificate --quiet -O - "${CMAKE_URL}" | tar --strip-components=1 -xz -C ${TRAVIS_BUILD_DIR}/deps/cmake
       fi
       export PATH="${TRAVIS_BUILD_DIR}/deps/cmake/bin:${PATH}"


### PR DESCRIPTION
Yes, this means we cannot have Travis both (a) build libc++ and (b) validate that our CMakeLists don't use features newer than version 3.0 which we require.

\*shrug\*