### PR TITLE
Clang/C2 is dead - long live ClangCL!

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,12 +13,6 @@ project(Range-v3 CXX)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON) # Export compilation data-base
 
-include(CTest) # invokes enable_testing() and defines BUILD_TESTING variable, defaulting to ON
-include(TestHeaders)
-include(ranges_options)
-include(ranges_env)
-include(ranges_flags)
-
 add_library(meta INTERFACE)
 target_include_directories(meta INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>)
 target_include_directories(meta SYSTEM INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
@@ -27,6 +21,12 @@ add_library(range-v3 INTERFACE)
 target_include_directories(range-v3 INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>)
 target_include_directories(range-v3 SYSTEM INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
 target_link_libraries(range-v3 INTERFACE meta)
+
+include(CTest) # invokes enable_testing() and defines BUILD_TESTING variable, defaulting to ON
+include(TestHeaders)
+include(ranges_options)
+include(ranges_env)
+include(ranges_flags)
 
 # Test for <thread>
 try_compile(RANGE_V3_TRY_THREAD ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/thread_test_code.cpp)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ The code is known to work on the following compilers:
 
 - clang 3.6.2 (or later)
 - GCC 4.9.1 (or later) (C++14 support requires GCC 5.2; C++14 "extended constexpr" support is poor before 6.1.)
-- "Clang with Microsoft CodeGen" (Clang/C2) VS2015 Update 3 (or later)
+- Clang/LLVM 6 (or later) on Windows (older versions may work - we haven't tested.)
+
+[ Note: We've "retired" support for Clang/C2 with the VS2015 toolset (i.e., the `v140_clang_c2` toolset) which Microsoft no longer supports for C++ use. We no longer have CI runs, but haven't gone out of our way to break anything, so it will likely continue to work. ]
 
 **Development Status:** This code is fairly stable, well-tested, and suitable for casual use, although currently lacking documentation. No promise is made about support or long-term stability. This code *will* evolve without regard to backwards compatibility.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 shallow_clone: true
 
+image: Visual Studio 2017
+
 platform:
   - x86
   - x64
@@ -8,31 +10,45 @@ configuration:
   - Debug
   - Release
 
+environment:
+  matrix:
+    - CPP: latest
+
+#    - CPP: 14
+
 cache:
-  - C:\cmake-3.6.3-win32-x86
+  - C:\ninja-1.8.2
 
 install:
   - ps: |
-      if (![IO.File]::Exists("C:\cmake-3.6.3-win32-x86\bin\cmake.exe")) {
-        Start-FileDownload 'https://cmake.org/files/v3.6/cmake-3.6.3-win32-x86.zip'
-        7z x -y cmake-3.6.3-win32-x86.zip -oC:\
+      if (![IO.File]::Exists("C:\ninja-1.8.2\ninja.exe")) {
+        Start-FileDownload 'https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-win.zip'
+        7z x -y ninja-win.zip -oC:\ninja-1.8.2
       }
-      $env:PATH="C:\cmake-3.6.3-win32-x86\bin;$env:PATH"
+      $env:PATH="C:\ninja-1.8.2;$env:PATH"
+  - for /f "tokens=1* delims=" %%i in ('"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath') do call "%%i\VC\Auxiliary\Build\vcvarsall.bat" %PLATFORM:x86=x64_x86%
+  - cmake --version
+  - ninja --version
+  - clang-cl --version
+
+build_script:
   - mkdir build && cd build
   - ps: |
-      if ($env:PLATFORM -eq "x64" -and $env:CONFIGURATION -eq "Debug") {
-        $env:HEADER_CHECK=1
+      $env:CC='clang-cl'
+      $env:CXX='clang-cl'
+      $env:HEADER_CHECK=0
+      if ($env:PLATFORM -eq "x64") {
+        if ($env:CONFIGURATION -eq "Debug") {
+          $env:HEADER_CHECK=1
+        }
       } else {
-        $env:HEADER_CHECK=0
+        $env:CXXFLAGS='-m32'
+        $env:CFLAGS='-m32'
       }
-  - cmake .. -DRANGE_V3_HEADER_CHECKS=%HEADER_CHECK% -DCMAKE_BUILD_TYPE=%CONFIGURATION% -T v140_clang_c2
-
-build:
-  project: c:/projects/range-v3/build/ALL_BUILD.vcxproj
-  parallel: true
-  verbosity: minimal
+  - cmake .. -G Ninja -Wdev -DRANGE_V3_HEADER_CHECKS=%HEADER_CHECK% -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DRANGES_CXX_STD=%CPP%
+  - ninja -v
 
 test_script:
-  - ctest -j2
+  - ctest -j2 --output-on-failure
 
 deploy: off

--- a/cmake/ranges_env.cmake
+++ b/cmake/ranges_env.cmake
@@ -7,9 +7,9 @@ include(CheckCXXCompilerFlag)
 
 if("x${CMAKE_CXX_COMPILER_ID}" MATCHES "x.*Clang")
   if("x${CMAKE_CXX_SIMULATE_ID}" STREQUAL "xMSVC")
-    set (RANGES_CXX_COMPILER_CLANGC2 TRUE)
+    set (RANGES_CXX_COMPILER_CLANGCL TRUE)
     if (RANGES_VERBOSE_BUILD)
-      message("[range-v3]: compiler is clangC2.")
+      message("[range-v3]: compiler is clang-cl.")
     endif()
   else()
     set (RANGES_CXX_COMPILER_CLANG TRUE)
@@ -45,11 +45,14 @@ else()
   message("[range-v3 warning]: unknown system ${CMAKE_SYSTEM_NAME} !")
 endif()
 
-# Clang/C2 will blow up with various parts of the standard library
+# Clang-CL will blow up with various parts of the standard library
 # if compiling with -std less than c++14.
-if ((RANGES_CXX_COMPILER_CLANGC2) AND (RANGES_CXX_STD EQUAL 11))
-  set(CMAKE_CXX_STANDARD 14)
-  set(RANGES_CXX_STD 14)
+if (RANGES_CXX_COMPILER_CLANGCL)
+  if (RANGES_CXX_STD EQUAL 11)
+    set(CMAKE_CXX_STANDARD 14)
+    set(RANGES_CXX_STD 14)
+  endif()
+  target_compile_definitions(range-v3 INTERFACE _SILENCE_CXX17_TEMPORARY_BUFFER_DEPRECATION_WARNING)
 endif()
 
 # Build type

--- a/cmake/ranges_flags.cmake
+++ b/cmake/ranges_flags.cmake
@@ -18,13 +18,21 @@ endmacro()
 # All compilation flags
 # Language flag: version of the C++ standard to use
 message("[range-v3]: C++ std=${RANGES_CXX_STD}")
-ranges_append_flag(RANGES_HAS_CXXSTD "-std=c++${RANGES_CXX_STD}")
+if (RANGES_CXX_COMPILER_CLANGCL)
+  ranges_append_flag(RANGES_HAS_CXXSTDCOLON "-std:c++${RANGES_CXX_STD}")
+else()
+  ranges_append_flag(RANGES_HAS_CXXSTD "-std=c++${RANGES_CXX_STD}")
+endif()
 
 # Enable "normal" warnings and make them errors:
-ranges_append_flag(RANGES_HAS_WERROR -Werror)
-ranges_append_flag(RANGES_HAS_WX -WX)
-ranges_append_flag(RANGES_HAS_WALL -Wall)
-ranges_append_flag(RANGES_HAS_WEXTRA -Wextra)
+if (RANGES_CXX_COMPILER_CLANGCL)
+  ranges_append_flag(RANGES_HAS_W3 -W3)
+  ranges_append_flag(RANGES_HAS_WX -WX)
+else()
+  ranges_append_flag(RANGES_HAS_WALL -Wall)
+  ranges_append_flag(RANGES_HAS_WEXTRA -Wextra)
+  ranges_append_flag(RANGES_HAS_WERROR -Werror)
+endif()
 
 if (RANGES_ENV_LINUX AND RANGES_CXX_COMPILER_CLANG)
   # On linux libc++ re-exports the system math headers. The ones from libstdc++
@@ -134,9 +142,7 @@ if (RANGES_RELEASE_BUILD)
     ranges_append_flag(RANGES_HAS_O2 -O2)
   endif()
   ranges_append_flag(RANGES_HAS_STRICT_ALIASING -fstrict-aliasing)
-  if (NOT RANGES_CXX_COMPILER_CLANGC2)
-    ranges_append_flag(RANGES_HAS_STRICT_VTABLE_POINTERS -fstrict-vtable-pointers)
-  endif()
+  ranges_append_flag(RANGES_HAS_STRICT_VTABLE_POINTERS -fstrict-vtable-pointers)
   ranges_append_flag(RANGES_HAS_FAST_MATH -ffast-math)
   ranges_append_flag(RANGES_HAS_VECTORIZE -fvectorize)
 

--- a/example/comprehensions.cpp
+++ b/example/comprehensions.cpp
@@ -31,8 +31,8 @@ main()
 
     //// This alternate syntax also works:
     // auto triples = ints(1)      >>= [] (int z) { return
-    //               ints(1, z+1) >>= [=](int x) { return
-    //               ints(x, z+1) >>= [=](int y) { return
+    //                ints(1, z+1) >>= [=](int x) { return
+    //                ints(x, z+1) >>= [=](int y) { return
     //    yield_if(x*x + y*y == z*z,
     //        std::make_tuple(x, y, z)); };}; };
 

--- a/include/meta/meta.hpp
+++ b/include/meta/meta.hpp
@@ -1981,8 +1981,12 @@ namespace meta
             template <typename... T, typename V>
             struct find_index_<list<T...>, V>
             {
+#if defined(__clang__) & __clang_major__ < 6
                 // Explicitly specify extent to avoid https://llvm.org/bugs/show_bug.cgi?id=28385
                 static constexpr bool s_v[sizeof...(T)] = {std::is_same<T, V>::value...};
+#else
+                static constexpr bool s_v[] = {std::is_same<T, V>::value...};
+#endif
                 using type = size_t<find_index_i_(s_v, s_v + sizeof...(T))>;
             };
         } // namespace detail
@@ -2034,8 +2038,12 @@ namespace meta
             template <typename... T, typename V>
             struct reverse_find_index_<list<T...>, V>
             {
+#if defined(__clang__) & __clang_major__ < 6
                 // Explicitly specify extent to avoid https://llvm.org/bugs/show_bug.cgi?id=28385
                 static constexpr bool s_v[sizeof...(T)] = {std::is_same<T, V>::value...};
+#else
+                static constexpr bool s_v[] = {std::is_same<T, V>::value...};
+#endif
                 using type = size_t<reverse_find_index_i_(s_v, s_v + sizeof...(T), sizeof...(T))>;
             };
         } // namespace detail
@@ -2122,8 +2130,12 @@ namespace meta
             struct find_if_<list<List...>, Fun,
                             void_<integer_sequence<bool, bool(invoke<Fun, List>::type::value)...>>>
             {
+#if defined(__clang__) & __clang_major__ < 6
                 // Explicitly specify extent to avoid https://llvm.org/bugs/show_bug.cgi?id=28385
                 static constexpr bool s_v[sizeof...(List)] = {invoke<Fun, List>::type::value...};
+#else
+                static constexpr bool s_v[] = {invoke<Fun, List>::type::value...};
+#endif
                 using type =
                     drop_c<list<List...>, detail::find_if_i_(s_v, s_v + sizeof...(List)) - s_v>;
             };
@@ -2178,8 +2190,12 @@ namespace meta
                 list<List...>, Fun,
                 void_<integer_sequence<bool, bool(invoke<Fun, List>::type::value)...>>>
             {
+#if defined(__clang__) & __clang_major__ < 6
                 // Explicitly specify extent to avoid https://llvm.org/bugs/show_bug.cgi?id=28385
                 static constexpr bool s_v[sizeof...(List)] = {invoke<Fun, List>::type::value...};
+#else
+                static constexpr bool s_v[] = {invoke<Fun, List>::type::value...};
+#endif
                 using type =
                   drop_c<list<List...>, detail::reverse_find_if_i_(s_v, s_v + sizeof...(List),
                                                                    s_v + sizeof...(List)) - s_v>;
@@ -2301,8 +2317,12 @@ namespace meta
             template <typename... List, typename T>
             struct count_<list<List...>, T>
             {
+#if defined(__clang__) & __clang_major__ < 6
                 // Explicitly specify extent to avoid https://llvm.org/bugs/show_bug.cgi?id=28385
                 static constexpr bool s_v[sizeof...(List)] = {std::is_same<T, List>::value...};
+#else
+                static constexpr bool s_v[] = {std::is_same<T, List>::value...};
+#endif
                 using type = meta::size_t<detail::count_i_(s_v, s_v + sizeof...(List), 0u)>;
             };
         }
@@ -2341,8 +2361,12 @@ namespace meta
             struct count_if_<list<List...>, Fn,
                              void_<integer_sequence<bool, bool(invoke<Fn, List>::type::value)...>>>
             {
+#if defined(__clang__) & __clang_major__ < 6
                 // Explicitly specify extent to avoid https://llvm.org/bugs/show_bug.cgi?id=28385
                 static constexpr bool s_v[sizeof...(List)] = {invoke<Fn, List>::type::value...};
+#else
+                static constexpr bool s_v[] = {invoke<Fn, List>::type::value...};
+#endif
                 using type = meta::size_t<detail::count_i_(s_v, s_v + sizeof...(List), 0u)>;
             };
         }

--- a/include/range/v3/detail/adl_get.hpp
+++ b/include/range/v3/detail/adl_get.hpp
@@ -1,0 +1,48 @@
+/// \file
+// Range v3 library
+//
+//  Copyright Casey Carter 2018
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+
+#ifndef RANGES_V3_DETAIL_ADL_GET_HPP
+#define RANGES_V3_DETAIL_ADL_GET_HPP
+
+#include <cstddef>
+#include <range/v3/range_fwd.hpp>
+
+namespace ranges
+{
+    inline namespace v3
+    {
+        namespace detail
+        {
+            namespace _adl_get_
+            {
+                template<class> void get();
+
+                template<std::size_t I, typename Tuple>
+                constexpr auto adl_get(Tuple &&t)
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                (
+                    get<I>(static_cast<Tuple &&>(t))
+                )
+
+                template<typename T, typename Tuple>
+                constexpr auto adl_get(Tuple &&t)
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                (
+                    get<T>(static_cast<Tuple &&>(t))
+                )
+            }
+            using _adl_get_::adl_get;
+        }
+    }
+}
+
+#endif // RANGES_V3_DETAIL_ADL_GET_HPP

--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -18,8 +18,8 @@
 #include <iosfwd>
 #if (defined(NDEBUG) && !defined(RANGES_ENSURE_MSG)) || \
     (!defined(NDEBUG) && !defined(RANGES_ASSERT) && \
-     defined(__GNUC__) && !defined(__clang__) && \
-     (__GNUC__ < 5 || defined(__MINGW32__)))
+     ((defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 5 || defined(__MINGW32__))) || \
+      defined(_MSVC_STL_VERSION)))
 #include <cstdio>
 #include <cstdlib>
 
