### PR TITLE
Invalid sentinel type in the iter_transform2_view::sentinel constructor (second range)

### DIFF
--- a/include/range/v3/view/transform.hpp
+++ b/include/range/v3/view/transform.hpp
@@ -167,7 +167,7 @@ namespace ranges
                 sentinel_t<Rng2> end2_;
             public:
                 sentinel() = default;
-                sentinel(detail::any, sentinel_t<Rng1> end1, sentinel_t<Rng1> end2)
+                sentinel(detail::any, sentinel_t<Rng1> end1, sentinel_t<Rng2> end2)
                   : end1_(std::move(end1)), end2_(std::move(end2))
                 {}
             };


### PR DESCRIPTION
The sentinel type for the second range in the constructor of the sentinel class of the iter_transform2_view is in the wrong type (reference to the first range instead of the second range).

This is similar to another fix made to the transform view (#267)