### PR TITLE
Fixes #869 any_view<Foo, category::sized | category::input>

### DIFF
--- a/include/range/v3/view/any_view.hpp
+++ b/include/range/v3/view/any_view.hpp
@@ -586,7 +586,8 @@ namespace ranges
             }
         private:
             template<typename Rng>
-            using impl_t = detail::any_input_view_impl<view::all_t<Rng>, Ref>;
+            using impl_t = detail::any_input_view_impl<view::all_t<Rng>, Ref,
+                (Cat & category::sized) == category::sized>;
 
             detail::any_input_cursor<Ref> begin_cursor()
             {
@@ -597,7 +598,9 @@ namespace ranges
                 return detail::any_input_cursor<Ref>{*ptr_};
             }
 
-            std::shared_ptr<detail::any_input_view_interface<Ref>> ptr_;
+            std::shared_ptr<detail::any_input_view_interface<Ref,
+                (Cat & category::sized) == category::sized>>
+            ptr_;
         };
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17

--- a/test/view/any_view.cpp
+++ b/test/view/any_view.cpp
@@ -110,6 +110,13 @@ RANGES_DIAGNOSTIC_POP
         static_assert((get_categories<decltype(ints)>() & category::sized) == category::sized, "");
     }
     {
+        any_view<int, category::input | category::sized> ints = view::ints | view::take_exactly(10);
+        CONCEPT_ASSERT(InputView<decltype(ints)>());
+        CONCEPT_ASSERT(SizedView<decltype(ints)>());
+        static_assert((get_categories<decltype(ints)>() & category::input) == category::input, "");
+        static_assert((get_categories<decltype(ints)>() & category::sized) == category::sized, "");
+    }
+    {
         any_view<int, category::bidirectional> ints = view::ints;
         CONCEPT_ASSERT(BidirectionalView<decltype(ints)>());
         CONCEPT_ASSERT(!RandomAccessView<decltype(ints)>());


### PR DESCRIPTION
The sized category information wasn't getting propagated to the implementation.

Apologies if I'm mistaken!