@@ -41,8 +41,9 @@ namespace ranges
 #endif
 
 #ifndef RANGES_ASSERT
-#if !defined(NDEBUG) && defined(__GNUC__) && !defined(__clang__) && \
-    (__GNUC__ < 5 || defined(__MINGW32__))
+#if !defined(NDEBUG) && \
+    ((defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 5 || defined(__MINGW32__))) || \
+     defined(_MSVC_STL_VERSION))
 #define RANGES_ASSERT(...) \
     static_cast<void>((__VA_ARGS__) ? void(0) : \
         ::ranges::detail::assert_failure(__FILE__, __LINE__, "assertion failed: " #__VA_ARGS__))

--- a/include/range/v3/utility/move.hpp
+++ b/include/range/v3/utility/move.hpp
@@ -63,7 +63,7 @@ namespace ranges
         /// \cond
         namespace adl_move_detail
         {
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5
+#if (defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5) || defined(_MSC_VER)
             // Workaround unclassified GCC4 bug
             void iter_move(); // unqualified name lookup block
 #endif

--- a/include/range/v3/utility/safe_int.hpp
+++ b/include/range/v3/utility/safe_int.hpp
@@ -290,8 +290,6 @@ namespace ranges
         template<typename Int>
         using make_safe_int_t = typename make_safe_int<Int>::type;
 
-        static_assert(std::is_literal_type<safe_int<int>>::value, "");
-
         template<typename SignedInteger>
         constexpr SignedInteger safe_int<SignedInteger>::pos_inf_;
 
@@ -305,11 +303,6 @@ namespace ranges
 
 namespace std
 {
-    template<typename T>
-    struct is_integral<::ranges::v3::safe_int<T>>
-      : is_integral<T>
-    {};
-
     template<typename T>
     class numeric_limits<::ranges::v3::safe_int<T>>
       : public numeric_limits<T>

--- a/include/range/v3/utility/tagged_pair.hpp
+++ b/include/range/v3/utility/tagged_pair.hpp
@@ -17,6 +17,7 @@
 #include <utility>
 #include <meta/meta.hpp>
 #include <range/v3/range_fwd.hpp>
+#include <range/v3/detail/adl_get.hpp>
 #include <range/v3/utility/concepts.hpp>
 #include <range/v3/utility/swap.hpp>
 
@@ -32,19 +33,6 @@ namespace ranges
 
             template<typename T>
             using tag_elem = meta::back<meta::as_list<T>>;
-
-            namespace adl_get_detail
-            {
-                using std::get;
-
-                template<std::size_t I, typename T>
-                constexpr auto adl_get(T && t)
-                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
-                (
-                    get<I>((T &&) t)
-                )
-            }
-            using adl_get_detail::adl_get;
         }
 
         namespace _tagged_
@@ -157,6 +145,48 @@ namespace ranges
             }
         }
 #endif
+
+        template<std::size_t I, typename Base, typename... Tags>
+        auto get(tagged<Base, Tags...> &t)
+        RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+        (
+            ranges::detail::adl_get<I>(static_cast<Base &>(t))
+        )
+        template<std::size_t I, typename Base, typename... Tags>
+        auto get(tagged<Base, Tags...> const &t)
+        RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+        (
+            ranges::detail::adl_get<I>(static_cast<Base const &>(t))
+        )
+        template<std::size_t I, typename Base, typename... Tags>
+        auto get(tagged<Base, Tags...> &&t)
+        RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+        (
+            ranges::detail::adl_get<I>(static_cast<Base &&>(t))
+        )
+        template<std::size_t I, typename Base, typename... Tags>
+        void get(tagged<Base, Tags...> const &&) = delete;
+
+        template<typename T, typename Base, typename... Tags>
+        auto get(tagged<Base, Tags...> &t)
+        RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+        (
+            ranges::detail::adl_get<T>(static_cast<Base &>(t))
+        )
+        template<typename T, typename Base, typename... Tags>
+        auto get(tagged<Base, Tags...> const &t)
+        RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+        (
+            ranges::detail::adl_get<T>(static_cast<Base const &>(t))
+        )
+        template<typename T, typename Base, typename... Tags>
+        auto get(tagged<Base, Tags...> &&t)
+        RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+        (
+            ranges::detail::adl_get<T>(static_cast<Base &&>(t))
+        )
+        template<typename T, typename Base, typename... Tags>
+        void get(tagged<Base, Tags...> const &&) = delete;
 
         template<typename F, typename S>
         using tagged_pair =

--- a/include/range/v3/utility/tuple_algorithm.hpp
+++ b/include/range/v3/utility/tuple_algorithm.hpp
@@ -21,6 +21,7 @@
 #include <functional>
 #include <meta/meta.hpp>
 #include <range/v3/range_fwd.hpp>
+#include <range/v3/detail/adl_get.hpp>
 #include <range/v3/utility/static_const.hpp>
 #include <range/v3/utility/invoke.hpp>
 
@@ -42,7 +43,7 @@ namespace ranges
             static auto impl(Fun &&fun, Tup &&tup, meta::index_sequence<Is...>)
             RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
-                invoke(static_cast<Fun&&>(fun), std::get<Is>(static_cast<Tup&&>(tup))...)
+                invoke(static_cast<Fun&&>(fun), detail::adl_get<Is>(static_cast<Tup&&>(tup))...)
             )
         public:
             template<typename Fun, typename Tup>
