### PR TITLE
More flexible type erasure (resolves #707)

### DIFF
--- a/test/view/any_view.cpp
+++ b/test/view/any_view.cpp
@@ -80,15 +80,25 @@ int main()
         any_view<int> ints = view::ints;
         CONCEPT_ASSERT(InputView<decltype(ints)>());
         CONCEPT_ASSERT(!ForwardView<decltype(ints)>());
+        static_assert((get_categories(view::ints) & category::random_access) == category::random_access, "");
+        static_assert((get_categories(ints) & category::random_access) == category::input, "");
         ::check_equal(std::move(ints) | view::take(10), ten_ints);
     }
+#if RANGES_CXX_DEDUCTION_GUIDES >= 201606L
+    {
+        any_view ints = view::ints;
+        CONCEPT_ASSERT(RandomAccessView<decltype(ints)>());
+        static_assert((get_categories(ints) & category::random_access) == category::random_access, "");
+        ::check_equal(std::move(ints) | view::take(10), ten_ints);
+    }
+#endif
     {
         any_view<int> ints2 = view::ints | view::take(10);
         ::check_equal(ints2, ten_ints);
         ::check_equal(ints2, ten_ints);
     }
     {
-        any_random_access_view<int> ints3 = view::ints | view::take(10);
+        any_view<int, category::random_access> ints3 = view::ints | view::take(10);
         ::models<concepts::RandomAccessView>(aux::copy(ints3));
         ::check_equal(ints3, ten_ints);
         ::check_equal(ints3, ten_ints);
@@ -101,8 +111,8 @@ int main()
         CHECK(e.begin() == e.end());
     }
     {
-        iterator_t<any_random_access_view<int&>> i{},j{};
-        sentinel_t<any_random_access_view<int&>> k{};
+        iterator_t<any_view<int&, category::random_access>> i{},j{};
+        sentinel_t<any_view<int&, category::random_access>> k{};
         CHECK(i == j);
         CHECK(i == k);
         CHECK((i - j) == 0);

--- a/test/view/any_view.cpp
+++ b/test/view/any_view.cpp
@@ -80,18 +80,28 @@ int main()
         any_view<int> ints = view::ints;
         CONCEPT_ASSERT(InputView<decltype(ints)>());
         CONCEPT_ASSERT(!ForwardView<decltype(ints)>());
-        static_assert((get_categories(view::ints) & category::random_access) == category::random_access, "");
-        static_assert((get_categories(ints) & category::random_access) == category::input, "");
         ::check_equal(std::move(ints) | view::take(10), ten_ints);
     }
-#if RANGES_CXX_DEDUCTION_GUIDES >= 201606L
     {
-        any_view ints = view::ints;
-        CONCEPT_ASSERT(RandomAccessView<decltype(ints)>());
-        static_assert((get_categories(ints) & category::random_access) == category::random_access, "");
-        ::check_equal(std::move(ints) | view::take(10), ten_ints);
+        any_view<int> ints = view::ints | view::take_exactly(5);
+        CONCEPT_ASSERT(InputView<decltype(ints)>());
+        CONCEPT_ASSERT(!RandomAccessView<decltype(ints)>());
+        CONCEPT_ASSERT(!SizedView<decltype(ints)>());
+        static_assert((get_categories(ints) & category::random_access) == category::input, "");
+        static_assert((get_categories(ints) & category::sized) == category::none, "");
     }
+    {
+#if RANGES_CXX_DEDUCTION_GUIDES >= 201606L
+        any_view ints = view::ints | view::take_exactly(5);
+#else
+        any_view<int, category::random_access | category::sized> ints = view::ints | view::take_exactly(5);
 #endif
+        CONCEPT_ASSERT(InputView<decltype(ints)>());
+        CONCEPT_ASSERT(RandomAccessView<decltype(ints)>());
+        CONCEPT_ASSERT(SizedView<decltype(ints)>());
+        static_assert((get_categories(ints) & category::random_access) == category::random_access, "");
+        static_assert((get_categories(ints) & category::sized) == category::sized, "");
+    }
     {
         any_view<int> ints2 = view::ints | view::take(10);
         ::check_equal(ints2, ten_ints);


### PR DESCRIPTION
I have made the changes proposed in #707. I have also introduced a user defined type deduction guide for `any_view` that does the least amount of erasure possible (it preserves what it can).

Open questions:
* `detail::to_cat_()` is now `get_categories()` (not in detail); is the name ok, or should it be changed? 
* `get_categories()` is a constexpr function, but it could just as well be a constexpr variable template; do you have any preferences in this regard?
* sized'ness can now be represented in any_view and the result satisfies the `SizedView` concept, however I introduced this very superficially, i.e. just save the size on construction... I originally wanted to make the sentinel sized and go via the regular view_interface's size(), but this proved rather difficult with all the levels of inheritance, CRTP and specialisation. If you think it is important to have SizedSentinel also, please give me some hints as to what exactly needs to change in which if the classes.
