### PR TITLE
Fix bug in the input-range specialization of chunk_view

### DIFF
--- a/include/range/v3/view/chunk.hpp
+++ b/include/range/v3/view/chunk.hpp
@@ -346,7 +346,7 @@ namespace ranges
         public:
             chunk_view() = default;
             RANGES_CXX14_CONSTEXPR
-            chunk_view(Rng &&rng, range_difference_type_t<Rng> n)
+            chunk_view(Rng rng, range_difference_type_t<Rng> n)
               : data_{detail::move(rng), (RANGES_EXPECT(0 < n), n), n, nullopt}
             {}
             CONCEPT_REQUIRES(SizedRange<Rng const>())

--- a/include/range/v3/view/iota.hpp
+++ b/include/range/v3/view/iota.hpp
@@ -118,15 +118,12 @@ namespace ranges
                         meta::not_<std::is_same<Val, difference_t>>,
                         meta::_t<std::make_signed<difference_t>>,
                         meta::if_c<
-                            (bits < 8),
-                            std::int_fast8_t,
+                            (bits < 16),
+                            std::int_fast16_t,
                             meta::if_c<
-                                (bits < 16),
-                                std::int_fast16_t,
-                                meta::if_c<
-                                    (bits < 32),
-                                    std::int_fast32_t,
-                                    std::int_fast64_t> > > >;
+                                (bits < 32),
+                                std::int_fast32_t,
+                                std::int_fast64_t>>>;
             };
 
             template<typename Val>
@@ -171,7 +168,7 @@ namespace ranges
                 static_assert(sizeof(iota_difference_t<Val>) >= sizeof(Val),
                     "iota_difference_type must be at least as wide as the signed integer type; "
                     "otherwise the expression below might overflow when to - from would not.");
-                return static_cast<D>(to) - static_cast<D>(from);  
+                return static_cast<D>(to) - static_cast<D>(from);
             }
 
             template<typename Val, CONCEPT_REQUIRES_(UnsignedIntegral<Val>())>
@@ -543,7 +540,7 @@ namespace ranges
                 {
                     return iota_view<Val>{value};
                 }
-                
+
                 template<typename Val, CONCEPT_REQUIRES_(Integral<Val>())>
                 auto operator()(Val from, Val to) const
                 RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT

--- a/test/view/chunk.cpp
+++ b/test/view/chunk.cpp
@@ -204,5 +204,13 @@ int main()
         ::check_equal(rng, expected);
     }
 
+    {
+        // Regression test for not-exactly #567 (https://github.com/ericniebler/range-v3/issues/567#issuecomment-315148392)
+        int some_ints[] = {0,1,2,3};
+        int const expected[][2] = {{0, 1}, {2, 3}};
+        auto rng = view::all(some_ints);
+        ::check_equal(rng | view::chunk(2), expected);
+    }
+
     return ::test_result();
 }


### PR DESCRIPTION
Reported in #567.

Drive-by: In `iota_difference_`, `sizeof(difference_t) * CHAR_BIT < 8` is impossible.