@@ -65,17 +66,17 @@ namespace ranges
             static auto impl1(Tup && tup, Fun &fun, meta::index_sequence<Is...>)
             RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
-                std::tuple<decltype(fun(std::get<Is>(static_cast<Tup&&>(tup))))...>{
-                    fun(std::get<Is>(static_cast<Tup&&>(tup)))...}
+                std::tuple<decltype(fun(detail::adl_get<Is>(static_cast<Tup&&>(tup))))...>{
+                    fun(detail::adl_get<Is>(static_cast<Tup&&>(tup)))...}
             )
             template<typename Tup0, typename Tup1, typename Fun, std::size_t...Is>
             static auto impl2(Tup0 && tup0, Tup1 && tup1, Fun &fun, meta::index_sequence<Is...>)
             RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
-                std::tuple<decltype(fun(std::get<Is>(static_cast<Tup0&&>(tup0)),
-                                        std::get<Is>(static_cast<Tup1&&>(tup1))))...>{
-                    fun(std::get<Is>(static_cast<Tup0&&>(tup0)),
-                        std::get<Is>(static_cast<Tup1&&>(tup1)))...}
+                std::tuple<decltype(fun(detail::adl_get<Is>(static_cast<Tup0&&>(tup0)),
+                                        detail::adl_get<Is>(static_cast<Tup1&&>(tup1))))...>{
+                    fun(detail::adl_get<Is>(static_cast<Tup0&&>(tup0)),
+                        detail::adl_get<Is>(static_cast<Tup1&&>(tup1)))...}
             )
         public:
             template<typename Tup, typename Fun>
