### PR TITLE
Fix #839 macro to the clang version for MacOs

### DIFF
--- a/include/meta/meta.hpp
+++ b/include/meta/meta.hpp
@@ -1990,8 +1990,9 @@ namespace meta
             template <typename... T, typename V>
             struct find_index_<list<T...>, V>
             {
-#if defined(__clang__) && __clang_major__ < 6
+#if (defined(__clang__) && __clang_major__ < 6) || defined(__apple_build_version__)
                 // Explicitly specify extent to avoid https://llvm.org/bugs/show_bug.cgi?id=28385
+                // Track Apple's version here: https://en.wikipedia.org/wiki/Xcode#Toolchain_Versions
                 static constexpr bool s_v[sizeof...(T)] = {std::is_same<T, V>::value...};
 #else
                 static constexpr bool s_v[] = {std::is_same<T, V>::value...};
@@ -2047,8 +2048,9 @@ namespace meta
             template <typename... T, typename V>
             struct reverse_find_index_<list<T...>, V>
             {
-#if defined(__clang__) && __clang_major__ < 6
+#if (defined(__clang__) && __clang_major__ < 6) || defined(__apple_build_version__)
                 // Explicitly specify extent to avoid https://llvm.org/bugs/show_bug.cgi?id=28385
+                // Track Apple's version here: https://en.wikipedia.org/wiki/Xcode#Toolchain_Versions
                 static constexpr bool s_v[sizeof...(T)] = {std::is_same<T, V>::value...};
 #else
                 static constexpr bool s_v[] = {std::is_same<T, V>::value...};
@@ -2141,7 +2143,7 @@ namespace meta
             {
 #if (defined(__clang__) && __clang_major__ < 6) || defined(__apple_build_version__)
                 // Explicitly specify extent to avoid https://llvm.org/bugs/show_bug.cgi?id=28385
-                // Track Apples version here: https://en.wikipedia.org/wiki/Xcode#Toolchain_Versions
+                // Track Apple's version here: https://en.wikipedia.org/wiki/Xcode#Toolchain_Versions
                 static constexpr bool s_v[sizeof...(List)] = {invoke<Fun, List>::type::value...};
 #else
                 static constexpr bool s_v[] = {invoke<Fun, List>::type::value...};
@@ -2200,8 +2202,9 @@ namespace meta
                 list<List...>, Fun,
                 void_<integer_sequence<bool, bool(invoke<Fun, List>::type::value)...>>>
             {
-#if defined(__clang__) && __clang_major__ < 6
+#if (defined(__clang__) && __clang_major__ < 6) || defined(__apple_build_version__)
                 // Explicitly specify extent to avoid https://llvm.org/bugs/show_bug.cgi?id=28385
+                // Track Apple's version here: https://en.wikipedia.org/wiki/Xcode#Toolchain_Versions
                 static constexpr bool s_v[sizeof...(List)] = {invoke<Fun, List>::type::value...};
 #else
                 static constexpr bool s_v[] = {invoke<Fun, List>::type::value...};
@@ -2327,8 +2330,9 @@ namespace meta
             template <typename... List, typename T>
             struct count_<list<List...>, T>
             {
-#if defined(__clang__) && __clang_major__ < 6
+#if (defined(__clang__) && __clang_major__ < 6) || defined(__apple_build_version__)
                 // Explicitly specify extent to avoid https://llvm.org/bugs/show_bug.cgi?id=28385
+                // Track Apple's version here: https://en.wikipedia.org/wiki/Xcode#Toolchain_Versions
                 static constexpr bool s_v[sizeof...(List)] = {std::is_same<T, List>::value...};
 #else
                 static constexpr bool s_v[] = {std::is_same<T, List>::value...};
@@ -2371,8 +2375,9 @@ namespace meta
             struct count_if_<list<List...>, Fn,
                              void_<integer_sequence<bool, bool(invoke<Fn, List>::type::value)...>>>
             {
-#if defined(__clang__) && __clang_major__ < 6
+#if (defined(__clang__) && __clang_major__ < 6) || defined(__apple_build_version__)
                 // Explicitly specify extent to avoid https://llvm.org/bugs/show_bug.cgi?id=28385
+                // Track Apple's version here: https://en.wikipedia.org/wiki/Xcode#Toolchain_Versions
                 static constexpr bool s_v[sizeof...(List)] = {invoke<Fn, List>::type::value...};
 #else
                 static constexpr bool s_v[] = {invoke<Fn, List>::type::value...};

--- a/include/meta/meta.hpp
+++ b/include/meta/meta.hpp
@@ -2143,7 +2143,7 @@ namespace meta
                 // Explicitly specify extent to avoid https://llvm.org/bugs/show_bug.cgi?id=28385
                 // Track Apples version here: https://en.wikipedia.org/wiki/Xcode#Toolchain_Versions
                 static constexpr bool s_v[sizeof...(List)] = {invoke<Fun, List>::type::value...};
-#elif
+#else
                 static constexpr bool s_v[] = {invoke<Fun, List>::type::value...};
 #endif
                 using type =

--- a/include/meta/meta.hpp
+++ b/include/meta/meta.hpp
@@ -1992,7 +1992,6 @@ namespace meta
             {
 #if (defined(__clang__) && __clang_major__ < 6) || defined(__apple_build_version__)
                 // Explicitly specify extent to avoid https://llvm.org/bugs/show_bug.cgi?id=28385
-                // Track Apple's version here: https://en.wikipedia.org/wiki/Xcode#Toolchain_Versions
                 static constexpr bool s_v[sizeof...(T)] = {std::is_same<T, V>::value...};
 #else
                 static constexpr bool s_v[] = {std::is_same<T, V>::value...};
@@ -2050,7 +2049,6 @@ namespace meta
             {
 #if (defined(__clang__) && __clang_major__ < 6) || defined(__apple_build_version__)
                 // Explicitly specify extent to avoid https://llvm.org/bugs/show_bug.cgi?id=28385
-                // Track Apple's version here: https://en.wikipedia.org/wiki/Xcode#Toolchain_Versions
                 static constexpr bool s_v[sizeof...(T)] = {std::is_same<T, V>::value...};
 #else
                 static constexpr bool s_v[] = {std::is_same<T, V>::value...};
@@ -2143,7 +2141,6 @@ namespace meta
             {
 #if (defined(__clang__) && __clang_major__ < 6) || defined(__apple_build_version__)
                 // Explicitly specify extent to avoid https://llvm.org/bugs/show_bug.cgi?id=28385
-                // Track Apple's version here: https://en.wikipedia.org/wiki/Xcode#Toolchain_Versions
                 static constexpr bool s_v[sizeof...(List)] = {invoke<Fun, List>::type::value...};
 #else
                 static constexpr bool s_v[] = {invoke<Fun, List>::type::value...};
@@ -2204,7 +2201,6 @@ namespace meta
             {
 #if (defined(__clang__) && __clang_major__ < 6) || defined(__apple_build_version__)
                 // Explicitly specify extent to avoid https://llvm.org/bugs/show_bug.cgi?id=28385
-                // Track Apple's version here: https://en.wikipedia.org/wiki/Xcode#Toolchain_Versions
                 static constexpr bool s_v[sizeof...(List)] = {invoke<Fun, List>::type::value...};
 #else
                 static constexpr bool s_v[] = {invoke<Fun, List>::type::value...};
@@ -2332,7 +2328,6 @@ namespace meta
             {
 #if (defined(__clang__) && __clang_major__ < 6) || defined(__apple_build_version__)
                 // Explicitly specify extent to avoid https://llvm.org/bugs/show_bug.cgi?id=28385
-                // Track Apple's version here: https://en.wikipedia.org/wiki/Xcode#Toolchain_Versions
                 static constexpr bool s_v[sizeof...(List)] = {std::is_same<T, List>::value...};
 #else
                 static constexpr bool s_v[] = {std::is_same<T, List>::value...};
@@ -2377,7 +2372,6 @@ namespace meta
             {
 #if (defined(__clang__) && __clang_major__ < 6) || defined(__apple_build_version__)
                 // Explicitly specify extent to avoid https://llvm.org/bugs/show_bug.cgi?id=28385
-                // Track Apple's version here: https://en.wikipedia.org/wiki/Xcode#Toolchain_Versions
                 static constexpr bool s_v[sizeof...(List)] = {invoke<Fn, List>::type::value...};
 #else
                 static constexpr bool s_v[] = {invoke<Fn, List>::type::value...};

--- a/include/meta/meta.hpp
+++ b/include/meta/meta.hpp
@@ -2139,10 +2139,11 @@ namespace meta
             struct find_if_<list<List...>, Fun,
                             void_<integer_sequence<bool, bool(invoke<Fun, List>::type::value)...>>>
             {
-#if defined(__clang__) && __clang_major__ < 6
+#if (defined(__clang__) && __clang_major__ < 6) || defined(__apple_build_version__)
                 // Explicitly specify extent to avoid https://llvm.org/bugs/show_bug.cgi?id=28385
+                // Track Apples version here: https://en.wikipedia.org/wiki/Xcode#Toolchain_Versions
                 static constexpr bool s_v[sizeof...(List)] = {invoke<Fun, List>::type::value...};
-#else
+#elif
                 static constexpr bool s_v[] = {invoke<Fun, List>::type::value...};
 #endif
                 using type =


### PR DESCRIPTION
This should fix #839 