### PR TITLE
view_adaptor update

### DIFF
--- a/include/range/v3/range_access.hpp
+++ b/include/range/v3/range_access.hpp
@@ -168,51 +168,51 @@ namespace ranges
             };
 
             template<typename Rng>
-            static RANGES_CXX14_CONSTEXPR auto begin_cursor(Rng & rng, long)
-            RANGES_DECLTYPE_AUTO_RETURN
+            static RANGES_CXX14_CONSTEXPR auto begin_cursor(Rng &rng, long)
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
                 rng.begin_cursor()
             )
             template<typename Rng>
-            static RANGES_CXX14_CONSTEXPR auto begin_cursor(Rng & rng, int)
-            RANGES_DECLTYPE_AUTO_RETURN
+            static RANGES_CXX14_CONSTEXPR auto begin_cursor(Rng &rng, int)
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
                 static_cast<Rng const &>(rng).begin_cursor()
             )
             template<typename Rng>
-            static RANGES_CXX14_CONSTEXPR auto end_cursor(Rng & rng, long)
-            RANGES_DECLTYPE_AUTO_RETURN
+            static RANGES_CXX14_CONSTEXPR auto end_cursor(Rng &rng, long)
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
                 rng.end_cursor()
             )
             template<typename Rng>
-            static RANGES_CXX14_CONSTEXPR auto end_cursor(Rng & rng, int)
-            RANGES_DECLTYPE_AUTO_RETURN
+            static RANGES_CXX14_CONSTEXPR auto end_cursor(Rng &rng, int)
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
                 static_cast<Rng const &>(rng).end_cursor()
             )
 
             template<typename Rng>
-            static RANGES_CXX14_CONSTEXPR auto begin_adaptor(Rng & rng, long)
-            RANGES_DECLTYPE_AUTO_RETURN
+            static RANGES_CXX14_CONSTEXPR auto begin_adaptor(Rng &rng, long)
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
                 rng.begin_adaptor()
             )
             template<typename Rng>
-            static RANGES_CXX14_CONSTEXPR auto begin_adaptor(Rng & rng, int)
-            RANGES_DECLTYPE_AUTO_RETURN
+            static RANGES_CXX14_CONSTEXPR auto begin_adaptor(Rng &rng, int)
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
                 static_cast<Rng const &>(rng).begin_adaptor()
             )
             template<typename Rng>
-            static RANGES_CXX14_CONSTEXPR auto end_adaptor(Rng & rng, long)
-            RANGES_DECLTYPE_AUTO_RETURN
+            static RANGES_CXX14_CONSTEXPR auto end_adaptor(Rng &rng, long)
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
                 rng.end_adaptor()
             )
             template<typename Rng>
-            static RANGES_CXX14_CONSTEXPR auto end_adaptor(Rng & rng, int)
-            RANGES_DECLTYPE_AUTO_RETURN
+            static RANGES_CXX14_CONSTEXPR auto end_adaptor(Rng &rng, int)
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
                 static_cast<Rng const &>(rng).end_adaptor()
             )
@@ -333,19 +333,9 @@ namespace ranges
             }
 
         private:
-            template<typename RangeAdaptor>
-            static meta::id<typename RangeAdaptor::base_range_t> base_range_2_();
             template<typename RangeFacade>
             static meta::id<typename RangeFacade::view_facade_t> view_facade_2_();
         public:
-            template<typename RangeAdaptor>
-            struct base_range
-              : decltype(range_access::base_range_2_<RangeAdaptor>())
-            {};
-            template<typename RangeAdaptor>
-            struct base_range<RangeAdaptor const>
-              : std::add_const<meta::_t<base_range<RangeAdaptor>>>
-            {};
             template<typename RangeFacade>
             struct view_facade
               : decltype(range_access::view_facade_2_<RangeFacade>())

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -413,15 +413,15 @@ namespace ranges
             }
             template<typename D = Derived, CONCEPT_REQUIRES_(Same<D, Derived>())>
             RANGES_CXX14_CONSTEXPR auto begin_cursor()
-            RANGES_DECLTYPE_NOEXCEPT(begin_cursor_(std::declval<D &>()))
+            RANGES_DECLTYPE_NOEXCEPT(view_adaptor::begin_cursor_(std::declval<D &>()))
             {
-                return begin_cursor_(derived());
+                return view_adaptor::begin_cursor_(derived());
             }
             template<typename D = Derived, CONCEPT_REQUIRES_(Same<D, Derived>())>
             RANGES_CXX14_CONSTEXPR auto begin_cursor() const
-            RANGES_DECLTYPE_NOEXCEPT(begin_cursor_(std::declval<D const &>()))
+            RANGES_DECLTYPE_NOEXCEPT(view_adaptor::begin_cursor_(std::declval<D const &>()))
             {
-                return begin_cursor_(derived());
+                return view_adaptor::begin_cursor_(derived());
             }
 
             template<typename D>
