### PR TITLE
Rework ranges::reference_wrapper in light of LWG#2993

### DIFF
--- a/include/range/v3/action/concepts.hpp
+++ b/include/range/v3/action/concepts.hpp
@@ -126,7 +126,7 @@ namespace ranges
             std::true_type is_lvalue_container_like(T &);
 
             template<typename T, CONCEPT_REQUIRES_(Container<T>())>
-            std::true_type is_lvalue_container_like(reference_wrapper<T>);
+            meta::not_<std::is_rvalue_reference<T>> is_lvalue_container_like(reference_wrapper<T>);
 
             template<typename T, CONCEPT_REQUIRES_(Container<T>())>
             std::true_type is_lvalue_container_like(std::reference_wrapper<T>);

--- a/include/range/v3/begin_end.hpp
+++ b/include/range/v3/begin_end.hpp
@@ -93,8 +93,8 @@ namespace ranges
                     Fn()(ref.get())
                 )
 
-                template<typename T, bool RValue, typename Fn = fn>
-                constexpr auto operator()(ranges::reference_wrapper<T, RValue> ref) const
+                template<typename T, typename Fn = fn>
+                constexpr auto operator()(ranges::reference_wrapper<T> ref) const
                 RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
                 (
                     Fn()(ref.get())
@@ -174,8 +174,8 @@ namespace ranges
                     Fn()(ref.get())
                 )
 
-                template<typename T, bool RValue, typename Fn = fn>
-                constexpr auto operator()(ranges::reference_wrapper<T, RValue> ref) const
+                template<typename T, typename Fn = fn>
+                constexpr auto operator()(ranges::reference_wrapper<T> ref) const
                 RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
                 (
                     Fn()(ref.get())
@@ -304,8 +304,8 @@ namespace ranges
                     Fn()(ref.get())
                 )
 
-                template<typename T, bool RValue, typename Fn = fn>
-                constexpr auto operator()(ranges::reference_wrapper<T, RValue> ref) const
+                template<typename T, typename Fn = fn>
+                constexpr auto operator()(ranges::reference_wrapper<T> ref) const
                 RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
                 (
                     Fn()(ref.get())
@@ -379,8 +379,8 @@ namespace ranges
                     Fn()(ref.get())
                 )
 
