### PR TITLE
when a range is its own sentinel (e.g. std::string), resolve overloads in favor of Range

### DIFF
--- a/include/range/v3/action/insert.hpp
+++ b/include/range/v3/action/insert.hpp
@@ -42,7 +42,7 @@ namespace ranges
 
             template<typename Cont, typename I, typename S,
                 typename C = common_iterator_t<I, S>,
-                CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Sentinel<S, I>())>
+                CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Sentinel<S, I>() && !Range<S>())>
             auto insert(Cont && cont, I i, S j) ->
                 decltype(unwrap_reference(cont).insert(C{i}, C{j}))
             {
@@ -81,7 +81,8 @@ namespace ranges
             {
                 template<typename Cont, typename P, typename I, typename S,
                     typename C = common_iterator_t<I, S>,
-                    CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<P>() && Sentinel<S, I>())>
+                    CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<P>() && Sentinel<S, I>() &&
+                                      !Range<S>())>
                 auto insert_impl(Cont && cont, P p, I i, S j, std::false_type) ->
                     decltype(unwrap_reference(cont).insert(p, C{i}, C{j}))
                 {
@@ -91,7 +92,7 @@ namespace ranges
                 template<typename Cont, typename P, typename I, typename S,
                     typename C = common_iterator_t<I, S>,
                     CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<P>() && SizedSentinel<S, I>() &&
-                                      RandomAccessReservable<Cont>())>
+                                      RandomAccessReservable<Cont>() && !Range<S>())>
                 auto insert_impl(Cont && cont, P p, I i, S j, std::true_type) ->
                     decltype(unwrap_reference(cont).insert(begin(unwrap_reference(cont)), C{i}, C{j}))
                 {
@@ -128,7 +129,8 @@ namespace ranges
 
             template<typename Cont, typename P, typename I, typename S,
                 typename C = common_iterator_t<I, S>,
-                CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<P>() && Sentinel<S, I>())>
+                CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<P>() && Sentinel<S, I>() &&
+                                  !Range<S>())>
             auto insert(Cont && cont, P p, I i, S j)
             RANGES_DECLTYPE_AUTO_RETURN
             (
@@ -175,7 +177,7 @@ namespace ranges
                 }
 
                 template<typename Rng, typename I, typename S,
-                    CONCEPT_REQUIRES_(Range<Rng>() && Sentinel<S, I>())>
+                    CONCEPT_REQUIRES_(Range<Rng>() && Sentinel<S, I>() && !Range<S>())>
                 auto operator()(Rng && rng, I i, S j) const ->
                     decltype(insert(static_cast<Rng&&>(rng), i, j))
                 {
@@ -219,7 +221,8 @@ namespace ranges
                 }
 
                 template<typename Rng, typename P, typename I, typename S,
-                    CONCEPT_REQUIRES_(Range<Rng>() && Iterator<P>() && Sentinel<S, I>())>
+                    CONCEPT_REQUIRES_(Range<Rng>() && Iterator<P>() && Sentinel<S, I>() &&
+                                      !Range<S>())>
                 auto operator()(Rng && rng, P p, I i, S j) const ->
                     decltype(insert(static_cast<Rng&&>(rng), p, i, j))
                 {

--- a/include/range/v3/action/push_back.hpp
+++ b/include/range/v3/action/push_back.hpp
@@ -83,7 +83,7 @@ namespace ranges
             #ifndef RANGES_DOXYGEN_INVOKED
                 template<typename Rng, typename T,
                     CONCEPT_REQUIRES_(!Concept<Rng, T>())>
-                void operator()(Rng &&, T &&) const
+                void operator()(Rng &&rng, T &&t) const
                 {
                     CONCEPT_ASSERT_MSG(InputRange<Rng>(),
                         "The object on which action::push_back operates must be a model of the "
@@ -94,6 +94,7 @@ namespace ranges
                         "The object to be inserted with action::push_back must either be "
                         "convertible to the range's value type, or else it must be a range "
                         "of elements that are convertible to the range's value type.");
+                    push_back(rng, (T &&) t);
                 }
             #endif
             };

--- a/include/range/v3/action/push_front.hpp
+++ b/include/range/v3/action/push_front.hpp
@@ -83,7 +83,7 @@ namespace ranges
             #ifndef RANGES_DOXYGEN_INVOKED
                 template<typename Rng, typename T,
                     CONCEPT_REQUIRES_(!Concept<Rng, T>())>
-                void operator()(Rng &&, T &&) const
+                void operator()(Rng &&rng, T &&t) const
                 {
                     CONCEPT_ASSERT_MSG(InputRange<Rng>(),
                         "The object on which action::push_front operates must be a model of the "
@@ -94,6 +94,7 @@ namespace ranges
                         "The object to be inserted with action::push_front must either be "
                         "convertible to the range's value type, or else it must be a range "
                         "of elements that are convertible to the range's value type.");
+                    push_front(rng, (T &&) t);
                 }
             #endif
             };

--- a/test/action/join.cpp
+++ b/test/action/join.cpp
@@ -28,7 +28,7 @@ int main()
 
     auto s2 = v | view::transform(view::all) | action::join;
     static_assert(std::is_same<decltype(s2), std::vector<char>>::value, "");
-    CHECK(equal(s, s2));
+    CHECK(std::string(s2.begin(), s2.end()) == "hello world");
 
     return ::test_result();
 }


### PR DESCRIPTION
... in `action::insert`