### PR TITLE
Inclusive scan

### DIFF
--- a/include/range/v3/numeric/inclusive_scan.hpp
+++ b/include/range/v3/numeric/inclusive_scan.hpp
@@ -1,0 +1,164 @@
+/// \file
+// Range v3 library
+//
+//  Copyright Rostislav Khlebnikov 2017
+//  Copyright Eric Niebler 2013-2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+#ifndef RANGES_V3_NUMERIC_inclusive_scan_HPP
+#define RANGES_V3_NUMERIC_inclusive_scan_HPP
+
+#include <meta/meta.hpp>
+#include <range/v3/begin_end.hpp>
+#include <range/v3/range_traits.hpp>
+#include <range/v3/range_concepts.hpp>
+#include <range/v3/algorithm/tagspec.hpp>
+#include <range/v3/utility/functional.hpp>
+#include <range/v3/utility/iterator_traits.hpp>
+#include <range/v3/utility/iterator_concepts.hpp>
+#include <range/v3/utility/static_const.hpp>
+#include <range/v3/utility/unreachable.hpp>
+#include <range/v3/numeric/partial_sum.hpp>
+
+namespace ranges
+{
+    inline namespace v3
+    {
+        namespace detail {
+            template<typename AccT, typename BOp, typename I1, typename I2>
+            using IndirectInvocableAndAssignable = meta::strict_and<
+                IndirectRegularInvocable<BOp, I1, I2>,
+                Assignable<detail::decay_t<AccT>&, indirect_result_of_t<BOp&(I1, I2)>>>;
+        }
+        
+        template<typename I, typename O, typename BOp = plus, typename P = ident, typename T = void, 
+            typename IProj = projected<projected<I, detail::as_value_type_t<I>>, P>,
+            typename AccT = meta::if_c<std::is_void<T>::value, value_type_t<IProj>, T>>
+        using InclusiveScannable = meta::strict_and<
+            InputIterator<I>,
+            OutputIterator<O, AccT const&>,
+            MoveConstructible<AccT>,
+            detail::IndirectInvocableAndAssignable<AccT, BOp, AccT*, AccT*>,
+            detail::IndirectInvocableAndAssignable<AccT, BOp, AccT*, IProj>,
+            detail::IndirectInvocableAndAssignable<AccT, BOp, IProj, IProj>>;
+
+
+        struct inclusive_scan_fn
+        {
+            // No-init version
+            template<typename I, typename S, typename O, typename S2,
+                typename BOp = plus, typename P = ident,
+                CONCEPT_REQUIRES_(Sentinel<S, I>() && Sentinel<S2, O>() &&
+                    InclusiveScannable<I, O, BOp, P>())>
+            tagged_pair<tag::in(I), tag::out(O)>
+            operator()(I begin, S end, O result, S2 end_result, BOp bop = BOp{}, P proj = P{}) const
+            {
+                return detail::partial_sum_no_check(std::move(begin), std::move(end), 
+                    std::move(result), std::move(end_result),
+                    std::move(bop), std::move(proj));
+            }
+
+            template<typename I, typename S, typename O, typename BOp = plus,
+                typename P = ident,
+                CONCEPT_REQUIRES_(Sentinel<S, I>() && InclusiveScannable<I, O, BOp, P>())>
+            tagged_pair<tag::in(I), tag::out(O)>
+            operator()(I begin, S end, O result, BOp bop = BOp{}, P proj = P{}) const
+            {
+                return (*this)(std::move(begin), std::move(end), std::move(result), 
+                               unreachable{}, std::move(bop), std::move(proj));
+            }
+
+             template<typename Rng, typename ORef, typename BOp = plus,
+                typename P = ident, typename I = iterator_t<Rng>,
+                typename O = uncvref_t<ORef>,
+                CONCEPT_REQUIRES_(Range<Rng>() && InclusiveScannable<I, O, BOp, P>())>
+            tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
+            operator()(Rng && rng, ORef && result, BOp bop = BOp{}, P proj = P{}) const
+            {
+                return (*this)(begin(rng), end(rng), static_cast<ORef&&>(result),
+                               std::move(bop), std::move(proj));
+            }
+
+            template<typename Rng, typename ORng, typename BOp = plus,
+                typename P = ident, typename I = iterator_t<Rng>,
+                typename O = iterator_t<ORng>,
+                CONCEPT_REQUIRES_(Range<Rng>() && Range<ORng>() &&
+                    InclusiveScannable<I, O, BOp, P>())>
+            tagged_pair<tag::in(safe_iterator_t<Rng>),
+                tag::out(safe_iterator_t<ORng>)>
+            operator()(Rng && rng, ORng && result, BOp bop = BOp{}, P proj = P{}) const
+            {
+                return (*this)(begin(rng), end(rng), begin(result), end(result),
+                               std::move(bop), std::move(proj));
+            }
+            
+            // init version
+            template<typename I, typename S, typename O, typename S2,
+                typename BOp, typename T, typename P = ident,
+                CONCEPT_REQUIRES_(Sentinel<S, I>() && Sentinel<S2, O>() &&
+                    InclusiveScannable<I, O, BOp, P, T>())>
+            tagged_pair<tag::in(I), tag::out(O)>
+            operator()(I begin, S end, O result, S2 end_result, BOp bop, T init, P proj = P{}) const
+            {
+                coerce<value_type_t<I>> v;
+
+                if(begin != end && result != end_result)
+                {
+                    for(; begin != end && result != end_result;
+                        ++begin, ++result)
+                    {
+                        auto &&cur = v(*begin);
+                        init = invoke(bop, init, invoke(proj, cur));
+                        *result = init;
+                    }
+                }
+                return {begin, result};
+            }
+
+            template<typename I, typename S, typename O, typename BOp,
+                typename T, typename P = ident,
+                CONCEPT_REQUIRES_(Sentinel<S, I>() && InclusiveScannable<I, O, BOp, P, T>())>
+            tagged_pair<tag::in(I), tag::out(O)>
+            operator()(I begin, S end, O result, BOp bop, T init, P proj = P{}) const
+            {
+                return (*this)(std::move(begin), std::move(end), std::move(result), 
+                               unreachable{}, std::move(bop), std::move(init), std::move(proj));
+            }
+
+             template<typename Rng, typename ORef, typename BOp, typename T,
+                typename P = ident, typename I = iterator_t<Rng>,
+                typename O = uncvref_t<ORef>,
+                CONCEPT_REQUIRES_(Range<Rng>() && InclusiveScannable<I, O, BOp, P, T>())>
+            tagged_pair<tag::in(safe_iterator_t<Rng>), tag::out(O)>
+            operator()(Rng && rng, ORef && result, BOp bop, T init, P proj = P{}) const
+            {
+                return (*this)(begin(rng), end(rng), static_cast<ORef&&>(result),
+                               std::move(bop), std::move(init), std::move(proj));
+            }
+
+            template<typename Rng, typename ORng, typename BOp, typename T,
+                typename P = ident, typename I = iterator_t<Rng>,
+                typename O = iterator_t<ORng>,
+                CONCEPT_REQUIRES_(Range<Rng>() && Range<ORng>() &&
+                    InclusiveScannable<I, O, BOp, P, T>())>
+            tagged_pair<tag::in(safe_iterator_t<Rng>),
+                tag::out(safe_iterator_t<ORng>)>
+            operator()(Rng && rng, ORng && result, BOp bop, T init, P proj = P{}) const
+            {
+                return (*this)(begin(rng), end(rng), begin(result), end(result),
+                               std::move(bop), std::move(init), std::move(proj));
+            }
+            
+        };
+
+        RANGES_INLINE_VARIABLE(inclusive_scan_fn, inclusive_scan)
+    }
+}
+
+#endif

