### PR TITLE
fix bug with decrementing the end of a non-const-iterable, bounded, bidirectional stride view

### DIFF
--- a/include/range/v3/view/stride.hpp
+++ b/include/range/v3/view/stride.hpp
@@ -77,9 +77,9 @@ namespace ranges
                 void set_offset(range_difference_type_t<Rng> const) const noexcept
                 {}
                 RANGES_CXX14_CONSTEXPR
-                range_difference_type_t<Rng> get_offset() const noexcept
+                range_difference_type_t<Rng> get_offset(bool check = true) const noexcept
                 {
-                    RANGES_EXPECT(0 <= offset_);
+                    RANGES_EXPECT(!check || 0 <= offset_);
                     return offset_;
                 }
 
@@ -117,7 +117,7 @@ namespace ranges
                 void set_offset(range_difference_type_t<Rng> const) const noexcept
                 {}
                 RANGES_CXX14_CONSTEXPR
-                range_difference_type_t<Rng> get_offset() const noexcept
+                range_difference_type_t<Rng> get_offset(bool = true) const noexcept
                 {
                     return 0;
                 }
@@ -174,6 +174,11 @@ namespace ranges
                     auto delta = -rng_->stride_;
                     if(it == ranges::end(rng_->base()))
                     {
+                        if(rng_->get_offset(false) < 0) // hasn't been set yet!
+                        {
+                            auto const rem = ranges::distance(rng_->base()) % rng_->stride_;
+                            rng_->set_offset(rem ? rng_->stride_ - rem : 0);
+                        }
                         delta += rng_->get_offset();
                     }
                     ranges::advance(it, delta);

--- a/test/view/stride.cpp
+++ b/test/view/stride.cpp
@@ -115,5 +115,23 @@ int main()
         ::check_equal(rng, {0,2,4,6});
     }
 
+    {
+        std::list<int> li;
+        copy(v, back_inserter(li));
+        iterator_range<std::list<int>::const_iterator> tmp{li.begin(), li.end()};
+        auto rng = tmp | view::stride(3);
+        using R = decltype(rng);
+        CONCEPT_ASSERT(BidirectionalView<R>());
+        CONCEPT_ASSERT(!RandomAccessRange<R>());
+        CONCEPT_ASSERT(BoundedRange<R>());
+        CONCEPT_ASSERT(!SizedRange<R>());
+        CONCEPT_ASSERT(!Range<R const>());
+        CHECK((*--rng.end()) == 48);
+        ::check_equal(rng,
+                    {0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45, 48});
+        ::check_equal(rng | view::reverse,
+                    {48, 45, 42, 39, 36, 33, 30, 27, 24, 21, 18, 15, 12, 9, 6, 3, 0});
+    }
+
     return ::test_result();
 }


### PR DESCRIPTION
@CaseyCarter I feel that `stride` needs a thorough rethink, but this puts a bandaid on the problem for now.

A better design, IMO, would be for a `stride` view of a Bidirectional, Common ("Bounded"), non-Sized range would not attempt to satisfy CommonRange since the end iterator could not be correctly decremented in O(1); the offset is not yet known.