### PR TITLE
Fix view::cartesian_product's cursor when adapting a non-Bounded rand…

### DIFF
--- a/include/range/v3/view/cartesian_product.hpp
+++ b/include/range/v3/view/cartesian_product.hpp
@@ -174,7 +174,7 @@ namespace ranges
                     cursor const &that, meta::size_t<1>, dist_info const inf) const
                 {
                     auto const my_distance = std::get<0>(that.its_) - std::get<0>(its_);
-                    return my_distance * inf.size_product + inf.distance;
+                    return static_cast<std::ptrdiff_t>(my_distance * inf.size_product + inf.distance);
                 }
                 template<std::size_t N>
                 std::ptrdiff_t distance_(
@@ -245,8 +245,8 @@ namespace ranges
                 cursor(end_tag, constify_if<cartesian_product_view> &view, std::false_type) // !Bounded
                   : cursor(begin_tag{}, view)
                 {
-                    std::get<0>(its_) =
-                        std::get<0>(its_) + ranges::distance(std::get<0>(view.views_));
+                    // Only called when the 0th view type is !Bounded && RandomAccess && Sized
+                    std::get<0>(its_) += ranges::distance(std::get<0>(view.views_));
                 }
             public:
                 using value_type = std::tuple<range_value_type_t<Views>...>;

--- a/include/range/v3/view/cartesian_product.hpp
+++ b/include/range/v3/view/cartesian_product.hpp
@@ -237,6 +237,17 @@ namespace ranges
                     return check_at_end_(meta::size_t<N - 1>{}, at_end ||
                         std::get<N - 1>(its_) == ranges::end(std::get<N - 1>(view_->views_)));
                 }
+                cursor(end_tag, constify_if<cartesian_product_view> &view, std::true_type) // Bounded
+                  : cursor(begin_tag{}, view)
+                {
+                    std::get<0>(its_) = ranges::end(std::get<0>(view.views_));
+                }
+                cursor(end_tag, constify_if<cartesian_product_view> &view, std::false_type) // !Bounded
+                  : cursor(begin_tag{}, view)
+                {
+                    std::get<0>(its_) =
+                        std::get<0>(its_) + ranges::distance(std::get<0>(view.views_));
+                }
             public:
                 using value_type = std::tuple<range_value_type_t<Views>...>;
                 cursor() = default;
@@ -247,10 +258,8 @@ namespace ranges
                     check_at_end_(meta::size_t<sizeof...(Views)>{});
                 }
                 explicit cursor(end_tag, constify_if<cartesian_product_view> &view)
-                  : cursor(begin_tag{}, view)
-                {
-                    std::get<0>(its_) = ranges::end(std::get<0>(view.views_));
-                }
+                  : cursor(end_tag{}, view, BoundedView<meta::at_c<meta::list<Views...>, 0>>{})
+                {}
                 ranges::common_tuple<range_reference_t<Views>...> read() const
                 {
                     return tuple_transform(its_, ranges::dereference);

--- a/test/view/cartesian_product.cpp
+++ b/test/view/cartesian_product.cpp
@@ -19,6 +19,8 @@
 #include <range/v3/span.hpp>
 #include <range/v3/utility/tuple_algorithm.hpp>
 #include <range/v3/view/cartesian_product.hpp>
+#include <range/v3/view/iota.hpp>
+#include <range/v3/view/take_exactly.hpp>
 #include <range/v3/view/empty.hpp>
 #include <range/v3/view/reverse.hpp>
 #include "../simple_test.hpp"
@@ -129,6 +131,21 @@ void test_empty_range()
     }
 }
 
+void test_bug_820()
+{
+    // https://github.com/ericniebler/range-v3/issues/820
+    using CT = common_tuple<int, int>;
+    std::initializer_list<CT> control = {
+        CT{0, 0}, CT{0, 1}, CT{0, 2},
+        CT{1, 0}, CT{1, 1}, CT{1, 2},
+        CT{2, 0}, CT{2, 1}, CT{2, 2}
+    };
+
+    auto x = ranges::view::iota(0) | ranges::view::take_exactly(3);
+    auto y = ranges::view::cartesian_product(x, x);
+    ::check_equal(y, control);
+}
+
 int main()
 {
     int some_ints[] = {0,1,2,3};
@@ -178,6 +195,7 @@ int main()
 
     test_empty_set();
     test_empty_range();
+    test_bug_820();
 
     return test_result();
 }


### PR DESCRIPTION
…om-access range, fixes #820