### PR TITLE
[doc] Change return type of is_word_boundary to bool

### DIFF
--- a/doc/std/D4128.md
+++ b/doc/std/D4128.md
@@ -1362,7 +1362,7 @@ Appendix 3: D Ranges and Algorithmic Complexity
 As currently defined, D's ranges make it difficult to implement algorithms over bidirectional sequences that take a position in the middle as an argument. A good example is a hypothetical `is_word_boundary` algorithm. In C++ with iterators, it might look like this:
 
     template< BidirectionalIterator I >
-    void is_word_boundary( I begin, I middle, I end )
+    bool is_word_boundary( I begin, I middle, I end )
     {
         bool is_word_prev = middle == begin ? false : isword(*prev(middle));
         bool is_word_this = middle == end ? false : isword(*middle);


### PR DESCRIPTION
is_word_boundary example using C++ iterators was incorrectly returning
void, while it should return bool.