### PR TITLE
Cleanup CPO declarations:

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Release Notes:
   - Add an experimental `shared` view for views that need container-like scratch
     space to do their work.
   - Faster, simpler `reverse_view`.
-  - Rework `ranges::reference_wrapper` to avoid [LWG\#2993](http://www.open-std.org/jtc1/sc22/wg21/docs/lwg-defects.html#2993).
+  - Rework `ranges::reference_wrapper` to avoid [LWG\#2993](https://wg21.link/lwg2993).
   - Reworked `any_view`, the type-erased view wrapper.
   - `equal` algorithm is `constexpr` in C++14.
   - `stride_view` no longer needs an `atomic` data member.
@@ -107,7 +107,7 @@ Release Notes:
   - Various portability fixes for gcc and clang trunk.
 * **0.3.0** June 30, 2017
   - Input views may now be move-only (from @CaseyCarter)
-  - Input `any_view`s are now *much* more efficicient (from @CaseyCarter)
+  - Input `any_view`s are now *much* more efficient (from @CaseyCarter)
   - Better support for systems lacking a working `<thread>` header (from @CaseyCarter)
 * **0.2.6** June 21, 2017
   - Experimental coroutines with `ranges::experimental::generator` (from @CaseyCarter)

--- a/include/meta/meta_fwd.hpp
+++ b/include/meta/meta_fwd.hpp
@@ -17,27 +17,69 @@
 
 #include <utility>
 
-#ifndef META_DISABLE_DEPRECATED_WARNINGS
-#ifdef __cpp_attribute_deprecated
-#define META_DEPRECATED(MSG) [[deprecated(MSG)]]
+#define META_CXX_STD_14 201402L
+
+#if defined(_MSC_VER) && defined(_MSVC_LANG)
+#define META_CXX_VER _MSVC_LANG
+#define META_HAS_MAKE_INTEGER_SEQ 1
 #else
-#if defined(__clang__) || defined(__GNUC__)
-#define META_DEPRECATED(MSG) __attribute__((deprecated(MSG)))
-#elif defined(_MSC_VER)
-#define META_DEPRECATED(MSG) __declspec(deprecated(MSG))
+#define META_CXX_VER __cplusplus
+#endif
+
+#ifndef META_CXX_VARIABLE_TEMPLATES
+#ifdef __cpp_variable_templates
+#define META_CXX_VARIABLE_TEMPLATES __cpp_variable_templates
 #else
-#define META_DEPRECATED(MSG)
+#define META_CXX_VARIABLE_TEMPLATES (META_CXX_VER >= META_CXX_STD_14)
 #endif
 #endif
+
+#ifndef META_CXX_INTEGER_SEQUENCE
+#ifdef __cpp_lib_integer_sequence
+#define META_CXX_INTEGER_SEQUENCE __cpp_lib_integer_sequence
 #else
-#define META_DEPRECATED(MSG)
+#define META_CXX_INTEGER_SEQUENCE (META_CXX_VER >= META_CXX_STD_14)
+#endif
+#endif
+
+#ifndef META_HAS_MAKE_INTEGER_SEQ
+#ifdef __has_builtin
+#if __has_builtin(__make_integer_seq)
+#define META_HAS_MAKE_INTEGER_SEQ 1
+#endif
+#endif
+#endif
+#ifndef META_HAS_MAKE_INTEGER_SEQ
+#define META_HAS_MAKE_INTEGER_SEQ 0
+#endif
+
+#ifndef META_HAS_TYPE_PACK_ELEMENT
+#ifdef __has_builtin
+#if __has_builtin(__type_pack_element)
+#define META_HAS_TYPE_PACK_ELEMENT 1
+#endif
+#endif
+#endif
+#ifndef META_HAS_TYPE_PACK_ELEMENT
+#define META_HAS_TYPE_PACK_ELEMENT 0
+#endif
+
+#if !defined(META_DEPRECATED) && !defined(META_DISABLE_DEPRECATED_WARNINGS)
+#if defined(__cpp_attribute_deprecated) || META_CXX_VER >= META_CXX_STD_14
+#define META_DEPRECATED(...) [[deprecated(__VA_ARGS__)]]
+#elif defined(__clang__) || defined(__GNUC__)
+#define META_DEPRECATED(...) __attribute__((deprecated(__VA_ARGS__)))
+#endif
+#endif
+#ifndef META_DEPRECATED
+#define META_DEPRECATED(...)
 #endif
 
 namespace meta
 {
     inline namespace v1
     {
-#ifdef __cpp_lib_integer_sequence
+#if META_CXX_INTEGER_SEQUENCE
         using std::integer_sequence;
 #else
         template <typename T, T...>

--- a/include/range/v3/algorithm/equal.hpp
+++ b/include/range/v3/algorithm/equal.hpp
@@ -72,7 +72,7 @@ namespace ranges
             bool operator()(I0 begin0, S0 end0, I1 begin1, S1 end1, C pred = C{},
                 P0 proj0 = P0{}, P1 proj1 = P1{}) const
             {
-                if(SizedSentinel<S0, I0>() && SizedSentinel<S1, I1>())
+                if RANGES_CONSTEXPR_IF(SizedSentinel<S0, I0>() && SizedSentinel<S1, I1>())
                     if(distance(begin0, end0) != distance(begin1, end1))
                         return false;
                 return this->nocheck(std::move(begin0), std::move(end0), std::move(begin1),
@@ -107,7 +107,7 @@ namespace ranges
             bool operator()(Rng0 && rng0, Rng1 && rng1, C pred = C{}, P0 proj0 = P0{},
                 P1 proj1 = P1{}) const
             {
-                if(SizedRange<Rng0>() && SizedRange<Rng1>())
+                if RANGES_CONSTEXPR_IF (SizedRange<Rng0>() && SizedRange<Rng1>())
                     if(distance(rng0) != distance(rng1))
                         return false;
                 return this->nocheck(begin(rng0), end(rng0), begin(rng1), end(rng1),

--- a/include/range/v3/begin_end.hpp
+++ b/include/range/v3/begin_end.hpp
@@ -116,7 +116,10 @@ namespace ranges
         /// \return \c r, if \c r is an array. Otherwise, `r.begin()` if that expression is
         ///   well-formed and returns an Iterator. Otherwise, `begin(r)` if that expression
         ///   returns an Iterator.
-        RANGES_INLINE_VARIABLE(_begin_::fn, begin)
+        inline namespace CPOs
+        {
+            RANGES_INLINE_VARIABLE(_begin_::fn, begin)
+        }
 
         /// \cond
         namespace _end_
@@ -205,7 +208,10 @@ namespace ranges
         /// \return \c r+size(r), if \c r is an array. Otherwise, `r.end()` if that expression is
         ///   well-formed and returns an Iterator. Otherwise, `end(r)` if that expression
         ///   returns an Iterator.
-        RANGES_INLINE_VARIABLE(_end_::fn, end)
+        inline namespace CPOs
+        {
+            RANGES_INLINE_VARIABLE(_end_::fn, end)
+        }
 
         /// \cond
         namespace _cbegin_
@@ -234,7 +240,10 @@ namespace ranges
         /// \param r
         /// \return The result of calling `ranges::begin` with a const-qualified
         ///    reference to r.
-        RANGES_INLINE_VARIABLE(_cbegin_::fn, cbegin)
+        inline namespace CPOs
+        {
+            RANGES_INLINE_VARIABLE(_cbegin_::fn, cbegin)
+        }
 
         /// \cond
         namespace _cend_
@@ -263,7 +272,10 @@ namespace ranges
         /// \param r
         /// \return The result of calling `ranges::end` with a const-qualified
         ///    reference to r.
-        RANGES_INLINE_VARIABLE(_cend_::fn, cend)
+        inline namespace CPOs
+        {
+            RANGES_INLINE_VARIABLE(_cend_::fn, cend)
+        }
 
         /// \cond
         namespace _rbegin_
@@ -337,7 +349,10 @@ namespace ranges
         ///   Otherwise, `make_reverse_iterator(ranges::end(r))` if `ranges::begin(r)`
         ///   and `ranges::end(r)` are both well-formed and have the same type that
         ///   satisfies BidirectionalIterator.
-        RANGES_INLINE_VARIABLE(_rbegin_::fn, rbegin)
+        inline namespace CPOs
+        {
+            RANGES_INLINE_VARIABLE(_rbegin_::fn, rbegin)
+        }
 
         /// \cond
         namespace _rend_
@@ -413,7 +428,10 @@ namespace ranges
         ///   Otherwise, `make_reverse_iterator(ranges::begin(r))` if `ranges::begin(r)`
         ///   and `ranges::end(r)` are both well-formed and have the same type that
         ///   satisfies BidirectionalIterator.
-        RANGES_INLINE_VARIABLE(_rend_::fn, rend)
+        inline namespace CPOs
+        {
+            RANGES_INLINE_VARIABLE(_rend_::fn, rend)
+        }
 
         /// \cond
         namespace _crbegin_
@@ -442,7 +460,10 @@ namespace ranges
         /// \param r
         /// \return The result of calling `ranges::rbegin` with a const-qualified
         ///    reference to r.
-        RANGES_INLINE_VARIABLE(_crbegin_::fn, crbegin)
+        inline namespace CPOs
+        {
+            RANGES_INLINE_VARIABLE(_crbegin_::fn, crbegin)
+        }
 
         /// \cond
         namespace _crend_
@@ -471,7 +492,10 @@ namespace ranges
         /// \param r
         /// \return The result of calling `ranges::rend` with a const-qualified
         ///    reference to r.
-        RANGES_INLINE_VARIABLE(_crend_::fn, crend)
+        inline namespace CPOs
+        {
+            RANGES_INLINE_VARIABLE(_crend_::fn, crend)
+        }
     }
 }
 

--- a/include/range/v3/data.hpp
+++ b/include/range/v3/data.hpp
@@ -79,7 +79,10 @@ namespace ranges
         }
         /// \endcond
 
-        RANGES_INLINE_VARIABLE(data_detail::data_fn, data)
+        inline namespace CPOs
+        {
+            RANGES_INLINE_VARIABLE(data_detail::data_fn, data)
+        }
     }
 }
 

--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -143,7 +143,7 @@ namespace ranges
 #define RANGES_CXX_STD_11 201103L
 #define RANGES_CXX_STD_14 201402L
 #define RANGES_CXX_STD_17 201703L
-#define RANGES_CXX_THREAD_LOCAL_PRE_STANDARD 200000L // Arbitrarily number between 0 and C++11
+#define RANGES_CXX_THREAD_LOCAL_PRE_STANDARD 200000L // Arbitrary number between 0 and C++11
 #define RANGES_CXX_THREAD_LOCAL_11 RANGES_CXX_STD_11
 #define RANGES_CXX_THREAD_LOCAL_14 RANGES_CXX_THREAD_LOCAL_11
 #define RANGES_CXX_THREAD_LOCAL_17 RANGES_CXX_THREAD_LOCAL_14
@@ -165,30 +165,7 @@ namespace ranges
 #define RANGES_CXX_IF_CONSTEXPR_17 201606L
 
 #if defined(_MSC_VER) && !defined(__clang__)
-#if _MSC_VER >= 1900
-#ifndef RANGES_CXX_VARIABLE_TEMPLATES
-#define RANGES_CXX_VARIABLE_TEMPLATES RANGES_CXX_VARIABLE_TEMPLATES_14
-#endif
-#ifndef RANGES_CXX_ATTRIBUTE_DEPRECATED
-#define RANGES_CXX_ATTRIBUTE_DEPRECATED RANGES_CXX_ATTRIBUTE_DEPRECATED_14
-#endif
-#if !defined(RANGES_CXX_RANGE_BASED_FOR) && defined(_MSVC_LANG) && _MSVC_LANG > 201402
-#define RANGES_CXX_RANGE_BASED_FOR RANGES_CXX_RANGE_BASED_FOR_17
-#endif
-#ifndef RANGES_CXX_LIB_IS_FINAL
-#define RANGES_CXX_LIB_IS_FINAL RANGES_CXX_LIB_IS_FINAL_14
-#endif
-#ifndef RANGES_CXX_RETURN_TYPE_DEDUCTION
-#define RANGES_CXX_RETURN_TYPE_DEDUCTION RANGES_CXX_RETURN_TYPE_DEDUCTION_14
-#endif
-#ifndef RANGES_CXX_GENERIC_LAMBDAS
-#define RANGES_CXX_GENERIC_LAMBDAS RANGES_CXX_GENERIC_LAMBDAS_14
-#endif
-
-#else // _MSC_VER < 1900
-#error Unsupported version of Visual C++
-#endif // _MSC_VER switch
-
+#define RANGES_CXX_VER _MSVC_LANG
 #define RANGES_DIAGNOSTIC_PUSH __pragma(warning(push))
 #define RANGES_DIAGNOSTIC_POP __pragma(warning(pop))
 #define RANGES_DIAGNOSTIC_IGNORE_PRAGMAS __pragma(warning(disable:4068))
@@ -211,6 +188,7 @@ namespace ranges
 
 #else // ^^^ defined(_MSC_VER) ^^^ / vvv !defined(_MSC_VER) vvv
 // Generic configuration using SD-6 feature test macros with fallback to __cplusplus
+#define RANGES_CXX_VER __cplusplus
 #if defined(__GNUC__) || defined(__clang__)
 #define RANGES_PRAGMA(X) _Pragma(#X)
 #define RANGES_DIAGNOSTIC_PUSH RANGES_PRAGMA(GCC diagnostic push)
@@ -255,17 +233,16 @@ namespace ranges
 
 #define RANGES_CXX_FEATURE_CONCAT2(y, z) RANGES_CXX_ ## y ## _ ## z
 #define RANGES_CXX_FEATURE_CONCAT(y, z) RANGES_CXX_FEATURE_CONCAT2(y, z)
-#define RANGES_CXX_FEATURE(x) RANGES_CXX_FEATURE_CONCAT(x, RANGES_CXX_STD_NAME)
 
-#if __cplusplus >= RANGES_CXX_STD_17
-#define RANGES_CXX_STD_NAME 17
+#if RANGES_CXX_VER >= RANGES_CXX_STD_17
 #define RANGES_CXX_STD RANGES_CXX_STD_17
-#elif __cplusplus >= RANGES_CXX_STD_14
-#define RANGES_CXX_STD_NAME 14
+#define RANGES_CXX_FEATURE(x) RANGES_CXX_FEATURE_CONCAT(x, 17)
+#elif RANGES_CXX_VER >= RANGES_CXX_STD_14
 #define RANGES_CXX_STD RANGES_CXX_STD_14
+#define RANGES_CXX_FEATURE(x) RANGES_CXX_FEATURE_CONCAT(x, 14)
 #else
-#define RANGES_CXX_STD_NAME 11
 #define RANGES_CXX_STD RANGES_CXX_STD_11
+#define RANGES_CXX_FEATURE(x) RANGES_CXX_FEATURE_CONCAT(x, 11)
 #endif
 
 #ifndef RANGES_CXX_STATIC_ASSERT
@@ -347,19 +324,16 @@ namespace ranges
 #endif
 #endif
 
-#ifndef RANGES_DISABLE_DEPRECATED_WARNINGS
+#if !defined(RANGES_DEPRECATED) && !defined(RANGES_DISABLE_DEPRECATED_WARNINGS)
 #if RANGES_CXX_ATTRIBUTE_DEPRECATED &&            \
    !((defined(__clang__) || defined(__GNUC__)) && \
      RANGES_CXX_STD < RANGES_CXX_STD_14)
 #define RANGES_DEPRECATED(MSG) [[deprecated(MSG)]]
 #elif defined(__clang__) || defined(__GNUC__)
 #define RANGES_DEPRECATED(MSG) __attribute__((deprecated(MSG)))
-#elif defined(_MSC_VER)
-#define RANGES_DEPRECATED(MSG) __declspec(deprecated(MSG))
-#else
-#define RANGES_DEPRECATED(MSG)
 #endif
-#else
+#endif
+#ifndef RANGES_DEPRECATED
 #define RANGES_DEPRECATED(MSG)
 #endif
 
@@ -391,36 +365,26 @@ namespace ranges
 #endif
 
 #ifndef RANGES_CXX_INLINE_VARIABLES
-
-#ifdef __cpp_inline_variables // TODO: fix this if SD-6 picks another name
+#ifdef __cpp_inline_variables
 #define RANGES_CXX_INLINE_VARIABLES __cpp_inline_variables
-#elif defined(__clang__) && \
-    (__clang_major__ > 3 || __clang_major__ == 3 && __clang_minor__ == 9) && \
-    __cplusplus > 201402L
-// TODO: remove once clang defines __cpp_inline_variables (or equivalent)
+#elif defined(__clang__) && (__clang_major__ == 3 && __clang_minor__ == 9) && \
+    RANGES_CXX_VER > RANGES_CXX_STD_14
+// Clang 3.9 supports inline variables in C++17 mode, but doesn't define __cpp_inline_variables
 #define RANGES_CXX_INLINE_VARIABLES RANGES_CXX_INLINE_VARIABLES_17
 #else
 #define RANGES_CXX_INLINE_VARIABLES RANGES_CXX_FEATURE(INLINE_VARIABLES)
 #endif  // __cpp_inline_variables
-
 #endif  // RANGES_CXX_INLINE_VARIABLES
 
 #if RANGES_CXX_INLINE_VARIABLES < RANGES_CXX_INLINE_VARIABLES_17
-#define RANGES_INLINE_VARIABLE(type, name)                              \
-    inline namespace function_objects                                   \
-    {                                                                   \
-        inline namespace                                                \
-        {                                                               \
-            constexpr auto &name = ::ranges::static_const<type>::value; \
-        }                                                               \
+#define RANGES_INLINE_VARIABLE(type, name)                          \
+    inline namespace                                                \
+    {                                                               \
+        constexpr auto &name = ::ranges::static_const<type>::value; \
     }
-
 #else  // RANGES_CXX_INLINE_VARIABLES >= RANGES_CXX_INLINE_VARIABLES_17
 #define RANGES_INLINE_VARIABLE(type, name) \
-    inline namespace function_objects      \
-    {                                      \
-        inline constexpr type name{};      \
-    }
+    inline constexpr type name{};
 #endif // RANGES_CXX_INLINE_VARIABLES
 
 #ifndef RANGES_CXX_DEDUCTION_GUIDES

--- a/include/range/v3/detail/variant.hpp
+++ b/include/range/v3/detail/variant.hpp
@@ -60,11 +60,8 @@ namespace ranges
             constexpr auto& emplaced_index = static_const<emplaced_index_t<I>>::value;
         }
     #else // RANGES_CXX_INLINE_VARIABLES >= RANGES_CXX_INLINE_VARIABLES_17
-        inline namespace function_objects
-        {
-            template<std::size_t I>
-            inline constexpr emplaced_index_t<I> emplaced_index{};
-        }
+        template<std::size_t I>
+        inline constexpr emplaced_index_t<I> emplaced_index{};
     #endif  // RANGES_CXX_INLINE_VARIABLES
 
         /// \cond
@@ -525,10 +522,10 @@ namespace ranges
           , private detail::variant_base<variant<Ts...>>
         {
         private:
-            friend struct detail::variant_core_access;
+            friend detail::variant_core_access;
             template<typename...>
             friend struct variant;
-            friend struct detail::variant_base<variant, false>;
+            friend detail::variant_base<variant, false>;
             template<std::size_t Index>
             using datum_t =
                 detail::variant_datum_t<Index, Ts...>;

--- a/include/range/v3/experimental/view/shared.hpp
+++ b/include/range/v3/experimental/view/shared.hpp
@@ -82,8 +82,8 @@ namespace ranges
                     void operator()(std::shared_ptr<Rng>) const
                     {
                         CONCEPT_ASSERT_MSG(Range<Rng>(),
-                            "The object on which view::shared operates must be a "
-                            "model of the Range concept.");
+                            "The object on which view::shared operates must be "
+                            "a model of the Range concept.");
                     }
 #endif
 
@@ -104,14 +104,14 @@ namespace ranges
                     void operator()(Rng &&) const
                     {
                         CONCEPT_ASSERT_MSG(Range<Rng>(),
-                            "The object on which view::shared operates must be a "
-                            "model of the Range concept.");
+                            "The object on which view::shared operates must be "
+                            "a model of the Range concept.");
                         CONCEPT_ASSERT_MSG(!View<Rng>(),
                             "view::shared cannot be constructed from a view. "
                             "Please copy the original view instead.");
                         CONCEPT_ASSERT_MSG(!std::is_reference<Rng>::value,
-                            "view::shared needs an rvalue reference "
-                            "to build a shared object.");
+                            "view::shared needs an rvalue to build a shared "
+                            "object.");
                     }
 #endif
                 };