@@ -111,7 +112,7 @@ namespace ranges
             RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
                 Impl::template impl<Is...>(static_cast<Tup&&>(tup),
-                    fun(std::move(val), std::get<I0>(static_cast<Tup&&>(tup))), fun)
+                    fun(std::move(val), detail::adl_get<I0>(static_cast<Tup&&>(tup))), fun)
             )
             template<typename Tup, typename Val, typename Fun, std::size_t...Is>
             static auto impl2(Tup && tup, Val val, Fun &fun, meta::index_sequence<Is...>)
@@ -140,7 +141,7 @@ namespace ranges
             static void impl(Tup && tup, Fun &fun, meta::index_sequence<Is...>)
             {
                 (void)std::initializer_list<int>{
-                    ((void)fun(std::get<Is>(static_cast<Tup&&>(tup))), 42)...};
+                    ((void)fun(detail::adl_get<Is>(static_cast<Tup&&>(tup))), 42)...};
             }
         public:
             template<typename Tup, typename Fun>

--- a/test/algorithm/merge.cpp
+++ b/test/algorithm/merge.cpp
@@ -35,9 +35,9 @@ int main()
             ib[i] = 2 * i + 1;
         auto r = ranges::merge(ia.get(), ia.get() + N,
             ib.get(), ib.get() + N, ic.get());