--- a/test/numeric/CMakeLists.txt
+++ b/test/numeric/CMakeLists.txt
@@ -12,3 +12,6 @@ add_test(test.num.iota num.iota)
 
 add_executable(num.partial_sum partial_sum.cpp)
 add_test(test.num.partial_sum num.partial_sum)
+
+add_executable(num.inclusive_scan inclusive_scan.cpp)
+add_test(test.num.inclusive_scan num.inclusive_scan)

--- a/test/numeric/adjacent_difference.cpp
+++ b/test/numeric/adjacent_difference.cpp
@@ -26,76 +26,52 @@
 #include <range/v3/numeric/adjacent_difference.hpp>
 #include "../simple_test.hpp"
 #include "../test_iterators.hpp"
+#include "../test_utils.hpp"
+#include <array>
 
-struct S
-{
-    int i;
-};
+template<typename TIn, typename TOut, std::size_t N, typename Func>
+void test_one(std::array<TIn, N> const& in, std::array<TOut, N> const& expected, Func run) {
+    std::array<TOut, N> result{};
+    auto r = run(in, result);
+    CHECK(base(std::get<0>(r)) == in.data() + in.size());
+    CHECK(base(std::get<1>(r)) == result.data() + result.size());
+    ::check_equal(result, expected);
+}
 
 template<class InIter, class OutIter, class InSent = InIter> void test()
 {
     using ranges::adjacent_difference;
     using ranges::make_iterator_range;
-    { // iterator
-        int ia[] = {15, 10, 6, 3, 1};
-        int ir[] = {15, -5, -4, -3, -2};
-        const unsigned s = sizeof(ia) / sizeof(ia[0]);
-        int ib[s] = {0};
-        auto r = adjacent_difference(InIter(ia), InSent(ia + s), OutIter(ib));
-        CHECK(base(std::get<0>(r)) == ia + s);
-        CHECK(base(std::get<1>(r)) == ib + s);
-        for(unsigned i = 0; i < s; ++i)
-        {
-            CHECK(ib[i] == ir[i]);
-        }
-    }
 
-    { // range + output iterator
-        int ia[] = {15, 10, 6, 3, 1};
-        int ir[] = {15, -5, -4, -3, -2};
-        const unsigned s = sizeof(ia) / sizeof(ia[0]);
-        int ib[s] = {0};
-        auto rng = make_iterator_range(InIter(ia), InSent(ia + s));
-        auto r = adjacent_difference(rng, OutIter(ib));
-        CHECK(base(std::get<0>(r)) == ia + s);
-        CHECK(base(std::get<1>(r)) == ib + s);
-        for(unsigned i = 0; i < s; ++i)
-        {
-            CHECK(ib[i] == ir[i]);
-        }
-    }
+    using ArrayT = std::array<int, 5>;
 
-    { // range + output range
-        int ia[] = {15, 10, 6, 3, 1};
-        int ir[] = {15, -5, -4, -3, -2};
-        const unsigned s = sizeof(ia) / sizeof(ia[0]);
-        int ib[s] = {0};
-        auto rng = make_iterator_range(InIter(ia), InSent(ia + s));
-        auto orng = make_iterator_range(OutIter(ib), OutIter(ib + s));
-        auto r = adjacent_difference(rng, orng);
-        CHECK(base(std::get<0>(r)) == ia + s);
-        CHECK(base(std::get<1>(r)) == ib + s);
-        for(unsigned i = 0; i < s; ++i)
-        {
-            CHECK(ib[i] == ir[i]);
-        }
-    }
+    ArrayT const in{{15, 10, 6, 3, 1}};
+    ArrayT const expected{{15, -5, -4, -3, -2}};
 
-    {
-        int ia[] = {15, 10, 6, 3, 1};
-        int ir[] = {15, 25, 16, 9, 4};
-        const unsigned s = sizeof(ia) / sizeof(ia[0]);
-        int ib[s] = {0};
-        auto rng = make_iterator_range(InIter(ia), InSent(ia + s));
-        auto orng = make_iterator_range(OutIter(ib), OutIter(ib + s));
-        auto r = adjacent_difference(rng, orng, std::plus<int>());
-        CHECK(base(std::get<0>(r)) == ia + s);
-        CHECK(base(std::get<1>(r)) == ib + s);
-        for(unsigned i = 0; i < s; ++i)
-        {
-            CHECK(ib[i] == ir[i]);
-        }
-    }
+    // iterator
+    test_one(in, expected, [](ArrayT const& in, ArrayT& result) {
+        return adjacent_difference(InIter(in.data()), InSent(in.data() + in.size()), OutIter(result.data()));
+    });
+
+    // range + output iterator
+    test_one(in, expected, [](ArrayT const& in, ArrayT& result) {
+        auto rng = make_iterator_range(InIter(in.data()), InSent(in.data() + in.size()));
+        return adjacent_difference(rng, OutIter(result.data()));
+    });
+
+    // range + output range
+    test_one(in, expected, [](ArrayT const& in, ArrayT& result) {
+        auto rng = make_iterator_range(InIter(in.data()), InSent(in.data() + in.size()));
+        auto orng = make_iterator_range(OutIter(result.data()), OutIter(result.data() + result.size()));
+        return adjacent_difference(rng, orng);
+    });
+
+    // BinaryOp
+    test_one(in, ArrayT{{15, 25, 16, 9, 4}}, [](ArrayT const& in, ArrayT& result) {
+        auto rng = make_iterator_range(InIter(in.data()), InSent(in.data() + in.size()));
+        auto orng = make_iterator_range(OutIter(result.data()), OutIter(result.data() + result.size()));
+        return adjacent_difference(rng, orng, std::plus<int>());
+    });
 }
 
 int main()
