### PR TITLE
Portability fixes

### DIFF
--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -410,7 +410,10 @@ namespace ranges
 #endif // RANGES_CXX_INLINE_VARIABLES
 
 #ifndef RANGES_CXX_DEDUCTION_GUIDES
-#ifdef __cpp_deduction_guides
+#if defined(__clang__) && defined(__apple_build_version__)
+// Apple's clang version doesn't do deduction guides very well.
+#define RANGES_CXX_DEDUCTION_GUIDES 0
+#elif defined(__cpp_deduction_guides)
 #define RANGES_CXX_DEDUCTION_GUIDES __cpp_deduction_guides
 #else
 #define RANGES_CXX_DEDUCTION_GUIDES RANGES_CXX_FEATURE(DEDUCTION_GUIDES)

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -309,9 +309,6 @@ namespace ranges
         #endif
 
             // Work around libc++'s buggy std::is_function
-        #if !defined(_LIBCPP_VERSION) || _LIBCPP_VERSION >= 3800
-            using std::is_function;
-        #else
             // Function types here:
             template<typename T>
             char (&is_function_impl_(priority_tag<0>))[1];
@@ -333,7 +330,6 @@ namespace ranges
             struct is_function
               : meta::bool_<sizeof(detail::is_function_impl_<T>(priority_tag<3>{})) == 1>
             {};
-        #endif
 
             template<typename T>
             struct remove_rvalue_reference


### PR DESCRIPTION
Apple clang's deduction guides are kind of broken in that they occasionally complain about missing definitions(!) of the deduction guides.

Also, when a compiler implements `noexcept` as part of a function's type and the standard library's `std::is_function` implementation isn't hip to that, hijinks ensue. Don't use `std::is_function`.