### PR TITLE
function_ref: remove unnecessary defaulted copy constructors

### DIFF
--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -107,8 +107,6 @@ private:
     }
 public:
     function_ref() = default;
-    function_ref(function_ref &) = default;
-    function_ref(function_ref const &) = default;
     template<typename T>
     function_ref(T const &t)
       : data_(&t)


### PR DESCRIPTION
I can only assume that the non-`const` copy constructor was a typo, and a move constructor was intended. I see no reason to forbid assignment of this type, so let's yank both copy constructors.