--- a/include/range/v3/istream_range.hpp
+++ b/include/range/v3/istream_range.hpp
@@ -66,7 +66,7 @@ namespace ranges
             }
         public:
             istream_range() = default;
-            istream_range(std::istream &sin)
+            explicit istream_range(std::istream &sin)
               : sin_(&sin), obj_{}
             {
                 next(); // prime the pump
@@ -83,7 +83,7 @@ namespace ranges
         {
             CONCEPT_ASSERT_MSG(DefaultConstructible<Val>(),
                "Only DefaultConstructible types are extractable from streams.");
-            return {sin};
+            return istream_range<Val>{sin};
         }
     #else
         template<typename Val, CONCEPT_REQUIRES_(DefaultConstructible<Val>())>
@@ -91,7 +91,7 @@ namespace ranges
         {
             istream_range<Val> operator()(std::istream & sin) const
             {
-                return {sin};
+                return istream_range<Val>{sin};
             }
         };
 
@@ -102,11 +102,8 @@ namespace ranges
             constexpr auto& istream = static_const<istream_fn<Val>>::value;
         }
     #else  // RANGES_CXX_INLINE_VARIABLES >= RANGES_CXX_INLINE_VARIABLES_17
-        inline namespace function_objects
-        {
-            template<typename Val>
-            inline constexpr istream_fn<Val> istream{};
-        }
+        template<typename Val>
+        inline constexpr istream_fn<Val> istream{};
     #endif  // RANGES_CXX_INLINE_VARIABLES
 
     #endif  // RANGES_CXX_VARIABLE_TEMPLATES

