### PR TITLE
insert action should not break vector's exponential growth

### DIFF
--- a/include/range/v3/action/concepts.hpp
+++ b/include/range/v3/action/concepts.hpp
@@ -86,16 +86,13 @@ namespace ranges
         namespace concepts
         {
             struct Reservable
-              : refines<Container>
+              : refines<Container, SizedRange>
             {
-                template<typename C>
-                using size_type =
-                    decltype(std::declval<const C&>().size());
-
-                template<typename C, typename S = size_type<C>>
-                auto requires_(C&& c, S&& s = S{}) -> decltype(
+                template<typename C, typename S = concepts::SizedRange::size_t<C>>
+                auto requires_(C &&c, const C &&cc = C{}, S &&s = S{}) -> decltype(
                     concepts::valid_expr(
-                        concepts::model_of<Integral, S>(),
+                        concepts::has_type<S>(cc.capacity()),
+                        concepts::has_type<S>(cc.max_size()),
                         ((void)c.reserve(s), 42)
                     ));
             };
@@ -104,7 +101,7 @@ namespace ranges
               : refines<Reservable(_1), InputIterator(_2)>
             {
                 template<typename C, typename I>
-                auto requires_(C&& c, I&& i) -> decltype(
+                auto requires_(C &&c, I &&i) -> decltype(
                     concepts::valid_expr(
                         ((void)c.assign(i, i), 42)
                     ));
@@ -142,9 +139,9 @@ namespace ranges
               : refines<ForwardRange>
             {
                 template<typename T>
-                auto requires_(T&& t) -> decltype(
+                auto requires_(T &&t) -> decltype(
                     concepts::valid_expr(
-                        detail::is_lvalue_container_like(static_cast<T&&>(t))
+                        detail::is_lvalue_container_like(static_cast<T &&>(t))
                     ));
             };
         }

--- a/include/range/v3/action/insert.hpp
+++ b/include/range/v3/action/insert.hpp
@@ -14,15 +14,15 @@
 #ifndef RANGES_V3_ACTION_INSERT_HPP
 #define RANGES_V3_ACTION_INSERT_HPP
 
-#include <utility>
 #include <functional>
 #include <initializer_list>
+#include <utility>
 #include <range/v3/range_fwd.hpp>
-#include <range/v3/begin_end.hpp>
 #include <range/v3/range_traits.hpp>
-#include <range/v3/utility/functional.hpp>
-#include <range/v3/utility/common_iterator.hpp>
 #include <range/v3/action/concepts.hpp>
+#include <range/v3/algorithm/max.hpp>
+#include <range/v3/utility/common_iterator.hpp>
+#include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/static_const.hpp>
 
 namespace ranges
@@ -33,118 +33,142 @@ namespace ranges
         namespace adl_insert_detail
         {
             template<typename Cont, typename T,
-                CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Constructible<range_value_type_t<Cont>, T>())>
-            auto insert(Cont && cont, T && t) ->
-                decltype(unwrap_reference(cont).insert(static_cast<T&&>(t)))
-            {
-                return unwrap_reference(cont).insert(static_cast<T&&>(t));
-            }
+                CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() &&
+                    Constructible<range_value_type_t<Cont>, T>())>
+            auto insert(Cont &&cont, T &&t)
+            RANGES_DECLTYPE_AUTO_RETURN
+            (
+                unwrap_reference(cont).insert(static_cast<T &&>(t))
+            )
 
             template<typename Cont, typename I, typename S,
                 typename C = common_iterator_t<I, S>,
                 CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Sentinel<S, I>() && !Range<S>())>
-            auto insert(Cont && cont, I i, S j) ->
-                decltype(unwrap_reference(cont).insert(C{i}, C{j}))
-            {
-                return unwrap_reference(cont).insert(C{i}, C{j});
-            }
+            auto insert(Cont &&cont, I i, S j)
+            RANGES_DECLTYPE_AUTO_RETURN
+            (
+                unwrap_reference(cont).insert(C{i}, C{j})
+            )
 
             template<typename Cont, typename Rng,
                 typename C = range_common_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Range<Rng>())>
-            auto insert(Cont && cont, Rng && rng) ->
-                decltype(unwrap_reference(cont).insert(C{begin(rng)}, C{end(rng)}))
-            {
-                return unwrap_reference(cont).insert(C{begin(rng)}, C{end(rng)});
-            }
+            auto insert(Cont &&cont, Rng &&rng)
+            RANGES_DECLTYPE_AUTO_RETURN
+            (
+                unwrap_reference(cont).insert(C{ranges::begin(rng)}, C{ranges::end(rng)})
+            )
 
             template<typename Cont, typename I, typename T,
                 CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<I>() &&
                     Constructible<range_value_type_t<Cont>, T>())>