-                template<typename T, bool RValue, typename Fn = fn>
-                constexpr auto operator()(ranges::reference_wrapper<T, RValue> ref) const
+                template<typename T, typename Fn = fn>
+                constexpr auto operator()(ranges::reference_wrapper<T> ref) const
                 RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
                 (
                     Fn()(ref.get())

--- a/include/range/v3/detail/variant.hpp
+++ b/include/range/v3/detail/variant.hpp
@@ -89,18 +89,6 @@ namespace ranges
         {
             using reference_wrapper<T>::reference_wrapper;
         };
-        template<typename T, std::size_t Index>
-        struct indexed_element<T &, Index>
-          : reference_wrapper<T>
-        {
-            using reference_wrapper<T>::reference_wrapper;
-        };
-        template<typename T, std::size_t Index>
-        struct indexed_element<T &&, Index>
-          : reference_wrapper<T, true>
-        {
-            using reference_wrapper<T, true>::reference_wrapper;
-        };
         template<std::size_t Index>
         struct indexed_element<void, Index>
         {
@@ -175,10 +163,10 @@ namespace ranges
 
             template<typename T, typename Index>
             struct indexed_datum<T &, Index>
-              : reference_wrapper<T>
+              : reference_wrapper<T &>
             {
                 indexed_datum() = delete;
-                using reference_wrapper<T>::reference_wrapper;
+                using reference_wrapper<T &>::reference_wrapper;
                 constexpr indexed_element<T &, Index::value> ref() const noexcept
                 {
                     return {this->get()};
@@ -186,10 +174,10 @@ namespace ranges
             };
             template<typename T, typename Index>
             struct indexed_datum<T &&, Index>
-              : reference_wrapper<T, true>
+              : reference_wrapper<T &&>
             {
                 indexed_datum() = delete;
-                using reference_wrapper<T, true>::reference_wrapper;
+                using reference_wrapper<T &&>::reference_wrapper;
                 constexpr indexed_element<T &&, Index::value> ref() const noexcept
                 {
                     return {this->get()};

--- a/include/range/v3/empty.hpp
+++ b/include/range/v3/empty.hpp
@@ -69,8 +69,8 @@ namespace ranges
                     Fn()(ref.get())
                 )
 
-                template<typename T, bool RValue, typename Fn = fn>
-                constexpr auto operator()(ranges::reference_wrapper<T, RValue> ref) const
+                template<typename T, typename Fn = fn>
+                constexpr auto operator()(ranges::reference_wrapper<T> ref) const
                 RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
                 (
                     Fn()(ref.get())

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -481,14 +481,11 @@ namespace ranges
         template<typename I, typename S = I>
         struct sized_iterator_range;
 
-        template<typename T, bool RValue = false>
+        template<typename T>
         struct reference_wrapper;
 
         template<typename>
         struct is_reference_wrapper;
-
-        template<typename T>
-        using rvalue_reference_wrapper = reference_wrapper<T, true>;
 
         // Views
         //

--- a/include/range/v3/size.hpp
+++ b/include/range/v3/size.hpp
@@ -90,8 +90,8 @@ namespace ranges
                     Fn()(ref.get())
                 )
 
-                template<typename T, bool RValue, typename Fn = fn>
-                constexpr auto operator()(ranges::reference_wrapper<T, RValue> ref) const
+                template<typename T, typename Fn = fn>
+                constexpr auto operator()(ranges::reference_wrapper<T> ref) const
                 RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
                 (
                     Fn()(ref.get())

--- a/include/range/v3/utility/semiregular.hpp
+++ b/include/range/v3/utility/semiregular.hpp
@@ -161,34 +161,34 @@ namespace ranges
 
         template<typename T>
         struct semiregular<T &>
-          : private ranges::reference_wrapper<T>
+          : private ranges::reference_wrapper<T &>
         {
             semiregular() = default;
             template<typename Arg,
-                CONCEPT_REQUIRES_(Constructible<T &, Arg &>())>
+                CONCEPT_REQUIRES_(Constructible<ranges::reference_wrapper<T &>, Arg &>())>
             semiregular(in_place_t, Arg &arg)
-              : ranges::reference_wrapper<T>(static_cast<T &>(arg))
+              : ranges::reference_wrapper<T &>(arg)
             {}
-            using ranges::reference_wrapper<T>::reference_wrapper;
-            using ranges::reference_wrapper<T>::get;
-            using ranges::reference_wrapper<T>::operator T &;
-            using ranges::reference_wrapper<T>::operator();
+            using ranges::reference_wrapper<T &>::reference_wrapper;
+            using ranges::reference_wrapper<T &>::get;
+            using ranges::reference_wrapper<T &>::operator T &;
+            using ranges::reference_wrapper<T &>::operator();
         };
 
         template<typename T>
         struct semiregular<T &&>
-          : private ranges::reference_wrapper<T, true>
+          : private ranges::reference_wrapper<T &&>
         {
             semiregular() = default;
             template<typename Arg,
-                CONCEPT_REQUIRES_(Constructible<T &&, Arg>())>
+                CONCEPT_REQUIRES_(Constructible<ranges::reference_wrapper<T &&>, Arg>())>
             semiregular(in_place_t, Arg &&arg)
-              : ranges::reference_wrapper<T, true>(static_cast<T &&>(arg))
+              : ranges::reference_wrapper<T &>(static_cast<Arg &&>(arg))
             {}
-            using ranges::reference_wrapper<T, true>::reference_wrapper;
-            using ranges::reference_wrapper<T, true>::get;
-            using ranges::reference_wrapper<T, true>::operator T &&;
-            using ranges::reference_wrapper<T, true>::operator();
+            using ranges::reference_wrapper<T &&>::reference_wrapper;
+            using ranges::reference_wrapper<T &&>::get;
+            using ranges::reference_wrapper<T &&>::operator T &&;
+            using ranges::reference_wrapper<T &&>::operator();
         };
 
         template<typename T>

--- a/test/utility/functional.cpp
+++ b/test/utility/functional.cpp
@@ -24,8 +24,8 @@
 
 CONCEPT_ASSERT(ranges::Constructible<ranges::reference_wrapper<int>, int&>());
 CONCEPT_ASSERT(!ranges::Constructible<ranges::reference_wrapper<int>, int&&>());
-CONCEPT_ASSERT(!ranges::Constructible<ranges::reference_wrapper<int, true>, int&>());
-CONCEPT_ASSERT(ranges::Constructible<ranges::reference_wrapper<int, true>, int&&>());
+CONCEPT_ASSERT(!ranges::Constructible<ranges::reference_wrapper<int &&>, int&>());
+CONCEPT_ASSERT(ranges::Constructible<ranges::reference_wrapper<int &&>, int&&>());
 
 namespace
 {


### PR DESCRIPTION
Also, change the spelling of a wrapper of an rvalue from `reference_wrapper<T, true>` to `reference_wrapper<T &&>`.

Future: Further consider combining this with `box<>`.