-        CHECK(std::get<0>(r) == ia.get() + N);
-        CHECK(std::get<1>(r) == ib.get() + N);
-        CHECK(std::get<2>(r) == ic.get() + 2 * N);
+        CHECK(ranges::get<0>(r) == ia.get() + N);
+        CHECK(ranges::get<1>(r) == ib.get() + N);
+        CHECK(ranges::get<2>(r) == ic.get() + 2 * N);
         CHECK(ic[0] == 0);
         CHECK(ic[2 * N - 1] == 2 * N - 1);
         CHECK(std::is_sorted(ic.get(), ic.get() + 2 * N));
@@ -55,9 +55,9 @@ int main()
         auto r0 = ranges::make_iterator_range(ia.get(), ia.get() + N);
         auto r1 = ranges::make_iterator_range(ib.get(), ib.get() + N);
         auto r = ranges::merge(r0, r1, ic.get());
-        CHECK(std::get<0>(r) == ia.get() + N);
-        CHECK(std::get<1>(r) == ib.get() + N);
-        CHECK(std::get<2>(r) == ic.get() + 2 * N);
+        CHECK(ranges::get<0>(r) == ia.get() + N);
+        CHECK(ranges::get<1>(r) == ib.get() + N);
+        CHECK(ranges::get<2>(r) == ic.get() + 2 * N);
         CHECK(ic[0] == 0);
         CHECK(ic[2 * N - 1] == 2 * N - 1);
         CHECK(std::is_sorted(ic.get(), ic.get() + 2 * N));
