### PR TITLE
view_adaptor: guard const overloads of (begin|end)_cursor

### DIFF
--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -417,7 +417,8 @@ namespace ranges
             {
                 return view_adaptor::begin_cursor_(derived());
             }
-            template<typename D = Derived, CONCEPT_REQUIRES_(Same<D, Derived>())>
+            template<typename D = Derived,
+                CONCEPT_REQUIRES_(Same<D, Derived>() && Range<base_range_t const>())>
             RANGES_CXX14_CONSTEXPR auto begin_cursor() const
             RANGES_DECLTYPE_NOEXCEPT(view_adaptor::begin_cursor_(std::declval<D const &>()))
             {
@@ -440,7 +441,8 @@ namespace ranges
             {
                 return view_adaptor::end_cursor_(derived());
             }
-            template<typename D = Derived, CONCEPT_REQUIRES_(Same<D, Derived>())>
+            template<typename D = Derived,
+                CONCEPT_REQUIRES_(Same<D, Derived>() && Range<base_range_t const>())>
             RANGES_CXX14_CONSTEXPR auto end_cursor() const
             RANGES_DECLTYPE_NOEXCEPT(view_adaptor::end_cursor_(std::declval<D const &>()))
             {


### PR DESCRIPTION
...with `Range<foo const>()`. Compilers - clang 5, at least - cache the value of *successful* template substitution, not the value of *failed* template substitution.

Fixes #758.