### PR TITLE
(adjacent_)?remove_if cleanup:

### DIFF
--- a/include/range/v3/view/adjacent_remove_if.hpp
+++ b/include/range/v3/view/adjacent_remove_if.hpp
@@ -65,21 +65,16 @@ namespace ranges
                   : rng_(&rng)
                 {}
                 RANGES_CXX14_CONSTEXPR static iterator_t<Rng> begin(adjacent_remove_if_view &rng)
-                    noexcept(std::is_nothrow_copy_constructible<iterator_t<Rng>>::value)
                 {
                     return *rng.begin_;
                 }
                 RANGES_CXX14_CONSTEXPR void next(iterator_t<Rng> &it) const
-                    noexcept(noexcept((void)(it != ranges::end(std::declval<Rng &>())),
-                        std::declval<adjacent_remove_if_view &>().satisfy_forward(++it)))
                 {
                     RANGES_ASSERT(it != ranges::end(rng_->base()));
                     rng_->satisfy_forward(++it);
                 }
                 CONCEPT_REQUIRES(BidirectionalRange<Rng>())
                 RANGES_CXX14_CONSTEXPR void prev(iterator_t<Rng> &it) const
-                    noexcept(noexcept(
-                        std::declval<adjacent_remove_if_view &>().satisfy_reverse(it)))
                 {
                     rng_->satisfy_reverse(it);
                 }
@@ -87,14 +82,12 @@ namespace ranges
                 void distance_to() = delete;
             };
             RANGES_CXX14_CONSTEXPR adaptor begin_adaptor()
-                noexcept(noexcept(std::declval<adjacent_remove_if_view &>().cache_begin()))
             {
                 cache_begin();
                 return {*this};
             }
             CONCEPT_REQUIRES(BoundedRange<Rng>())
             RANGES_CXX14_CONSTEXPR adaptor end_adaptor()
-                noexcept(noexcept(std::declval<adjacent_remove_if_view &>().cache_begin()))
             {
                 if(BidirectionalRange<Rng>()) cache_begin();
                 return {*this};
@@ -129,17 +122,13 @@ namespace ranges
             }
 
             void cache_begin()
-                noexcept(noexcept(ranges::begin(std::declval<Rng &>()),
-                    std::declval<adjacent_remove_if_view &>().
-                        satisfy_forward(std::declval<iterator_t<Rng> &>())) &&
-                    std::is_nothrow_assignable<
-                        detail::non_propagating_cache<iterator_t<Rng>> &, iterator_t<Rng>>::value)
             {
                 if(begin_) return;
                 auto it = ranges::begin(this->base());
                 satisfy_forward(it);
-                begin_ = it;
+                begin_.emplace(std::move(it));
             }
+
             detail::non_propagating_cache<iterator_t<Rng>> begin_;
         };
 

--- a/include/range/v3/view/remove_if.hpp
+++ b/include/range/v3/view/remove_if.hpp
@@ -14,20 +14,19 @@
 #ifndef RANGES_V3_VIEW_REMOVE_IF_HPP
 #define RANGES_V3_VIEW_REMOVE_IF_HPP
 
-#include <utility>
 #include <type_traits>
+#include <utility>
 #include <meta/meta.hpp>
-#include <range/v3/detail/satisfy_boost_range.hpp>
-#include <range/v3/range_fwd.hpp>
 #include <range/v3/begin_end.hpp>
+#include <range/v3/range_concepts.hpp>
+#include <range/v3/range_fwd.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/view_adaptor.hpp>
-#include <range/v3/range_concepts.hpp>
-#include <range/v3/utility/functional.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
+#include <range/v3/utility/box.hpp>
 #include <range/v3/utility/optional.hpp>
 #include <range/v3/utility/semiregular.hpp>
 #include <range/v3/utility/static_const.hpp>
-#include <range/v3/algorithm/find_if_not.hpp>
 #include <range/v3/view/view.hpp>
 
 RANGES_DISABLE_WARNINGS
