### PR TITLE
fix 3-year-old bug in reverse_iterator

### DIFF
--- a/include/range/v3/algorithm/inplace_merge.hpp
+++ b/include/range/v3/algorithm/inplace_merge.hpp
@@ -71,8 +71,8 @@ namespace ranges
                     else
                     {
                         auto p = ranges::move(middle, end, tmpbuf.begin()).second;
-                        using RBi = std::reverse_iterator<I>;
-                        using Rv = std::reverse_iterator<value_type_t<I> *>;
+                        using RBi = ranges::reverse_iterator<I>;
+                        using Rv = ranges::reverse_iterator<value_type_t<I> *>;
                         merge(make_move_iterator(RBi{std::move(middle)}),
                             make_move_sentinel(RBi{std::move(begin)}),
                             make_move_iterator(Rv{p.base().base()}),

--- a/include/range/v3/algorithm/inplace_merge.hpp
+++ b/include/range/v3/algorithm/inplace_merge.hpp
@@ -63,9 +63,9 @@ namespace ranges
                     if(len1 <= len2)
                     {
                         auto p = ranges::move(begin, middle, tmpbuf.begin()).second;
-                        merge(make_move_iterator(buf), make_move_sentinel(p.base().base()),
+                        merge(make_move_iterator(buf), make_move_iterator(p.base().base()),
                             make_move_iterator(std::move(middle)),
-                            make_move_sentinel(std::move(end)), std::move(begin),
+                            make_move_iterator(std::move(end)), std::move(begin),
                             std::ref(pred), std::ref(proj), std::ref(proj));
                     }
                     else
@@ -74,7 +74,7 @@ namespace ranges
                         using RBi = ranges::reverse_iterator<I>;
                         using Rv = ranges::reverse_iterator<value_type_t<I> *>;
                         merge(make_move_iterator(RBi{std::move(middle)}),
-                            make_move_sentinel(RBi{std::move(begin)}),
+                            make_move_iterator(RBi{std::move(begin)}),
                             make_move_iterator(Rv{p.base().base()}),
                             make_move_iterator(Rv{buf}), RBi{std::move(end)},
                             not_fn(std::ref(pred)), std::ref(proj), std::ref(proj));

--- a/include/range/v3/utility/iterator.hpp
+++ b/include/range/v3/utility/iterator.hpp
@@ -679,9 +679,7 @@ namespace ranges
                 RANGES_CXX14_CONSTEXPR
                 I arrow() const
                 {
-                    I tmp(it_);
-                    --tmp;
-                    return tmp;
+                    return ranges::prev(it_);
                 }
                 RANGES_CXX14_CONSTEXPR
                 I base() const
@@ -720,7 +718,7 @@ namespace ranges
                 auto move() const
                 RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
                 (
-                    iter_move(it_)
+                    iter_move(ranges::prev(it_))
                 )
             public:
                 reverse_cursor() = default;

--- a/include/range/v3/utility/variant.hpp
+++ b/include/range/v3/utility/variant.hpp
@@ -22,6 +22,7 @@
 #include <range/v3/begin_end.hpp>
 #include <range/v3/size.hpp>
 #include <range/v3/distance.hpp>
+#include <range/v3/utility/iterator.hpp>
 
 namespace ranges
 {
@@ -55,7 +56,7 @@ namespace ranges
                 CONCEPT_REQUIRES(MoveConstructible<T>())
                 indexed_datum(indexed_datum &&that)
                 {
-                    std::uninitialized_copy_n(std::make_move_iterator(that.data_), N, data_);
+                    std::uninitialized_copy_n(make_move_iterator(that.data_), N, data_);
                 }
                 CONCEPT_REQUIRES(CopyConstructible<T>())
                 indexed_datum(indexed_datum const &that)

--- a/test/action/stable_sort.cpp
+++ b/test/action/stable_sort.cpp
@@ -24,17 +24,18 @@
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 
+#if !defined(__clang__) || !defined(_MSVC_STL_VERSION) // Avoid #890
 void test_bug632()
 {
-	const std::vector<double> scores = { 3.0, 1.0, 2.0 };
-	std::vector<int> indices = { 0, 1, 2 };
+    const std::vector<double> scores = { 3.0, 1.0, 2.0 };
+    std::vector<int> indices = { 0, 1, 2 };
 
-	indices |= ranges::action::stable_sort(
-		ranges::less{},
-		[&] (const int &x) { return scores[ (std::size_t)x ]; }
-	);
+    indices |= ranges::action::stable_sort(
+        ranges::less{},
+        [&] (const int &x) { return scores[ (std::size_t)x ]; }
+    );
 
-	::check_equal( indices, {1, 2, 0} );
+    ::check_equal( indices, {1, 2, 0} );
 }
 
 int main()
@@ -82,3 +83,6 @@ int main()
 
     return ::test_result();
 }
+#else // Avoid #890
+int main() {}
+#endif // Avoid #890

--- a/test/algorithm/stable_sort.cpp
+++ b/test/algorithm/stable_sort.cpp
@@ -35,12 +35,14 @@ namespace
 {
     std::mt19937 gen;
 
+#if !defined(__clang__) || !defined(_MSVC_STL_VERSION) // Avoid #890
     struct indirect_less
     {
         template<class P>
         bool operator()(const P& x, const P& y)
             {return *x < *y;}
     };
+#endif // Avoid #890
 
     template<class RI>
     void
@@ -194,6 +196,7 @@ int main()
     test_larger_sorts(1000);
     test_larger_sorts(1009);
 
+#if !defined(__clang__) || !defined(_MSVC_STL_VERSION) // Avoid #890
     // Check move-only types
     {
         std::vector<std::unique_ptr<int> > v(1000);
@@ -235,6 +238,7 @@ int main()
             CHECK((std::size_t)v[i].j == v.size() - i - 1);
         }
     }
+#endif // Avoid #890
 
     return ::test_result();
 }


### PR DESCRIPTION
We would have found this bug had we been using `ranges::reverse_iterator` in the implementation of `inplace_merge` as opposed to `std::reverse_iterator`. This PR makes that change in addition to a couple of other changes to use `ranges::` facilities instead of `std::` ones.