### PR TITLE
Added explicit options to enable or disable testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -292,8 +292,7 @@ install:
   - if [ -n "$CLANG_VERSION" -a "$ASAN" == "On" -a "$LIBCXX" == "On" ]; then CXX_FLAGS="${CXX_FLAGS} -fsanitize=address"; fi
   # Required to test the C++ compiler since libc++ is compiled with MSan enabled:
   - if [ -n "$CLANG_VERSION" -a "$MSAN" == "On" -a "$LIBCXX" == "On" ]; then CXX_FLAGS="${CXX_FLAGS} -fsanitize=memory"; fi
-  - if [ "$HEADERS" == "On" ]; then NO_HEADER_CHECK=0; else NO_HEADER_CHECK=1; fi
-  - cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" -DCMAKE_EXE_LINKER_FLAGS="${CXX_LINKER_FLAGS}" -DRANGES_CXX_STD=$CPP -DRANGE_V3_NO_HEADER_CHECK=$NO_HEADER_CHECK -DRANGES_VERBOSE_BUILD=On -DRANGES_ASAN=$ASAN -DRANGES_MSAN=$MSAN -Wdev
+  - cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" -DCMAKE_EXE_LINKER_FLAGS="${CXX_LINKER_FLAGS}" -DRANGES_CXX_STD=$CPP -DRANGE_V3_HEADER_CHECKS=$HEADERS -DRANGES_VERBOSE_BUILD=On -DRANGES_ASAN=$ASAN -DRANGES_MSAN=$MSAN -Wdev
   - cat CMakeFiles/CMakeError.log
   - cat CMakeFiles/CMakeOutput.log
   - |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if(RANGE_V3_EXAMPLES)
   add_subdirectory(example)
 endif()
 
-if(RANGE_V3_BENCHMARKS)
+if(RANGE_V3_PERF)
   add_subdirectory(perf)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,19 +6,18 @@
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 cmake_minimum_required(VERSION 3.6)
+get_directory_property(is_subproject PARENT_DIRECTORY)
 
 project(Range-v3 CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON) # Export compilation data-base
 
+include(CTest) # invokes enable_testing() and defines BUILD_TESTING variable, defaulting to ON
 include(TestHeaders)
 include(ranges_options)
 include(ranges_env)
 include(ranges_flags)
-include(CTest)
-
-enable_testing()
 
 add_library(meta INTERFACE)
 target_include_directories(meta INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>)
@@ -31,15 +30,15 @@ target_link_libraries(range-v3 INTERFACE meta)
 
 add_subdirectory(doc)
 
-if(NOT RANGE_V3_NO_TESTING)
+if(RANGE_V3_TESTS)
   add_subdirectory(test)
 endif()
 
-if(NOT RANGE_V3_NO_EXAMPLE)
+if(RANGE_V3_EXAMPLES)
   add_subdirectory(example)
 endif()
 
-if(NOT RANGE_V3_NO_PERF)
+if(RANGE_V3_BENCHMARKS)
   add_subdirectory(perf)
 endif()
 
@@ -70,10 +69,10 @@ file(GLOB_RECURSE RANGE_V3_PUBLIC_HEADERS_ABSOLUTE
                   "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp")
 
 include(TestHeaders)
-if(RANGE_V3_NO_HEADER_CHECK)
-  add_custom_target(headers SOURCES ${RANGE_V3_PUBLIC_HEADERS_ABSOLUTE})
-else()
+if(RANGE_V3_HEADER_CHECKS)
   add_custom_target(headers ALL SOURCES ${RANGE_V3_PUBLIC_HEADERS_ABSOLUTE})
+else()
+  add_custom_target(headers SOURCES ${RANGE_V3_PUBLIC_HEADERS_ABSOLUTE})
 endif()
 generate_standalone_header_tests(EXCLUDE_FROM_ALL MASTER_TARGET headers HEADERS ${RANGE_V3_PUBLIC_HEADERS})
 

--- a/cmake/ranges_options.cmake
+++ b/cmake/ranges_options.cmake
@@ -40,6 +40,8 @@ CMAKE_DEPENDENT_OPTION(RANGE_V3_EXAMPLES
   "Build the Range-v3 examples and integrate with ctest"
   ON "${is_subproject}" OFF)
 
-CMAKE_DEPENDENT_OPTION(RANGE_V3_BENCHMARKS
+CMAKE_DEPENDENT_OPTION(RANGE_V3_PERF
   "Build the Range-v3 performance benchmarks"
   ON "${is_subproject}" OFF)
+
+mark_as_advanced(RANGE_V3_PERF)

--- a/cmake/ranges_options.cmake
+++ b/cmake/ranges_options.cmake
@@ -7,7 +7,6 @@
 include(CMakeDependentOption)
 
 set(RANGES_CXX_STD 11 CACHE STRING "C++ standard version.")
-option(RANGE_V3_NO_HEADER_CHECK "Build all headers." OFF)
 option(RANGE_BUILD_CALENDAR_EXAMPLE "Builds the calendar example." ON)
 option(RANGES_ASAN "Run the tests using AddressSanitizer." OFF)
 option(RANGES_MSAN "Run the tests using MemorySanitizer." OFF)
@@ -28,3 +27,19 @@ endif()
 if (RANGES_VERBOSE_BUILD)
   message("[range-v3]: verbose build enabled.")
 endif()
+
+CMAKE_DEPENDENT_OPTION(RANGE_V3_TESTS
+  "Build the Range-v3 tests and integrate with ctest"
+  "${BUILD_TESTING}" "${is_subproject}" OFF)
+
+CMAKE_DEPENDENT_OPTION(RANGE_V3_HEADER_CHECKS
+  "Build the Range-v3 header checks and integrate with ctest"
+  "${BUILD_TESTING}" "${is_subproject}" OFF)
+
+CMAKE_DEPENDENT_OPTION(RANGE_V3_EXAMPLES
+  "Build the Range-v3 examples and integrate with ctest"
+  ON "${is_subproject}" OFF)
+
+CMAKE_DEPENDENT_OPTION(RANGE_V3_BENCHMARKS
+  "Build the Range-v3 performance benchmarks"
+  ON "${is_subproject}" OFF)


### PR DESCRIPTION
These options are visible from the cmake-gui and cmake-curses-gui;
their presence is more discoverable than the local variables used
previously.

In addition, the default values for these options is contingent
upon whether range-v3 is the highest level project. When range-v3
is composed in another project (as a git submodule, for instance)
tests are not built and no option appears in the GUI.