### PR TITLE
make the generate and generate_n views work with move-only types

### DIFF
--- a/include/range/v3/detail/variant.hpp
+++ b/include/range/v3/detail/variant.hpp
@@ -391,14 +391,14 @@ namespace ranges
                 }
                 template<typename U>
                 meta::if_<std::is_object<U>>
-                    operator()(indexed_datum<U, meta::size_t<N>> &u)
+                operator()(indexed_datum<U, meta::size_t<N>> &u)
                     noexcept(std::is_nothrow_constructible<U, Ts...>::value)
                 {
                     this->construct_(u.get(), meta::make_index_sequence<sizeof...(Ts)>{});
                 }
                 template<typename U>
                 meta::if_<meta::not_<std::is_object<U>>>
-                    operator()(indexed_datum<U, meta::size_t<N>> &u)
+                operator()(indexed_datum<U, meta::size_t<N>> &u)
                     noexcept(std::is_nothrow_constructible<detail::decay_t<U>, Ts...>::value)
                 {
                     this->construct_(u, meta::make_index_sequence<sizeof...(Ts)>{});
@@ -419,6 +419,12 @@ namespace ranges
                 void operator()(indexed_element<U, N> t) const noexcept
                 {
                     *t_ = std::addressof(t.get());
+                }
+                template<typename U>
+                void operator()(indexed_element<U &&, N> t) const noexcept
+                {
+                    U &&u = t.get();
+                    *t_ = std::addressof(u);
                 }
                 void operator()(indexed_element<void, N>) const noexcept
                 {}

--- a/include/range/v3/view/generate.hpp
+++ b/include/range/v3/view/generate.hpp
@@ -52,9 +52,10 @@ namespace ranges
                 explicit cursor(generate_view &view)
                   : view_(&view)
                 {}
-                result_t read() const
+                result_t &&read() const
                 {
-                    return view_->val_;
+                    return static_cast<result_t &&>(
+                        static_cast<result_t &>(view_->val_));
                 }
                 void next()
                 {

--- a/include/range/v3/view/generate_n.hpp
+++ b/include/range/v3/view/generate_n.hpp
@@ -56,9 +56,10 @@ namespace ranges
                 {
                     return 0 == rng_->n_;
                 }
-                result_t read() const
+                result_t &&read() const
                 {
-                    return rng_->val_;
+                    return static_cast<result_t &&>(
+                        static_cast<result_t &>(rng_->val_));
                 }
                 void next()
                 {

--- a/test/view/generate.cpp
+++ b/test/view/generate.cpp
@@ -57,5 +57,19 @@ int main()
         check_equal(rng, {'H', 'e', 'l', 'l', 'o'});
     }
 
+    // Test for generator functions that return move-only types
+    {
+        char str[] = "gi";
+        auto rng = view::generate([&]{str[0]++; return MoveOnlyString{str};}) | view::take_exactly(2);
+        auto i = rng.begin();
+        CHECK(bool(*i == MoveOnlyString{"hi"}));
+        CHECK(bool(*i == MoveOnlyString{"hi"}));
+        CHECK(bool(*rng.begin() == MoveOnlyString{"hi"}));
+        CHECK(bool(*rng.begin() == MoveOnlyString{"hi"}));
+        CONCEPT_ASSERT(ranges::InputView<decltype(rng)>());
+        check_equal(rng, {MoveOnlyString{"hi"}, MoveOnlyString{"ii"}});
+        static_assert(std::is_same<ranges::range_reference_t<decltype(rng)>, MoveOnlyString &&>::value, "");
+    }
+
     return test_result();
 }

--- a/test/view/generate_n.cpp
+++ b/test/view/generate_n.cpp
@@ -55,5 +55,20 @@ int main()
         check_equal(rng, {'H', 'e', 'l', 'l', 'o'});
     }
 
+    // Test for generator functions that return move-only types
+    {
+        char str[] = "gi";
+        auto rng = view::generate_n([&]{str[0]++; return MoveOnlyString{str};}, 2);
+        CONCEPT_ASSERT(ranges::InputView<decltype(rng)>());
+        auto i = rng.begin();
+        CHECK(bool(*i == MoveOnlyString{"hi"}));
+        CHECK(bool(*i == MoveOnlyString{"hi"}));
+        CHECK(bool(*rng.begin() == MoveOnlyString{"hi"}));
+        CHECK(bool(*rng.begin() == MoveOnlyString{"hi"}));
+        CONCEPT_ASSERT(ranges::InputView<decltype(rng)>());
+        check_equal(rng, {MoveOnlyString{"hi"}, MoveOnlyString{"ii"}});
+        static_assert(std::is_same<ranges::range_reference_t<decltype(rng)>, MoveOnlyString &&>::value, "");
+    }
+
     return test_result();
 }


### PR DESCRIPTION
fixes #905

NOTE WELL: This changes generators so that they return xvalue references to the cached value. This is a silent breaking change for some valid code. It is, however, arguably closest to the programmer's intent as I imagine it.

@CaseyCarter, please offer your perspectives here. 