@@ -76,9 +76,9 @@ int main()
         auto r0 = ranges::make_iterator_range(ia.get(), ia.get() + N);
         auto r1 = ranges::make_iterator_range(ib.get(), ib.get() + N);
         auto r = ranges::merge(std::move(r0), std::move(r1), ic.get());
-        CHECK(std::get<0>(r).get_unsafe() == ia.get() + N);
-        CHECK(std::get<1>(r).get_unsafe() == ib.get() + N);
-        CHECK(std::get<2>(r) == ic.get() + 2 * N);
+        CHECK(ranges::get<0>(r).get_unsafe() == ia.get() + N);
+        CHECK(ranges::get<1>(r).get_unsafe() == ib.get() + N);
+        CHECK(ranges::get<2>(r) == ic.get() + 2 * N);
         CHECK(ic[0] == 0);
         CHECK(ic[2 * N - 1] == 2 * N - 1);
         CHECK(std::is_sorted(ic.get(), ic.get() + 2 * N));

--- a/test/algorithm/partition_copy.cpp
+++ b/test/algorithm/partition_copy.cpp
@@ -116,13 +116,13 @@ void test_rvalue()
     S r1[10] = {S{0}};
     S r2[10] = {S{0}};
     auto p = ranges::partition_copy(ranges::view::all(ia), r1, r2, is_odd(), &S::i);
-    CHECK(std::get<0>(p).get_unsafe() == std::end(ia));
-    CHECK(std::get<1>(p) == r1 + 4);
+    CHECK(ranges::get<0>(p).get_unsafe() == std::end(ia));
+    CHECK(ranges::get<1>(p) == r1 + 4);
     CHECK(r1[0].i == 1);
     CHECK(r1[1].i == 3);
     CHECK(r1[2].i == 5);
     CHECK(r1[3].i == 7);
-    CHECK(std::get<2>(p) == r2 + 4);
+    CHECK(ranges::get<2>(p) == r2 + 4);
     CHECK(r2[0].i == 2);
     CHECK(r2[1].i == 4);
     CHECK(r2[2].i == 6);

--- a/test/algorithm/set_symmetric_difference.hpp
+++ b/test/algorithm/set_symmetric_difference.hpp
@@ -307,18 +307,18 @@ int main()
 
         auto res1 =
             ranges::set_symmetric_difference(ranges::view::all(ia), ranges::view::all(ib), ic, std::less<int>(), &S::i, &T::j);