--- a/include/range/v3/range_access.hpp
+++ b/include/range/v3/range_access.hpp
@@ -72,6 +72,9 @@ namespace ranges
                         concepts::model_of<concepts::Constructible, mixin_base_t<T>, T>(),
                         concepts::model_of<concepts::Constructible, mixin_base_t<T>, T const &>()
                     ));
+                    // Axiom: mixin_base_t<T> has a member get(), accessible to derived classes,
+                    //   which perfectly-returns the contained cursor object and does not throw
+                    //   exceptions.
             };
             struct HasCursorNext
             {

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -46,27 +46,7 @@ namespace ranges
 {
     inline namespace v3
     {
-        inline namespace function_objects {}
-
-        namespace aux
-        {
-            inline namespace function_objects {}
-        }
-
-        namespace view
-        {
-            inline namespace function_objects {}
-        }
-
-        namespace action
-        {
-            inline namespace function_objects {}
-        }
-
-        namespace detail
-        {
-            inline namespace function_objects {}
-        }
+        inline namespace CPOs {}
 
         /// \cond
         namespace _end_

--- a/include/range/v3/range_traits.hpp
+++ b/include/range/v3/range_traits.hpp
@@ -88,7 +88,7 @@ namespace ranges
         template<typename Rng>
         using range_size_t
             RANGES_DEPRECATED("Please use ranges::range_size_type_t instead") =
-                meta::_t<std::make_unsigned<range_difference_t<Rng>>>;
+                meta::_t<std::make_unsigned<range_difference_type_t<Rng>>>;
 
         template<typename Rng>
         using range_value_t
@@ -112,12 +112,12 @@ namespace ranges
         template<typename Rng>
         using range_iterator
             RANGES_DEPRECATED("range_iterator is deprecated") =
-                meta::defer<range_iterator_t, Rng>;
+                meta::defer<iterator_t, Rng>;
 
         template<typename Rng>
         using range_sentinel
             RANGES_DEPRECATED("range_sentinel is deprecated") =
-                meta::defer<range_sentinel_t, Rng>;
+                meta::defer<sentinel_t, Rng>;
 
         template<typename Rng>
         using range_category
@@ -127,12 +127,12 @@ namespace ranges
         template<typename Rng>
         using range_value
             RANGES_DEPRECATED("range_value is deprecated") =
-                meta::defer<range_value_t, Rng>;
+                meta::defer<range_value_type_t, Rng>;
 
         template<typename Rng>
         using range_difference
             RANGES_DEPRECATED("range_difference is deprecated") =
-                meta::defer<range_difference_t, Rng>;
+                meta::defer<range_difference_type_t, Rng>;
 
         template<typename Rng>
         using range_reference
@@ -152,7 +152,7 @@ namespace ranges
         template<typename Rng>
         using range_size
             RANGES_DEPRECATED("range_size is deprecated") =
-                meta::defer<range_size_t, Rng>;
+                meta::defer<range_size_type_t, Rng>;
 
         namespace detail
         {

--- a/include/range/v3/size.hpp
+++ b/include/range/v3/size.hpp
@@ -102,9 +102,10 @@ namespace ranges
 
         /// \ingroup group-core
         /// \return The result of an unqualified call to `size`
-        /// Not to spec per N4651: allow non-const size functions (See
-        /// https://github.com/ericniebler/range-v3/issues/385)
-        RANGES_INLINE_VARIABLE(_size_::fn, size)
+        inline namespace CPOs
+        {
+            RANGES_INLINE_VARIABLE(_size_::fn, size)
+        }
     }
 }
 

--- a/include/range/v3/utility/basic_iterator.hpp
+++ b/include/range/v3/utility/basic_iterator.hpp
@@ -339,12 +339,12 @@ namespace ranges
               : box<T>{}
             {}
             CONCEPT_REQUIRES(MoveConstructible<T>())
-            constexpr basic_mixin(T && t)
+            explicit constexpr basic_mixin(T &&t)
                 noexcept(std::is_nothrow_move_constructible<T>::value)
               : box<T>(detail::move(t))
             {}
             CONCEPT_REQUIRES(CopyConstructible<T>())
-            constexpr basic_mixin(T const &t)
+            explicit constexpr basic_mixin(T const &t)
                 noexcept(std::is_nothrow_copy_constructible<T>::value)
               : box<T>(t)
             {}
@@ -374,11 +374,11 @@ namespace ranges
             using typename assoc_types_::cursor_concept_t;
             using typename assoc_types_::reference_t;
             using typename assoc_types_::const_reference_t;
-            RANGES_CXX14_CONSTEXPR Cur &pos() noexcept // this noexcept is a lie
+            RANGES_CXX14_CONSTEXPR Cur &pos() noexcept
             {
                 return this->mixin_t::get();
             }
-            constexpr Cur const &pos() const noexcept // this noexcept is a lie
+            constexpr Cur const &pos() const noexcept
             {
                 return this->mixin_t::get();
             }
@@ -386,9 +386,6 @@ namespace ranges
         public:
             using typename assoc_types_::difference_type;
             constexpr basic_iterator() = default;
-            RANGES_CXX14_CONSTEXPR basic_iterator(Cur pos)
-              : mixin_t{std::move(pos)}
-            {}
             template<typename OtherCur,
                 CONCEPT_REQUIRES_(ConvertibleTo<OtherCur, Cur>() &&
                     Constructible<mixin_t, OtherCur>())>
@@ -396,28 +393,26 @@ namespace ranges
             basic_iterator(basic_iterator<OtherCur> that)
               : mixin_t{std::move(that.pos())}
             {}
-            // Mix in any additional constructors defined and exported by the mixin
+            // Mix in any additional constructors provided by the mixin
             using mixin_t::mixin_t;
 
             template<typename T,
-                CONCEPT_REQUIRES_(!Same<detail::decay_t<T>, basic_iterator>() &&
+                CONCEPT_REQUIRES_(!Same<uncvref_t<T>, basic_iterator>() &&
                     !detail::HasCursorNext<Cur>() && detail::WritableCursor<Cur, T>())>
             RANGES_CXX14_CONSTEXPR
             basic_iterator &operator=(T && t)
-            noexcept(noexcept(
-                std::declval<Cur &>().write(static_cast<T &&>(t))))
+            noexcept(noexcept(std::declval<Cur &>().write(static_cast<T &&>(t))))
             {
                 pos().write(static_cast<T &&>(t));
                 return *this;
             }
 
             template<typename T,
-                CONCEPT_REQUIRES_(!Same<detail::decay_t<T>, basic_iterator>() &&
+                CONCEPT_REQUIRES_(!Same<uncvref_t<T>, basic_iterator>() &&
                     !detail::HasCursorNext<Cur>() && detail::WritableCursor<Cur const, T>())>
             RANGES_CXX14_CONSTEXPR
             basic_iterator const &operator=(T && t) const
-            noexcept(noexcept(
-                std::declval<Cur const &>().write(static_cast<T &&>(t))))
+            noexcept(noexcept(std::declval<Cur const &>().write(static_cast<T &&>(t))))
             {
                 pos().write(static_cast<T &&>(t));
                 return *this;
@@ -440,8 +435,7 @@ namespace ranges
             CONCEPT_REQUIRES(detail::HasCursorNext<Cur>() &&
                 detail::is_writable_cursor<Cur const>())
             constexpr const_reference_t operator*() const
-            noexcept(noexcept(
-                const_reference_t{std::declval<Cur const &>()}))
+            noexcept(noexcept(const_reference_t{std::declval<Cur const &>()}))
             {
                 return const_reference_t{pos()};
             }
@@ -455,7 +449,7 @@ namespace ranges
             template<typename C = Cur,
                 CONCEPT_REQUIRES_(detail::HasCursorArrow<C>())>
             constexpr auto operator->() const
-                noexcept(noexcept(range_access::arrow(std::declval<C const &>())))
+            noexcept(noexcept(range_access::arrow(std::declval<C const &>())))
                 -> detail::cursor_arrow_t<C>
             {
                 return range_access::arrow(pos());
@@ -470,7 +464,7 @@ namespace ranges
                         uncvref_t<const_reference_t>>())>
             constexpr meta::_t<std::add_pointer<const_reference_t>>
             operator->() const
-                noexcept(noexcept(*std::declval<basic_iterator const &>()))
+            noexcept(noexcept(*std::declval<basic_iterator const &>()))
             {
                 return std::addressof(**this);
             }

--- a/include/range/v3/utility/invoke.hpp
+++ b/include/range/v3/utility/invoke.hpp
@@ -167,7 +167,7 @@ namespace ranges
         /// \endcond
 
         // Can be used to store rvalue references in addition to lvalue references.
-        // Also, see: https://cplusplus.github.io/LWG/lwg-active.html#2993
+        // Also, see: https://wg21.link/lwg2993
         template<typename T>
         struct reference_wrapper : private detail::reference_wrapper_<T>
         {

--- a/include/range/v3/utility/iterator.hpp
+++ b/include/range/v3/utility/iterator.hpp
@@ -140,7 +140,11 @@ namespace ranges
 
         /// \ingroup group-utility
         /// \sa `advance_fn`
-        RANGES_INLINE_VARIABLE(adl_advance_detail::advance_fn, advance)
+        /// Not to spec: advance is an ADL customization point
+        inline namespace CPOs
+        {
+            RANGES_INLINE_VARIABLE(adl_advance_detail::advance_fn, advance)
+        }
 
         namespace adl_advance_detail
         {

--- a/include/range/v3/utility/iterator_concepts.hpp
+++ b/include/range/v3/utility/iterator_concepts.hpp
@@ -182,12 +182,12 @@ namespace ranges
                 using reference_t = Readable::reference_t<Out>;
 
                 template<typename Out, typename T>
-                auto requires_(Out&& o, T &&t) -> decltype(
+                auto requires_(Out &&o, T &&t) -> decltype(
                     concepts::valid_expr(
-                        ((void)(*o = (T &&) t), 42),
-                        ((void)(*((Out &&) o) = (T &&) t), 42),
-                        ((void)(const_cast<reference_t<Out> const &&>(*o) = (T &&)t), 42),
-                        ((void)(const_cast<reference_t<Out> const &&>(*((Out &&) o)) = (T &&)t), 42)
+                        ((void)(*o = static_cast<T &&>(t)), 42),
+                        ((void)(*static_cast<Out &&>(o) = static_cast<T &&>(t)), 42),
+                        ((void)(const_cast<reference_t<Out> const &&>(*o) = static_cast<T &&>(t)), 42),
+                        ((void)(const_cast<reference_t<Out> const &&>(*static_cast<Out &&>(o)) = static_cast<T &&>(t)), 42)
                     ));
             };
 

--- a/include/range/v3/utility/move.hpp
+++ b/include/range/v3/utility/move.hpp
@@ -104,7 +104,10 @@ namespace ranges
         }
         /// \endcond
 
-        RANGES_INLINE_VARIABLE(adl_move_detail::iter_move_fn, iter_move)
+        inline namespace CPOs
+        {
+            RANGES_INLINE_VARIABLE(adl_move_detail::iter_move_fn, iter_move)
+        }
 
         /// \cond
         struct indirect_move_fn

--- a/include/range/v3/utility/swap.hpp
+++ b/include/range/v3/utility/swap.hpp
@@ -208,7 +208,7 @@ namespace ranges
             //    std::reference_wrapper<T>. How do I make it model IndirectlySwappable?
             // A: With an overload of iter_swap.
 
-            // Intentionally create an ambiguity with std::swap, which is
+            // Intentionally create an ambiguity with std::iter_swap, which is
             // (possibly) unconstrained.
             template<typename T>
             void iter_swap(T, T) = delete;
@@ -338,13 +338,17 @@ namespace ranges
                 adl_swap_detail::is_nothrow_indirectly_swappable_<T, U>>
         {};
 
-        /// \ingroup group-utility
-        /// \relates adl_swap_detail::swap_fn
-        RANGES_INLINE_VARIABLE(adl_swap_detail::swap_fn, swap)
+        inline namespace CPOs
+        {
+            /// \ingroup group-utility
+            /// \relates adl_swap_detail::swap_fn
+            RANGES_INLINE_VARIABLE(adl_swap_detail::swap_fn, swap)
 
-        /// \ingroup group-utility
-        /// \relates adl_swap_detail::iter_swap_fn
-        RANGES_INLINE_VARIABLE(adl_swap_detail::iter_swap_fn, iter_swap)
+            /// \ingroup group-utility
+            /// \relates adl_swap_detail::iter_swap_fn
+            RANGES_INLINE_VARIABLE(adl_swap_detail::iter_swap_fn, iter_swap)
+        }
+
 
         /// \cond
         struct indirect_swap_fn

--- a/include/range/v3/view/all.hpp
+++ b/include/range/v3/view/all.hpp
@@ -75,7 +75,8 @@ namespace ranges
                 static auto from_range(T && t) ->
                     decltype(all_fn::from_container(t, SIC(), SIRC()))
                 {
-                    static_assert(std::is_lvalue_reference<T>::value, "Cannot get a view of a temporary container");
+                    static_assert(std::is_lvalue_reference<T>::value,
+                        "Cannot get a view of a temporary container");
                     return all_fn::from_container(t, SIC(), SIRC());
                 }
 

--- a/include/range/v3/view_facade.hpp
+++ b/include/range/v3/view_facade.hpp
@@ -84,13 +84,15 @@ namespace ranges
             template<typename D = Derived, CONCEPT_REQUIRES_(Same<D, Derived>())>
             detail::facade_iterator_t<D> begin()
             {
-                return {range_access::begin_cursor(derived(), 42)};
+                return detail::facade_iterator_t<D>{
+                    range_access::begin_cursor(derived(), 42)};
             }
             /// \overload
             template<typename D = Derived, CONCEPT_REQUIRES_(Same<D, Derived>())>
             detail::facade_iterator_t<D const> begin() const
             {
-                return {range_access::begin_cursor(derived(), 42)};
+                return detail::facade_iterator_t<D const>{
+                    range_access::begin_cursor(derived(), 42)};
             }
             /// Let `d` be `static_cast<Derived &>(*this)`. Let `e` be
             /// `std::as_const(d).end_cursor()` if that expression is well-formed;

--- a/test/algorithm/copy.cpp
+++ b/test/algorithm/copy.cpp
@@ -23,7 +23,7 @@ RANGES_CXX14_CONSTEXPR
 bool test_constexpr_copy()
 {
     int a[4] = {0, 0, 0, 0};
-    int b[4] = {1, 2, 3, 4};
+    int const b[4] = {1, 2, 3, 4};
     ranges::copy(b, a);
     return ranges::equal(b, a);
 }

--- a/test/container_conversion.cpp
+++ b/test/container_conversion.cpp
@@ -93,7 +93,7 @@ int main()
     std::set<int> s = view::ints | view::take(10);
     ::check_equal(s, {0,1,2,3,4,5,6,7,8,9});
 
-    static_assert(!ranges::is_view<std::initializer_list<int>>::value, "");
+    static_assert(!View<std::initializer_list<int>>(), "");
 
     return ::test_result();
 }

--- a/test/experimental/utility/generator.cpp
+++ b/test/experimental/utility/generator.cpp
@@ -82,7 +82,10 @@ public:
     }
 };
 
-RANGES_INLINE_VARIABLE(coro_fn, coro)
+inline namespace function_objects
+{
+    RANGES_INLINE_VARIABLE(coro_fn, coro)
+}
 
 auto f(int const n)
 RANGES_DECLTYPE_AUTO_RETURN

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -61,7 +61,10 @@ struct check_equal_fn
     }
 };
 
-RANGES_INLINE_VARIABLE(check_equal_fn, check_equal)
+inline namespace function_objects
+{
+    RANGES_INLINE_VARIABLE(check_equal_fn, check_equal)
+}
 
 template<typename Expected, typename Actual>
 void has_type(Actual &&)

--- a/test/utility/basic_iterator.cpp
+++ b/test/utility/basic_iterator.cpp
@@ -140,20 +140,20 @@ namespace test_weak_output
     template<typename I>
     struct cursor
     {
-    private:
-        friend ranges::range_access;
-        I it_;
-        void write(ranges::value_type_t<I> v) const { *it_ = v; }
-        void next() { ++it_; }
-    public:
         struct mixin : ranges::basic_mixin<cursor>
         {
             mixin() = default;
             using ranges::basic_mixin<cursor>::basic_mixin;
-            mixin(I i) : mixin(cursor{i}) {}
+            explicit mixin(I i) : mixin(cursor{i}) {}
         };
+
         cursor() = default;
         explicit cursor(I i) : it_(i) {}
+
+        void write(ranges::value_type_t<I> v) const { *it_ = v; }
+        void next() { ++it_; }
+    private:
+        I it_;
     };
 
     CONCEPT_ASSERT(ranges::detail::OutputCursor<cursor<char *>, char>());

--- a/test/utility/meta.cpp
+++ b/test/utility/meta.cpp
@@ -92,7 +92,7 @@ struct can_invoke : can_invoke_<F, meta::list<As...>>
 static_assert(can_invoke<meta::quote<std::pair>, int, int>::value, "");
 // I'm guessing this failure is due to GCC #64970
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64970
-#if !defined(__GNUC__) || defined(__clang__)
+#if !defined(__GNUC__) || defined(__clang__) || __GNUC__ >= 5
 static_assert(!can_invoke<meta::quote<std::pair>, int, int, int>::value, "");
 #endif
 
@@ -126,7 +126,7 @@ static_assert(
 static_assert(can_invoke<lambda<_a, lazy::if_<std::is_integral<_a>, _a>>, int>::value, "");
 // I'm guessing this failure is due to GCC #64970
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64970
-#if !defined(__GNUC__) || defined(__clang__)
+#if !defined(__GNUC__) || defined(__clang__) || __GNUC__ >= 5
 static_assert(!can_invoke<lambda<_a, lazy::if_<std::is_integral<_a>, _a>>, float>::value, "");
 #endif
 
@@ -219,9 +219,6 @@ static_assert(factorial<meta::size_t<1>>::value == 1, "");
 static_assert(factorial<meta::size_t<2>>::value == 2, "");
 static_assert(factorial<meta::size_t<3>>::value == 6, "");
 static_assert(factorial<meta::size_t<4>>::value == 24, "");
-
-template<typename T>
-struct undef_t;
 
 int main()
 {
@@ -371,7 +368,7 @@ int main()
 
 // I'm guessing this failure is due to GCC #64970
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64970
-#if !defined(__GNUC__) || defined(__clang__)
+#if !defined(__GNUC__) || defined(__clang__) || __GNUC__ >= 5
         static_assert(!can_invoke<lambda<_args, defer<std::pair, _args>>, int>::value, "");
         static_assert(!can_invoke<lambda<_args, defer<std::pair, _args>>, int, short, double>::value,
                       "");


### PR DESCRIPTION
  * Eradicate the inline namespace `function_objects`. `RANGES_INLINE_VARIABLE` puts variables directly in the containing namespace when inline variables are available, and in an inline unnamed namespace otherwise.

  * *Explicitly* place CPOs that are truly customization points in an inline namespace `CPOs` inside `ranges::v3` (which keeps them from colliding with hidden friend functions of the same name)

  (Note that `advance` is a "true" CPO because `counted_iterator` defines a hidden friend overload in namespace `ranges::v3`.)

Bundle of dozens of drive-by changes:

* Implement `meta::at` with `__type_pack_element` when available

* Use wg21.link for LWG issues so we don't need to care about active vs. closed vs. defect [NFC]

* Wrap `view/all.hpp` at 100 [NFC]

* `experimental/view/shared.hpp`: `view::shared` requires the user to pass a container *rvalue*, the user doesn't care what if any reference type we bind to that argument. [NFC]

* `meta.hpp`: `s/#if defined(X)/#ifdef X/`

* `meta.cpp`: GCC #64970 has been fixed in GCC 5+

* Copypasta in `swap.hpp`

* MSVC-friendly feature detection/configuration (Use `_MSVC_LANG` when it's defined instead of `__cplusplus`)

* Allows users to override detection in meta as was already the case for range-v3.

* Don't define components - even deprecated ones - in terms of deprecated components.

* Simplify `CONCEPT_REQUIRES` macros

* Restrict the `gcc_bugs_bugs_bugs` workaround to affected versions of GCC 5.

* Remove extraneous `basic_iterator` constructor (we inherit the mixin's cursor constructors - there's no need to implement one.)

* `basic_mixin` constructors from `T` (and consequently `basic_iterator`'s cursor constructors) should be `explicit`

* `const`-ify source range in alg.copy test

* Sprinkle some `RANGES_CONSTEXPR_IF` in `ranges::equal`

* use simplified friend declarations in `ranges::variant` [NFC]

* Simplify `meta::as_list`: `curry<quote_trait<id>>` expands to `compose<quote_trait<id>, quote<list>>` which is equivalent to `quote<list>` [Almost NFC, negligible compile time reduction.]