@@ -436,15 +436,15 @@ namespace ranges
             }
             template<typename D = Derived, CONCEPT_REQUIRES_(Same<D, Derived>())>
             RANGES_CXX14_CONSTEXPR auto end_cursor()
-            RANGES_DECLTYPE_NOEXCEPT(end_cursor_(std::declval<D &>()))
+            RANGES_DECLTYPE_NOEXCEPT(view_adaptor::end_cursor_(std::declval<D &>()))
             {
-                return end_cursor_(derived());
+                return view_adaptor::end_cursor_(derived());
             }
             template<typename D = Derived, CONCEPT_REQUIRES_(Same<D, Derived>())>
             RANGES_CXX14_CONSTEXPR auto end_cursor() const
-            RANGES_DECLTYPE_NOEXCEPT(end_cursor_(std::declval<D const &>()))
+            RANGES_DECLTYPE_NOEXCEPT(view_adaptor::end_cursor_(std::declval<D const &>()))
             {
-                return end_cursor_(derived());
+                return view_adaptor::end_cursor_(derived());
             }
         protected:
             ~view_adaptor() = default;

--- a/include/range/v3/view_facade.hpp
+++ b/include/range/v3/view_facade.hpp
@@ -32,11 +32,11 @@ namespace ranges
         {
             template<typename Derived>
             using begin_cursor_t =
-                decltype(range_access::begin_cursor(std::declval<Derived &>(), 42));
+                detail::decay_t<decltype(range_access::begin_cursor(std::declval<Derived &>(), 42))>;
 
             template<typename Derived>
             using end_cursor_t =
-                decltype(range_access::end_cursor(std::declval<Derived &>(), 42));
+                detail::decay_t<decltype(range_access::end_cursor(std::declval<Derived &>(), 42))>;
 
             template<typename Derived>
             using facade_iterator_t = basic_iterator<begin_cursor_t<Derived>>;

--- a/include/range/v3/view_interface.hpp
+++ b/include/range/v3/view_interface.hpp
@@ -345,9 +345,9 @@ namespace ranges
             }
             /// \brief Print a range to an ostream
         private:
-            template<typename Rng,
+            template<typename Stream, typename Rng,
                 CONCEPT_REQUIRES_(Same<Derived, meta::_t<std::remove_cv<Rng>>>())>