-            auto insert(Cont && cont, I p, T && t) ->
-                decltype(unwrap_reference(cont).insert(p, static_cast<T&&>(t)))
-            {
-                return unwrap_reference(cont).insert(p, static_cast<T&&>(t));
-            }
+            auto insert(Cont &&cont, I p, T &&t)
+            RANGES_DECLTYPE_AUTO_RETURN
+            (
+                unwrap_reference(cont).insert(p, static_cast<T &&>(t))
+            )
 
             template<typename Cont, typename I, typename N, typename T,
                 CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<I>() && Integral<N>() &&
                     Constructible<range_value_type_t<Cont>, T>())>
-            auto insert(Cont && cont, I p, N n, T && t) ->
-                decltype(unwrap_reference(cont).insert(p, n, static_cast<T&&>(t)))
-            {
-                return unwrap_reference(cont).insert(p, n, static_cast<T&&>(t));
-            }
+            auto insert(Cont &&cont, I p, N n, T &&t)
+            RANGES_DECLTYPE_AUTO_RETURN
+            (
+                unwrap_reference(cont).insert(p, n, static_cast<T &&>(t))
+            )
 
             /// \cond
             namespace detail
             {
-                template<typename Cont, typename P, typename I, typename S,
-                    typename C = common_iterator_t<I, S>,
-                    CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<P>() && Sentinel<S, I>() &&
-                                      !Range<S>())>
-                auto insert_impl(Cont && cont, P p, I i, S j, std::false_type) ->
-                    decltype(unwrap_reference(cont).insert(p, C{i}, C{j}))
+                template<typename Cont, typename P,
+                    CONCEPT_REQUIRES_(Container<Cont>() && Iterator<P>() &&
+                        RandomAccessReservable<Cont>())>
+                iterator_t<Cont> insert_reserve_helper(
+                    Cont &cont, P const p, range_size_type_t<Cont> const delta)
                 {
-                    return unwrap_reference(cont).insert(p, C{i}, C{j});
+                    auto const old_size = ranges::size(cont);
+                    auto const max_size = cont.max_size();
+                    RANGES_EXPECT(delta <= max_size - old_size);
+                    auto const new_size = old_size + delta;
+                    auto const old_capacity = cont.capacity();
+                    auto const index = p - ranges::begin(cont);
+                    if (old_capacity < new_size)
+                    {
+                        auto const new_capacity = (old_capacity <= max_size / 3 * 2)
+                            ? ranges::max(old_capacity + old_capacity / 2, new_size)
+                            : max_size;
+                        cont.reserve(new_capacity);
+                    }
+                    return ranges::begin(cont) + index;
                 }
 
                 template<typename Cont, typename P, typename I, typename S,
                     typename C = common_iterator_t<I, S>,
-                    CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<P>() && SizedSentinel<S, I>() &&
-                                      RandomAccessReservable<Cont>() && !Range<S>())>
-                auto insert_impl(Cont && cont, P p, I i, S j, std::true_type) ->
-                    decltype(unwrap_reference(cont).insert(begin(unwrap_reference(cont)), C{i}, C{j}))
-                {
-                    auto const index = p - unwrap_reference(cont).begin();
-                    using size_type = decltype(unwrap_reference(cont).size());
-                    unwrap_reference(cont).reserve(unwrap_reference(cont).size() + static_cast<size_type>(j - i));
-                    return unwrap_reference(cont).insert(begin(unwrap_reference(cont)) + index, C{i}, C{j});
-                }
+                    CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<P>() &&
+                        Sentinel<S, I>() && !Range<S>())>
+                auto insert_impl(Cont &&cont, P p, I i, S j, std::false_type)
+                RANGES_DECLTYPE_AUTO_RETURN
+                (
+                    unwrap_reference(cont).insert(p, C{i}, C{j})
+                )
 
