### PR TITLE
stride_view refactor:

### DIFF
--- a/include/range/v3/utility/box.hpp
+++ b/include/range/v3/utility/box.hpp
@@ -15,7 +15,6 @@
 #ifndef RANGES_V3_UTILITY_BOX_HPP
 #define RANGES_V3_UTILITY_BOX_HPP
 
-#include <atomic>
 #include <utility>
 #include <cstdlib>
 #include <type_traits>
@@ -56,49 +55,6 @@ namespace ranges
                 return *this;
             }
             constexpr operator T &() const &
-            {
-                return value;
-            }
-        };
-
-        template<typename T>
-        struct mutable_<std::atomic<T>>
-        {
-            mutable std::atomic<T> value;
-            mutable_() = default;
-            mutable_(mutable_ const &that)
-              : value(static_cast<T>(that.value))
-            {}
-            constexpr explicit mutable_(T &&t)
-              : value(detail::move(t))
-            {}
-            constexpr explicit mutable_(T const &t)
-              : value(t)
-            {}
-            mutable_ const &operator=(mutable_ const &that) const
-            {
-                value = static_cast<T>(that.value);
-                return *this;
-            }
-            mutable_ const &operator=(T &&t) const
-            {
-                value = std::move(t);
-                return *this;
-            }
-            mutable_ const &operator=(T const &t) const
-            {
-                value = t;
-                return *this;
-            }
-            operator T() const
-            {
-                return value;
-            }
-            T exchange(T desired)
-            {
-                return value.exchange(desired);
-            }
-            operator std::atomic<T> &() const &
             {
                 return value;
             }

--- a/include/range/v3/view/stride.hpp
+++ b/include/range/v3/view/stride.hpp
@@ -2,6 +2,7 @@
 // Range v3 library
 //
 //  Copyright Eric Niebler 2013-2014
+//  Copyright Casey Carter 2017
 //
 //  Use, modification and distribution is subject to the
 //  Boost Software License, Version 1.0. (See accompanying
@@ -14,173 +15,285 @@
 #ifndef RANGES_V3_VIEW_STRIDE_HPP
 #define RANGES_V3_VIEW_STRIDE_HPP
 
-#include <atomic>
-#include <utility>
 #include <type_traits>
+#include <utility>
 #include <meta/meta.hpp>
-#include <range/v3/detail/satisfy_boost_range.hpp>
-#include <range/v3/range_fwd.hpp>
-#include <range/v3/size.hpp>
-#include <range/v3/distance.hpp>
 #include <range/v3/begin_end.hpp>
-#include <range/v3/range_traits.hpp>
+#include <range/v3/distance.hpp>
 #include <range/v3/range_concepts.hpp>
+#include <range/v3/range_fwd.hpp>
+#include <range/v3/range_traits.hpp>
+#include <range/v3/size.hpp>
 #include <range/v3/view_adaptor.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/iterator.hpp>
 #include <range/v3/utility/static_const.hpp>
-#include <range/v3/view/view.hpp>
 #include <range/v3/view/all.hpp>
+#include <range/v3/view/view.hpp>
 
 namespace ranges
 {
     inline namespace v3
     {
+        /// \cond
+        template<typename Rng>
+        struct stride_view;
+
+        namespace detail
+        {
+            template<typename Rng>
+            using stride_view_adaptor = view_adaptor<stride_view<Rng>, Rng,
+                is_finite<Rng>::value ? finite : range_cardinality<Rng>::value>;
+
+            // Bidirectional stride views need to remember the distance between
+            // the penultimate iterator and the end iterator - which may be less
+            // than the stride - so that decrementing an end iterator properly
+            // produces the penultimate iterator. stride_view_base specializes on
+            // that distinction so that only Bidirectional stride views have the
+            // data member "offset_".
+            template<typename Rng, bool = BidirectionalRange<Rng>()>
+            struct stride_view_base
+              : stride_view_adaptor<Rng>
+            {
+                stride_view_base() = default;
+                RANGES_CXX14_CONSTEXPR
+                stride_view_base(Rng &&rng, range_difference_type_t<Rng> const stride)
+                    noexcept(std::is_nothrow_constructible<stride_view_adaptor<Rng>, Rng>::value &&
+                        noexcept(std::declval<stride_view_base &>().calc_offset(SizedRange<Rng>())))
+                  : stride_view_adaptor<Rng>{std::move(rng)},
+                    stride_{(RANGES_EXPECT(0 < stride), stride)},
+                    offset_{calc_offset(SizedRange<Rng>())}
+                {}
+            protected:
+                RANGES_CXX14_CONSTEXPR
+                void set_offset(range_difference_type_t<Rng> const delta) noexcept
+                {
+                    RANGES_EXPECT(0 <= delta && delta < stride_);
+                    if(0 > offset_) offset_ = delta;
+                    else RANGES_EXPECT(offset_ == delta);
+                }
+                RANGES_CXX14_CONSTEXPR
+                void set_offset(range_difference_type_t<Rng> const) const noexcept
+                {}
+                RANGES_CXX14_CONSTEXPR
+                range_difference_type_t<Rng> get_offset() const noexcept
+                {
+                    RANGES_EXPECT(0 <= offset_);
+                    return offset_;
+                }
+
+                range_difference_type_t<Rng> stride_;
+                range_difference_type_t<Rng> offset_ = -1;
+            private:
+                RANGES_CXX14_CONSTEXPR
+                range_difference_type_t<Rng> calc_offset(std::true_type)
+                    noexcept(noexcept(ranges::distance(std::declval<stride_view_base &>().base())))
+                {
+                    if(auto const rem = ranges::distance(this->base()) % stride_)
+                        return stride_ - rem;
+                    else
+                        return 0;
+                }
+                RANGES_CXX14_CONSTEXPR
+                range_difference_type_t<Rng> calc_offset(std::false_type) const noexcept
+                {
+                    return -1;
+                }
+            };
+
+            template<typename Rng>
+            struct stride_view_base<Rng, false>
+              : stride_view_adaptor<Rng>
+            {
+                stride_view_base() = default;
+                constexpr stride_view_base(Rng &&rng, range_difference_type_t<Rng> const stride)
+                    noexcept(std::is_nothrow_constructible<stride_view_adaptor<Rng>, Rng>::value)
+                  : stride_view_adaptor<Rng>{std::move(rng)},
+                    stride_{(RANGES_EXPECT(0 < stride), stride)}
+                {}
+            protected:
+                RANGES_CXX14_CONSTEXPR
+                void set_offset(range_difference_type_t<Rng> const) const noexcept
+                {}
+                RANGES_CXX14_CONSTEXPR
+                range_difference_type_t<Rng> get_offset() const noexcept
+                {
+                    return 0;
+                }
+
+                range_difference_type_t<Rng> stride_;
+            };
+        }
+        /// \endcond
+
         /// \addtogroup group-views
         /// @{
         template<typename Rng>
         struct stride_view
-          : view_adaptor<
-                stride_view<Rng>,
-                Rng,
-                is_finite<Rng>::value ? finite : range_cardinality<Rng>::value>
+          : detail::stride_view_base<Rng>
         {
         private:
             friend range_access;
-            using size_type_ = range_size_type_t<Rng>;
-            using difference_type_ = range_difference_type_t<Rng>;
 
-            // Bidirectional and random-access stride iterators need to remember how
-            // far past they end they are, so that when they're decremented, they can
-            // visit the correct elements.
-            using offset_t =
-                meta::if_<
-                    BidirectionalRange<Rng>,
-                    mutable_<std::atomic<difference_type_>>,
-                    constant<difference_type_, 0>>;
+            // stride_view const models Range if Rng const models Range, and
+            // either (1) Rng is sized, so we can pre-calculate offset_, or (2)
+            // Rng is not Bidirectional, so it does not need offset_.
+            static constexpr bool const_iterable =
+                Range<Rng const>() && (SizedRange<Rng>() || !BidirectionalRange<Rng>());
 
-            difference_type_ stride_;
-
-            struct adaptor : adaptor_base, private offset_t
+            struct adaptor : adaptor_base
             {
             private:
-                using iterator = ranges::iterator_t<Rng>;
-                stride_view const *rng_;
-                offset_t & offset() { return *this; }
-                offset_t const & offset() const { return *this; }
-                difference_type_ clean_(std::true_type) const
-                {
-                    std::atomic<difference_type_>& off = offset();
-                    difference_type_ o = off;
-                    if(o == -1)
-                    {
-                        // Set the offset if it's still -1. If not, leave it alone.
-                        (void) off.compare_exchange_strong(o, calc_offset());
-                    }
-                    return o;
-                }
-                difference_type_ clean_(std::false_type) const
-                {
-                    return 0;
-                }
-                difference_type_ clean() const
-                {
-                    return clean_(BidirectionalRange<Rng>());
-                }
-                difference_type_ calc_offset() const
-                {
-                    auto tmp = ranges::distance(rng_->base()) % rng_->stride_;
-                    return 0 != tmp ? rng_->stride_ - tmp : tmp;
-                }
+                using stride_view_t = meta::const_if_c<const_iterable, stride_view>;
+                stride_view_t *rng_;
             public:
                 adaptor() = default;
-                adaptor(stride_view const &rng, begin_tag)
-                  : offset_t(0), rng_(&rng)
+                explicit constexpr adaptor(stride_view_t &rng) noexcept
+                  : rng_(&rng)
                 {}
-                adaptor(stride_view const &rng, end_tag)
-                  : offset_t(-1), rng_(&rng)
+                RANGES_CXX14_CONSTEXPR void next(iterator_t<Rng> &it)
+                    noexcept(noexcept(it != ranges::end(std::declval<Rng &>()),
+                        ranges::advance(it, 0, std::declval<sentinel_t<Rng> &>())))
                 {
-                    // Opportunistic eager cleaning when we can do so in O(1)
-                    if(BidirectionalRange<Rng>() && SizedRange<Rng>())
-                        offset() = calc_offset();
-                }
-                void next(iterator &it)
-                {
-                    difference_type_ off = offset();
-                    RANGES_EXPECT(0 == off);
-                    RANGES_ASSERT(it != ranges::end(rng_->mutable_base()));
-                    offset() = ranges::advance(it, rng_->stride_ + off,
-                        ranges::end(rng_->mutable_base()));
+                    auto const last = ranges::end(rng_->base());
+                    RANGES_EXPECT(it != last);
+                    auto const delta = ranges::advance(it, rng_->stride_, last);
+                    if(it == last)
+                    {
+                        rng_->set_offset(delta);
+                    }
                 }
                 CONCEPT_REQUIRES(BidirectionalRange<Rng>())
-                void prev(iterator &it)
+                RANGES_CXX14_CONSTEXPR void prev(iterator_t<Rng> &it)
+                    noexcept(noexcept(ranges::advance(it, 0),
+                        it != ranges::begin(std::declval<Rng &>()),
+                        it == ranges::end(std::declval<Rng &>())))
                 {
-                    difference_type_ off = clean();
-                    offset() = off = ranges::advance(it, -rng_->stride_ + off,
-                        ranges::begin(rng_->mutable_base()));
-                    RANGES_EXPECT(0 == off);
+                    RANGES_EXPECT(it != ranges::begin(rng_->base()));
+                    auto delta = -rng_->stride_;
+                    if(it == ranges::end(rng_->base()))
+                    {
+                        delta += rng_->get_offset();
+                    }
+                    ranges::advance(it, delta);
                 }
-                CONCEPT_REQUIRES(SizedSentinel<iterator, iterator>())
-                difference_type_ distance_to(iterator here, iterator there, adaptor const &that) const
+                template<class Other,
+                    CONCEPT_REQUIRES_(SizedSentinel<Other, iterator_t<Rng>>())>
+                RANGES_CXX14_CONSTEXPR range_difference_type_t<Rng> distance_to(
+                    iterator_t<Rng> const &here, Other const &there) const
+                    noexcept(noexcept(there - here))
                 {
-                    RANGES_EXPECT(rng_ == that.rng_);
-                    difference_type_ delta = (there - here) + (that.clean() - clean());
-                    if(BidirectionalIterator<iterator>())
-                    {
-                        RANGES_EXPECT(0 == delta % rng_->stride_);
-                    }
+                    range_difference_type_t<Rng> delta = there - here;
+                    if(delta < 0)
+                        delta -= rng_->stride_ - 1;
                     else
-                    {
                         delta += rng_->stride_ - 1;
-                    }
                     return delta / rng_->stride_;
                 }
                 CONCEPT_REQUIRES(RandomAccessRange<Rng>())
-                void advance(iterator &it, difference_type_ n)
+                RANGES_CXX14_CONSTEXPR void advance(
+                    iterator_t<Rng> &it, range_difference_type_t<Rng> n)
+                    noexcept(noexcept(
+                        ranges::begin(std::declval<Rng &>()) == ranges::end(std::declval<Rng &>()),
+                        ranges::advance(it, n, std::declval<sentinel_t<Rng> &>()),
+                        ranges::advance(it, n),
+                        ranges::advance(it, n, std::declval<iterator_t<Rng> &>())))
                 {
-                    if(0 == n)
-                        return;
-                    difference_type_ off = clean();
+                    if(0 == n) return;
+                    n *= rng_->stride_;
+                    auto const last = ranges::end(rng_->base());
+                    if(it == last) n -= rng_->get_offset();
                     if(0 < n)
-                        offset() = ranges::advance(it, n * rng_->stride_ + off,
-                            ranges::end(rng_->mutable_base()));
+                    {
+                        auto delta = ranges::advance(it, n, last);
+                        if(it == last)
+                        {
+                            // advance hit the end of the base range.
+                            rng_->set_offset(delta % rng_->stride_);
+                        }
+                    }
                     else if(0 > n)
-                        offset() = ranges::advance(it, n * rng_->stride_ + off,
-                            ranges::begin(rng_->mutable_base()));
+                    {
+#ifdef NDEBUG
+                        ranges::advance(it, n);
+#else
+                        auto const first = ranges::begin(rng_->base());
+                        auto const delta = ranges::advance(it, n, first);
+                        RANGES_EXPECT(delta == 0);
+#endif
+                    }
                 }
             };
-            adaptor begin_adaptor() const
+            CONCEPT_REQUIRES(const_iterable)
+            constexpr adaptor begin_adaptor() const
+                noexcept(std::is_nothrow_constructible<adaptor, stride_view const &>::value &&
+                    std::is_nothrow_move_constructible<adaptor>::value)
             {
-                return {*this, begin_tag{}};
+                return adaptor{*this};
+            }
+            CONCEPT_REQUIRES(!const_iterable)
+            RANGES_CXX14_CONSTEXPR adaptor begin_adaptor()
+                noexcept(std::is_nothrow_constructible<adaptor, stride_view &>::value &&
+                    std::is_nothrow_move_constructible<adaptor>::value)
+            {
+                return adaptor{*this};
             }
             // If the underlying sequence object doesn't model BoundedRange, then we can't
             // decrement the end and there's no reason to adapt the sentinel. Strictly
             // speaking, we don't have to adapt the end iterator of Input and Forward
             // Ranges, but in the interests of making the resulting stride view model
             // BoundedView, adapt it anyway.
-            CONCEPT_REQUIRES(!BoundedRange<Rng>())
-            adaptor_base end_adaptor() const
+            CONCEPT_REQUIRES(const_iterable && BoundedRange<Rng>())
+            constexpr adaptor end_adaptor() const
+                noexcept(std::is_nothrow_constructible<adaptor, stride_view const &>::value &&
+                    std::is_nothrow_move_constructible<adaptor>::value)
+            {
+                return adaptor{*this};
+            }
+            CONCEPT_REQUIRES(!const_iterable && BoundedRange<Rng>())
+            RANGES_CXX14_CONSTEXPR adaptor end_adaptor()
+                noexcept(std::is_nothrow_constructible<adaptor, stride_view &>::value &&
+                    std::is_nothrow_move_constructible<adaptor>::value)
+            {
+                return adaptor{*this};
+            }
+            CONCEPT_REQUIRES(const_iterable && !BoundedRange<Rng>())
+            constexpr adaptor_base end_adaptor() const
+                noexcept(std::is_nothrow_constructible<adaptor_base, stride_view const &>::value)
             {
                 return {};
             }
-            CONCEPT_REQUIRES(BoundedRange<Rng>())
-            adaptor end_adaptor() const
+            CONCEPT_REQUIRES(!const_iterable && !BoundedRange<Rng>())
+            RANGES_CXX14_CONSTEXPR adaptor_base end_adaptor()
+                noexcept(std::is_nothrow_constructible<adaptor_base, stride_view &>::value)
             {
-                return {*this, end_tag{}};
+                return {};
+            }
+
+            constexpr range_size_type_t<Rng> size_(range_size_type_t<Rng> const n) const noexcept
+            {
+                return (n + static_cast<range_size_type_t<Rng>>(this->stride_) - 1) /
+                    static_cast<range_size_type_t<Rng>>(this->stride_);
             }
         public:
             stride_view() = default;
-            stride_view(Rng rng, difference_type_ stride)
-              : stride_view::view_adaptor{std::move(rng)}
-              , stride_(stride)
+            constexpr stride_view(Rng rng, range_difference_type_t<Rng> const stride)
+                noexcept(std::is_nothrow_constructible<detail::stride_view_base<Rng>,
+                    Rng, range_difference_type_t<Rng>>::value)
+              : detail::stride_view_base<Rng>{std::move(rng), stride}
+            {}
+            CONCEPT_REQUIRES(SizedRange<Rng const>())
+            constexpr range_size_type_t<Rng> size() const
+                noexcept(noexcept(ranges::size(std::declval<Rng const &>())))
             {
-                RANGES_EXPECT(0 < stride_);
+                return size_(ranges::size(this->base()));
             }
-            CONCEPT_REQUIRES(SizedRange<Rng>())
-            size_type_ size() const
+            CONCEPT_REQUIRES(!SizedRange<Rng const>() && SizedRange<Rng>())
+            RANGES_CXX14_CONSTEXPR range_size_type_t<Rng> size()
+                noexcept(noexcept(ranges::size(std::declval<Rng &>())))
             {
-                return (ranges::size(this->base()) + static_cast<size_type_>(stride_) - 1) /
-                    static_cast<size_type_>(stride_);
+                return size_(ranges::size(this->base()));
             }
         };
 
@@ -191,17 +304,19 @@ namespace ranges
             private:
                 friend view_access;
                 template<typename Difference, CONCEPT_REQUIRES_(Integral<Difference>())>
+                RANGES_CXX14_CONSTEXPR
                 static auto bind(stride_fn stride, Difference step)
-                RANGES_DECLTYPE_AUTO_RETURN
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
                 (
                     make_pipeable(std::bind(stride, std::placeholders::_1, std::move(step)))
                 )
             public:
                 template<typename Rng, CONCEPT_REQUIRES_(InputRange<Rng>())>
-                stride_view<all_t<Rng>> operator()(Rng && rng, range_difference_type_t<Rng> step) const
-                {
-                    return {all(static_cast<Rng&&>(rng)), step};
-                }
+                constexpr auto operator()(Rng &&rng, range_difference_type_t<Rng> step) const
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                (
+                    stride_view<all_t<Rng>>{all(static_cast<Rng &&>(rng)), step}
+                )
 
                 // For the purpose of better error messages:
             #ifndef RANGES_DOXYGEN_INVOKED

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -448,15 +448,16 @@ namespace ranges
             view_adaptor(view_adaptor const &) = default;
             view_adaptor &operator=(view_adaptor &&) = default;
             view_adaptor &operator=(view_adaptor const &) = default;
-            constexpr view_adaptor(BaseRng && rng)
-              : rng_(view::all(static_cast<BaseRng&&>(rng)))
+            constexpr view_adaptor(BaseRng &&rng)
+              : rng_(view::all(static_cast<BaseRng &&>(rng)))
             {}
-            base_range_t & base()
+            RANGES_CXX14_CONSTEXPR
+            base_range_t &base() noexcept
             {
                 return rng_;
             }
             /// \overload
-            base_range_t const & base() const
+            constexpr base_range_t const &base() const noexcept
             {
                 return rng_;
             }

--- a/test/view/stride.cpp
+++ b/test/view/stride.cpp
@@ -18,7 +18,6 @@
 #include <range/v3/view/reverse.hpp>
 #include <range/v3/view/stride.hpp>
 #include <range/v3/algorithm/copy.hpp>
-#include <range/v3/utility/counted_iterator.hpp>
 #include <range/v3/utility/iterator.hpp>
 #include <range/v3/numeric.hpp>
 #include "../simple_test.hpp"
@@ -29,44 +28,68 @@ int main()
 {
     using namespace ranges;
 
-    std::vector<int> v(50);
-    iota(v, 0);
+    auto const v = []
+    {
+        std::vector<int> v(50);
+        iota(v, 0);
+        return v;
+    }();
+    {
+        auto rng = v | view::stride(3);
+        using R = decltype(rng);
+        CONCEPT_ASSERT(RandomAccessView<R>());
+        CONCEPT_ASSERT(!ContiguousRange<R>());
+        CONCEPT_ASSERT(BoundedRange<R>());
+        CONCEPT_ASSERT(SizedRange<R>());
+        CONCEPT_ASSERT(Range<R const>());
+        ::check_equal(rng | view::reverse,
+                    {48, 45, 42, 39, 36, 33, 30, 27, 24, 21, 18, 15, 12, 9, 6, 3, 0});
+    }
 
-    if (!ranges::v3::detail::broken_ebo)
-        CHECK(
-            sizeof((v | view::stride(3)).begin()) ==
-            sizeof(void*) + sizeof(v.begin()) + sizeof(std::ptrdiff_t));
-    ::check_equal(v | view::stride(3) | view::reverse,
-                  {48, 45, 42, 39, 36, 33, 30, 27, 24, 21, 18, 15, 12, 9, 6, 3, 0});
+    {
+        std::stringstream str;
+        copy(v, ostream_iterator<int>{str, " "});
+        auto rng = istream<int>(str) | view::stride(3);
+        using R = decltype(rng);
+        CONCEPT_ASSERT(InputView<R>());
+        CONCEPT_ASSERT(!ForwardRange<R>());
+        CONCEPT_ASSERT(!BoundedRange<R>());
+        CONCEPT_ASSERT(!SizedRange<R>());
+        CONCEPT_ASSERT(!Range<R const>());
+        check_equal(rng, {0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45, 48});
+    }
 
-    std::stringstream str;
-    copy(v, ostream_iterator<int>{str, " "});
-    auto x = istream<int>(str) | view::stride(3);
-    CONCEPT_ASSERT(InputView<decltype(x)>());
-    CONCEPT_ASSERT(!InputView<decltype(x) const>());
-    CONCEPT_ASSERT(!ForwardView<decltype(x)>());
-    check_equal(x, {0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45, 48});
+    {
+        std::list<int> li;
+        copy(v, back_inserter(li));
+        auto rng = li | view::stride(3);
+        using R = decltype(rng);
+        CONCEPT_ASSERT(BidirectionalView<R>());
+        CONCEPT_ASSERT(!RandomAccessRange<R>());
+        CONCEPT_ASSERT(BoundedRange<R>());
+        CONCEPT_ASSERT(SizedRange<R>());
+        CONCEPT_ASSERT(Range<R const>());
+        ::check_equal(rng,
+                    {0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45, 48});
+        ::check_equal(rng | view::reverse,
+                    {48, 45, 42, 39, 36, 33, 30, 27, 24, 21, 18, 15, 12, 9, 6, 3, 0});
 
-    std::list<int> li;
-    copy(v, back_inserter(li));
-    ::check_equal(li | view::stride(3),
-                  {0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45, 48});
-    ::check_equal(li | view::stride(3) | view::reverse,
-                  {48, 45, 42, 39, 36, 33, 30, 27, 24, 21, 18, 15, 12, 9, 6, 3, 0});
+        for(int i : rng | view::reverse)
+            std::cout << i << ' ';
+        std::cout << '\n';
+    }
 
-    for(int i : li | view::stride(3) | view::reverse)
-        std::cout << i << ' ';
-    std::cout << '\n';
+    {
+        auto x2 = v | view::stride(3);
+        CHECK(ranges::distance(x2) == 17);
 
-    auto x2 = v | view::stride(3);
-    CHECK(ranges::distance(x2) == 17);
-
-    auto it0 = x2.begin();
-    auto it1 = std::next(it0, 10);
-    CHECK((it1 - it0) == 10);
-    CHECK((it0 - it1) == -10);
-    CHECK((it0 - it0) == 0);
-    CHECK((it1 - it1) == 0);
+        auto it0 = x2.begin();
+        auto it1 = std::next(it0, 10);
+        CHECK((it1 - it0) == 10);
+        CHECK((it0 - it1) == -10);
+        CHECK((it0 - it0) == 0);
+        CHECK((it1 - it1) == 0);
+    }
 
     {
         const auto n = 4;
@@ -83,6 +106,12 @@ int main()
     {
         int const some_ints[] = {0,1,2,3,4,5,6,7};
         auto rng = debug_input_view<int const>{some_ints} | view::stride(2);
+        using R = decltype(rng);
+        CONCEPT_ASSERT(InputView<R>());
+        CONCEPT_ASSERT(!ForwardRange<R>());
+        CONCEPT_ASSERT(!BoundedRange<R>());
+        CONCEPT_ASSERT(SizedRange<R>());
+        CONCEPT_ASSERT(!Range<R const>());
         ::check_equal(rng, {0,2,4,6});
     }
 


### PR DESCRIPTION
stride views must track the distance in the base range between the last dereferenceable iterator and the end iterator ("offset"). The offset is used when decrementing bidirectional end iterators. Since there's one unique offset value per underlying range, we can store a single offset value in the stride_view rather than in each of its iterators.

Using a mutable std::atomic to store the offset and provide const-iterable stride_views was a design mistake: all users pay the cost of the atomic despite that few users will actually access the same stride_view simultaneously from multiple threads. Let's instead store the offset in a plain vanilla member variable, and make the view not const iterable when it must update the offset during iteration.