### PR TITLE
Build missing: Automatic package creation

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -18,6 +18,7 @@ class Rangev3Conan(ConanFile):
     url = "https://github.com/ericniebler/range-v3"
     description = """Experimental range library for C++11/14/17"""
     exports_sources = "include*", "LICENSE.txt"
+    build_policy = "missing"
 
     def package(self):
         self.copy("*.hpp", src="include", dst="include", keep_path=True)


### PR DESCRIPTION
I noticed that you (or your CI) are not building a binary package for Conan, just uploading the recipe, that, of course in your case, contains all the needed headers.

In this case, when a consumer of your library tries to install it, it will fail because it doesn't find the binary package available, and the consumer have to specify `--build range-v3` or `--build missing`. To improve the UX, for header only libraries there are two possible approaches:

a) The author generates the unique binary package (no settings involved, so there could be only 1 package) and uploads it together with the recipe.
b) The author specifies "build_policy=missing", so the package will be created on the fly.

This PR provides b).

Luis
