### PR TITLE
Misc cleanup:

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -55,7 +55,6 @@
         {
             "name": "Win32",
             "includePath": [
-                "C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/include",
                 "${workspaceRoot}/include"
             ],
             "defines": [
@@ -65,7 +64,6 @@
             "intelliSenseMode": "msvc-x64",
             "browse": {
                 "path": [
-                    "C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/include/*",
                     "${workspaceRoot}/include"
                 ],
                 "limitSymbolsToIncludedHeaders": true,

--- a/include/meta/meta.hpp
+++ b/include/meta/meta.hpp
@@ -1012,7 +1012,7 @@ namespace meta
         /// \endcond
 
         /// Use as `on<F, Gs...>`. Creates an Callable that applies Callable \c F to the
-        /// result of applying Callable `compose<Gs...>` to all the arguments.
+        /// result of applying Callable `compose<Gs...>` to each of the arguments.
         /// \ingroup composition
         template <typename... Fs>
         using on = detail::on_<Fs...>;

--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -41,6 +41,9 @@ namespace ranges
 #endif
 
 #ifndef RANGES_ASSERT
+    // Always use our hand-rolled assert implementation on older GCCs, which do
+    // not allow assert to be used in a constant expression, and on MSVC whose
+    // assert is not marked [[noreturn]].
 #if !defined(NDEBUG) && \
     ((defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 5 || defined(__MINGW32__))) || \
      defined(_MSVC_STL_VERSION))
@@ -171,6 +174,7 @@ namespace ranges
 #define RANGES_CXX_IF_CONSTEXPR_14 0L
 #define RANGES_CXX_IF_CONSTEXPR_17 201606L
 
+// Implementation-specific diagnostic control
 #if defined(_MSC_VER) && !defined(__clang__)
 #define RANGES_CXX_VER _MSVC_LANG
 #define RANGES_DIAGNOSTIC_PUSH __pragma(warning(push))

--- a/include/range/v3/span.hpp
+++ b/include/range/v3/span.hpp
@@ -328,17 +328,12 @@ namespace ranges
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
         template<typename Rng,
-            CONCEPT_REQUIRES_(ContiguousRange<Rng>() &&
-                range_cardinality<Rng>::value < cardinality{})>
-        span(Rng &&rng) ->
-            span<concepts::ContiguousRange::element_t<Rng>>;
-
-        template<typename Rng,
-            CONCEPT_REQUIRES_(ContiguousRange<Rng>() &&
-                range_cardinality<Rng>::value >= cardinality{})>
+            CONCEPT_REQUIRES_(ContiguousRange<Rng>())>
         span(Rng &&rng) ->
             span<concepts::ContiguousRange::element_t<Rng>,
-                static_cast<detail::span_index_t>(range_cardinality<Rng>::value)>;
+                (range_cardinality<Rng>::value < cardinality{}
+                    ? dynamic_extent
+                    : static_cast<detail::span_index_t>(range_cardinality<Rng>::value))>;
 #endif
 
         template<typename T, detail::span_index_t N>

--- a/include/range/v3/utility/common_type.hpp
+++ b/include/range/v3/utility/common_type.hpp
@@ -90,8 +90,8 @@ namespace ranges
             {};
             template<typename T, typename U>
             struct _builtin_common<T &&, U &&, meta::if_<meta::and_<
-                std::is_convertible<T &&, _rref_res<T, U>>,
-                std::is_convertible<U &&, _rref_res<T, U>>>>>
+                std::is_convertible<T, _rref_res<T, U>>,
+                std::is_convertible<U, _rref_res<T, U>>>>>
             {
                 using type = _rref_res<T, U>;
             };
@@ -101,7 +101,7 @@ namespace ranges
             {};
             template<typename T, typename U>
             struct _builtin_common<T &, U &&, meta::if_<
-                std::is_convertible<U &&, _builtin_common_t<T &, U const &>>>>
+                std::is_convertible<U, _builtin_common_t<T &, U const &>>>>
               : _builtin_common<T &, U const &>
             {};
             template<typename T, typename U>
@@ -126,8 +126,8 @@ namespace ranges
             {};
             template<typename T, typename U>
             struct _builtin_common_rr<T, U, meta::if_<meta::and_<
-                std::is_convertible<T &&, _rref_res<T, U>>,
-                std::is_convertible<U &&, _rref_res<T, U>>>>>
+                std::is_convertible<T, _rref_res<T, U>>,
+                std::is_convertible<U, _rref_res<T, U>>>>>
             {
                 using type = _rref_res<T, U>;
             };
@@ -145,7 +145,7 @@ namespace ranges
             {};
             template<typename T, typename U>
             struct _builtin_common_lr<T, U, meta::if_<
-                std::is_convertible<U &&, _builtin_common_t<T &, U const &>>>>
+                std::is_convertible<U, _builtin_common_t<T &, U const &>>>>
               : _builtin_common<T &, U const &>
             {};
             template<typename T, typename U>
@@ -257,17 +257,10 @@ namespace ranges
                     common_type<T, U>>
             {};
 
-        #if 0 //!defined(__clang__) && __GNUC__ == 4 && __GNUC_MINOR__ <= 8
-            template<typename T, typename U>
-            struct _common_reference2<T, U, meta::if_<meta::is_trait<_builtin_common<T, U>>>>
-              : _builtin_common<T, U>
-            {};
-        #else
             template<typename T, typename U>
             struct _common_reference2<T, U, meta::if_<std::is_reference<_builtin_common_t<T, U>>>>
               : _builtin_common<T, U>
             {};
-        #endif
         }
         /// \endcond
 

--- a/include/range/v3/utility/invoke.hpp
+++ b/include/range/v3/utility/invoke.hpp
@@ -224,7 +224,6 @@ namespace ranges
         struct result_of<Fun(Args...)>
           : meta::defer<invoke_result_t, Fun, Args...>
         {};
-
     } // namespace v3
 } // namespace ranges
 

