### PR TITLE
Don't workaround clang 37556 on non-clang

### DIFF
--- a/include/range/v3/algorithm/stable_sort.hpp
+++ b/include/range/v3/algorithm/stable_sort.hpp
@@ -48,7 +48,6 @@
 #include <range/v3/utility/iterator_concepts.hpp>
 #include <range/v3/utility/iterator_traits.hpp>
 #include <range/v3/utility/functional.hpp>
-#include <range/v3/utility/counted_iterator.hpp>
 #include <range/v3/algorithm/merge.hpp>
 #include <range/v3/algorithm/min.hpp>
 #include <range/v3/algorithm/sort.hpp>

--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -485,4 +485,15 @@ namespace ranges {
     }
 }
 
+#if !defined(RANGES_BROKEN_CPO_LOOKUP) && !defined(RANGES_DOXYGEN_INVOKED)
+#if defined(__clang__) // Workaround https://bugs.llvm.org/show_bug.cgi?id=37556
+#define RANGES_BROKEN_CPO_LOOKUP 1
+#elif defined(__GNUC__) && __GNUC__ < 6 // Workaround unknown GCC bug
+#define RANGES_BROKEN_CPO_LOOKUP 1
+#endif
+#endif
+#ifndef RANGES_BROKEN_CPO_LOOKUP
+#define RANGES_BROKEN_CPO_LOOKUP 0
+#endif
+
 #endif

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -421,14 +421,8 @@ namespace ranges
         template<typename Cur>
         struct basic_mixin;
 
-        /// \cond
-        namespace _basic_iterator_
-        {
-            template<typename Cur>
-            struct basic_iterator;
-        }
-        using _basic_iterator_::basic_iterator;
-        /// \endcond
+        template<typename Cur>
+        struct basic_iterator;
 
         template<cardinality>
         struct basic_view : view_base
@@ -442,14 +436,8 @@ namespace ranges
                  cardinality C = range_cardinality<BaseRng>::value>
         struct view_adaptor;
 
-        /// \cond
-        namespace _common_iterator_
-        {
-            template<typename I, typename S>
-            struct common_iterator;
-        }
-        using _common_iterator_::common_iterator;
-        /// \endcond
+        template<typename I, typename S>
+        struct common_iterator;
 
         template<typename I, typename S>
         using common_iterator_t =
@@ -535,12 +523,6 @@ namespace ranges
         }
 
         struct default_sentinel { };
-
-        namespace _counted_iterator_
-        {
-            template<typename I, typename = void>
-            struct counted_iterator;
-        }
 
         template<typename I>
         struct move_iterator;

--- a/include/range/v3/utility/common_iterator.hpp
+++ b/include/range/v3/utility/common_iterator.hpp
@@ -44,15 +44,15 @@ namespace ranges
             }
         }
 
-        // Detail namespace, otherwise clang complains that iter_move
-        // and iter_swap conflict with the namespace scope objects of the
-        // same name.
-        namespace _common_iterator_
-        {
-        /// \endcond
+#if RANGES_BROKEN_CPO_LOOKUP
+        namespace _common_iterator_ { template <typename> struct adl_hook {}; }
+#endif
 
         template<typename I, typename S>
         struct common_iterator
+#if RANGES_BROKEN_CPO_LOOKUP
+          : private _common_iterator_::adl_hook<common_iterator<I, S>>
+#endif
         {
         private:
             CONCEPT_ASSERT(Iterator<I>());
@@ -167,6 +167,7 @@ namespace ranges
                 return common_iterator(ranges::get<0>(data_)++);
             }
 
+#if !RANGES_BROKEN_CPO_LOOKUP
             CONCEPT_REQUIRES(InputIterator<I>())
             friend RANGES_CXX14_CONSTEXPR
             auto iter_move(const common_iterator& i)
@@ -184,7 +185,31 @@ namespace ranges
                     ranges::get<0>(detail::cidata(x)),
                     ranges::get<0>(detail::cidata(y)))
             )
+#endif
         };
+
+#if RANGES_BROKEN_CPO_LOOKUP
+        namespace _common_iterator_
+        {
+            template<typename I, typename S,
+                CONCEPT_REQUIRES_(InputIterator<I>())>
+            RANGES_CXX14_CONSTEXPR
+            auto iter_move(common_iterator<I, S> const &i)
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+            (
+                ranges::iter_move(ranges::get<0>(detail::cidata(i)))
+            )
+            template<typename I1, typename S1, typename I2, typename S2,
+                CONCEPT_REQUIRES_(IndirectlySwappable<I2, I1>())>
+            auto iter_swap(common_iterator<I1, S1> const &x, common_iterator<I2, S2> const &y)
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+            (
+                ranges::iter_swap(
+                    ranges::get<0>(detail::cidata(x)),
+                    ranges::get<0>(detail::cidata(y)))
+            )
+        }
+#endif
 
         template<typename I1, typename I2, typename S1, typename S2,
             CONCEPT_REQUIRES_(Sentinel<S1, I2>() && Sentinel<S2, I1>() &&
@@ -227,10 +252,6 @@ namespace ranges
                     ranges::get<0>(detail::cidata(x)) - ranges::get<1>(detail::cidata(y)) :
                     ranges::get<0>(detail::cidata(x)) - ranges::get<0>(detail::cidata(y)));
         }
-
-        /// \cond
-        } // namespace _common_iterator_
-        /// \endcond
 
         template<typename I, typename S>
         struct value_type<common_iterator<I, S>>

--- a/include/range/v3/utility/move.hpp
+++ b/include/range/v3/utility/move.hpp
@@ -63,6 +63,11 @@ namespace ranges
         /// \cond
         namespace adl_move_detail
         {
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5
+            // Workaround unclassified GCC4 bug
+            void iter_move(); // unqualified name lookup block
+#endif
+
             template<typename T,
                 typename = decltype(iter_move(std::declval<T>()))>
             std::true_type try_adl_iter_move_(int);


### PR DESCRIPTION
Move class template declarations from nested detail namespaces into `ranges:v3`, and - on clang only - implement friends with the same names as CPOs in those same detail namespaces. This affects:

* `tagged`
* `basic_iterator`
* `common_iterator`
* `counted_iterator`

NOTE TO REVIEWERS: This changes indentation for some big chunks of code, you may want to ignore whitespace changes to focus on the actual differences.