### PR TITLE
cmake interfaces and better installation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,16 @@ if(NOT RANGE_V3_NEW_VERSION_HPP STREQUAL RANGE_V3_OLD_VERSION_HPP)
   message("  conan upload --all range-v3/${RANGE_V3_VERSION}@ericniebler/stable")
 endif()
 
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/range-v3-config-version.cmake
+  VERSION ${RANGE_V3_VERSION}
+  COMPATIBILITY ExactVersion
+)
+
 install(TARGETS meta range-v3 EXPORT range-v3-targets DESTINATION lib)
 install(EXPORT range-v3-targets FILE range-v3-config.cmake DESTINATION lib/cmake/range-v3)
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/range-v3-config-version.cmake
+  DESTINATION lib/cmake/range-v3)
 install(DIRECTORY include/ DESTINATION include FILES_MATCHING PATTERN "*.hpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,11 +22,11 @@ enable_testing()
 
 add_library(meta INTERFACE)
 target_include_directories(meta INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>)
-target_include_directories(meta SYSTEM INTERFACE $<INSTALL_INTERFACE:/include>)
+target_include_directories(meta SYSTEM INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
 
 add_library(range-v3 INTERFACE)
 target_include_directories(range-v3 INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>)
-target_include_directories(range-v3 SYSTEM INTERFACE $<INSTALL_INTERFACE:/include>)
+target_include_directories(range-v3 SYSTEM INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
 target_link_libraries(range-v3 INTERFACE meta)
 
 add_subdirectory(doc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,11 +20,28 @@ include(CTest)
 
 enable_testing()
 
-include_directories(include)
+add_library(meta INTERFACE)
+target_include_directories(meta INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>)
+target_include_directories(meta SYSTEM INTERFACE $<INSTALL_INTERFACE:/include>)
+
+add_library(range-v3 INTERFACE)
+target_include_directories(range-v3 INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>)
+target_include_directories(range-v3 SYSTEM INTERFACE $<INSTALL_INTERFACE:/include>)
+target_link_libraries(range-v3 INTERFACE meta)
+
 add_subdirectory(doc)
-add_subdirectory(test)
-add_subdirectory(example)
-add_subdirectory(perf)
+
+if(NOT RANGE_V3_NO_TESTING)
+  add_subdirectory(test)
+endif()
+
+if(NOT RANGE_V3_NO_EXAMPLE)
+  add_subdirectory(example)
+endif()
+
+if(NOT RANGE_V3_NO_PERF)
+  add_subdirectory(perf)
+endif()
 
 # Test for <thread>
 try_compile(RANGE_V3_TRY_THREAD ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/thread_test_code.cpp)
@@ -114,6 +131,6 @@ if(NOT RANGE_V3_NEW_VERSION_HPP STREQUAL RANGE_V3_OLD_VERSION_HPP)
   message("  conan upload --all range-v3/${RANGE_V3_VERSION}@ericniebler/stable")
 endif()
 
-
-install(DIRECTORY include/ DESTINATION include
-        FILES_MATCHING PATTERN "*.hpp")
+install(TARGETS meta range-v3 EXPORT range-v3-targets DESTINATION lib)
+install(EXPORT range-v3-targets FILE range-v3-config.cmake DESTINATION lib/cmake/range-v3)
+install(DIRECTORY include/ DESTINATION include FILES_MATCHING PATTERN "*.hpp")

--- a/cmake/TestHeaders.cmake
+++ b/cmake/TestHeaders.cmake
@@ -127,6 +127,7 @@ int main() { }
             ${ARGS_EXCLUDE_FROM_ALL}
             "${CMAKE_CURRENT_BINARY_DIR}/headers/${directory}/${filename}.cpp"
         )
+        target_include_directories(test.header.${target} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
         if (ARGS_LINK_LIBRARIES)
             target_link_libraries(test.header.${target} ${ARGS_LINK_LIBRARIES})
         endif()

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -2,18 +2,23 @@
 ranges_append_flag(RANGES_HAS_WNO_MISSING_BRACES -Wno-missing-braces)
 
 add_executable(comprehensions comprehensions.cpp)
+target_link_libraries(comprehensions range-v3)
 add_test(example.comprehensions, comprehensions)
 
 add_executable(hello hello.cpp)
+target_link_libraries(hello range-v3)
 add_test(example.hello, hello)
 
 add_executable(count count.cpp)
+target_link_libraries(count range-v3)
 add_test(example.count, count)
 
 add_executable(count_if count_if.cpp)
+target_link_libraries(count_if range-v3)
 add_test(example.count_if, count_if)
 
 # add_executable(fibonacci fibonacci.cpp)
+# target_link_libraries(fibonacci range-v3)
 # add_test(example.fibonacci, fibonacci)
 
 # Guarded with a variable because the calendar example causes gcc to puke.
@@ -26,6 +31,7 @@ if(RANGES_BUILD_CALENDAR_EXAMPLE)
     if (Boost_FOUND)
         include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
         add_executable(calendar calendar.cpp)
+        target_link_libraries(calendar range-v3)
         target_link_libraries(calendar ${Boost_LIBRARIES})
         message ("boost: ${Boost_LIBRARY_DIRS}")
         target_compile_definitions(calendar PUBLIC -DBOOST_NO_AUTO_PTR)

--- a/perf/CMakeLists.txt
+++ b/perf/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_executable(counted_insertion_sort counted_insertion_sort.cpp)
 
 add_executable(sort_patterns sort_patterns.cpp)
+target_link_libraries(sort_patterns range-v3)

--- a/perf/CMakeLists.txt
+++ b/perf/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(counted_insertion_sort counted_insertion_sort.cpp)
+target_link_libraries(counted_insertion_sort range-v3)
 
 add_executable(sort_patterns sort_patterns.cpp)
 target_link_libraries(sort_patterns range-v3)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(view_adaptor range-v3)
 add_test(test.view_adaptor view_adaptor)
 
 add_executable(index index.cpp)
+target_link_libraries(index range-v3)
 add_test(test.index index)
 
 add_executable(iterator_range iterator_range.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,46 +8,60 @@ add_subdirectory(view)
 add_subdirectory(experimental)
 
 add_executable(config config.cpp)
+target_link_libraries(config range-v3)
 add_test(test.config config)
 
 add_executable(container_conversion container_conversion.cpp)
+target_link_libraries(container_conversion range-v3)
 add_test(test.container_conversion container_conversion)
 
 add_executable(constexpr_core constexpr_core.cpp)
+target_link_libraries(constexpr_core range-v3)
 add_test(test.constexpr_core constexpr_core)
 
 add_executable(view_facade view_facade.cpp)
+target_link_libraries(view_facade range-v3)
 add_test(test.view_facade view_facade)
 
 add_executable(view_adaptor view_adaptor.cpp)
+target_link_libraries(view_adaptor range-v3)
 add_test(test.view_adaptor view_adaptor)
 
 add_executable(index index.cpp)
 add_test(test.index index)
 
 add_executable(iterator_range iterator_range.cpp)
+target_link_libraries(iterator_range range-v3)
 add_test(test.iterator_range iterator_range)
 
 add_executable(multiple multiple1.cpp multiple2.cpp)
+target_link_libraries(multiple range-v3)
 add_test(test.multiple multiple)
 
 add_executable(distance distance.cpp)
+target_link_libraries(distance range-v3)
 add_test(test.distance distance)
 
 add_executable(to_container to_container.cpp)
+target_link_libraries(to_container range-v3)
 add_test(test.to_container to_container)
 
 add_executable(getlines getlines.cpp)
+target_link_libraries(getlines range-v3)
 add_test(test.getlines getlines)
 
 add_executable(istream_range istream_range.cpp)
+target_link_libraries(istream_range range-v3)
 add_test(test.istream_range istream_range)
 
 add_executable(bug474 bug474.cpp)
+target_link_libraries(bug474 range-v3)
 add_test(test.bug474 bug474)
 
 add_executable(bug566 bug566.cpp)
+target_link_libraries(bug566 range-v3)
 add_test(test.bug566 bug566)
 
 add_executable(span span.cpp)
+target_link_libraries(span range-v3)
 add_test(test.span span)

--- a/test/action/CMakeLists.txt
+++ b/test/action/CMakeLists.txt
@@ -1,56 +1,72 @@
 add_executable(act.concepts cont_concepts.cpp)
+target_link_libraries(act.concepts range-v3)
 add_test(test.act.concepts act.concepts)
 
 add_executable(act.drop drop.cpp)
+target_link_libraries(act.drop range-v3)
 add_test(test.act.drop act.drop)
 
 add_executable(act.drop_while drop_while.cpp)
+target_link_libraries(act.drop_while range-v3)
 add_test(test.act.drop_while act.drop_while)
 
 add_executable(act.insert insert.cpp)
+target_link_libraries(act.insert range-v3)
 add_test(test.act.insert act.insert)
 
 add_executable(act.join join.cpp)
 add_test(test.act.join act.join)
 
 add_executable(act.push_front push_front.cpp)
+target_link_libraries(act.push_front range-v3)
 add_test(test.act.push_front act.push_front)
 
 add_executable(act.push_back push_back.cpp)
+target_link_libraries(act.push_back range-v3)
 add_test(test.act.push_back act.push_back)
 
 add_executable(act.remove_if remove_if.cpp)
+target_link_libraries(act.remove_if range-v3)
 add_test(test.act.remove_if act.remove_if)
 
 add_executable(act.reverse reverse.cpp)
 add_test(test.act.reverse act.reverse)
 
 add_executable(act.shuffle shuffle.cpp)
+target_link_libraries(act.shuffle range-v3)
 add_test(test.act.shuffle act.shuffle)
 
 add_executable(act.slice slice.cpp)
+target_link_libraries(act.slice range-v3)
 add_test(test.act.slice act.slice)
 
 add_executable(act.sort sort.cpp)
+target_link_libraries(act.sort range-v3)
 add_test(test.act.sort act.sort)
 
 add_executable(act.split split.cpp)
+target_link_libraries(act.split range-v3)
 add_test(test.act.split act.split)
 
 add_executable(act.stable_sort stable_sort.cpp)
 add_test(test.act.stable_sort act.stable_sort)
 
 add_executable(act.stride stride.cpp)
+target_link_libraries(act.stride range-v3)
 add_test(test.act.stride act.stride)
 
 add_executable(act.take take.cpp)
+target_link_libraries(act.take range-v3)
 add_test(test.act.take act.take)
 
 add_executable(act.take_while take_while.cpp)
+target_link_libraries(act.take_while range-v3)
 add_test(test.act.take_while act.take_while)
 
 add_executable(act.transform transform.cpp)
+target_link_libraries(act.transform range-v3)
 add_test(test.act.transform act.transform)
 
 add_executable(act.unique unique.cpp)
+target_link_libraries(act.unique range-v3)
 add_test(test.act.unique act.unique)

--- a/test/action/CMakeLists.txt
+++ b/test/action/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(act.insert range-v3)
 add_test(test.act.insert act.insert)
 
 add_executable(act.join join.cpp)
+target_link_libraries(act.join range-v3)
 add_test(test.act.join act.join)
 
 add_executable(act.push_front push_front.cpp)
@@ -30,6 +31,7 @@ target_link_libraries(act.remove_if range-v3)
 add_test(test.act.remove_if act.remove_if)
 
 add_executable(act.reverse reverse.cpp)
+target_link_libraries(act.reverse range-v3)
 add_test(test.act.reverse act.reverse)
 
 add_executable(act.shuffle shuffle.cpp)
@@ -49,6 +51,7 @@ target_link_libraries(act.split range-v3)
 add_test(test.act.split act.split)
 
 add_executable(act.stable_sort stable_sort.cpp)
+target_link_libraries(act.stable_sort range-v3)
 add_test(test.act.stable_sort act.stable_sort)
 
 add_executable(act.stride stride.cpp)

--- a/test/algorithm/CMakeLists.txt
+++ b/test/algorithm/CMakeLists.txt
@@ -67,6 +67,7 @@ target_link_libraries(alg.for_each range-v3)
 add_test(test.alg.for_each, alg.for_each)
 
 add_executable(alg.for_each_n for_each_n.cpp)
+target_link_libraries(alg.for_each_n range-v3)
 add_test(test.alg.for_each_n, alg.for_each_n)
 
 add_executable(alg.generate generate.cpp)
@@ -86,27 +87,35 @@ target_link_libraries(alg.inplace_merge range-v3)
 add_test(test.alg.inplace_merge, alg.inplace_merge)
 
 add_executable(alg.is_heap1 is_heap1.cpp)
+target_link_libraries(alg.is_heap1 range-v3)
 add_test(test.alg.is_heap1, alg.is_heap1)
 
 add_executable(alg.is_heap2 is_heap2.cpp)
+target_link_libraries(alg.is_heap2 range-v3)
 add_test(test.alg.is_heap2, alg.is_heap2)
 
 add_executable(alg.is_heap3 is_heap3.cpp)
+target_link_libraries(alg.is_heap3 range-v3)
 add_test(test.alg.is_heap3, alg.is_heap3)
 
 add_executable(alg.is_heap4 is_heap4.cpp)
+target_link_libraries(alg.is_heap4 range-v3)
 add_test(test.alg.is_heap4, alg.is_heap4)
 
 add_executable(alg.is_heap_until1 is_heap_until1.cpp)
+target_link_libraries(alg.is_heap_until1 range-v3)
 add_test(test.alg.is_heap_until1, alg.is_heap_until1)
 
 add_executable(alg.is_heap_until2 is_heap_until2.cpp)
+target_link_libraries(alg.is_heap_until2 range-v3)
 add_test(test.alg.is_heap_until2, alg.is_heap_until2)
 
 add_executable(alg.is_heap_until3 is_heap_until3.cpp)
+target_link_libraries(alg.is_heap_until3 range-v3)
 add_test(test.alg.is_heap_until3, alg.is_heap_until3)
 
 add_executable(alg.is_heap_until4 is_heap_until4.cpp)
+target_link_libraries(alg.is_heap_until4 range-v3)
 add_test(test.alg.is_heap_until4, alg.is_heap_until4)
 
 add_executable(alg.is_partitioned is_partitioned.cpp)
@@ -278,75 +287,99 @@ target_link_libraries(alg.search_n range-v3)
 add_test(test.alg.search_n, alg.search_n)
 
 add_executable(alg.set_difference1 set_difference1.cpp)
+target_link_libraries(alg.set_difference1 range-v3)
 add_test(test.alg.set_difference1, alg.set_difference1)
 
 add_executable(alg.set_difference2 set_difference2.cpp)
+target_link_libraries(alg.set_difference2 range-v3)
 add_test(test.alg.set_difference2, alg.set_difference2)
 
 add_executable(alg.set_difference3 set_difference3.cpp)
+target_link_libraries(alg.set_difference3 range-v3)
 add_test(test.alg.set_difference3, alg.set_difference3)
 
 add_executable(alg.set_difference4 set_difference4.cpp)
+target_link_libraries(alg.set_difference4 range-v3)
 add_test(test.alg.set_difference4, alg.set_difference4)
 
 add_executable(alg.set_difference5 set_difference5.cpp)
+target_link_libraries(alg.set_difference5 range-v3)
 add_test(test.alg.set_difference5, alg.set_difference5)
 
 add_executable(alg.set_difference6 set_difference6.cpp)
+target_link_libraries(alg.set_difference6 range-v3)
 add_test(test.alg.set_difference6, alg.set_difference6)
 
 add_executable(alg.set_intersection1 set_intersection1.cpp)
+target_link_libraries(alg.set_intersection1 range-v3)
 add_test(test.alg.set_intersection1, alg.set_intersection1)
 
 add_executable(alg.set_intersection2 set_intersection2.cpp)
+target_link_libraries(alg.set_intersection2 range-v3)
 add_test(test.alg.set_intersection2, alg.set_intersection2)
 
 add_executable(alg.set_intersection3 set_intersection3.cpp)
+target_link_libraries(alg.set_intersection3 range-v3)
 add_test(test.alg.set_intersection3, alg.set_intersection3)
 
 add_executable(alg.set_intersection4 set_intersection4.cpp)
+target_link_libraries(alg.set_intersection4 range-v3)
 add_test(test.alg.set_intersection4, alg.set_intersection4)
 
 add_executable(alg.set_intersection5 set_intersection5.cpp)
+target_link_libraries(alg.set_intersection5 range-v3)
 add_test(test.alg.set_intersection5, alg.set_intersection5)
 
 add_executable(alg.set_intersection6 set_intersection6.cpp)
+target_link_libraries(alg.set_intersection6 range-v3)
 add_test(test.alg.set_intersection6, alg.set_intersection6)
 
 add_executable(alg.set_symmetric_difference1 set_symmetric_difference1.cpp)
+target_link_libraries(alg.set_symmetric_difference1 range-v3)
 add_test(test.alg.set_symmetric_difference1, alg.set_symmetric_difference1)
 
 add_executable(alg.set_symmetric_difference2 set_symmetric_difference2.cpp)
+target_link_libraries(alg.set_symmetric_difference2 range-v3)
 add_test(test.alg.set_symmetric_difference2, alg.set_symmetric_difference2)
 
 add_executable(alg.set_symmetric_difference3 set_symmetric_difference3.cpp)
+target_link_libraries(alg.set_symmetric_difference3 range-v3)
 add_test(test.alg.set_symmetric_difference3, alg.set_symmetric_difference3)
 
 add_executable(alg.set_symmetric_difference4 set_symmetric_difference4.cpp)
+target_link_libraries(alg.set_symmetric_difference4 range-v3)
 add_test(test.alg.set_symmetric_difference4, alg.set_symmetric_difference4)
 
 add_executable(alg.set_symmetric_difference5 set_symmetric_difference5.cpp)
+target_link_libraries(alg.set_symmetric_difference5 range-v3)
 add_test(test.alg.set_symmetric_difference5, alg.set_symmetric_difference5)
 
 add_executable(alg.set_symmetric_difference6 set_symmetric_difference6.cpp)
+target_link_libraries(alg.set_symmetric_difference6 range-v3)
 add_test(test.alg.set_symmetric_difference6, alg.set_symmetric_difference6)
 
 add_executable(alg.set_union1 set_union1.cpp)
+target_link_libraries(alg.set_union1 range-v3)
 add_test(test.alg.set_union1, alg.set_union1)
 
 add_executable(alg.set_union2 set_union2.cpp)
+target_link_libraries(alg.set_union2 range-v3)
 add_test(test.alg.set_union2, alg.set_union2)
 
 add_executable(alg.set_union3 set_union3.cpp)
+target_link_libraries(alg.set_union3 range-v3)
 add_test(test.alg.set_union3, alg.set_union3)
 
 add_executable(alg.set_union4 set_union4.cpp)
+target_link_libraries(alg.set_union4 range-v3)
 add_test(test.alg.set_union4, alg.set_union4)
 
 add_executable(alg.set_union5 set_union5.cpp)
+target_link_libraries(alg.set_union5 range-v3)
 add_test(test.alg.set_union5, alg.set_union5)
 
 add_executable(alg.set_union6 set_union6.cpp)
+target_link_libraries(alg.set_union6 range-v3)
 add_test(test.alg.set_union6, alg.set_union6)
 
 add_executable(alg.shuffle shuffle.cpp)
@@ -390,4 +423,5 @@ target_link_libraries(alg.upper_bound range-v3)
 add_test(test.alg.upper_bound, alg.upper_bound)
 
 add_executable(alg.sort_n_with_buffer sort_n_with_buffer.cpp)
+target_link_libraries(alg.sort_n_with_buffer range-v3)
 add_test(test.alg.sort_n_with_buffer alg.sort_n_with_buffer)

--- a/test/algorithm/CMakeLists.txt
+++ b/test/algorithm/CMakeLists.txt
@@ -1,67 +1,88 @@
 add_executable(alg.adjacent_find adjacent_find.cpp)
+target_link_libraries(alg.adjacent_find range-v3)
 add_test(test.alg.adjacent_find, alg.adjacent_find)
 
 add_executable(alg.all_of all_of.cpp)
+target_link_libraries(alg.all_of range-v3)
 add_test(test.alg.all_of, alg.all_of)
 
 add_executable(alg.any_of any_of.cpp)
+target_link_libraries(alg.any_of range-v3)
 add_test(test.alg.any_of, alg.any_of)
 
 add_executable(alg.none_of none_of.cpp)
+target_link_libraries(alg.none_of range-v3)
 add_test(test.alg.none_of, alg.none_of)
 
 add_executable(alg.binary_search binary_search.cpp)
+target_link_libraries(alg.binary_search range-v3)
 add_test(test.alg.binary_search, alg.binary_search)
 
 add_executable(alg.copy copy.cpp)
+target_link_libraries(alg.copy range-v3)
 add_test(test.alg.copy, alg.copy)
 
 add_executable(alg.copy_backward copy_backward.cpp)
+target_link_libraries(alg.copy_backward range-v3)
 add_test(test.alg.copy_backward, alg.copy_backward)
 
 add_executable(alg.count count.cpp)
+target_link_libraries(alg.count range-v3)
 add_test(test.alg.count, alg.count)
 
 add_executable(alg.count_if count_if.cpp)
+target_link_libraries(alg.count_if range-v3)
 add_test(test.alg.count_if, alg.count_if)
 
 add_executable(alg.equal equal.cpp)
+target_link_libraries(alg.equal range-v3)
 add_test(test.alg.equal, alg.equal)
 
 add_executable(alg.equal_range equal_range.cpp)
+target_link_libraries(alg.equal_range range-v3)
 add_test(test.alg.equal_range, alg.equal_range)
 
 add_executable(alg.fill fill.cpp)
+target_link_libraries(alg.fill range-v3)
 add_test(test.alg.fill, alg.fill)
 
 add_executable(alg.find find.cpp)
+target_link_libraries(alg.find range-v3)
 add_test(test.alg.find, alg.find)
 
 add_executable(alg.find_end find_end.cpp)
+target_link_libraries(alg.find_end range-v3)
 add_test(test.alg.find_end, alg.find_end)
 
 add_executable(alg.find_if find_if.cpp)
+target_link_libraries(alg.find_if range-v3)
 add_test(test.alg.find_if, alg.find_if)
 
 add_executable(alg.find_first_of find_first_of.cpp)
+target_link_libraries(alg.find_first_of range-v3)
 add_test(test.alg.find_first_of, alg.find_first_of)
 
 add_executable(alg.for_each for_each.cpp)
+target_link_libraries(alg.for_each range-v3)
 add_test(test.alg.for_each, alg.for_each)
 
 add_executable(alg.for_each_n for_each_n.cpp)
 add_test(test.alg.for_each_n, alg.for_each_n)
 
 add_executable(alg.generate generate.cpp)
+target_link_libraries(alg.generate range-v3)
 add_test(test.alg.generate, alg.generate)
 
 add_executable(alg.generate_n generate_n.cpp)
+target_link_libraries(alg.generate_n range-v3)
 add_test(test.alg.generate_n, alg.generate_n)
 
 add_executable(alg.includes includes.cpp)
+target_link_libraries(alg.includes range-v3)
 add_test(test.alg.includes, alg.includes)
 
 add_executable(alg.inplace_merge inplace_merge.cpp)
+target_link_libraries(alg.inplace_merge range-v3)
 add_test(test.alg.inplace_merge, alg.inplace_merge)
 
 add_executable(alg.is_heap1 is_heap1.cpp)
@@ -89,129 +110,171 @@ add_executable(alg.is_heap_until4 is_heap_until4.cpp)
 add_test(test.alg.is_heap_until4, alg.is_heap_until4)
 
 add_executable(alg.is_partitioned is_partitioned.cpp)
+target_link_libraries(alg.is_partitioned range-v3)
 add_test(test.alg.is_partitioned, alg.is_partitioned)
 
 add_executable(alg.is_permutation is_permutation.cpp)
+target_link_libraries(alg.is_permutation range-v3)
 add_test(test.alg.is_permutation, alg.is_permutation)
 
 add_executable(alg.is_sorted_until is_sorted_until.cpp)
+target_link_libraries(alg.is_sorted_until range-v3)
 add_test(test.alg.is_sorted_until, alg.is_sorted_until)
 
 add_executable(alg.is_sorted is_sorted.cpp)
+target_link_libraries(alg.is_sorted range-v3)
 add_test(test.alg.is_sorted, alg.is_sorted)
 
 add_executable(alg.lexicographical_compare lexicographical_compare.cpp)
+target_link_libraries(alg.lexicographical_compare range-v3)
 add_test(test.alg.lexicographical_compare, alg.lexicographical_compare)
 
 add_executable(alg.lower_bound lower_bound.cpp)
+target_link_libraries(alg.lower_bound range-v3)
 add_test(test.alg.lower_bound, alg.lower_bound)
 
 add_executable(alg.make_heap make_heap.cpp)
+target_link_libraries(alg.make_heap range-v3)
 add_test(test.alg.make_heap, alg.make_heap)
 
 add_executable(alg.max max.cpp)
+target_link_libraries(alg.max range-v3)
 add_test(test.alg.max, alg.max)
 
 add_executable(alg.max_element max_element.cpp)
+target_link_libraries(alg.max_element range-v3)
 add_test(test.alg.max_element, alg.max_element)
 
 add_executable(alg.merge merge.cpp)
+target_link_libraries(alg.merge range-v3)
 add_test(test.alg.merge, alg.merge)
 
 add_executable(alg.min min.cpp)
+target_link_libraries(alg.min range-v3)
 add_test(test.alg.min, alg.min)
 
 add_executable(alg.min_element min_element.cpp)
+target_link_libraries(alg.min_element range-v3)
 add_test(test.alg.min_element, alg.min_element)
 
 add_executable(alg.minmax minmax.cpp)
+target_link_libraries(alg.minmax range-v3)
 add_test(test.alg.minmax, alg.minmax)
 
 add_executable(alg.minmax_element minmax_element.cpp)
+target_link_libraries(alg.minmax_element range-v3)
 add_test(test.alg.minmax_element, alg.minmax_element)
 
 add_executable(alg.mismatch mismatch.cpp)
+target_link_libraries(alg.mismatch range-v3)
 add_test(test.alg.mismatch, alg.mismatch)
 
 add_executable(alg.move move.cpp)
+target_link_libraries(alg.move range-v3)
 add_test(test.alg.move alg.move)
 
 add_executable(alg.move_backward move_backward.cpp)
+target_link_libraries(alg.move_backward range-v3)
 add_test(test.alg.move_backward alg.move_backward)
 
 add_executable(alg.next_permutation next_permutation.cpp)
+target_link_libraries(alg.next_permutation range-v3)
 add_test(test.alg.next_permutation alg.next_permutation)
 
 add_executable(alg.nth_element nth_element.cpp)
+target_link_libraries(alg.nth_element range-v3)
 add_test(test.alg.nth_element alg.nth_element)
 
 add_executable(alg.partial_sort partial_sort.cpp)
+target_link_libraries(alg.partial_sort range-v3)
 add_test(test.alg.partial_sort, alg.partial_sort)
 
 add_executable(alg.partial_sort_copy partial_sort_copy.cpp)
+target_link_libraries(alg.partial_sort_copy range-v3)
 add_test(test.alg.partial_sort_copy, alg.partial_sort_copy)
 
 add_executable(alg.partition partition.cpp)
+target_link_libraries(alg.partition range-v3)
 add_test(test.alg.partition, alg.partition)
 
 add_executable(alg.partition_copy partition_copy.cpp)
+target_link_libraries(alg.partition_copy range-v3)
 add_test(test.alg.partition_copy, alg.partition_copy)
 
 add_executable(alg.partition_point partition_point.cpp)
+target_link_libraries(alg.partition_point range-v3)
 add_test(test.alg.partition_point, alg.partition_point)
 
 add_executable(alg.pop_heap pop_heap.cpp)
+target_link_libraries(alg.pop_heap range-v3)
 add_test(test.alg.pop_heap alg.pop_heap)
 
 add_executable(alg.prev_permutation prev_permutation.cpp)
+target_link_libraries(alg.prev_permutation range-v3)
 add_test(test.alg.prev_permutation alg.prev_permutation)
 
 add_executable(alg.push_heap push_heap.cpp)
+target_link_libraries(alg.push_heap range-v3)
 add_test(test.alg.push_heap alg.push_heap)
 
 add_executable(alg.remove remove.cpp)
+target_link_libraries(alg.remove range-v3)
 add_test(test.alg.remove, alg.remove)
 
 add_executable(alg.remove_copy remove_copy.cpp)
+target_link_libraries(alg.remove_copy range-v3)
 add_test(test.alg.remove_copy, alg.remove_copy)
 
 add_executable(alg.remove_copy_if remove_copy_if.cpp)
+target_link_libraries(alg.remove_copy_if range-v3)
 add_test(test.alg.remove_copy_if, alg.remove_copy_if)
 
 add_executable(alg.remove_if remove_if.cpp)
+target_link_libraries(alg.remove_if range-v3)
 add_test(test.alg.remove_if, alg.remove_if)
 
 add_executable(alg.replace replace.cpp)
+target_link_libraries(alg.replace range-v3)
 add_test(test.alg.replace, alg.replace)
 
 add_executable(alg.replace_copy replace_copy.cpp)
+target_link_libraries(alg.replace_copy range-v3)
 add_test(test.alg.replace_copy, alg.replace_copy)
 
 add_executable(alg.replace_copy_if replace_copy_if.cpp)
+target_link_libraries(alg.replace_copy_if range-v3)
 add_test(test.alg.replace_copy_if, alg.replace_copy_if)
 
 add_executable(alg.replace_if replace_if.cpp)
+target_link_libraries(alg.replace_if range-v3)
 add_test(test.alg.replace_if, alg.replace_if)
 
 add_executable(alg.reverse reverse.cpp)
+target_link_libraries(alg.reverse range-v3)
 add_test(test.alg.reverse, alg.reverse)
 
 add_executable(alg.reverse_copy reverse_copy.cpp)
+target_link_libraries(alg.reverse_copy range-v3)
 add_test(test.alg.reverse_copy, alg.reverse_copy)
 
 add_executable(alg.rotate rotate.cpp)
+target_link_libraries(alg.rotate range-v3)
 add_test(test.alg.rotate, alg.rotate)
 
 add_executable(alg.rotate_copy rotate_copy.cpp)
+target_link_libraries(alg.rotate_copy range-v3)
 add_test(test.alg.rotate_copy, alg.rotate_copy)
 
 add_executable(alg.sample sample.cpp)
+target_link_libraries(alg.sample range-v3)
 add_test(test.alg.sample, alg.sample)
 
 add_executable(alg.search search.cpp)
+target_link_libraries(alg.search range-v3)
 add_test(test.alg.search, alg.search)
 
 add_executable(alg.search_n search_n.cpp)
+target_link_libraries(alg.search_n range-v3)
 add_test(test.alg.search_n, alg.search_n)
 
 add_executable(alg.set_difference1 set_difference1.cpp)
@@ -287,33 +350,43 @@ add_executable(alg.set_union6 set_union6.cpp)
 add_test(test.alg.set_union6, alg.set_union6)
 
 add_executable(alg.shuffle shuffle.cpp)
+target_link_libraries(alg.shuffle range-v3)
 add_test(test.alg.shuffle, alg.shuffle)
 
 add_executable(alg.sort sort.cpp)
+target_link_libraries(alg.sort range-v3)
 add_test(test.alg.sort, alg.sort)
 
 add_executable(alg.sort_heap sort_heap.cpp)
+target_link_libraries(alg.sort_heap range-v3)
 add_test(test.alg.sort_heap, alg.sort_heap)
 
 add_executable(alg.stable_partition stable_partition.cpp)
+target_link_libraries(alg.stable_partition range-v3)
 add_test(test.alg.stable_partition, alg.stable_partition)
 
 add_executable(alg.stable_sort stable_sort.cpp)
+target_link_libraries(alg.stable_sort range-v3)
 add_test(test.alg.stable_sort, alg.stable_sort)
 
 add_executable(alg.swap_ranges swap_ranges.cpp)
+target_link_libraries(alg.swap_ranges range-v3)
 add_test(test.alg.swap_ranges, alg.swap_ranges)
 
 add_executable(alg.transform transform.cpp)
+target_link_libraries(alg.transform range-v3)
 add_test(test.alg.transform, alg.transform)
 
 add_executable(alg.unique unique.cpp)
+target_link_libraries(alg.unique range-v3)
 add_test(test.alg.unique, alg.unique)
 
 add_executable(alg.unique_copy unique_copy.cpp)
+target_link_libraries(alg.unique_copy range-v3)
 add_test(test.alg.unique_copy, alg.unique_copy)
 
 add_executable(alg.upper_bound upper_bound.cpp)
+target_link_libraries(alg.upper_bound range-v3)
 add_test(test.alg.upper_bound, alg.upper_bound)
 
 add_executable(alg.sort_n_with_buffer sort_n_with_buffer.cpp)

--- a/test/experimental/utility/CMakeLists.txt
+++ b/test/experimental/utility/CMakeLists.txt
@@ -1,3 +1,4 @@
 
 add_executable(generator generator.cpp)
+target_link_libraries(generator range-v3)
 add_test(test.generator generator)

--- a/test/experimental/view/CMakeLists.txt
+++ b/test/experimental/view/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_executable(view.shared shared.cpp)
+target_link_libraries(view.shared range-v3)
 add_test(test.view.shared, view.shared)

--- a/test/numeric/CMakeLists.txt
+++ b/test/numeric/CMakeLists.txt
@@ -1,14 +1,19 @@
 add_executable(num.accumulate accumulate.cpp)
+target_link_libraries(num.accumulate range-v3)
 add_test(test.num.accumulate num.accumulate)
 
 add_executable(num.adjacent_difference adjacent_difference.cpp)
+target_link_libraries(num.adjacent_difference range-v3)
 add_test(test.num.adjacent_difference num.adjacent_difference)
 
 add_executable(num.inner_product inner_product.cpp)
+target_link_libraries(num.inner_product range-v3)
 add_test(test.num.inner_product num.inner_product)
 
 add_executable(num.iota iota.cpp)
+target_link_libraries(num.iota range-v3)
 add_test(test.num.iota num.iota)
 
 add_executable(num.partial_sum partial_sum.cpp)
+target_link_libraries(num.partial_sum range-v3)
 add_test(test.num.partial_sum num.partial_sum)

--- a/test/utility/CMakeLists.txt
+++ b/test/utility/CMakeLists.txt
@@ -1,31 +1,40 @@
 add_executable(utility.basic_iterator basic_iterator.cpp)
+target_link_libraries(utility.basic_iterator range-v3)
 add_test(test.utility.basic_iterator utility.basic_iterator)
 
 add_executable(utility.concepts concepts.cpp)
+target_link_libraries(utility.concepts range-v3)
 add_test(test.utility.concepts utility.concepts)
 
 add_executable(utility.common_type common_type.cpp)
+target_link_libraries(utility.common_type range-v3)
 add_test(test.utility.common_type utility.common_type)
 
 add_executable(utility.functional functional.cpp)
+target_link_libraries(utility.functional range-v3)
 add_test(test.utility.functional utility.functional)
 
 add_executable(utility.iterator iterator.cpp)
+target_link_libraries(utility.iterator range-v3)
 add_test(test.utility.iterator utility.iterator)
 
 add_executable(utility.common_iterator common_iterator.cpp)
 add_test(test.utility.common_iterator utility.common_iterator)
 
 add_executable(utility.reverse_iterator reverse_iterator.cpp)
+target_link_libraries(utility.reverse_iterator range-v3)
 add_test(test.utility.reverse_iterator utility.reverse_iterator)
 
 add_executable(utility.swap swap.cpp)
+target_link_libraries(utility.swap range-v3)
 add_test(test.utility.swap utility.swap)
 
 add_executable(utility.variant variant.cpp)
+target_link_libraries(utility.variant range-v3)
 add_test(test.utility.variant utility.variant)
 
 add_executable(utility.meta meta.cpp)
+target_link_libraries(utility.meta range-v3)
 add_test(test.utility.meta utility.meta)
 
 add_executable(utility.scope_exit scope_exit.cpp)

--- a/test/utility/CMakeLists.txt
+++ b/test/utility/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(utility.iterator range-v3)
 add_test(test.utility.iterator utility.iterator)
 
 add_executable(utility.common_iterator common_iterator.cpp)
+target_link_libraries(utility.common_iterator range-v3)
 add_test(test.utility.common_iterator utility.common_iterator)
 
 add_executable(utility.reverse_iterator reverse_iterator.cpp)
@@ -38,4 +39,5 @@ target_link_libraries(utility.meta range-v3)
 add_test(test.utility.meta utility.meta)
 
 add_executable(utility.scope_exit scope_exit.cpp)
+target_link_libraries(utility.scope_exit range-v3)
 add_test(test.utility.scope_exit utility.scope_exit)

--- a/test/view/CMakeLists.txt
+++ b/test/view/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(view.bounded range-v3)
 add_test(test.view.bounded, view.bounded)
 
 add_executable(view.cartesian_product cartesian_product.cpp)
+target_link_libraries(view.cartesian_product range-v3)
 add_test(test.view.cartesian_product, view.cartesian_product)
 
 add_executable(view.chunk chunk.cpp)
@@ -82,6 +83,7 @@ target_link_libraries(view.join range-v3)
 add_test(test.view.join, view.join)
 
 add_executable(view.linear_distribute linear_distribute.cpp)
+target_link_libraries(view.linear_distribute range-v3)
 add_test(test.view.linear_distribute, view.linear_distribute)
 
 add_executable(view.map keys_value.cpp)
@@ -141,6 +143,7 @@ target_link_libraries(view.slice range-v3)
 add_test(test.view.slice, view.slice)
 
 add_executable(view.sliding sliding.cpp)
+target_link_libraries(view.sliding range-v3)
 add_test(test.view.sliding, view.sliding)
 
 add_executable(view.split split.cpp)
@@ -152,6 +155,7 @@ target_link_libraries(view.stride range-v3)
 add_test(test.view.stride, view.stride)
 
 add_executable(view.tail tail.cpp)
+target_link_libraries(view.tail range-v3)
 add_test(test.view.tail, view.tail)
 
 add_executable(view.take take.cpp)

--- a/test/view/CMakeLists.txt
+++ b/test/view/CMakeLists.txt
@@ -1,140 +1,183 @@
 add_executable(view.adjacent_remove_if adjacent_remove_if.cpp)
+target_link_libraries(view.adjacent_remove_if range-v3)
 add_test(test.view.adjacent_remove_if, view.adjacent_remove_if)
 
 add_executable(view.all all.cpp)
+target_link_libraries(view.all range-v3)
 add_test(test.view.all, view.all)
 
 add_executable(view.any_view any_view.cpp)
+target_link_libraries(view.any_view range-v3)
 add_test(test.view.any_view, view.any_view)
 
 add_executable(view.bounded bounded.cpp)
+target_link_libraries(view.bounded range-v3)
 add_test(test.view.bounded, view.bounded)
 
 add_executable(view.cartesian_product cartesian_product.cpp)
 add_test(test.view.cartesian_product, view.cartesian_product)
 
 add_executable(view.chunk chunk.cpp)
+target_link_libraries(view.chunk range-v3)
 add_test(test.view.chunk, view.chunk)
 
 add_executable(view.concat concat.cpp)
+target_link_libraries(view.concat range-v3)
 add_test(test.view.concat, view.concat)
 
 add_executable(view.const const.cpp)
+target_link_libraries(view.const range-v3)
 add_test(test.view.const, view.const)
 
 add_executable(view.counted counted.cpp)
+target_link_libraries(view.counted range-v3)
 add_test(test.view.counted, view.counted)
 
 add_executable(view.cycle cycle.cpp)
+target_link_libraries(view.cycle range-v3)
 add_test(test.view.cycle, view.cycle)
 
 add_executable(view.delimit delimit.cpp)
+target_link_libraries(view.delimit range-v3)
 add_test(test.view.delimit, view.delimit)
 
 add_executable(view.drop drop.cpp)
+target_link_libraries(view.drop range-v3)
 add_test(test.view.drop, view.drop)
 
 add_executable(view.drop_exactly drop_exactly.cpp)
+target_link_libraries(view.drop_exactly range-v3)
 add_test(test.view.drop_exactly, view.drop_exactly)
 
 add_executable(view.drop_while drop_while.cpp)
+target_link_libraries(view.drop_while range-v3)
 add_test(test.view.drop_while, view.drop_while)
 
 add_executable(view.generate generate.cpp)
+target_link_libraries(view.generate range-v3)
 add_test(test.view.generate, view.generate)
 
 add_executable(view.generate_n generate_n.cpp)
+target_link_libraries(view.generate_n range-v3)
 add_test(test.view.generate_n, view.generate_n)
 
 add_executable(view.group_by group_by.cpp)
+target_link_libraries(view.group_by range-v3)
 add_test(test.view.group_by, view.group_by)
 
 add_executable(view.indirect indirect.cpp)
+target_link_libraries(view.indirect range-v3)
 add_test(test.view.indirect, view.indirect)
 
 add_executable(view.intersperse intersperse.cpp)
+target_link_libraries(view.intersperse range-v3)
 add_test(test.view.intersperse, view.intersperse)
 
 add_executable(view.iota iota.cpp)
+target_link_libraries(view.iota range-v3)
 add_test(test.view.iota, view.iota)
 
 add_executable(view.join join.cpp)
+target_link_libraries(view.join range-v3)
 add_test(test.view.join, view.join)
 
 add_executable(view.linear_distribute linear_distribute.cpp)
 add_test(test.view.linear_distribute, view.linear_distribute)
 
 add_executable(view.map keys_value.cpp)
+target_link_libraries(view.map range-v3)
 add_test(test.view.map, view.map)
 
 add_executable(view.move move.cpp)
+target_link_libraries(view.move range-v3)
 add_test(test.view.move, view.move)
 
 add_executable(view.partial_sum partial_sum.cpp)
+target_link_libraries(view.partial_sum range-v3)
 add_test(test.view.partial_sum, view.partial_sum)
 
 add_executable(view.repeat repeat.cpp)
+target_link_libraries(view.repeat range-v3)
 add_test(test.view.repeat, view.repeat)
 
 add_executable(view.remove_if remove_if.cpp)
+target_link_libraries(view.remove_if range-v3)
 add_test(test.view.remove_if, view.remove_if)
 
 add_executable(view.replace replace.cpp)
+target_link_libraries(view.replace range-v3)
 add_test(test.view.replace, view.replace)
 
 add_executable(view.replace_if replace_if.cpp)
+target_link_libraries(view.replace_if range-v3)
 add_test(test.view.replace_if, view.replace_if)
 
 add_executable(view.reverse reverse.cpp)
+target_link_libraries(view.reverse range-v3)
 add_test(test.view.reverse, view.reverse)
 
 add_executable(view.sample sample.cpp)
+target_link_libraries(view.sample range-v3)
 add_test(test.view.sample, view.sample)
 
 add_executable(view.set_difference set_difference.cpp)
+target_link_libraries(view.set_difference range-v3)
 add_test(test.view.set_difference, view.set_difference)
 
 add_executable(view.set_intersection set_intersection.cpp)
+target_link_libraries(view.set_intersection range-v3)
 add_test(test.view.set_intersection, view.set_intersection)
 
 add_executable(view.set_symmetric_difference set_symmetric_difference.cpp)
+target_link_libraries(view.set_symmetric_difference range-v3)
 add_test(test.view.set_symmetric_difference, view.set_symmetric_difference)
 
 add_executable(view.set_union set_union.cpp)
+target_link_libraries(view.set_union range-v3)
 add_test(test.view.set_union, view.set_union)
 
 add_executable(view.slice slice.cpp)
+target_link_libraries(view.slice range-v3)
 add_test(test.view.slice, view.slice)
 
 add_executable(view.sliding sliding.cpp)
 add_test(test.view.sliding, view.sliding)
 
 add_executable(view.split split.cpp)
+target_link_libraries(view.split range-v3)
 add_test(test.view.split, view.split)
 
 add_executable(view.stride stride.cpp)
+target_link_libraries(view.stride range-v3)
 add_test(test.view.stride, view.stride)
 
 add_executable(view.tail tail.cpp)
 add_test(test.view.tail, view.tail)
 
 add_executable(view.take take.cpp)
+target_link_libraries(view.take range-v3)
 add_test(test.view.take, view.take)
 
 add_executable(view.take_exactly take_exactly.cpp)
+target_link_libraries(view.take_exactly range-v3)
 add_test(test.view.take_exactly, view.take_exactly)
 
 add_executable(view.take_while take_while.cpp)
+target_link_libraries(view.take_while range-v3)
 add_test(test.view.take_while, view.take_while)
 
 add_executable(view.tokenize tokenize.cpp)
+target_link_libraries(view.tokenize range-v3)
 add_test(test.view.tokenize, view.tokenize)
 
 add_executable(view.transform transform.cpp)
+target_link_libraries(view.transform range-v3)
 add_test(test.view.transform, view.transform)
 
 add_executable(view.unique unique.cpp)
+target_link_libraries(view.unique range-v3)
 add_test(test.view.unique, view.unique)
 
 add_executable(view.zip zip.cpp)
+target_link_libraries(view.zip range-v3)
 add_test(test.view.zip, view.zip)


### PR DESCRIPTION
I have integrated range-v3 into my library, however, the current CMakeLists.txt makes it almost impossible.

With my changes, one can use `add_subdirectory(range-v3)` and `target_link_libraries(foo range-v3)` to "link" the library to the target "foo".
See [my example](https://github.com/verri/jules/blob/8a42b703d4cfe795124291f502cabe4259111310/CMakeLists.txt#L73).

Other convenient changes:
- I've added `RANGE_V3_NO_{TESTING,EXAMPLE,PERF}`, so one can opt for a "light" integration; and
- I've added `range-v3-config.cmake` in the installation.