-        CHECK(std::get<0>(res1).get_unsafe() == ranges::end(ia));
-        CHECK(std::get<1>(res1).get_unsafe() == ranges::end(ib));
-        CHECK((std::get<2>(res1) - ic) == sr);
-        CHECK(ranges::lexicographical_compare(ic, std::get<2>(res1), ir, ir+sr, std::less<int>(), &U::k) == false);
+        CHECK(ranges::get<0>(res1).get_unsafe() == ranges::end(ia));
+        CHECK(ranges::get<1>(res1).get_unsafe() == ranges::end(ib));
+        CHECK((ranges::get<2>(res1) - ic) == sr);
+        CHECK(ranges::lexicographical_compare(ic, ranges::get<2>(res1), ir, ir+sr, std::less<int>(), &U::k) == false);
         ranges::fill(ic, U{0});
 
         auto res2 =
             ranges::set_symmetric_difference(ranges::view::all(ib), ranges::view::all(ia), ic, std::less<int>(), &T::j, &S::i);
-        CHECK(std::get<0>(res2).get_unsafe() == ranges::end(ib));
-        CHECK(std::get<1>(res2).get_unsafe() == ranges::end(ia));
-        CHECK((std::get<2>(res2) - ic) == sr);
-        CHECK(ranges::lexicographical_compare(ic, std::get<2>(res2), ir, ir+sr, std::less<int>(), &U::k) == false);
+        CHECK(ranges::get<0>(res2).get_unsafe() == ranges::end(ib));
+        CHECK(ranges::get<1>(res2).get_unsafe() == ranges::end(ia));
+        CHECK((ranges::get<2>(res2) - ic) == sr);
+        CHECK(ranges::lexicographical_compare(ic, ranges::get<2>(res2), ir, ir+sr, std::less<int>(), &U::k) == false);
     }
 #endif
 

--- a/test/algorithm/set_union.hpp
+++ b/test/algorithm/set_union.hpp
@@ -265,17 +265,17 @@ int main()
         static const int sr = sizeof(ir)/sizeof(ir[0]);
 
         auto res = ranges::set_union(ranges::view::all(ia), ranges::view::all(ib), ic, std::less<int>(), &S::i, &T::j);
-        CHECK(std::get<0>(res).get_unsafe() == ranges::end(ia));
-        CHECK(std::get<1>(res).get_unsafe() == ranges::end(ib));
-        CHECK((std::get<2>(res) - ic) == sr);
-        CHECK(ranges::lexicographical_compare(ic, std::get<2>(res), ir, ir+sr, std::less<int>(), &U::k) == false);
+        CHECK(ranges::get<0>(res).get_unsafe() == ranges::end(ia));
+        CHECK(ranges::get<1>(res).get_unsafe() == ranges::end(ib));
+        CHECK((ranges::get<2>(res) - ic) == sr);
+        CHECK(ranges::lexicographical_compare(ic, ranges::get<2>(res), ir, ir+sr, std::less<int>(), &U::k) == false);
         ranges::fill(ic, U{0});
 
         auto res2 = ranges::set_union(ranges::view::all(ib), ranges::view::all(ia), ic, std::less<int>(), &T::j, &S::i);
-        CHECK(std::get<0>(res2).get_unsafe() == ranges::end(ib));
-        CHECK(std::get<1>(res2).get_unsafe() == ranges::end(ia));
-        CHECK((std::get<2>(res2) - ic) == sr);
-        CHECK(ranges::lexicographical_compare(ic, std::get<2>(res2), ir, ir+sr, std::less<int>(), &U::k) == false);
+        CHECK(ranges::get<1>(res2).get_unsafe() == ranges::end(ia));
+        CHECK(ranges::get<0>(res2).get_unsafe() == ranges::end(ib));
+        CHECK((ranges::get<2>(res2) - ic) == sr);
+        CHECK(ranges::lexicographical_compare(ic, ranges::get<2>(res2), ir, ir+sr, std::less<int>(), &U::k) == false);
     }
 #endif
 

--- a/test/algorithm/transform.cpp
+++ b/test/algorithm/transform.cpp
@@ -147,9 +147,9 @@ test2()
         auto r =
             ranges::transform(std::move(rng0), InIter2(ia),
                               OutIter(ib), std::minus<int>());
-        CHECK(base(std::get<0>(r).get_unsafe()) == ib + sa);
-        CHECK(base(std::get<1>(r)) == ia + sa);
-        CHECK(base(std::get<2>(r)) == ib + sa);
+        CHECK(base(ranges::get<0>(r).get_unsafe()) == ib + sa);
+        CHECK(base(ranges::get<1>(r)) == ia + sa);
+        CHECK(base(ranges::get<2>(r)) == ib + sa);
         CHECK(ib[0] == 1);
         CHECK(ib[1] == 1);
         CHECK(ib[2] == 1);
@@ -183,9 +183,9 @@ test2()
         auto rng1 = ranges::make_iterator_range(InIter2(ia), sentinel<int const *>(ia + sa));
         auto r =
             ranges::transform(std::move(rng0), std::move(rng1), OutIter(ib), std::minus<int>());