--- a/include/range/v3/utility/iterator_concepts.hpp
+++ b/include/range/v3/utility/iterator_concepts.hpp
@@ -118,7 +118,7 @@ namespace ranges
             meta::_t<upgrade_iterator_category<typename T::iterator_category>>
             iterator_category_helper(T *);
 
-            template<class T>
+            template<typename T>
             using iterator_category_ = decltype(detail::iterator_category_helper(_nullptr_v<T>()));
         }
         /// \endcond
@@ -494,7 +494,7 @@ namespace ranges
             // Call ApplyFn with the cartesian product of the Readables' value and reference
             // types. In addition, call ApplyFn with the common_reference type of all the
             // Readables. Return all the results as a list.
-            template<class...Is>
+            template<typename...Is>
             using iter_args_lists_ =
                 meta::push_back<
                     meta::cartesian_product<
@@ -672,12 +672,12 @@ namespace ranges
 
 namespace __gnu_debug
 {
-    template<class I1, class I2, class Seq,
+    template<typename I1, typename I2, typename Seq,
         CONCEPT_REQUIRES_(!::ranges::SizedSentinel<I1, I2>())>
     void operator-(
         _Safe_iterator<I1, Seq> const &, _Safe_iterator<I2, Seq> const &) = delete;
 
-    template<class I1, class Seq,
+    template<typename I1, typename Seq,
         CONCEPT_REQUIRES_(!::ranges::SizedSentinel<I1, I1>())>
     void operator-(
         _Safe_iterator<I1, Seq> const &, _Safe_iterator<I1, Seq> const &) = delete;

--- a/include/range/v3/view/cartesian_product.hpp
+++ b/include/range/v3/view/cartesian_product.hpp
@@ -190,7 +190,7 @@ namespace ranges
                         ranges::size(std::get<N - 1>(view_->views_)));
                     auto const first = ranges::begin(std::get<N - 1>(view_->views_));
 
-                    auto const idx = i - first;
+                    auto const idx = static_cast<std::ptrdiff_t>(i - first);
                     RANGES_EXPECT(0 <= idx && idx < my_size);
                     RANGES_EXPECT(n < PTRDIFF_MAX - idx);
                     n += idx;
@@ -250,7 +250,7 @@ namespace ranges
                 explicit cursor(end_tag, constify_if<cartesian_product_view> &view)
                   : cursor(end_tag{}, view, BoundedView<meta::at_c<meta::list<Views...>, 0>>{})
                 {}
-                ranges::common_tuple<range_reference_t<Views>...> read() const
+                common_tuple<range_reference_t<Views>...> read() const
                 {
                     return tuple_transform(its_, ranges::dereference);
                 }
@@ -315,7 +315,7 @@ namespace ranges
         public:
             cartesian_product_view() = default;
             CONCEPT_REQUIRES(sizeof...(Views) > 0)
-            constexpr cartesian_product_view(Views... views)
+            explicit constexpr cartesian_product_view(Views... views)
               : views_{detail::move(views)...}
             {}
             CONCEPT_REQUIRES(CanSize<true>())

--- a/include/range/v3/view/sliding.hpp
+++ b/include/range/v3/view/sliding.hpp
@@ -111,7 +111,7 @@ namespace ranges
                 CONCEPT_ASSERT(ForwardRange<Rng>());
                 sv_base() = default;
                 sv_base(Rng rng, range_difference_type_t<Rng> n)
-                : sv_base::view_adaptor(std::move(rng)), n_(n)
+                  : sv_base::view_adaptor(std::move(rng)), n_(n)
                 {
                     RANGES_ASSERT(0 < n_);
                 }

--- a/include/range/v3/view/zip_with.hpp
+++ b/include/range/v3/view/zip_with.hpp
@@ -372,7 +372,7 @@ namespace ranges
             {
                 template<typename Fun, typename ...Rngs>
                 using Concept = meta::and_<
-                    meta::and_<InputRange<Rngs>...>,
+                    InputRange<Rngs>...,
                     CopyConstructible<Fun>,
                     Invocable<Fun&, range_reference_t<Rngs> &&...>>;
 


### PR DESCRIPTION
* Fix incorrect description for `meta::on`
* Don't violate [temp.deduct.guide]/3 in `span.hpp`
* `iterator_concepts.hpp`: range-v3 uses `typename` for template type parameters, not `class`
* Silence potential warning when `cartesian_product_view::advance_` implicitly converts `difference_type` to `ptrdiff_t`
* `sliding.hpp` fix bad indent
* `zip_with_fn::Concept`: remove redundant `meta::and_` nested in `meta::and_`
* `common_type.hpp`: remove `#if 0` block, and strip extraneous `&&` from the first argument to `is_convertible`.
* Don't put MSVC include path in `c_cpp_propertes`: it's too volatile