+                template<typename Cont, typename P, typename I, typename S,
+                    typename C = common_iterator_t<I, S>,
+                    CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<P>() &&
+                        SizedSentinel<S, I>() && RandomAccessReservable<Cont>() && !Range<S>())>
+                auto insert_impl(Cont &&cont_, P p, I i, S j, std::true_type) ->
+                    decltype(unwrap_reference(cont_).insert(
+                        ranges::begin(unwrap_reference(cont_)), C{i}, C{j}))
+                {
+                    auto &&cont = unwrap_reference(cont_);
+                    auto const delta = static_cast<range_size_type_t<Cont>>(j - i);
+                    auto pos = insert_reserve_helper(cont, std::move(p), delta);
+                    return cont.insert(pos, C{std::move(i)}, C{std::move(j)});
+                }
 
                 template<typename Cont, typename I, typename Rng,
                     typename C = range_common_iterator_t<Rng>,
                     CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<I>() && Range<Rng>())>
-                auto insert_impl(Cont && cont, I p, Rng && rng, std::false_type) ->
-                    decltype(unwrap_reference(cont).insert(p, C{begin(rng)}, C{end(rng)}))
-                {
-                    return unwrap_reference(cont).insert(p, C{begin(rng)}, C{end(rng)});
-                }
+                auto insert_impl(Cont &&cont, I p, Rng &&rng, std::false_type)
+                RANGES_DECLTYPE_AUTO_RETURN
+                (
+                    unwrap_reference(cont).insert(p, C{ranges::begin(rng)}, C{ranges::end(rng)})
+                )
 
                 template<typename Cont, typename I, typename Rng,
                     typename C = range_common_iterator_t<Rng>,
-                    CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<I>() && SizedRange<Rng>() &&
-                                      RandomAccessReservable<Cont>())>
-                auto insert_impl(Cont && cont, I p, Rng && rng, std::true_type) ->
-                    decltype(unwrap_reference(cont).insert(begin(unwrap_reference(cont)), C{begin(rng)}, C{end(rng)}))
+                    CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<I>() &&
+                        RandomAccessReservable<Cont>() && SizedRange<Rng>())>
+                auto insert_impl(Cont &&cont_, I p, Rng &&rng, std::true_type) ->
+                    decltype(unwrap_reference(cont_).insert(
+                        begin(unwrap_reference(cont_)), C{ranges::begin(rng)}, C{ranges::end(rng)}))
                 {
-                    auto const index = p - begin(unwrap_reference(cont));
-                    using size_type = decltype(unwrap_reference(cont).size());
-                    unwrap_reference(cont).reserve(unwrap_reference(cont).size() + static_cast<size_type>(size(rng)));
-                    return unwrap_reference(cont).insert(begin(unwrap_reference(cont)) + index, C{begin(rng)}, C{end(rng)});
+                    auto &&cont = unwrap_reference(cont_);
+                    auto const delta = static_cast<range_size_type_t<Cont>>(ranges::size(rng));
+                    auto pos = insert_reserve_helper(cont, std::move(p), delta);
+                    return cont.insert(pos, C{ranges::begin(rng)}, C{ranges::end(rng)});
                 }
             }
             /// \endcond
 
             template<typename Cont, typename P, typename I, typename S,
                 typename C = common_iterator_t<I, S>,
-                CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<P>() && Sentinel<S, I>() &&
-                                  !Range<S>())>
-            auto insert(Cont && cont, P p, I i, S j)
+                CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<P>() &&
+                    Sentinel<S, I>() && !Range<S>())>
+            auto insert(Cont &&cont, P p, I i, S j)
             RANGES_DECLTYPE_AUTO_RETURN
             (
-                detail::insert_impl(static_cast<Cont&&>(cont), std::move(p), std::move(i), std::move(j),
+                detail::insert_impl(static_cast<Cont &&>(cont), std::move(p), std::move(i), std::move(j),
                                     meta::strict_and<RandomAccessReservable<Cont>, SizedSentinel<S, I>>{})
             )
 
             template<typename Cont, typename I, typename Rng,
                 typename C = range_common_iterator_t<Rng>,
                 CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<I>() && Range<Rng>())>