-            static std::ostream &print_(std::ostream &sout, Rng &rng)
+            static Stream &print_(Stream &sout, Rng &rng)
             {
                 sout << '[';
                 auto it = ranges::begin(rng);

--- a/include/range/v3/view_interface.hpp
+++ b/include/range/v3/view_interface.hpp
@@ -15,14 +15,15 @@
 
 #include <iosfwd>
 #include <meta/meta.hpp>
-#include <range/v3/range_fwd.hpp>
-#include <range/v3/range_concepts.hpp>
-#include <range/v3/range_traits.hpp>
 #include <range/v3/begin_end.hpp>
+#include <range/v3/empty.hpp>
+#include <range/v3/range_concepts.hpp>
+#include <range/v3/range_fwd.hpp>
+#include <range/v3/range_traits.hpp>
 #include <range/v3/to_container.hpp>
+#include <range/v3/utility/common_iterator.hpp>
 #include <range/v3/utility/concepts.hpp>
 #include <range/v3/utility/iterator.hpp>
-#include <range/v3/utility/common_iterator.hpp>
 
 namespace ranges
 {
@@ -65,13 +66,13 @@ namespace ranges
           : basic_view<Cardinality>
         {
         protected:
-            Derived & derived()
+            RANGES_CXX14_CONSTEXPR Derived &derived() noexcept
             {
                 CONCEPT_ASSERT(DerivedFrom<Derived, view_interface>());
                 return static_cast<Derived &>(*this);
             }
             /// \overload
-            Derived const & derived() const
+            constexpr Derived const &derived() const noexcept
             {
                 CONCEPT_ASSERT(DerivedFrom<Derived, view_interface>());
                 return static_cast<Derived const &>(*this);
@@ -85,32 +86,35 @@ namespace ranges
             view_interface &operator=(view_interface const &) = default;
             // A few ways of testing whether a range can be empty:
             CONCEPT_REQUIRES(Cardinality >= 0)
-            constexpr bool empty() const
+            constexpr bool empty() const noexcept
             {
                 return Cardinality == 0;
             }
-            template<class D = Derived,
+            template<typename D = Derived,
                 CONCEPT_REQUIRES_(Same<D, Derived>() && Cardinality < 0 && ForwardRange<D const>())>
             constexpr bool empty() const
+                noexcept(noexcept(bool(ranges::begin(std::declval<D const &>()) ==
+                    ranges::end(std::declval<D const &>()))))
             {
-                return derived().begin() == derived().end();
+                return ranges::begin(derived()) == ranges::end(derived());
             }
-            template<class D = Derived,
-                CONCEPT_REQUIRES_(Same<D, Derived>() && (Cardinality >= 0 || ForwardRange<D const>()))>
-            constexpr bool operator!() const
+            template<typename D = Derived, CONCEPT_REQUIRES_(Same<D, Derived>())>
+            constexpr auto operator!() const
+            RANGES_DECLTYPE_NOEXCEPT(ranges::empty(std::declval<D const &>()))
             {
-                return empty();
+                return ranges::empty(derived());
             }
-            template<class D = Derived,
-                CONCEPT_REQUIRES_(Same<D, Derived>() && (Cardinality >= 0 || ForwardRange<D const>()))>
+            template<typename D = Derived, CONCEPT_REQUIRES_(Same<D, Derived>()),
+                typename = decltype(ranges::empty(std::declval<D const &>()))>
             constexpr explicit operator bool() const
+                noexcept(noexcept(ranges::empty(std::declval<D const &>())))
             {
-                return !empty();
+                return !ranges::empty(derived());
             }
             /// Access the size of the range, if it can be determined:
             template<typename D = Derived,
                 CONCEPT_REQUIRES_(Same<D, Derived>() && Cardinality >= 0)>
-            constexpr range_size_type_t<D> size() const
+            constexpr range_size_type_t<D> size() const noexcept
             {
                 return (range_size_type_t<D>)Cardinality;
             }
@@ -340,43 +344,46 @@ namespace ranges
                 return ranges::to_<Container>(derived());
             }
             /// \brief Print a range to an ostream
-            template<bool B = true, typename Stream = meta::if_c<B, std::ostream>>
-            friend Stream &operator<<(Stream &sout, Derived &rng)
+        private:
+            template<typename Rng,
+                CONCEPT_REQUIRES_(Same<Derived, meta::_t<std::remove_cv<Rng>>>())>
+            static std::ostream &print_(std::ostream &sout, Rng &rng)
             {
+                sout << '[';
                 auto it = ranges::begin(rng);
                 auto const e = ranges::end(rng);
-                if(it == e)
-                    return sout << "[]";
-                sout << '[' << *it;
-                while(++it != e)
-                    sout << ',' << *it;
-                sout << ']';
-                return sout;
-            }
-            /// \overload
-            template<bool B = true, typename Stream = meta::if_c<B, std::ostream>,
-                typename D = Derived, CONCEPT_REQUIRES_(InputRange<D const>())>
-            friend Stream &operator<<(Stream &sout, Derived const &rng)
-            {
-                auto it = ranges::begin(rng);
-                auto const e = ranges::end(rng);
-                if(it == e)
+                if(it != e)
                 {
-                    sout << "[]";
-                    return sout;
+                    for(;;)
+                    {
+                        sout << *it;
+                        if(++it == e) break;
+                        sout << ',';
+                    }
                 }
-                sout << '[' << *it;
-                while(++it != e)
-                    sout << ',' << *it;
                 sout << ']';
                 return sout;
             }
-            /// \overload
-            template<bool B = true, typename Stream = meta::if_c<B, std::ostream>>
-            friend Stream &operator<<(Stream &sout, Derived &&rng)
+
+            template<typename D = Derived,
+                CONCEPT_REQUIRES_(Same<D, Derived>() && InputRange<D const>())>
+            friend std::ostream &operator<<(std::ostream &sout, Derived const &rng)
             {
-                sout << rng;
-                return sout;
+                return view_interface::print_(sout, rng);
+            }
+            /// \overload
+            template<typename D = Derived,
+                CONCEPT_REQUIRES_(Same<D, Derived>() && !Range<D const>() && InputRange<D>())>
+            friend std::ostream &operator<<(std::ostream &sout, Derived &rng)
+            {
+                return view_interface::print_(sout, rng);
+            }
+            /// \overload
+            template<typename D = Derived,
+                CONCEPT_REQUIRES_(Same<D, Derived>() && !Range<D const>() && InputRange<D>())>
+            friend std::ostream &operator<<(std::ostream &sout, Derived &&rng)
+            {
+                return view_interface::print_(sout, rng);
             }
         };
         /// @}


### PR DESCRIPTION
Fixes #726.

`view_adaptor`:
* decay the types of `(begin|end)_adaptor_t` and `adapted_(iterator|sentinel)_t`
* Deduce return type/noexcept for `adaptor_base::(begin|end)`
* remove `base_range_t`
* remove `mutable` specifier from base range, and remove `mutable_base()`
* constexpr / noexcept

`view_facade`:
* decay the types of `begin_cursor_t` and `end_cursor_t`

`view_interface`:
* Cleanup constraints on `empty`
* DRY the range printing code

`range_access`:
* conditional noexcept for `(begin|end)_(adaptor|cursor)`
* Remove `base_range`