### PR TITLE
counted_iterator: fix post-increment bug

### DIFF
--- a/include/range/v3/detail/satisfy_boost_range.hpp
+++ b/include/range/v3/detail/satisfy_boost_range.hpp
@@ -43,25 +43,25 @@ namespace boost                                                                 
         view_name<Ts...>,                                                       \
         ::meta::if_c<(bool)::ranges::BoundedRange<view_name<Ts...>>()>>         \
     {                                                                           \
-        using type = ::ranges::iterator_t<view_name<Ts...>>;              \
+        using type = ::ranges::iterator_t<view_name<Ts...>>;                    \
     };                                                                          \
     template<typename... Ts>                                                    \
     struct range_const_iterator<                                                \
         view_name<Ts...>,                                                       \
         ::meta::if_c<(bool)::ranges::BoundedRange<view_name<Ts...> const>()>>   \
     {                                                                           \
-        using type = ::ranges::iterator_t<view_name<Ts...> const>;        \
+        using type = ::ranges::iterator_t<view_name<Ts...> const>;              \
     };                                                                          \
     template<typename... Ts>                                                    \
     struct range_value<view_name<Ts...>>                                        \
     {                                                                           \
-        using type = ::ranges::range_value_type_t<view_name<Ts...>>;                 \
+        using type = ::ranges::range_value_type_t<view_name<Ts...>>;            \
     };                                                                          \
     template<typename... Ts>                                                    \
     struct range_size<view_name<Ts...>>                                         \
       : ::meta::if_c<                                                           \
             (bool)::ranges::BoundedRange<view_name<Ts...>>(),                   \
-            ::meta::defer<::ranges::range_size_type_t, view_name<Ts...>>,            \
+            ::meta::defer<::ranges::range_size_type_t, view_name<Ts...>>,       \
             ::meta::nil_>                                                       \
     {                                                                           \
     };                                                                          \
@@ -69,7 +69,7 @@ namespace boost                                                                 
     struct range_size<view_name<Ts...> const>                                   \
       : ::meta::if_c<                                                           \
             (bool)::ranges::BoundedRange<view_name<Ts...> const>(),             \
-            ::meta::defer<::ranges::range_size_type_t, view_name<Ts...> const>,      \
+            ::meta::defer<::ranges::range_size_type_t, view_name<Ts...> const>, \
             ::meta::nil_>                                                       \
     {                                                                           \
     };                                                                          \

--- a/include/range/v3/utility/move.hpp
+++ b/include/range/v3/utility/move.hpp
@@ -64,7 +64,7 @@ namespace ranges
         namespace adl_move_detail
         {
             template<typename T,
-                typename = decltype(iter_move(std::declval<T &&>()))>
+                typename = decltype(iter_move(std::declval<T>()))>
             std::true_type try_adl_iter_move_(int);
 
             template<typename T>

--- a/test/view/counted.cpp
+++ b/test/view/counted.cpp
@@ -68,7 +68,7 @@ int main()
         // Regression test: ensure that we can post-increment a counted_iterator<I>
         // when decltype(declval<I &>()++) is void.
         CONCEPT_ASSERT(ranges::InputIterator<fortytwo_erator>());
-        ranges::counted_iterator<fortytwo_erator> c{};
+        ranges::counted_iterator<fortytwo_erator> c{{}, 42};
         c++;
     }
 

--- a/test/view/counted.cpp
+++ b/test/view/counted.cpp
@@ -16,6 +16,16 @@
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
 
+struct fortytwo_erator {
+    using difference_type = int;
+    using iterator_category = ranges::input_iterator_tag;
+    using value_type = int;
+    fortytwo_erator() = default;
+    int operator*() const { return 42; }
+    fortytwo_erator& operator++() { return *this; }
+    void operator++(int) {}
+};
+
 int main()
 {
     using namespace ranges;
@@ -52,6 +62,14 @@ int main()
             d-d,
             c-d,
             d-c);
+    }
+
+    {
+        // Regression test: ensure that we can post-increment a counted_iterator<I>
+        // when decltype(declval<I &>()++) is void.
+        CONCEPT_ASSERT(ranges::InputIterator<fortytwo_erator>());
+        ranges::counted_iterator<fortytwo_erator> c{};
+        c++;
     }
 
     return ::test_result();


### PR DESCRIPTION
When the base iterator's post-increment operator has `void` return type, we can't bind a reference thereto.