-            auto insert(Cont && cont, I p, Rng && rng)
+            auto insert(Cont &&cont, I p, Rng &&rng)
             RANGES_DECLTYPE_AUTO_RETURN
             (
-                detail::insert_impl(static_cast<Cont&&>(cont), std::move(p), static_cast<Rng&&>(rng),
+                detail::insert_impl(static_cast<Cont &&>(cont), std::move(p), static_cast<Rng &&>(rng),
                                     meta::strict_and<RandomAccessReservable<Cont>, SizedRange<Rng>>{})
             )
 
@@ -152,82 +176,82 @@ namespace ranges
             {
                 template<typename Rng, typename T,
                     CONCEPT_REQUIRES_(Range<Rng>() && Constructible<range_value_type_t<Rng>, T>())>
-                auto operator()(Rng && rng, T && t) const ->
-                    decltype(insert(static_cast<Rng&&>(rng), static_cast<T&&>(t)))
-                {
-                    return insert(static_cast<Rng&&>(rng), static_cast<T&&>(t));
-                }
+                auto operator()(Rng &&rng, T &&t) const
+                RANGES_DECLTYPE_AUTO_RETURN
+                (
+                    insert(static_cast<Rng &&>(rng), static_cast<T &&>(t))
+                )
 
                 template<typename Rng, typename Rng2,
                     CONCEPT_REQUIRES_(Range<Rng>() && Range<Rng2>())>
-                auto operator()(Rng && rng, Rng2 && rng2) const ->
-                    decltype(insert(static_cast<Rng&&>(rng), static_cast<Rng2&&>(rng2)))
+                auto operator()(Rng &&rng, Rng2 &&rng2) const ->
+                    decltype(insert(static_cast<Rng &&>(rng), static_cast<Rng2 &&>(rng2)))
                 {
                     static_assert(!is_infinite<Rng>::value,
                         "Attempting to insert an infinite range into a container");
-                    return insert(static_cast<Rng&&>(rng), static_cast<Rng2&&>(rng2));
+                    return insert(static_cast<Rng &&>(rng), static_cast<Rng2 &&>(rng2));
                 }
 
                 template<typename Rng, typename T,
                     CONCEPT_REQUIRES_(Range<Rng>())>
-                auto operator()(Rng && rng, std::initializer_list<T> rng2) const ->
-                    decltype(insert(static_cast<Rng&&>(rng), rng2))
-                {
-                    return insert(static_cast<Rng&&>(rng), rng2);
-                }
+                auto operator()(Rng &&rng, std::initializer_list<T> rng2) const
+                RANGES_DECLTYPE_AUTO_RETURN
+                (
+                    insert(static_cast<Rng &&>(rng), rng2)
+                )
 
                 template<typename Rng, typename I, typename S,
                     CONCEPT_REQUIRES_(Range<Rng>() && Sentinel<S, I>() && !Range<S>())>
-                auto operator()(Rng && rng, I i, S j) const ->
-                    decltype(insert(static_cast<Rng&&>(rng), i, j))
-                {
-                    return insert(static_cast<Rng&&>(rng), i, j);
-                }
+                auto operator()(Rng &&rng, I i, S j) const
+                RANGES_DECLTYPE_AUTO_RETURN
+                (
+                    insert(static_cast<Rng &&>(rng), std::move(i), std::move(j))
+                )
 
                 template<typename Rng, typename I, typename T,
                     CONCEPT_REQUIRES_(Range<Rng>() && Iterator<I>() &&
                         Constructible<range_value_type_t<Rng>, T>())>
-                auto operator()(Rng && rng, I p, T && t) const ->
-                    decltype(insert(static_cast<Rng&&>(rng), p, static_cast<T&&>(t)))
-                {
-                    return insert(static_cast<Rng&&>(rng), p, static_cast<T&&>(t));
-                }
+                auto operator()(Rng &&rng, I p, T &&t) const
+                RANGES_DECLTYPE_AUTO_RETURN
+                (
+                    insert(static_cast<Rng &&>(rng), std::move(p), static_cast<T &&>(t))
+                )
 
                 template<typename Rng, typename I, typename Rng2,
                     CONCEPT_REQUIRES_(Range<Rng>() && Iterator<I>() && Range<Rng2>())>
-                auto operator()(Rng && rng, I p, Rng2 && rng2) const ->
-                    decltype(insert(static_cast<Rng&&>(rng), p, static_cast<Rng2&&>(rng2)))
+                auto operator()(Rng &&rng, I p, Rng2 &&rng2) const ->
+                    decltype(insert(static_cast<Rng &&>(rng), std::move(p), static_cast<Rng2 &&>(rng2)))
                 {
                     static_assert(!is_infinite<Rng>::value,
                         "Attempting to insert an infinite range into a container");
-                    return insert(static_cast<Rng&&>(rng), p, static_cast<Rng2&&>(rng2));
+                    return insert(static_cast<Rng &&>(rng), std::move(p), static_cast<Rng2 &&>(rng2));
                 }
 
                 template<typename Rng, typename I, typename T,
                     CONCEPT_REQUIRES_(Range<Rng>() && Iterator<I>())>
-                auto operator()(Rng && rng, I p, std::initializer_list<T> rng2) const ->
-                    decltype(insert(static_cast<Rng&&>(rng), p, rng2))
-                {
-                    return insert(static_cast<Rng&&>(rng), p, rng2);
-                }
+                auto operator()(Rng &&rng, I p, std::initializer_list<T> rng2) const
+                RANGES_DECLTYPE_AUTO_RETURN
+                (
+                    insert(static_cast<Rng &&>(rng), std::move(p), rng2)
+                )
 
                 template<typename Rng, typename I, typename N, typename T,
                     CONCEPT_REQUIRES_(Range<Rng>() && Iterator<I>() && Integral<N>()
                         && Constructible<range_value_type_t<Rng>, T>())>
-                auto operator()(Rng && rng, I p, N n, T && t) const ->
-                    decltype(insert(static_cast<Rng&&>(rng), p, n, static_cast<T&&>(t)))
-                {
-                    return insert(static_cast<Rng&&>(rng), p, n, static_cast<T&&>(t));
-                }
+                auto operator()(Rng &&rng, I p, N n, T &&t) const
+                RANGES_DECLTYPE_AUTO_RETURN
+                (
+                    insert(static_cast<Rng &&>(rng), std::move(p), n, static_cast<T &&>(t))
+                )
 
                 template<typename Rng, typename P, typename I, typename S,
                     CONCEPT_REQUIRES_(Range<Rng>() && Iterator<P>() && Sentinel<S, I>() &&
                                       !Range<S>())>
-                auto operator()(Rng && rng, P p, I i, S j) const ->
-                    decltype(insert(static_cast<Rng&&>(rng), p, i, j))
-                {
-                    return insert(static_cast<Rng&&>(rng), p, i, j);
-                }
+                auto operator()(Rng &&rng, P p, I i, S j) const
+                RANGES_DECLTYPE_AUTO_RETURN
+                (
+                    insert(static_cast<Rng &&>(rng), std::move(p), std::move(i), std::move(j))
+                )
             };
         }
         /// \endcond