@@ -133,33 +109,19 @@ int main()
     using ranges::adjacent_difference;
 
     { // Test projections
-        S ia[] = {{15}, {10}, {6}, {3}, {1}};
-        int ir[] = {15, -5, -4, -3, -2};
-        const unsigned s = sizeof(ir) / sizeof(ir[0]);
-        int ib[s] = {0};
-        auto r = adjacent_difference(ranges::begin(ia), ranges::begin(ia) + s,
-                                     ranges::begin(ib), std::minus<int>(), &S::i);
-        CHECK(base(std::get<0>(r)) == ia + s);
-        CHECK(base(std::get<1>(r)) == ib + s);
-        for(unsigned i = 0; i < s; ++i)
-        {
-            CHECK(ib[i] == ir[i]);
-        }
-    }
+        struct S {
+            int i;
+        };
 
-    { // Test BinaryOp
-        int ia[] = {15, 10, 6, 3, 1};
-        int ir[] = {15, 25, 16, 9, 4};
-        const unsigned s = sizeof(ir) / sizeof(ir[0]);
-        int ib[s] = {0};
-        auto r = adjacent_difference(ia, ranges::begin(ib), std::plus<int>());
-        CHECK(base(std::get<0>(r)) == ia + s);
-        CHECK(base(std::get<1>(r)) == ib + s);
-        for(unsigned i = 0; i < s; ++i)
-        {
-            CHECK(ib[i] == ir[i]);
-        }
-    }
+        using SArrayT = std::array<S, 5>;
+        using ArrayT = std::array<int, 5>;
+
+        test_one(SArrayT{{{15}, {10}, {6}, {3}, {1}}}, ArrayT{{15, -5, -4, -3, -2}},
+            [](SArrayT const& in, ArrayT& result) {
+                return adjacent_difference(in.data(), in.data() + in.size(), result.data(),
+                    std::minus<int>(), &S::i);
+            });
+   }
 
     { // Test calling it with an array
         int ia[] = {15, 10, 6, 3, 1};

--- a/test/numeric/inclusive_scan.cpp
+++ b/test/numeric/inclusive_scan.cpp
@@ -1,0 +1,178 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//  Copyright Gonzalo Brito Gadeschi 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+// Implementation based on the code in libc++
+//   http://http://libcxx.llvm.org/
+
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <range/v3/core.hpp>
+#include <range/v3/numeric/inclusive_scan.hpp>
+#include "../simple_test.hpp"
+#include "../test_iterators.hpp"
+#include "../test_utils.hpp"
+#include <array>
+
+template<typename TIn, typename TOut, std::size_t N, typename Func>
+void test_one(std::array<TIn, N> const& in, std::array<TOut, N> const& expected, Func run) 
+{
+    std::array<TOut, N> result{};
+    auto r = run(in, result);
+    CHECK(base(std::get<0>(r)) == in.data() + in.size());
+    CHECK(base(std::get<1>(r)) == result.data() + result.size());
+    ::check_equal(result, expected);
+}
+
+template<class InIter, class OutIter, class InSent = InIter> void test()
+{
+    using ranges::inclusive_scan;
+    using ranges::make_iterator_range;
+
+    using ArrayT = std::array<int, 5>;
+
+    { // No-init version
+        ArrayT const in{{1, 2, 3, 4, 5}};
+        ArrayT const expected{{1, 3, 6, 10, 15}};
+
+        // iterator
+        test_one(in, expected, [](ArrayT const& in, ArrayT& result) {
+            return inclusive_scan(InIter(in.data()), InSent(in.data() + in.size()), OutIter(result.data()));
+        });
+
+        // range + output iterator
+        test_one(in, expected, [](ArrayT const& in, ArrayT& result) {
+            auto rng = make_iterator_range(InIter(in.data()), InSent(in.data() + in.size()));
+            return inclusive_scan(rng, OutIter(result.data()));
+        });
+
+        // range + output range
+        test_one(in, expected, [](ArrayT const& in, ArrayT& result) {
+            auto rng = make_iterator_range(InIter(in.data()), InSent(in.data() + in.size()));
+            auto orng = make_iterator_range(OutIter(result.data()), OutIter(result.data() + result.size()));
+            return inclusive_scan(rng, orng);
+        });
+
+        // BinaryOp
+        test_one(in, ArrayT{{1, -1, -4, -8, -13}}, [](ArrayT const& in, ArrayT& result) {
+            auto rng = make_iterator_range(InIter(in.data()), InSent(in.data() + in.size()));
+            auto orng = make_iterator_range(OutIter(result.data()), OutIter(result.data() + result.size()));
+            return inclusive_scan(rng, orng, std::minus<int>());
+        });
+    }
+
+    { // Init version
+        ArrayT const in{{1, 2, 3, 4, 5}};
+        ArrayT const expected{{10, 12, 15, 19, 24}};
+        int const init = 9;
+
+        // iterator
+        test_one(in, expected, [](ArrayT const& in, ArrayT& result) {
+            return inclusive_scan(InIter(in.data()), InSent(in.data() + in.size()), OutIter(result.data()), std::plus<int>{}, init);
+        });
+
+        // range + output iterator
+        test_one(in, expected, [](ArrayT const& in, ArrayT& result) {
+            auto rng = make_iterator_range(InIter(in.data()), InSent(in.data() + in.size()));
+            return inclusive_scan(rng, OutIter(result.data()), std::plus<int>{}, init);
+        });
+
+        // range + output range
+        test_one(in, expected, [](ArrayT const& in, ArrayT& result) {
+            auto rng = make_iterator_range(InIter(in.data()), InSent(in.data() + in.size()));
+            auto orng = make_iterator_range(OutIter(result.data()), OutIter(result.data() + result.size()));
+            return inclusive_scan(rng, orng, std::plus<int>{}, init);
+        });
+
+        // BinaryOp
+        test_one(in, ArrayT{{8, 6, 3, -1, -6}}, [](ArrayT const& in, ArrayT& result) {
+            auto rng = make_iterator_range(InIter(in.data()), InSent(in.data() + in.size()));
+            auto orng = make_iterator_range(OutIter(result.data()), OutIter(result.data() + result.size()));
+            return inclusive_scan(rng, orng, std::minus<int>(), init);
+        });
+    }
+}
+
+int main()
+{
+    test<input_iterator<const int *>, input_iterator<int *>>();
+    test<input_iterator<const int *>, forward_iterator<int *>>();
+    test<input_iterator<const int *>, bidirectional_iterator<int *>>();
+    test<input_iterator<const int *>, random_access_iterator<int *>>();
+    test<input_iterator<const int *>, int *>();
+
+    test<forward_iterator<const int *>, input_iterator<int *>>();
+    test<forward_iterator<const int *>, forward_iterator<int *>>();
+    test<forward_iterator<const int *>, bidirectional_iterator<int *>>();
+    test<forward_iterator<const int *>, random_access_iterator<int *>>();
+    test<forward_iterator<const int *>, int *>();
+
+    test<bidirectional_iterator<const int *>, input_iterator<int *>>();
+    test<bidirectional_iterator<const int *>, forward_iterator<int *>>();
+    test<bidirectional_iterator<const int *>, bidirectional_iterator<int *>>();
+    test<bidirectional_iterator<const int *>, random_access_iterator<int *>>();
+    test<bidirectional_iterator<const int *>, int *>();
+
+    test<random_access_iterator<const int *>, input_iterator<int *>>();
+    test<random_access_iterator<const int *>, forward_iterator<int *>>();
+    test<random_access_iterator<const int *>, bidirectional_iterator<int *>>();
+    test<random_access_iterator<const int *>, random_access_iterator<int *>>();
+    test<random_access_iterator<const int *>, int *>();
+
+    test<const int *, input_iterator<int *>>();
+    test<const int *, forward_iterator<int *>>();
+    test<const int *, bidirectional_iterator<int *>>();
+    test<const int *, random_access_iterator<int *>>();
+    test<const int *, int *>();
+
+    using ranges::inclusive_scan;
+
+    { // Test projections
+        struct S {
+            int i;
+        };
+
+        using SArrayT = std::array<S, 5>;
+        using ArrayT = std::array<int, 5>;
+
+        test_one(SArrayT{{{1}, {2}, {3}, {4}, {5}}}, ArrayT{{1, 3, 6, 10, 15}},
+            [](SArrayT const& in, ArrayT& result) {
+                return inclusive_scan(in.data(), in.data() + in.size(), result.data(),
+                    std::plus<int>(), &S::i);
+            });
+
+        test_one(SArrayT{{{1}, {2}, {3}, {4}, {5}}}, ArrayT{{10, 12, 15, 19, 24}},
+            [](SArrayT const& in, ArrayT& result) {
+                return inclusive_scan(in.data(), in.data() + in.size(), result.data(),
+                    std::plus<int>(), 9, &S::i);
+            });
+    }
+
+    { // Test calling it with an array
+        int ia[] = {1, 2, 3, 4, 5};
+        int ir[] = {1, 2, 6, 24, 120};
+        const unsigned s = sizeof(ir) / sizeof(ir[0]);
+        int ib[s] = {0};
+        auto r = inclusive_scan(ia, ib, std::multiplies<int>());
+        CHECK(base(std::get<0>(r)) == ia + s);
+        CHECK(base(std::get<1>(r)) == ib + s);
+        ::check_equal(ib, ir);
+    }
+
+    return ::test_result();
+}


### PR DESCRIPTION
Concept is still the same (based on the Standard) - there's no clear analogy for semigroup when the accumulator type is different from value type.