### PR TITLE
fix bug in stride_view's iterator advance; fixes #901

### DIFF
--- a/include/range/v3/view/stride.hpp
+++ b/include/range/v3/view/stride.hpp
@@ -59,8 +59,6 @@ namespace ranges
                 stride_view_base() = default;
                 RANGES_CXX14_CONSTEXPR
                 stride_view_base(Rng &&rng, range_difference_type_t<Rng> const stride)
-                    noexcept(std::is_nothrow_constructible<stride_view_adaptor<Rng>, Rng>::value &&
-                        noexcept(std::declval<stride_view_base &>().calc_offset(SizedRange<Rng>())))
                   : stride_view_adaptor<Rng>{std::move(rng)},
                     stride_{(RANGES_EXPECT(0 < stride), stride)},
                     offset_{calc_offset(SizedRange<Rng>())}
@@ -88,7 +86,6 @@ namespace ranges
             private:
                 RANGES_CXX14_CONSTEXPR
                 range_difference_type_t<Rng> calc_offset(std::true_type)
-                    noexcept(noexcept(ranges::distance(std::declval<stride_view_base &>().base())))
                 {
                     if(auto const rem = ranges::distance(this->base()) % stride_)
                         return stride_ - rem;
@@ -108,7 +105,6 @@ namespace ranges
             {
                 stride_view_base() = default;
                 constexpr stride_view_base(Rng &&rng, range_difference_type_t<Rng> const stride)
-                    noexcept(std::is_nothrow_constructible<stride_view_adaptor<Rng>, Rng>::value)
                   : stride_view_adaptor<Rng>{std::move(rng)},
                     stride_{(RANGES_EXPECT(0 < stride), stride)}
                 {}
@@ -153,8 +149,6 @@ namespace ranges
                   : rng_(&rng)
                 {}
                 RANGES_CXX14_CONSTEXPR void next(iterator_t<Rng> &it)
-                    noexcept(noexcept(it != ranges::end(std::declval<Rng &>()),
-                        ranges::advance(it, 0, std::declval<sentinel_t<Rng> &>())))
                 {
                     auto const last = ranges::end(rng_->base());
                     RANGES_EXPECT(it != last);
@@ -166,9 +160,6 @@ namespace ranges
                 }
                 CONCEPT_REQUIRES(BidirectionalRange<Rng>())
                 RANGES_CXX14_CONSTEXPR void prev(iterator_t<Rng> &it)
-                    noexcept(noexcept(ranges::advance(it, 0),
-                        it != ranges::begin(std::declval<Rng &>()),
-                        it == ranges::end(std::declval<Rng &>())))
                 {
                     RANGES_EXPECT(it != ranges::begin(rng_->base()));
                     auto delta = -rng_->stride_;
@@ -187,7 +178,6 @@ namespace ranges
                     CONCEPT_REQUIRES_(SizedSentinel<Other, iterator_t<Rng>>())>
                 RANGES_CXX14_CONSTEXPR range_difference_type_t<Rng> distance_to(
                     iterator_t<Rng> const &here, Other const &there) const
-                    noexcept(noexcept(there - here))
                 {
                     range_difference_type_t<Rng> delta = there - here;
                     if(delta < 0)
@@ -199,11 +189,6 @@ namespace ranges
                 CONCEPT_REQUIRES(RandomAccessRange<Rng>())
                 RANGES_CXX14_CONSTEXPR void advance(
                     iterator_t<Rng> &it, range_difference_type_t<Rng> n)
-                    noexcept(noexcept(
-                        ranges::begin(std::declval<Rng &>()) == ranges::end(std::declval<Rng &>()),
-                        ranges::advance(it, n, std::declval<sentinel_t<Rng> &>()),
-                        ranges::advance(it, n),
-                        ranges::advance(it, n, std::declval<iterator_t<Rng> &>())))
                 {
                     if(0 == n)
                         return;
@@ -242,15 +227,11 @@ namespace ranges
             };
             CONCEPT_REQUIRES(const_iterable)
             constexpr adaptor begin_adaptor() const
-                noexcept(std::is_nothrow_constructible<adaptor, stride_view const &>::value &&
-                    std::is_nothrow_move_constructible<adaptor>::value)
             {
                 return adaptor{*this};
             }
             CONCEPT_REQUIRES(!const_iterable)
             RANGES_CXX14_CONSTEXPR adaptor begin_adaptor()
-                noexcept(std::is_nothrow_constructible<adaptor, stride_view &>::value &&
-                    std::is_nothrow_move_constructible<adaptor>::value)
             {
                 return adaptor{*this};
             }
@@ -261,27 +242,21 @@ namespace ranges
             // BoundedView, adapt it anyway.
             CONCEPT_REQUIRES(const_iterable && BoundedRange<Rng>())
             constexpr adaptor end_adaptor() const
-                noexcept(std::is_nothrow_constructible<adaptor, stride_view const &>::value &&
-                    std::is_nothrow_move_constructible<adaptor>::value)
             {
                 return adaptor{*this};
             }
             CONCEPT_REQUIRES(!const_iterable && BoundedRange<Rng>())
             RANGES_CXX14_CONSTEXPR adaptor end_adaptor()
-                noexcept(std::is_nothrow_constructible<adaptor, stride_view &>::value &&
-                    std::is_nothrow_move_constructible<adaptor>::value)
             {
                 return adaptor{*this};
             }
             CONCEPT_REQUIRES(const_iterable && !BoundedRange<Rng>())
             constexpr adaptor_base end_adaptor() const
-                noexcept(std::is_nothrow_constructible<adaptor_base, stride_view const &>::value)
             {
                 return {};
             }
             CONCEPT_REQUIRES(!const_iterable && !BoundedRange<Rng>())
             RANGES_CXX14_CONSTEXPR adaptor_base end_adaptor()
-                noexcept(std::is_nothrow_constructible<adaptor_base, stride_view &>::value)
             {
                 return {};
             }
@@ -294,19 +269,15 @@ namespace ranges
         public:
             stride_view() = default;
             constexpr stride_view(Rng rng, range_difference_type_t<Rng> const stride)
-                noexcept(std::is_nothrow_constructible<detail::stride_view_base<Rng>,
-                    Rng, range_difference_type_t<Rng>>::value)
               : detail::stride_view_base<Rng>{std::move(rng), stride}
             {}
             CONCEPT_REQUIRES(SizedRange<Rng const>())
             constexpr range_size_type_t<Rng> size() const
-                noexcept(noexcept(ranges::size(std::declval<Rng const &>())))
             {
                 return size_(ranges::size(this->base()));
             }
             CONCEPT_REQUIRES(!SizedRange<Rng const>() && SizedRange<Rng>())
             RANGES_CXX14_CONSTEXPR range_size_type_t<Rng> size()
-                noexcept(noexcept(ranges::size(std::declval<Rng &>())))
             {
                 return size_(ranges::size(this->base()));
             }

--- a/include/range/v3/view/stride.hpp
+++ b/include/range/v3/view/stride.hpp
@@ -205,10 +205,20 @@ namespace ranges
                         ranges::advance(it, n),
                         ranges::advance(it, n, std::declval<iterator_t<Rng> &>())))
                 {
-                    if(0 == n) return;
+                    if(0 == n)
+                        return;
                     n *= rng_->stride_;
                     auto const last = ranges::end(rng_->base());
-                    if(it == last) n -= rng_->get_offset();
+                    if(it == last)
+                    {
+                        RANGES_EXPECT(n < 0);
+                        if(rng_->get_offset(false) < 0) // hasn't been set yet!
+                        {
+                            auto const rem = ranges::distance(rng_->base()) % rng_->stride_;
+                            rng_->set_offset(rem ? rng_->stride_ - rem : 0);
+                        }
+                        n += rng_->get_offset();
+                    }
                     if(0 < n)
                     {
                         auto delta = ranges::advance(it, n, last);

--- a/test/view/stride.cpp
+++ b/test/view/stride.cpp
@@ -17,6 +17,7 @@
 #include <range/v3/view/move.hpp>
 #include <range/v3/view/reverse.hpp>
 #include <range/v3/view/stride.hpp>
+#include <range/v3/view/iota.hpp>
 #include <range/v3/algorithm/copy.hpp>
 #include <range/v3/utility/iterator.hpp>
 #include <range/v3/numeric.hpp>
@@ -133,5 +134,30 @@ int main()
                     {48, 45, 42, 39, 36, 33, 30, 27, 24, 21, 18, 15, 12, 9, 6, 3, 0});
     }
 
-    return ::test_result();
+    // https://github.com/ericniebler/range-v3/issues/901
+    {
+        auto r = view::iota( 0, 12 );
+
+        // Evenly divisible stride:
+        auto strided1 = r | view::stride(3);
+        ::check_equal(strided1, {0, 3, 6, 9});
+        CHECK(strided1.size() == 4u);
+        CHECK(strided1.front() == 0);
+        CHECK(strided1[0] == 0);
+        CHECK(strided1.back() == 9);
+        CHECK(strided1[3] == 9);
+        CHECK(strided1[(int)strided1.size() - 1] == 9);
+
+        // Not evenly divisible stride:
+        auto strided2 = r | view::stride(5);
+        ::check_equal(strided2, {0, 5, 10});
+        CHECK(strided2.size() == 3u);
+        CHECK(strided2.front() == 0);
+        CHECK(strided2[0] == 0);
+        CHECK(strided2.back() == 10);
+        CHECK(strided2[2] == 10);
+        CHECK(strided2[(int)strided2.size() - 1] == 10);
+    }
+
+    //return ::test_result();
 }


### PR DESCRIPTION
When "advancing" the end iterator by a negative amount, and the cached "offset" hasn't yet been computed yet, _compute it first_ before using it.