@@ -246,16 +270,16 @@ namespace ranges
             struct InsertableRange
               : refines<Range(_1)>
             {
-                template<typename Rng, typename...Rest>
-                auto requires_(Rng&& rng, Rest&&... rest) -> decltype(
+                template<typename Rng, typename... Rest>
+                auto requires_(Rng &&rng, Rest &&... rest) -> decltype(
                     concepts::valid_expr(
-                        ((void)ranges::insert(static_cast<Rng&&>(rng), static_cast<Rest&&>(rest)...), 42)
+                        ((void)ranges::insert(static_cast<Rng &&>(rng), static_cast<Rest &&>(rest)...), 42)
                     ));
             };
         }
 
         /// \ingroup group-concepts
-        template<typename Rng, typename...Rest>
+        template<typename Rng, typename... Rest>
         using InsertableRange = concepts::models<concepts::InsertableRange, Rng, Rest...>;
     }
 }

--- a/test/action/insert.cpp
+++ b/test/action/insert.cpp
@@ -37,46 +37,56 @@ int main()
 {
     using namespace ranges;
 
-    std::vector<int> v;
-    auto i = insert(v, v.begin(), 42);
-    CHECK(i == v.begin());
-    ::check_equal(v, {42});
-    insert(v, v.end(), {1,2,3});
-    ::check_equal(v, {42,1,2,3});
+    {
+        std::vector<int> v;
+        auto i = insert(v, v.begin(), 42);
+        CHECK(i == v.begin());
+        ::check_equal(v, {42});
+        insert(v, v.end(), {1,2,3});
+        ::check_equal(v, {42,1,2,3});
 
-    insert(v, v.begin(), view::ints | view::take(3));
-    ::check_equal(v, {0,1,2,42,1,2,3});
+        insert(v, v.begin(), view::ints | view::take(3));
+        ::check_equal(v, {0,1,2,42,1,2,3});
 
-    int rg[] = {9,8,7};
-    insert(v, v.begin()+3, rg);
-    ::check_equal(v, {0,1,2,9,8,7,42,1,2,3});
-    insert(v, v.begin()+1, rg);
-    ::check_equal(v, {0,9,8,7,1,2,9,8,7,42,1,2,3});
+        int rg[] = {9,8,7};
+        insert(v, v.begin()+3, rg);
+        ::check_equal(v, {0,1,2,9,8,7,42,1,2,3});
+        insert(v, v.begin()+1, rg);
+        ::check_equal(v, {0,9,8,7,1,2,9,8,7,42,1,2,3});
+    }
 
-    std::set<int> s;
-    insert(s,
-        view::ints|view::take(10)|view::for_each([](int i){return yield_if(i%2==0,i);}));
-    ::check_equal(s, {0,2,4,6,8});
-    auto j = insert(s, 10);
-    CHECK(j.first == prev(s.end()));
-    CHECK(j.second == true);
-    ::check_equal(s, {0,2,4,6,8,10});
+    {
+        std::set<int> s;
+        insert(s,
+            view::ints|view::take(10)|view::for_each([](int i){return yield_if(i%2==0,i);}));
+        ::check_equal(s, {0,2,4,6,8});
+        auto j = insert(s, 10);
+        CHECK(j.first == prev(s.end()));
+        CHECK(j.second == true);
+        ::check_equal(s, {0,2,4,6,8,10});
 
-    insert(std::ref(s), 12);
-    ::check_equal(s, {0,2,4,6,8,10,12});
+        insert(std::ref(s), 12);
+        ::check_equal(s, {0,2,4,6,8,10,12});
 
-    insert(ranges::ref(s), 14);
-    ::check_equal(s, {0,2,4,6,8,10,12,14});
+        insert(ranges::ref(s), 14);
+        ::check_equal(s, {0,2,4,6,8,10,12,14});
+    }
 
-    const std::size_t N = 1024;
-    vector_like<int> vl;
-    insert(vl, vl.end(), view::iota(0, int{N}));
-    CHECK(vl.reservation_count == std::size_t{1});
-    CHECK(vl.last_reservation == N);
-    auto r = view::iota(0, int{2 * N});
-    insert(vl, vl.begin() + 42, begin(r), end(r));
-    CHECK(vl.reservation_count == std::size_t{2});
-    CHECK(vl.last_reservation == 3 * N);
+    {
+        const std::size_t N = 1024;
+        vector_like<int> vl;
+        insert(vl, vl.end(), view::iota(0, int{N}));
+        CHECK(vl.reservation_count == 1u);
+        CHECK(vl.last_reservation == N);
+        auto r = view::iota(0, int{2 * N});
+        insert(vl, vl.begin() + 42, begin(r), end(r));
+        CHECK(vl.reservation_count == 2u);
+        CHECK(vl.last_reservation == 3 * N);
+        int i = 42;
+        insert(vl, vl.end(), &i, &i + 1);
+        CHECK(vl.reservation_count == 3u);
+        CHECK(vl.last_reservation > 3 * N + 1);
+    }
 
     return ::test_result();
 }


### PR DESCRIPTION
WG21 really should fix this in `std::vector::reserve`: when the argument to `reserve` is greater than the current capacity and less than the next exponential growth target, round it up.

There are also a bunch of unrelated style changes in action/insert.hpp, which I really should have put into a distinct commit to make it easier to review the behavioral changes. Those actual behavior changes are in the `insert_impl` overloads defined on 119 and 142, which call a new `insert_reserve_helper` defined on 86.

EDIT: I've also added some overflow paranoia to insert and `to_container`, and fixed `to_container` to properly use `ranges::size` instead of `foo.size()`.