@@ -44,66 +43,105 @@ namespace ranges
                 remove_if_view<Rng, Pred>,
                 Rng,
                 is_finite<Rng>::value ? finite : range_cardinality<Rng>::value>
+          , private box<semiregular_t<Pred>>
         {
+            remove_if_view() = default;
+            constexpr remove_if_view(Rng rng, Pred pred)
+                noexcept(
+                    std::is_nothrow_constructible<
+                        typename remove_if_view::view_adaptor, Rng>::value &&
+                    std::is_nothrow_constructible<
+                        typename remove_if_view::box, Pred>::value)
+              : remove_if_view::view_adaptor{detail::move(rng)}
+              , remove_if_view::box(detail::move(pred))
+            {}
         private:
             friend range_access;
-            semiregular_t<Pred> pred_;
-            detail::non_propagating_cache<iterator_t<Rng>> begin_;
 
-            struct adaptor
-              : adaptor_base
+            struct adaptor : adaptor_base
             {
-            private:
-                remove_if_view *rng_;
-                void satisfy(iterator_t<Rng> &it) const
-                {
-                    it = find_if_not(std::move(it), ranges::end(rng_->mutable_base()),
-                        std::ref(rng_->pred_));
-                }
-            public:
                 adaptor() = default;
-                adaptor(remove_if_view &rng)
+                constexpr adaptor(remove_if_view &rng) noexcept
                   : rng_(&rng)
                 {}
-                iterator_t<Rng> begin(remove_if_view &) const
+                static RANGES_CXX14_CONSTEXPR iterator_t<Rng> begin(remove_if_view &rng)
+                    noexcept(std::is_nothrow_copy_constructible<iterator_t<Rng>>::value)
                 {
-                    auto &beg = rng_->begin_;
-                    if(!beg)
-                    {
-                        beg = ranges::begin(rng_->mutable_base());
-                        this->satisfy(*beg);
-                    }
-                    return *beg;
+                    return *rng.begin_;
                 }
-                void next(iterator_t<Rng> &it) const
+                RANGES_CXX14_CONSTEXPR void next(iterator_t<Rng> &it) const
+                    noexcept(noexcept(
+                        (void)(it != ranges::end(std::declval<Rng &>())),
+                        std::declval<remove_if_view &>().satisfy_forward(++it)))
                 {
-                    this->satisfy(++it);
+                    RANGES_ASSERT(it != ranges::end(rng_->base()));
+                    rng_->satisfy_forward(++it);
                 }
                 CONCEPT_REQUIRES(BidirectionalRange<Rng>())
-                void prev(iterator_t<Rng> &it) const
+                RANGES_CXX14_CONSTEXPR void prev(iterator_t<Rng> &it) const
+                    noexcept(noexcept(std::declval<remove_if_view &>().satisfy_reverse(it)))
                 {
-                    auto &pred = rng_->pred_;
-                    do --it; while(invoke(pred, *it));
+                    rng_->satisfy_reverse(it);
                 }
                 void advance() = delete;
                 void distance_to() = delete;
+            private:
+                remove_if_view *rng_;
             };
-            adaptor begin_adaptor()
+            RANGES_CXX14_CONSTEXPR adaptor begin_adaptor()
+                noexcept(noexcept(std::declval<remove_if_view &>().cache_begin()))
             {
+                cache_begin();
                 return {*this};
             }
-            // TODO: if end is a sentinel, it holds an unnecessary pointer back to
-            // this range.
-            adaptor end_adaptor()
+            CONCEPT_REQUIRES(!BoundedRange<Rng>())
+            constexpr adaptor_base end_adaptor() const noexcept
             {
+                return {};
+            }
+            CONCEPT_REQUIRES(BoundedRange<Rng>())
+            RANGES_CXX14_CONSTEXPR adaptor end_adaptor()
+                noexcept(noexcept(std::declval<remove_if_view &>().cache_begin()))
+            {
+                if(BidirectionalRange<Rng>()) cache_begin();
                 return {*this};
             }
-        public:
-            remove_if_view() = default;
-            remove_if_view(Rng rng, Pred pred)
-              : remove_if_view::view_adaptor{std::move(rng)}
-              , pred_(std::move(pred))
-            {}
+
+            RANGES_CXX14_CONSTEXPR void satisfy_forward(iterator_t<Rng> &it)
+                noexcept(noexcept((void)(++it != ranges::end(std::declval<Rng &>())),
+                    invoke(std::declval<Pred &>(), *it)))
+            {
+                auto const last = ranges::end(this->base());
+                auto &pred = this->remove_if_view::box::get();
+                while (it != last && invoke(pred, *it))
+                    ++it;
+            }
+            RANGES_CXX14_CONSTEXPR void satisfy_reverse(iterator_t<Rng> &it)
+                noexcept(noexcept((void)(--it != it),
+                    invoke(std::declval<Pred &>(), *it)))
+            {
+                auto const &first = *begin_;
+                auto &pred = this->remove_if_view::box::get();
+                do
+                {
+                    RANGES_ASSERT(it != first); (void)first;
+                    --it;
+                } while(invoke(pred, *it));
+            }
+
+            RANGES_CXX14_CONSTEXPR void cache_begin()
+                noexcept(noexcept(ranges::begin(std::declval<Rng &>()),
+                    std::declval<remove_if_view &>().
+                        satisfy_forward(std::declval<iterator_t<Rng> &>())) &&
+                    std::is_nothrow_assignable<
+                        detail::non_propagating_cache<iterator_t<Rng>> &, iterator_t<Rng>>::value)
+            {
+                if(begin_) return;
+                auto it = ranges::begin(this->base());
+                satisfy_forward(it);
+                begin_ = std::move(it);
+            }
+            detail::non_propagating_cache<iterator_t<Rng>> begin_;
         };
 
         namespace view