-        CHECK(base(std::get<0>(r).get_unsafe()) == ib + sa);
-        CHECK(base(std::get<1>(r).get_unsafe()) == ia + sa);
-        CHECK(base(std::get<2>(r)) == ib + sa);
+        CHECK(base(ranges::get<0>(r).get_unsafe()) == ib + sa);
+        CHECK(base(ranges::get<1>(r).get_unsafe()) == ia + sa);
+        CHECK(base(ranges::get<2>(r)) == ib + sa);
         CHECK(ib[0] == 1);
         CHECK(ib[1] == 1);
         CHECK(ib[2] == 1);

--- a/test/span.cpp
+++ b/test/span.cpp
@@ -520,14 +520,6 @@ RANGES_DIAGNOSTIC_IGNORE_UNDEFINED_FUNC_TEMPLATE
             span s{arr};
             CONCEPT_ASSERT(std::is_same<span<int, 5>, decltype(s)>::value);
         }
-        {
-            span s{ranges::begin(arr), ranges::size(arr)};
-            CONCEPT_ASSERT(std::is_same<span<int>, decltype(s)>::value);
-        }
-        {
-            span s{ranges::begin(arr), ranges::end(arr)};
-            CONCEPT_ASSERT(std::is_same<span<int>, decltype(s)>::value);
-        }
     }
     {
         std::vector<int> vec = {1, 2, 3, 4, 5};

--- a/test/view/zip.cpp
+++ b/test/view/zip.cpp
@@ -9,13 +9,14 @@
 //
 // Project home: https://github.com/ericniebler/range-v3
 
+#include <memory>
+#include <sstream>
 #include <string>
 #include <vector>
-#include <sstream>
-#include <memory>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/copy.hpp>
 #include <range/v3/algorithm/move.hpp>
+#include <range/v3/utility/copy.hpp>
 #include <range/v3/utility/iterator.hpp>
 #include <range/v3/view/bounded.hpp>
 #include <range/v3/view/for_each.hpp>
@@ -26,7 +27,6 @@
 #include <range/v3/view/take_while.hpp>
 #include <range/v3/view/zip.hpp>
 #include <range/v3/view/zip_with.hpp>
-#include <range/v3/utility/copy.hpp>
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 


### PR DESCRIPTION
Individual commit logs:
* LLVM 28385 is fixed in clang 6

* Always implement `RANGES_ASSERT` on MSFTL

  `assert` failures don't necessarily terminate the program on Windows. In addition to being silly, this is problematic for range-v3 since we sometimes write:
  ```c++
  [[noreturn]] void foo() {
    RANGES_EXPECT(false);
  }
  ```
  and clang will complain about this `[[noreturn]]` function returning.

* Remove bogus `span` test

  `std::array`'s iterators aren't necessarily pointers.

* Remove specialization of `std::is_integral` in safe_int

   No, no, no! BAD!

   (Also, don't check `is_literal` since it's deprecated in C++17.)

* Support clang-cl, drop ClangC2 like a hot potato

   * Travis changes:
     * Define `_SILENCE_CXX17_TEMPORARY_BUFFER_DEPRECATION_WARNING` when building on MSFTL to silence deprecation warnings for `std::(get|return)_temporary_buffer`.
     * Some warning flags have different meaning to clang-cl than GCC and vanilla clang. We don't want `-Wall`, for example, which is the same as vanilla `-Weverything`.
     * Clang-CL apparently tries to be brain-damage compatible with MSVC - `iter_move` will recurse without the unqualified lookup block.
   
   * AppVeyor changes:
     * Use the default cmake; 3.6 does some stupid things with Clang-CL
     * Ninja is roughly 774289343928 times faster than msbuild
     * Test {x86,x64}x{Debug,Release}x{C++latest} (I honestly have no idea if clang-cl treats /std:c++latest as C++17 or C++2a.)
   
   Fixes #765.
   
* Workaround MSFTL tuple issues

   MSFTL `tuple` is recursive: `tuple<int, char>` derives from `tuple<char>` derives from `tuple<>`. Consequently, types derived from `tuple` - like `common_tuple` and `tagged<tuple>` - can't be passed to functions that deduce `tuple<Ts...>` because the deduction is ambiguous. This is a HUGE PITA, but can't be fixed until the next ABI break.

   The workaround is to define non-member `get` for range-v3 tuple types, use `ranges::get` when the concrete type of a tuple-like is known, and `ranges::detail::adl_get` when the concrete type is not known.

   We also need to define converting constructors from `common_tuple` to `common_tuple` since they can't implicitly convert to `std::tuple` and use the `std::tuple` converting constructors.
   