@@ -114,26 +152,26 @@ namespace ranges
                 friend view_access;
                 template<typename Pred>
                 static auto bind(remove_if_fn remove_if, Pred pred)
-                RANGES_DECLTYPE_AUTO_RETURN
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
                 (
                     make_pipeable(std::bind(remove_if, std::placeholders::_1, protect(std::move(pred))))
                 )
             public:
                 template<typename Rng, typename Pred>
-                using Concept = meta::and_<
+                using Constraint = meta::and_<
                     InputRange<Rng>,
                     IndirectPredicate<Pred, iterator_t<Rng>>>;
 
                 template<typename Rng, typename Pred,
-                    CONCEPT_REQUIRES_(Concept<Rng, Pred>())>
-                remove_if_view<all_t<Rng>, Pred>
-                operator()(Rng && rng, Pred pred) const
-                {
-                    return {all(static_cast<Rng&&>(rng)), std::move(pred)};
-                }
+                    CONCEPT_REQUIRES_(Constraint<Rng, Pred>())>
+                RANGES_CXX14_CONSTEXPR auto operator()(Rng &&rng, Pred pred) const
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                (
+                    remove_if_view<all_t<Rng>, Pred>{all(static_cast<Rng &&>(rng)), std::move(pred)}
+                )
             #ifndef RANGES_DOXYGEN_INVOKED
                 template<typename Rng, typename Pred,
-                    CONCEPT_REQUIRES_(!Concept<Rng, Pred>())>
+                    CONCEPT_REQUIRES_(!Constraint<Rng, Pred>())>
                 void operator()(Rng &&, Pred) const
                 {
                     CONCEPT_ASSERT_MSG(InputRange<Rng>(),


### PR DESCRIPTION
* Store the predicate in a `box` for EBO
* Only adapt the sentinel if it's an iterator
* Don't cache an incorrect begin iterator if an exception is thrown in satisfy_forward
* constexpr and noexcept
* Use `base()` instead of `mutable_base()` to access the underlying range

* `adjacent_remove_if`:
  * model `BidirectionalRange` when the base range does