### PR TITLE
Major view rejuvenation WRT const and mutable iterators

### DIFF
--- a/include/range/v3/experimental/view/shared.hpp
+++ b/include/range/v3/experimental/view/shared.hpp
@@ -55,14 +55,8 @@ namespace ranges
                     return ranges::end(*rng_ptr_);
                 }
 
-                // use the const-most size() function provided by the range
-                CONCEPT_REQUIRES(SizedRange<const Rng>())
+                CONCEPT_REQUIRES(SizedRange<Rng>())
                 range_size_type_t<Rng> size() const
-                {
-                    return ranges::size(*rng_ptr_);
-                }
-                CONCEPT_REQUIRES(SizedRange<Rng>() && !SizedRange<const Rng>())
-                range_size_type_t<Rng> size()
                 {
                     return ranges::size(*rng_ptr_);
                 }

--- a/include/range/v3/range_access.hpp
+++ b/include/range/v3/range_access.hpp
@@ -169,53 +169,29 @@ namespace ranges
             };
 
             template<typename Rng>
-            static RANGES_CXX14_CONSTEXPR auto begin_cursor(Rng &rng, long)
+            static RANGES_CXX14_CONSTEXPR auto begin_cursor(Rng &rng)
             RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
                 rng.begin_cursor()
             )
             template<typename Rng>
-            static RANGES_CXX14_CONSTEXPR auto begin_cursor(Rng &rng, int)
-            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
-            (
-                static_cast<Rng const &>(rng).begin_cursor()
-            )
-            template<typename Rng>
-            static RANGES_CXX14_CONSTEXPR auto end_cursor(Rng &rng, long)
+            static RANGES_CXX14_CONSTEXPR auto end_cursor(Rng &rng)
             RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
                 rng.end_cursor()
             )
-            template<typename Rng>
-            static RANGES_CXX14_CONSTEXPR auto end_cursor(Rng &rng, int)
-            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
-            (
-                static_cast<Rng const &>(rng).end_cursor()
-            )
 
             template<typename Rng>
-            static RANGES_CXX14_CONSTEXPR auto begin_adaptor(Rng &rng, long)
+            static RANGES_CXX14_CONSTEXPR auto begin_adaptor(Rng &rng)
             RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
                 rng.begin_adaptor()
             )
             template<typename Rng>
-            static RANGES_CXX14_CONSTEXPR auto begin_adaptor(Rng &rng, int)
-            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
-            (
-                static_cast<Rng const &>(rng).begin_adaptor()
-            )
-            template<typename Rng>
-            static RANGES_CXX14_CONSTEXPR auto end_adaptor(Rng &rng, long)
+            static RANGES_CXX14_CONSTEXPR auto end_adaptor(Rng &rng)
             RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
                 rng.end_adaptor()
-            )
-            template<typename Rng>
-            static RANGES_CXX14_CONSTEXPR auto end_adaptor(Rng &rng, int)
-            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
-            (
-                static_cast<Rng const &>(rng).end_adaptor()
             )
 
             template<typename Cur>

--- a/include/range/v3/size.hpp
+++ b/include/range/v3/size.hpp
@@ -65,7 +65,8 @@ namespace ranges
                     size(r)
                 )
 
-                template<typename R, typename I = decltype(ranges::cbegin(std::declval<R &>())),
+                template<typename R,
+                    typename I = decltype(ranges::cbegin(std::declval<R &>())),
                     CONCEPT_REQUIRES_(ForwardIterator<I>())>
                 static RANGES_CXX14_CONSTEXPR auto impl_(R &r, ...)
                 RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT

--- a/include/range/v3/utility/concepts.hpp
+++ b/include/range/v3/utility/concepts.hpp
@@ -225,6 +225,15 @@ namespace ranges
             // Core language concepts
             ////////////////////////////////////////////////////////////////////////////////////////////
 
+            struct Satisfies
+            {
+                template<typename T, typename Trait, typename ...Ts>
+                auto requires_() -> decltype(
+                    concepts::valid_expr(
+                        concepts::is_true(meta::invoke<Trait, T, Ts...>{})
+                    ));
+            };
+
             struct Same
             {
                 template<typename ...Ts>
@@ -579,6 +588,9 @@ namespace ranges
               : refines<SemiRegular, EqualityComparable>
             {};
         }
+
+        template<typename T, template<typename...> class Trait, typename ...Ts>
+        using Satisfies = concepts::models<concepts::Satisfies, T, meta::quote<Trait>, Ts...>;
 
         template<typename ...Ts>
         using Same = concepts::Same::same_t<Ts...>; // This handles void better than using the Same concept

--- a/include/range/v3/utility/iterator.hpp
+++ b/include/range/v3/utility/iterator.hpp
@@ -749,12 +749,17 @@ namespace ranges
         }  // namespace detail
         /// \endcond
 
-        template<typename I>
-        RANGES_CXX14_CONSTEXPR
-        reverse_iterator<I> make_reverse_iterator(I i)
+        struct make_reverse_iterator_fn
         {
-            return reverse_iterator<I>(i);
-        }
+            template<typename I>
+            RANGES_CXX14_CONSTEXPR
+            reverse_iterator<I> operator()(I i) const
+            {
+                return reverse_iterator<I>(i);
+            }
+        };
+
+        RANGES_INLINE_VARIABLE(make_reverse_iterator_fn, make_reverse_iterator)
 
         template<typename I>
         struct move_iterator

--- a/include/range/v3/utility/iterator.hpp
+++ b/include/range/v3/utility/iterator.hpp
@@ -265,7 +265,14 @@ namespace ranges
             template<typename I,
                 CONCEPT_REQUIRES_(BidirectionalIterator<I>())>
             RANGES_CXX14_CONSTEXPR
-            I operator()(I it, difference_type_t<I> n = 1) const
+            I operator()(I it) const
+            {
+                return --it;
+            }
+            template<typename I,
+                CONCEPT_REQUIRES_(BidirectionalIterator<I>())>
+            RANGES_CXX14_CONSTEXPR
+            I operator()(I it, difference_type_t<I> n) const
             {
                 advance(it, -n);
                 return it;

--- a/include/range/v3/utility/swap.hpp
+++ b/include/range/v3/utility/swap.hpp
@@ -34,10 +34,10 @@ namespace ranges
         {
             template<typename T>
             struct is_movable_
-              : meta::and_<
-                    std::is_object<T>,
-                    std::is_move_constructible<T>,
-                    std::is_move_assignable<T>>
+              : meta::bool_<
+                    std::is_object<T>::value &&
+                    std::is_move_constructible<T>::value &&
+                    std::is_move_assignable<T>::value>
             {};
         }
         /// \endcond

--- a/include/range/v3/view/adjacent_remove_if.hpp
+++ b/include/range/v3/view/adjacent_remove_if.hpp
@@ -44,18 +44,14 @@ namespace ranges
         {
             adjacent_remove_if_view() = default;
             constexpr adjacent_remove_if_view(Rng rng, Pred pred)
-                noexcept(
-                    std::is_nothrow_constructible<
-                        typename adjacent_remove_if_view::view_adaptor, Rng>::value &&
-                    std::is_nothrow_constructible<
-                        typename adjacent_remove_if_view::box, Pred>::value)
               : adjacent_remove_if_view::view_adaptor{detail::move(rng)}
               , adjacent_remove_if_view::box(detail::move(pred))
             {}
         private:
             friend range_access;
 
-            struct adaptor : adaptor_base
+            struct adaptor
+              : adaptor_base
             {
             private:
                 adjacent_remove_if_view *rng_;

--- a/include/range/v3/view/any_view.hpp
+++ b/include/range/v3/view/any_view.hpp
@@ -157,14 +157,13 @@ namespace ranges
             public:
                 any_view_sentinel_impl() = default;
                 any_view_sentinel_impl(Rng &rng)
-                    noexcept(noexcept(box_t(ranges::end(rng))))
                   : box_t(ranges::end(rng))
                 {}
                 void init(Rng &rng) noexcept
                 {
                     box_t::get() = ranges::end(rng);
                 }
-                sentinel_t<Rng> const &get(Rng const &) const noexcept
+                sentinel_t<Rng> const &get(Rng &) const noexcept
                 {
                     return box_t::get();
                 }
@@ -179,7 +178,7 @@ namespace ranges
                 {}
                 void init(Rng &) noexcept
                 {}
-                sentinel_t<Rng> get(Rng const &rng) const noexcept
+                sentinel_t<Rng> get(Rng &rng) const noexcept
                 {
                     return ranges::end(rng);
                 }
@@ -190,7 +189,7 @@ namespace ranges
             {
                 virtual ~any_input_view_interface() = default;
                 virtual void init() = 0;
-                virtual bool done() const = 0;
+                virtual bool done() = 0;
                 virtual Ref read() const = 0;
                 virtual void next() = 0;
             };
@@ -253,12 +252,18 @@ namespace ranges
                     sentinel_box_t::init(rng);
                     current() = ranges::begin(rng);
                 }
-                virtual bool done() const override
+                virtual bool done() override
                 {
                     return current() == sentinel_box_t::get(range());
                 }
-                virtual Ref read() const override { return *current(); }
-                virtual void next() override { ++current(); }
+                virtual Ref read() const override
+                {
+                    return *current();
+                }
+                virtual void next() override
+                {
+                    ++current();
+                }
                 std::size_t size() const // override-ish
                 {
                     return static_cast<std::size_t>(ranges::size(range()));
@@ -277,7 +282,6 @@ namespace ranges
                 virtual bool equal(any_cursor_interface const &) const = 0;
                 virtual void next() = 0;
             };
-
 
             template<typename Ref, category Cat>
             struct any_cursor_interface<Ref, Cat, meta::if_c<(Cat & category::mask) == category::bidirectional>>
@@ -353,8 +357,8 @@ namespace ranges
 
             struct fully_erased_view
             {
-                virtual bool at_end(any_ref) const = 0; // any_ref is a const ref to a wrapped iterator
-                                                        // to be compared to the erased view's end sentinel
+                virtual bool at_end(any_ref) = 0; // any_ref is a const ref to a wrapped iterator
+                                                  // to be compared to the erased view's end sentinel
             protected:
                 ~fully_erased_view() = default;
             };
@@ -362,13 +366,13 @@ namespace ranges
             struct any_sentinel
             {
                 any_sentinel() = default;
-                constexpr explicit any_sentinel(fully_erased_view const &view) noexcept
+                constexpr explicit any_sentinel(fully_erased_view &view) noexcept
                   : view_{&view}
                 {}
             private:
                 template<typename, category> friend struct any_cursor;
 
-                fully_erased_view const *view_ = nullptr;
+                fully_erased_view *view_ = nullptr;
             };
 
             template<typename Ref, category Cat>
@@ -484,7 +488,7 @@ namespace ranges
                 {
                     return any_cursor<Ref, Cat>{range_box_t::get()};
                 }
-                bool at_end(any_ref it_) const override
+                bool at_end(any_ref it_) override
                 {
                     auto &it = it_.get<iterator_t<Rng> const>();
                     return it == sentinel_box_t::get(range_box_t::get());
@@ -554,7 +558,7 @@ namespace ranges
             {
                 return ptr_ ? ptr_->begin_cursor() : detail::value_init{};
             }
-            detail::any_sentinel end_cursor() const noexcept
+            detail::any_sentinel end_cursor() noexcept
             {
                 return detail::any_sentinel{*ptr_};
             }

--- a/include/range/v3/view/chunk.hpp
+++ b/include/range/v3/view/chunk.hpp
@@ -162,9 +162,9 @@ namespace ranges
             };
 
             RANGES_CXX14_CONSTEXPR
-            adaptor<false> begin_adaptor()
+            adaptor<simple_view<Rng>()> begin_adaptor()
             {
-                return adaptor<false>{*this};
+                return adaptor<simple_view<Rng>()>{*this};
             }
             CONCEPT_REQUIRES(ForwardRange<Rng const>())
             constexpr adaptor<true> begin_adaptor() const

--- a/include/range/v3/view/chunk.hpp
+++ b/include/range/v3/view/chunk.hpp
@@ -51,47 +51,63 @@ namespace ranges
             friend range_access;
             CONCEPT_ASSERT(ForwardRange<Rng>());
 
-            template<typename T>
-            using constify = meta::const_if<ForwardRange<Rng const>, T>;
-            static constexpr bool CanSizedSentinel =
-                SizedSentinel<iterator_t<constify<Rng>>, iterator_t<constify<Rng>>>();
-
+            template<bool Const>
+            static constexpr bool CanSizedSentinel() noexcept
+            {
+                using I = iterator_t<meta::const_if_c<Const, Rng>>;
+                return (bool) SizedSentinel<I, I>();
+            }
+            template<bool Const>
             using offset_t =
                 meta::if_c<
-                    BidirectionalRange<constify<Rng>>() || CanSizedSentinel,
+                    BidirectionalRange<meta::const_if_c<Const, Rng>>() ||
+                        chunk_view::CanSizedSentinel<Const>(),
                     range_difference_type_t<Rng>,
                     constant<range_difference_type_t<Rng>, 0>>;
 
             range_difference_type_t<Rng> n_ = 0;
 
+            template<bool Const>
             struct adaptor
-              : adaptor_base, private box<offset_t>
+              : adaptor_base
+              , private box<offset_t<Const>>
             {
             private:
-                range_difference_type_t<Rng> n_;
-                sentinel_t<constify<Rng>> end_;
+                friend struct adaptor<!Const>;
+                using CRng = meta::const_if_c<Const, Rng>;
+
+                range_difference_type_t<CRng> n_;
+                sentinel_t<CRng> end_;
 
                 RANGES_CXX14_CONSTEXPR
-                offset_t const &offset() const
+                offset_t<Const> const &offset() const
                 {
-                    offset_t const &result = this->box<offset_t>::get();
+                    offset_t<Const> const &result = this->box<offset_t<Const>>::get();
                     RANGES_EXPECT(0 <= result && result < n_);
                     return result;
                 }
                 RANGES_CXX14_CONSTEXPR
-                offset_t &offset()
+                offset_t<Const> &offset()
                 {
-                    return const_cast<offset_t &>(const_cast<adaptor const &>(*this).offset());
+                    return const_cast<offset_t<Const> &>(
+                        const_cast<adaptor const &>(*this).offset());
                 }
             public:
                 adaptor() = default;
-                constexpr adaptor(constify<chunk_view> &cv)
-                  : box<offset_t>{0}
+                constexpr adaptor(meta::const_if_c<Const, chunk_view> &cv)
+                  : box<offset_t<Const>>{0}
                   , n_((RANGES_EXPECT(0 < cv.n_), cv.n_))
                   , end_(ranges::end(cv.base()))
                 {}
+                template<bool Other,
+                    CONCEPT_REQUIRES_(Const && !Other)>
+                constexpr adaptor(adaptor<Other> that)
+                  : box<offset_t<Const>>(that.offset())
+                  , n_(that.n_)
+                  , end_(that.end_)
+                {}
                 RANGES_CXX14_CONSTEXPR
-                auto read(iterator_t<constify<Rng>> const &it) const ->
+                auto read(iterator_t<CRng> const &it) const ->
                     decltype(view::take(make_iterator_range(it, end_), n_))
                 {
                     RANGES_EXPECT(it != end_);
@@ -99,23 +115,23 @@ namespace ranges
                     return view::take(make_iterator_range(it, end_), n_);
                 }
                 RANGES_CXX14_CONSTEXPR
-                void next(iterator_t<constify<Rng>> &it)
+                void next(iterator_t<CRng> &it)
                 {
                     RANGES_EXPECT(it != end_);
                     RANGES_EXPECT(0 == offset());
                     offset() = ranges::advance(it, n_, end_);
                 }
-                CONCEPT_REQUIRES(BidirectionalRange<constify<Rng>>())
+                CONCEPT_REQUIRES(BidirectionalRange<CRng>())
                 RANGES_CXX14_CONSTEXPR
-                void prev(iterator_t<constify<Rng>> &it)
+                void prev(iterator_t<CRng> &it)
                 {
                     ranges::advance(it, -n_ + offset());
                     offset() = 0;
                 }
-                CONCEPT_REQUIRES(CanSizedSentinel)
+                CONCEPT_REQUIRES(CanSizedSentinel<Const>())
                 RANGES_CXX14_CONSTEXPR
-                range_difference_type_t<Rng> distance_to(iterator_t<constify<Rng>> const &here,
-                    iterator_t<constify<Rng>> const &there, adaptor const &that) const
+                range_difference_type_t<Rng> distance_to(iterator_t<CRng> const &here,
+                    iterator_t<CRng> const &there, adaptor const &that) const
                 {
                     auto const delta = (there - here) + (that.offset() - offset());
                     // This can fail for cyclic base ranges when the chunk size does not divide the
@@ -123,9 +139,9 @@ namespace ranges
                     RANGES_ENSURE(0 == delta % n_);
                     return delta / n_;
                 }
-                CONCEPT_REQUIRES(RandomAccessRange<constify<Rng>>())
+                CONCEPT_REQUIRES(RandomAccessRange<CRng>())
                 RANGES_CXX14_CONSTEXPR
-                void advance(iterator_t<constify<Rng>> &it, range_difference_type_t<Rng> n)
+                void advance(iterator_t<CRng> &it, range_difference_type_t<Rng> n)
                 {
                     using Limits = std::numeric_limits<range_difference_type_t<Rng>>;
                     if(0 < n)
@@ -146,19 +162,19 @@ namespace ranges
             };
 
             RANGES_CXX14_CONSTEXPR
-            adaptor begin_adaptor()
+            adaptor<false> begin_adaptor()
             {
-                return adaptor{*this};
+                return adaptor<false>{*this};
             }
             CONCEPT_REQUIRES(ForwardRange<Rng const>())
-            constexpr adaptor begin_adaptor() const
+            constexpr adaptor<true> begin_adaptor() const
             {
-                return adaptor{*this};
+                return adaptor<true>{*this};
             }
             RANGES_CXX14_CONSTEXPR
             range_size_type_t<Rng> size_(range_difference_type_t<Rng> base_size) const
             {
-                CONCEPT_ASSERT(SizedRange<Rng>());
+                CONCEPT_ASSERT(SizedRange<Rng const>());
                 base_size = base_size / n_ + (0 != (base_size % n_));
                 return static_cast<range_size_type_t<Rng>>(base_size);
             }
@@ -201,8 +217,14 @@ namespace ranges
                 iter_cache_t                  // it
             > data_{};
 
-            RANGES_CXX14_CONSTEXPR Rng &base() noexcept { return ranges::get<0>(data_); }
-            constexpr Rng const &base() const noexcept { return ranges::get<0>(data_); }
+            RANGES_CXX14_CONSTEXPR Rng &base() noexcept
+            {
+                return ranges::get<0>(data_);
+            }
+            constexpr Rng const &base() const noexcept
+            {
+                return ranges::get<0>(data_);
+            }
             RANGES_CXX14_CONSTEXPR range_difference_type_t<Rng> &n() noexcept
             {
                 return ranges::get<1>(data_);
@@ -221,9 +243,18 @@ namespace ranges
                 return ranges::get<2>(data_);
             }
 
-            constexpr iter_cache_t &it_cache() const noexcept { return ranges::get<3>(data_); }
-            RANGES_CXX14_CONSTEXPR iterator_t<Rng> &it() noexcept { return *it_cache(); }
-            constexpr iterator_t<Rng> const &it() const noexcept { return *it_cache(); }
+            constexpr iter_cache_t &it_cache() const noexcept
+            {
+                return ranges::get<3>(data_);
+            }
+            RANGES_CXX14_CONSTEXPR iterator_t<Rng> &it() noexcept
+            {
+                return *it_cache();
+            }
+            constexpr iterator_t<Rng> const &it() const noexcept
+            {
+                return *it_cache();
+            }
 
             struct outer_cursor
             {
@@ -364,14 +395,12 @@ namespace ranges
             CONCEPT_REQUIRES(SizedRange<Rng const>())
             RANGES_CXX14_CONSTEXPR
             range_size_type_t<Rng> size() const
-                noexcept(noexcept(ranges::distance(std::declval<Rng const &>())))
             {
                 return size_(ranges::distance(base()));
             }
             CONCEPT_REQUIRES(SizedRange<Rng>())
             RANGES_CXX14_CONSTEXPR
             range_size_type_t<Rng> size()
-                noexcept(noexcept(ranges::distance(std::declval<Rng &>())))
             {
                 return size_(ranges::distance(base()));
             }

--- a/include/range/v3/view/concat.hpp
+++ b/include/range/v3/view/concat.hpp
@@ -31,6 +31,7 @@
 #include <range/v3/utility/tuple_algorithm.hpp>
 #include <range/v3/utility/static_const.hpp>
 #include <range/v3/view/all.hpp>
+#include <range/v3/view/view.hpp>
 
 namespace ranges
 {
@@ -300,11 +301,14 @@ namespace ranges
                     return -cursor::distance_to_(meta::size_t<0>{}, that, *this);
                 }
             };
-            cursor<false> begin_cursor()
+            cursor<meta::and_c<simple_view<Rngs>()...>::value> begin_cursor()
             {
                 return {*this, begin_tag{}};
             }
-            meta::if_<meta::and_c<(bool)BoundedRange<Rngs>()...>, cursor<false>, sentinel<false>>
+            meta::if_<
+                meta::and_c<(bool)BoundedRange<Rngs>()...>,
+                cursor<meta::and_c<simple_view<Rngs>()...>::value>,
+                sentinel<meta::and_c<simple_view<Rngs>()...>::value>>
             end_cursor()
             {
                 return {*this, end_tag{}};

--- a/include/range/v3/view/const.hpp
+++ b/include/range/v3/view/const.hpp
@@ -41,30 +41,47 @@ namespace ranges
         {
         private:
             friend range_access;
-            using value_ =
-                range_value_type_t<Rng>;
-            using reference_ =
-                common_reference_t<value_ const &&, range_reference_t<Rng>>;
-            using rvalue_reference_ =
-                common_reference_t<value_ const &&, range_rvalue_reference_t<Rng>>;
+            template<bool Const>
             struct adaptor
               : adaptor_base
             {
-                reference_ read(iterator_t<Rng> const &it) const
+                using CRng = meta::const_if_c<Const, Rng>;
+                using value_ =
+                    range_value_type_t<CRng>;
+                using reference_ =
+                    common_reference_t<value_ const &&, range_reference_t<CRng>>;
+                using rvalue_reference_ =
+                    common_reference_t<value_ const &&, range_rvalue_reference_t<CRng>>;
+                adaptor() = default;
+                template<bool Other,
+                    CONCEPT_REQUIRES_(Const && !Other)>
+                constexpr adaptor(adaptor<Other>)
+                {}
+                reference_ read(iterator_t<CRng> const &it) const
                 {
                     return *it;
                 }
-                rvalue_reference_ iter_move(iterator_t<Rng> const &it) const
+                rvalue_reference_ iter_move(iterator_t<CRng> const &it) const
                 RANGES_AUTO_RETURN_NOEXCEPT
                 (
                     ranges::iter_move(it)
                 )
             };
-            adaptor begin_adaptor() const
+            adaptor<false> begin_adaptor()
             {
                 return {};
             }
-            adaptor end_adaptor() const
+            adaptor<false> end_adaptor()
+            {
+                return {};
+            }
+            CONCEPT_REQUIRES(Range<Rng const>())
+            adaptor<true> begin_adaptor() const
+            {
+                return {};
+            }
+            CONCEPT_REQUIRES(Range<Rng const>())
+            adaptor<true> end_adaptor() const
             {
                 return {};
             }
@@ -73,13 +90,13 @@ namespace ranges
             explicit const_view(Rng rng)
               : const_view::view_adaptor{std::move(rng)}
             {}
-            CONCEPT_REQUIRES(SizedRange<Rng const>())
-            range_size_type_t<Rng> size() const
+            CONCEPT_REQUIRES(SizedRange<Rng>())
+            range_size_type_t<Rng> size()
             {
                 return ranges::size(this->base());
             }
-            CONCEPT_REQUIRES(SizedRange<Rng>())
-            range_size_type_t<Rng> size()
+            CONCEPT_REQUIRES(SizedRange<Rng const>())
+            range_size_type_t<Rng> size() const
             {
                 return ranges::size(this->base());
             }

--- a/include/range/v3/view/const.hpp
+++ b/include/range/v3/view/const.hpp
@@ -67,11 +67,11 @@ namespace ranges
                     ranges::iter_move(it)
                 )
             };
-            adaptor<false> begin_adaptor()
+            adaptor<simple_view<Rng>()> begin_adaptor()
             {
                 return {};
             }
-            adaptor<false> end_adaptor()
+            adaptor<simple_view<Rng>()> end_adaptor()
             {
                 return {};
             }

--- a/include/range/v3/view/cycle.hpp
+++ b/include/range/v3/view/cycle.hpp
@@ -94,7 +94,7 @@ namespace ranges
                 }
             public:
                 cursor() = default;
-                explicit cursor(cycled_view_t &rng)
+                cursor(cycled_view_t &rng)
                   : rng_(&rng), it_(ranges::begin(rng.rng_))
                 {}
                 template<bool Other,
@@ -166,14 +166,14 @@ namespace ranges
                 }
             };
 
-            cursor<false> begin_cursor()
+            cursor<simple_view<Rng>() && (bool) BoundedRange<Rng const>()> begin_cursor()
             {
-                return cursor<false>{*this};
+                return {*this};
             }
             CONCEPT_REQUIRES(BoundedRange<Rng const>())
             cursor<true> begin_cursor() const
             {
-                return cursor<true>{*this};
+                return {*this};
             }
 
         public:

--- a/include/range/v3/view/delimit.hpp
+++ b/include/range/v3/view/delimit.hpp
@@ -47,7 +47,8 @@ namespace ranges
                 sentinel_adaptor(Val value)
                   : value_(std::move(value))
                 {}
-                bool empty(iterator_t<Rng> it, sentinel_t<Rng> end) const
+                template<class I, class S>
+                bool empty(I const &it, S const &end) const
                 {
                     return it == end || *it == value_;
                 }

--- a/include/range/v3/view/drop.hpp
+++ b/include/range/v3/view/drop.hpp
@@ -51,10 +51,10 @@ namespace ranges
             Rng rng_;
             difference_type_ n_;
 
-            template<typename BaseRng = Rng>
-            iterator_t<BaseRng const> get_begin_(std::true_type, std::true_type) const
+            template<typename CRng = Rng const>
+            iterator_t<CRng> get_begin_(std::true_type, std::true_type) const
             {
-                CONCEPT_ASSERT(RandomAccessRange<Rng const>());
+                CONCEPT_ASSERT(RandomAccessRange<CRng>());
                 return next(ranges::begin(rng_), n_, ranges::end(rng_));
             }
             iterator_t<Rng> get_begin_(std::true_type, std::false_type)
@@ -79,25 +79,23 @@ namespace ranges
             {
                 RANGES_EXPECT(n >= 0);
             }
-            CONCEPT_REQUIRES(!RandomAccessRange<Rng const>())
             iterator_t<Rng> begin()
             {
                 return this->get_begin_(RandomAccessRange<Rng>{}, std::false_type{});
             }
-            CONCEPT_REQUIRES(!RandomAccessRange<Rng const>())
             sentinel_t<Rng> end()
             {
                 return ranges::end(rng_);
             }
-            template<typename BaseRng = Rng,
-                CONCEPT_REQUIRES_(RandomAccessRange<BaseRng const>())>
-            iterator_t<BaseRng const> begin() const
+            template<typename CRng = Rng const,
+                CONCEPT_REQUIRES_(RandomAccessRange<CRng>())>
+            iterator_t<CRng> begin() const
             {
                 return this->get_begin_(std::true_type{}, std::true_type{});
             }
-            template<typename BaseRng = Rng,
-                CONCEPT_REQUIRES_(RandomAccessRange<BaseRng const>())>
-            sentinel_t<BaseRng const> end() const
+            template<typename CRng = Rng const,
+                CONCEPT_REQUIRES_(RandomAccessRange<CRng>())>
+            sentinel_t<CRng> end() const
             {
                 return ranges::end(rng_);
             }
@@ -108,7 +106,7 @@ namespace ranges
                 auto const n = static_cast<range_size_type_t<Rng>>(n_);
                 return s < n ? 0 : s - n;
             }
-            CONCEPT_REQUIRES(!SizedRange<Rng const>() && SizedRange<Rng>())
+            CONCEPT_REQUIRES(SizedRange<Rng>())
             range_size_type_t<Rng> size()
             {
                 auto const s = static_cast<range_size_type_t<Rng>>(ranges::size(rng_));

--- a/include/range/v3/view/drop_exactly.hpp
+++ b/include/range/v3/view/drop_exactly.hpp
@@ -51,14 +51,12 @@ namespace ranges
             difference_type_ n_;
 
             // RandomAccessRange == true
-            template<typename BaseRng = Rng,
-                CONCEPT_REQUIRES_(RandomAccessRange<BaseRng const>())>
-            iterator_t<Rng> get_begin_(std::true_type) const
+            template<typename CRng = Rng const,
+                CONCEPT_REQUIRES_(RandomAccessRange<CRng>())>
+            iterator_t<CRng> get_begin_(std::true_type) const
             {
                 return next(ranges::begin(rng_), n_);
             }
-            template<typename BaseRng = Rng,
-                CONCEPT_REQUIRES_(!RandomAccessRange<BaseRng const>())>
             iterator_t<Rng> get_begin_(std::true_type)
             {
                 return next(ranges::begin(rng_), n_);
@@ -88,25 +86,25 @@ namespace ranges
             {
                 return ranges::end(rng_);
             }
-            template<typename BaseRng = Rng,
-                CONCEPT_REQUIRES_(RandomAccessRange<BaseRng const>())>
-            iterator_t<BaseRng const> begin() const
+            template<typename CRng = Rng const,
+                CONCEPT_REQUIRES_(RandomAccessRange<CRng>())>
+            iterator_t<CRng> begin() const
             {
                 return this->get_begin_(std::true_type{});
             }
-            template<typename BaseRng = Rng,
-                CONCEPT_REQUIRES_(RandomAccessRange<BaseRng const>())>
-            sentinel_t<BaseRng const> end() const
+            template<typename CRng = Rng const,
+                CONCEPT_REQUIRES_(RandomAccessRange<CRng>())>
+            sentinel_t<CRng> end() const
             {
                 return ranges::end(rng_);
             }
-            CONCEPT_REQUIRES(SizedRange<Rng const>())
-            range_size_type_t<Rng> size() const
+            CONCEPT_REQUIRES(SizedRange<Rng>())
+            range_size_type_t<Rng> size()
             {
                 return ranges::size(rng_) - static_cast<range_size_type_t<Rng>>(n_);
             }
-            CONCEPT_REQUIRES(SizedRange<Rng>())
-            range_size_type_t<Rng> size()
+            CONCEPT_REQUIRES(SizedRange<Rng const>())
+            range_size_type_t<Rng> size() const
             {
                 return ranges::size(rng_) - static_cast<range_size_type_t<Rng>>(n_);
             }

--- a/include/range/v3/view/empty.hpp
+++ b/include/range/v3/view/empty.hpp
@@ -22,58 +22,44 @@ namespace ranges
 {
     inline namespace v3
     {
-        template<typename T>
-        struct empty_view
-          : view_facade<empty_view<T>, (cardinality)0>
+        namespace detail
         {
-        private:
-            friend range_access;
-            struct cursor
+            struct empty_view_base
             {
-                [[noreturn]] T const & read() const
+                template<typename T>
+                friend constexpr T *begin(empty_view<T>) noexcept
                 {
-                    RANGES_ENSURE(false);
+                    return nullptr;
                 }
-                constexpr bool equal(default_sentinel) const
+                template<typename T>
+                friend constexpr T *end(empty_view<T>) noexcept
                 {
-                    return true;
-                }
-                constexpr bool equal(cursor const &) const
-                {
-                    return true;
-                }
-                [[noreturn]] void next()
-                {
-                    RANGES_ENSURE(false);
-                }
-                [[noreturn]] void prev()
-                {
-                    RANGES_ENSURE(false);
-                }
-                void advance(std::ptrdiff_t n)
-                {
-                    RANGES_EXPECT(n == 0);
-                }
-                std::ptrdiff_t distance_to(cursor const &) const
-                {
-                    return 0;
+                    return nullptr;
                 }
             };
-            cursor begin_cursor() const
-            {
-                return {};
-            }
-            cursor end_cursor() const
-            {
-                return {};
-            }
-        public:
+        }
+
+        template<typename T>
+        struct empty_view
+          : view_interface<empty_view<T>, (cardinality)0>
+          , private detail::empty_view_base
+        {
+            static_assert(std::is_object<T>::value,
+                "The template parameter to empty_view must be an object type.");
             empty_view() = default;
-            constexpr std::size_t size() const
+            constexpr static T *begin() noexcept
+            {
+                return nullptr;
+            }
+            constexpr static T *end() noexcept
+            {
+                return nullptr;
+            }
+            static constexpr std::size_t size() noexcept
             {
                 return 0u;
             }
-            constexpr T const *data() const
+            static constexpr T *data() noexcept
             {
                 return nullptr;
             }

--- a/include/range/v3/view/indices.hpp
+++ b/include/range/v3/view/indices.hpp
@@ -27,7 +27,6 @@ namespace ranges
 {
     inline namespace v3
     {
-
         namespace view
         {
             /// Half-open range of indices: [from, to).

--- a/include/range/v3/view/indirect.hpp
+++ b/include/range/v3/view/indirect.hpp
@@ -64,19 +64,15 @@ namespace ranges
         public:
             indirect_view() = default;
             explicit constexpr indirect_view(Rng rng)
-                noexcept(std::is_nothrow_constructible<
-                    typename indirect_view::view_adaptor, Rng>::value)
               : indirect_view::view_adaptor{detail::move(rng)}
             {}
             CONCEPT_REQUIRES(SizedRange<Rng const>())
             constexpr range_size_type_t<Rng> size() const
-                noexcept(noexcept(ranges::size(std::declval<Rng const &>())))
             {
                 return ranges::size(this->base());
             }
-            CONCEPT_REQUIRES(!SizedRange<Rng const>() && SizedRange<Rng>())
+            CONCEPT_REQUIRES(SizedRange<Rng>())
             RANGES_CXX14_CONSTEXPR range_size_type_t<Rng> size()
-                noexcept(noexcept(ranges::size(std::declval<Rng &>())))
             {
                 return ranges::size(this->base());
             }

--- a/include/range/v3/view/move.hpp
+++ b/include/range/v3/view/move.hpp
@@ -60,11 +60,11 @@ namespace ranges
                     return ranges::iter_move(it);
                 }
             };
-            adaptor<false> begin_adaptor()
+            adaptor<simple_view<Rng>()> begin_adaptor()
             {
                 return {};
             }
-            adaptor<false> end_adaptor()
+            adaptor<simple_view<Rng>()> end_adaptor()
             {
                 return {};
             }

--- a/include/range/v3/view/move.hpp
+++ b/include/range/v3/view/move.hpp
@@ -40,23 +40,41 @@ namespace ranges
         {
         private:
             friend range_access;
-            struct adaptor : adaptor_base
+            template<bool Const>
+            struct adaptor
+              : adaptor_base
             {
+                adaptor() = default;
+                template<bool Other,
+                    CONCEPT_REQUIRES_(Const && !Other)>
+                constexpr adaptor(adaptor<Other>)
+                {}
+                using CRng = meta::const_if_c<Const, Rng>;
                 using value_type = range_value_type_t<Rng>;
-                range_rvalue_reference_t<Rng> read(iterator_t<Rng> const &it) const
+                range_rvalue_reference_t<CRng> read(iterator_t<CRng> const &it) const
                 {
                     return ranges::iter_move(it);
                 }
-                range_rvalue_reference_t<Rng> iter_move(iterator_t<Rng> const &it) const
+                range_rvalue_reference_t<CRng> iter_move(iterator_t<CRng> const &it) const
                 {
                     return ranges::iter_move(it);
                 }
             };
-            adaptor begin_adaptor() const
+            adaptor<false> begin_adaptor()
             {
                 return {};
             }
-            adaptor end_adaptor() const
+            adaptor<false> end_adaptor()
+            {
+                return {};
+            }
+            CONCEPT_REQUIRES(InputRange<Rng const>())
+            adaptor<true> begin_adaptor() const
+            {
+                return {};
+            }
+            CONCEPT_REQUIRES(InputRange<Rng const>())
+            adaptor<true> end_adaptor() const
             {
                 return {};
             }

--- a/include/range/v3/view/remove_if.hpp
+++ b/include/range/v3/view/remove_if.hpp
@@ -47,11 +47,6 @@ namespace ranges
         {
             remove_if_view() = default;
             constexpr remove_if_view(Rng rng, Pred pred)
-                noexcept(
-                    std::is_nothrow_constructible<
-                        typename remove_if_view::view_adaptor, Rng>::value &&
-                    std::is_nothrow_constructible<
-                        typename remove_if_view::box, Pred>::value)
               : remove_if_view::view_adaptor{detail::move(rng)}
               , remove_if_view::box(detail::move(pred))
             {}
@@ -65,19 +60,16 @@ namespace ranges
                   : rng_(&rng)
                 {}
                 static RANGES_CXX14_CONSTEXPR iterator_t<Rng> begin(remove_if_view &rng)
-                    noexcept(std::is_nothrow_copy_constructible<iterator_t<Rng>>::value)
                 {
                     return *rng.begin_;
                 }
                 RANGES_CXX14_CONSTEXPR void next(iterator_t<Rng> &it) const
-                    noexcept(noexcept(std::declval<remove_if_view &>().satisfy_forward(++it)))
                 {
                     RANGES_ASSERT(it != ranges::end(rng_->base()));
                     rng_->satisfy_forward(++it);
                 }
                 CONCEPT_REQUIRES(BidirectionalRange<Rng>())
                 RANGES_CXX14_CONSTEXPR void prev(iterator_t<Rng> &it) const
-                    noexcept(noexcept(std::declval<remove_if_view &>().satisfy_reverse(it)))
                 {
                     rng_->satisfy_reverse(it);
                 }
@@ -87,7 +79,6 @@ namespace ranges
                 remove_if_view *rng_;
             };
             RANGES_CXX14_CONSTEXPR adaptor begin_adaptor()
-                noexcept(noexcept(std::declval<remove_if_view &>().cache_begin()))
             {
                 cache_begin();
                 return {*this};
@@ -99,15 +90,12 @@ namespace ranges
             }
             CONCEPT_REQUIRES(BoundedRange<Rng>())
             RANGES_CXX14_CONSTEXPR adaptor end_adaptor()
-                noexcept(noexcept(std::declval<remove_if_view &>().cache_begin()))
             {
                 if(BidirectionalRange<Rng>()) cache_begin();
                 return {*this};
             }
 
             RANGES_CXX14_CONSTEXPR void satisfy_forward(iterator_t<Rng> &it)
-                noexcept(noexcept((void)(++it != ranges::end(std::declval<Rng &>())),
-                    invoke(std::declval<Pred &>(), *it)))
             {
                 auto const last = ranges::end(this->base());
                 auto &pred = this->remove_if_view::box::get();
@@ -115,7 +103,6 @@ namespace ranges
                     ++it;
             }
             RANGES_CXX14_CONSTEXPR void satisfy_reverse(iterator_t<Rng> &it)
-                noexcept(noexcept(invoke(std::declval<Pred &>(), *--it)))
             {
                 RANGES_ASSERT(begin_);
                 auto const &first = *begin_;
@@ -128,10 +115,6 @@ namespace ranges
             }
 
             RANGES_CXX14_CONSTEXPR void cache_begin()
-                noexcept(noexcept(ranges::begin(std::declval<Rng &>()),
-                    std::declval<remove_if_view &>().
-                        satisfy_forward(std::declval<iterator_t<Rng> &>())) &&
-                    std::is_nothrow_move_constructible<iterator_t<Rng>>::value)
             {
                 if(begin_) return;
                 auto it = ranges::begin(this->base());

--- a/include/range/v3/view/reverse.hpp
+++ b/include/range/v3/view/reverse.hpp
@@ -38,171 +38,71 @@ namespace ranges
         /// @{
         template<typename Rng>
         struct reverse_view
-          : view_adaptor<reverse_view<Rng>, Rng>
+          : view_interface<reverse_view<Rng>, range_cardinality<Rng>::value>
           , private detail::non_propagating_cache<
                 iterator_t<Rng>, reverse_view<Rng>, !BoundedRange<Rng>()>
         {
-            CONCEPT_ASSERT(BidirectionalRange<Rng>());
-
-            reverse_view() = default;
-            explicit constexpr reverse_view(Rng rng)
-                noexcept(std::is_nothrow_constructible<
-                    typename reverse_view::view_adaptor, Rng>::value)
-              : reverse_view::view_adaptor{detail::move(rng)}
-            {}
-            CONCEPT_REQUIRES(SizedRange<Rng const>())
-            constexpr range_size_type_t<Rng> size() const
-                noexcept(noexcept(ranges::size(std::declval<Rng const &>())))
-            {
-                return ranges::size(this->base());
-            }
-            CONCEPT_REQUIRES(!SizedRange<Rng const>() && (SizedRange<Rng>() ||
-                SizedSentinel<iterator_t<Rng>, iterator_t<Rng>>()))
-            RANGES_CXX14_CONSTEXPR range_size_type_t<Rng> size()
-                noexcept(noexcept(std::declval<reverse_view &>().size_(SizedRange<Rng>())))
-            {
-                return size_(SizedRange<Rng>());
-            }
         private:
-            friend range_access;
-
-            static constexpr bool const_iterable = BoundedRange<Rng const>();
-
-            CONCEPT_REQUIRES(const_iterable)
-            constexpr iterator_t<Rng> get_end() const
-                noexcept(noexcept(ranges::end(std::declval<Rng const &>())))
+            CONCEPT_ASSERT(BidirectionalRange<Rng>());
+            Rng rng_;
+            RANGES_CXX14_CONSTEXPR
+            reverse_iterator<iterator_t<Rng>> begin_(std::true_type)
             {
-                return ranges::end(this->base());
+                return make_reverse_iterator(ranges::end(rng_));
             }
-            RANGES_CXX14_CONSTEXPR iterator_t<Rng> get_end_(std::true_type)
-                noexcept(noexcept(ranges::end(std::declval<Rng &>())))
+            RANGES_CXX14_CONSTEXPR
+            reverse_iterator<iterator_t<Rng>> begin_(std::false_type)
             {
-                CONCEPT_ASSERT(BoundedRange<Rng>());
-                return ranges::end(this->base());
-            }
-            RANGES_CXX14_CONSTEXPR iterator_t<Rng> get_end_(std::false_type)
-                noexcept(noexcept(iterator_t<Rng>(ranges::next(
-                    ranges::begin(std::declval<Rng &>()),
-                    ranges::end(std::declval<Rng &>())))))
-            {
-                CONCEPT_ASSERT(!BoundedRange<Rng>());
                 using cache_t = detail::non_propagating_cache<iterator_t<Rng>, reverse_view<Rng>>;
                 auto &end_ = static_cast<cache_t &>(*this);
                 if(!end_)
-                    end_ = ranges::next(ranges::begin(this->base()), ranges::end(this->base()));
-                return *end_;
+                    end_ = ranges::next(ranges::begin(rng_), ranges::end(rng_));
+                return make_reverse_iterator(*end_);
             }
-            CONCEPT_REQUIRES(!const_iterable)
-            RANGES_CXX14_CONSTEXPR iterator_t<Rng> get_end()
-                noexcept(noexcept(std::declval<reverse_view &>().get_end_(BoundedRange<Rng>())))
+            template<typename T>
+            using not_self_ =
+                meta::if_c<!std::is_same<reverse_view, detail::decay_t<T>>::value, T>;
+        public:
+            reverse_view() = default;
+            explicit constexpr reverse_view(Rng rng)
+              : rng_(detail::move(rng))
+            {}
+            template<typename O,
+                CONCEPT_REQUIRES_(view::ViewableRange<not_self_<O>>() &&
+                    BidirectionalRange<O>() && Constructible<Rng, view::all_t<O>>())>
+            explicit constexpr reverse_view(O&& o)
+              : rng_(view::all(static_cast<O &&>(o)))
+            {}
+            Rng base() const
             {
-                return get_end_(BoundedRange<Rng>());
+                return rng_;
             }
-
-            struct adaptor : adaptor_base
+            RANGES_CXX14_CONSTEXPR
+            reverse_iterator<iterator_t<Rng>> begin()
             {
-            private:
-                using Parent = meta::const_if_c<const_iterable, reverse_view>;
-                using Base = meta::const_if_c<const_iterable, Rng>;
-#ifndef NDEBUG
-                Parent *rng_;
-#endif
-            public:
-                adaptor() = default;
-#ifndef NDEBUG
-                constexpr adaptor(Parent &rng) noexcept
-                  : rng_(&rng)
-                {}
-#else
-                constexpr adaptor(Parent &) noexcept
-                {}
-#endif
-                RANGES_CXX14_CONSTEXPR static auto begin(Parent &rng)
-                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
-                (
-                    rng.get_end()
-                )
-                RANGES_CXX14_CONSTEXPR static auto end(Parent &rng)
-                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
-                (
-                    ranges::begin(rng.base())
-                )
-                RANGES_CXX14_CONSTEXPR auto read(iterator_t<Rng> it) const
-                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
-                (
-                    *--it
-                )
-                RANGES_CXX14_CONSTEXPR void next(iterator_t<Rng> &it) const
-                    noexcept(noexcept(--it))
-                {
-                    RANGES_ASSERT(it != ranges::begin(rng_->base()));
-                    --it;
-                }
-                RANGES_CXX14_CONSTEXPR void prev(iterator_t<Rng> &it) const
-                    noexcept(noexcept(++it))
-                {
-                    RANGES_ASSERT(it != ranges::end(rng_->base()));
-                    ++it;
-                }
-                CONCEPT_REQUIRES(RandomAccessRange<Rng>())
-                RANGES_CXX14_CONSTEXPR
-                void advance(iterator_t<Rng> &it, range_difference_type_t<Rng> n) const
-                    noexcept(noexcept(ranges::advance(it, -n)))
-                {
-                    RANGES_ASSERT(n <= it - ranges::begin(rng_->base()));
-                    RANGES_ASSERT(it - rng_->get_end() <= n);
-                    ranges::advance(it, -n);
-                }
-                CONCEPT_REQUIRES(SizedSentinel<iterator_t<Rng>, iterator_t<Rng>>())
-                RANGES_CXX14_CONSTEXPR range_difference_type_t<Rng>
-                distance_to(iterator_t<Rng> const &here, iterator_t<Rng> const &there,
-                    adaptor const &other_adapt) const
-                    noexcept(noexcept(here - there))
-                {
-                    RANGES_ASSERT(rng_ == other_adapt.rng_); (void)other_adapt;
-                    return here - there;
-                }
-            };
-            CONCEPT_REQUIRES(const_iterable)
-            RANGES_CXX14_CONSTEXPR adaptor begin_adaptor() const
-                noexcept(std::is_nothrow_constructible<adaptor, reverse_view const &>::value)
-            {
-                return {*this};
+                return begin_(meta::bool_<(bool) BoundedRange<Rng>()>{});
             }
-            CONCEPT_REQUIRES(const_iterable)
-            RANGES_CXX14_CONSTEXPR adaptor end_adaptor() const
-                noexcept(std::is_nothrow_constructible<adaptor, reverse_view const &>::value)
+            template<typename CRng = Rng const,
+                CONCEPT_REQUIRES_(BoundedRange<CRng>())>
+            constexpr reverse_iterator<iterator_t<CRng>> begin() const
             {
-                return {*this};
+                return make_reverse_iterator(ranges::end(rng_));
             }
-            CONCEPT_REQUIRES(!const_iterable)
-            RANGES_CXX14_CONSTEXPR adaptor begin_adaptor()
-                noexcept(std::is_nothrow_constructible<adaptor, reverse_view &>::value)
+            RANGES_CXX14_CONSTEXPR
+            reverse_iterator<iterator_t<Rng>> end()
             {
-                return {*this};
+                return make_reverse_iterator(ranges::begin(rng_));
             }
-            CONCEPT_REQUIRES(!const_iterable)
-            RANGES_CXX14_CONSTEXPR adaptor end_adaptor()
-                noexcept(std::is_nothrow_constructible<adaptor, reverse_view &>::value)
+            template<typename CRng = Rng const,
+                CONCEPT_REQUIRES_(BoundedRange<CRng>())>
+            constexpr reverse_iterator<iterator_t<CRng>> end() const
             {
-                return {*this};
+                return make_reverse_iterator(ranges::begin(rng_));
             }
-            // SizedRange == true
-            RANGES_CXX14_CONSTEXPR range_size_type_t<Rng> size_(std::true_type)
-                noexcept(noexcept(ranges::size(std::declval<Rng &>())))
+            CONCEPT_REQUIRES(SizedRange<Rng const>())
+            constexpr range_size_type_t<Rng> size() const
             {
-                return ranges::size(this->base());
-            }
-            // SizedRange == false, SizedSentinel == true
-            RANGES_CXX14_CONSTEXPR range_size_type_t<Rng> size_(std::false_type)
-                noexcept(noexcept(ranges::iter_size(
-                    std::declval<reverse_view &>().begin(),
-                    std::declval<reverse_view &>().end())))
-            {
-                // NB: This may trigger the O(N) walk over the sequence to find
-                // last iterator. That cost is amortized over all calls to size()
-                // and end, so we'll squint and call it "amortized O(1)."
-                return ranges::iter_size(this->begin(), this->end());
+                return ranges::size(rng_);
             }
         };
 

--- a/include/range/v3/view/reverse.hpp
+++ b/include/range/v3/view/reverse.hpp
@@ -68,7 +68,7 @@ namespace ranges
               : rng_(detail::move(rng))
             {}
             template<typename O,
-                CONCEPT_REQUIRES_(view::ViewableRange<not_self_<O>>() &&
+                CONCEPT_REQUIRES_(ViewableRange<not_self_<O>>() &&
                     BidirectionalRange<O>() && Constructible<Rng, view::all_t<O>>())>
             explicit constexpr reverse_view(O&& o)
               : rng_(view::all(static_cast<O &&>(o)))

--- a/include/range/v3/view/set_algorithm.hpp
+++ b/include/range/v3/view/set_algorithm.hpp
@@ -59,7 +59,7 @@ namespace ranges
                 template<bool IsConst>
                 using cursor = Cursor<IsConst, Rng1, Rng2, C, P1, P2>;
 
-                cursor<false> begin_cursor()
+                cursor<simple_view<Rng1>() && simple_view<Rng2>()> begin_cursor()
                 {
                     return {pred_, proj1_, proj2_,
                             ranges::begin(rng1_), ranges::end(rng1_),

--- a/include/range/v3/view/set_algorithm.hpp
+++ b/include/range/v3/view/set_algorithm.hpp
@@ -88,6 +88,7 @@ namespace ranges
             struct set_difference_cursor
             {
             private:
+                friend struct set_difference_cursor<!IsConst, Rng1, Rng2, C, P1, P2>;
                 using pred_ref_ = semiregular_ref_or_val_t<C, IsConst>;
                 using proj1_ref_ = semiregular_ref_or_val_t<P1, IsConst>;
                 using proj2_ref_ = semiregular_ref_or_val_t<P2, IsConst>;
@@ -138,6 +139,14 @@ namespace ranges
                 {
                     satisfy();
                 }
+                template<bool Other,
+                    CONCEPT_REQUIRES_(IsConst && !Other)>
+                set_difference_cursor(set_difference_cursor<Other, Rng1, Rng2, C, P1, P2> that)
+                  : pred_(std::move(that.pred_)), proj1_(std::move(that.proj1_))
+                  , proj2_(std::move(that.proj2_)), it1_(std::move(that.it1_))
+                  , end1_(std::move(that.end1_)), it2_(std::move(that.it2_))
+                  , end2_(std::move(that.end2_))
+                {}
                 auto read() const
                 RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
                 (
@@ -253,6 +262,7 @@ namespace ranges
             struct set_intersection_cursor
             {
             private:
+                friend struct set_intersection_cursor<!IsConst, Rng1, Rng2, C, P1, P2>;
                 using pred_ref_ = semiregular_ref_or_val_t<C, IsConst>;
                 using proj1_ref_ = semiregular_ref_or_val_t<P1, IsConst>;
                 using proj2_ref_ = semiregular_ref_or_val_t<P2, IsConst>;
@@ -301,6 +311,14 @@ namespace ranges
                 {
                     satisfy();
                 }
+                template<bool Other,
+                    CONCEPT_REQUIRES_(IsConst && !Other)>
+                set_intersection_cursor(set_intersection_cursor<Other, Rng1, Rng2, C, P1, P2> that)
+                  : pred_(std::move(that.pred_)), proj1_(std::move(that.proj1_))
+                  , proj2_(std::move(that.proj2_)), it1_(std::move(that.it1_))
+                  , end1_(std::move(that.end1_)), it2_(std::move(that.it2_))
+                  , end2_(std::move(that.end2_))
+                {}
                 auto read() const
                 RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
                 (
@@ -417,6 +435,7 @@ namespace ranges
             struct set_union_cursor
             {
             private:
+                friend struct set_union_cursor<!IsConst, Rng1, Rng2, C, P1, P2>;
                 using pred_ref_ = semiregular_ref_or_val_t<C, IsConst>;
                 using proj1_ref_ = semiregular_ref_or_val_t<P1, IsConst>;
                 using proj2_ref_ = semiregular_ref_or_val_t<P2, IsConst>;
@@ -484,6 +503,14 @@ namespace ranges
                 {
                     satisfy();
                 }
+                template<bool Other,
+                    CONCEPT_REQUIRES_(IsConst && !Other)>
+                set_union_cursor(set_union_cursor<Other, Rng1, Rng2, C, P1, P2> that)
+                  : pred_(std::move(that.pred_)), proj1_(std::move(that.proj1_))
+                  , proj2_(std::move(that.proj2_)), it1_(std::move(that.it1_))
+                  , end1_(std::move(that.end1_)), it2_(std::move(that.it2_))
+                  , end2_(std::move(that.end2_))
+                {}
                 reference_type read() const
                 noexcept(noexcept(*it1_) && noexcept(*it2_))
                 {
@@ -625,12 +652,18 @@ namespace ranges
 
         namespace detail
         {
+            enum class set_symmetric_difference_state_t
+            {
+                FIRST, SECOND, ONLY_FIRST, ONLY_SECOND
+            };
+
             template<bool IsConst,
                      typename Rng1, typename Rng2,
                      typename C, typename P1, typename P2>
             struct set_symmetric_difference_cursor
             {
             private:
+                friend struct set_symmetric_difference_cursor<!IsConst, Rng1, Rng2, C, P1, P2>;
                 using pred_ref_ = semiregular_ref_or_val_t<C, IsConst>;
                 using proj1_ref_ = semiregular_ref_or_val_t<P1, IsConst>;
                 using proj2_ref_ = semiregular_ref_or_val_t<P2, IsConst>;
@@ -650,10 +683,8 @@ namespace ranges
                 iterator_t<R2> it2_;
                 sentinel_t<R2> end2_;
 
-                enum class state_t
-                {
-                    FIRST, SECOND, ONLY_FIRST, ONLY_SECOND
-                } state;
+                using state_t = set_symmetric_difference_state_t;
+                state_t state;
 
                 void satisfy()
                 {
@@ -705,6 +736,15 @@ namespace ranges
                 {
                     satisfy();
                 }
+                template<bool Other,
+                    CONCEPT_REQUIRES_(IsConst && !Other)>
+                set_symmetric_difference_cursor(
+                    set_symmetric_difference_cursor<Other, Rng1, Rng2, C, P1, P2> that)
+                  : pred_(std::move(that.pred_)), proj1_(std::move(that.proj1_))
+                  , proj2_(std::move(that.proj2_)), it1_(std::move(that.it1_))
+                  , end1_(std::move(that.end1_)), it2_(std::move(that.it2_))
+                  , end2_(std::move(that.end2_)), state(that.state)
+                {}
                 reference_type read() const
                 noexcept(noexcept(*it1_) && noexcept(*it2_))
                 {

--- a/include/range/v3/view/single.hpp
+++ b/include/range/v3/view/single.hpp
@@ -24,6 +24,7 @@
 #include <range/v3/view_facade.hpp>
 #include <range/v3/utility/iterator_concepts.hpp>
 #include <range/v3/utility/iterator_traits.hpp>
+#include <range/v3/utility/optional.hpp>
 #include <range/v3/utility/semiregular.hpp>
 #include <range/v3/utility/static_const.hpp>
 
@@ -33,68 +34,71 @@ namespace ranges
     {
         /// \addtogroup group-views
         /// @{
-        template<typename Val>
+        template<typename T>
         struct single_view
-          : view_facade<single_view<Val>, (cardinality)1>
-        {
+          : view_interface<single_view<T>, (cardinality)1> {
         private:
-            friend struct ranges::range_access;
-            semiregular_t<Val> value_;
-            struct cursor
-            {
-            private:
-                semiregular_t<Val> value_;
-                bool done_;
-            public:
-                cursor() = default;
-                explicit cursor(Val value)
-                  : value_(std::move(value)), done_(false)
-                {}
-                Val read() const
-                {
-                    return value_;
-                }
-                bool equal(default_sentinel) const
-                {
-                    return done_;
-                }
-                bool equal(cursor const &that) const
-                {
-                    return done_ == that.done_;
-                }
-                void next()
-                {
-                    done_ = true;
-                }
-                void prev()
-                {
-                    done_ = false;
-                }
-                void advance(std::ptrdiff_t n)
-                {
-                    n += done_;
-                    RANGES_EXPECT(n == 0 || n == 1);
-                    done_ = n != 0;
-                }
-                std::ptrdiff_t distance_to(cursor const &that) const
-                {
-                    return that.done_ - done_;
-                }
-            };
-            cursor begin_cursor() const
-            {
-                return cursor{value_};
-            }
+            CONCEPT_ASSERT(CopyConstructible<T>());
+            CONCEPT_ASSERT(Satisfies<T, std::is_object>());
+            semiregular_t<T> value_;
+            template<typename... Args>
+            constexpr single_view(in_place_t, std::true_type, Args &&...args)
+              : value_{static_cast<Args &&>(args)...}
+            {}
+            template<typename... Args>
+            constexpr single_view(in_place_t, std::false_type, Args &&...args)
+              : value_{in_place, static_cast<Args &&>(args)...}
+            {}
         public:
             single_view() = default;
-            constexpr explicit single_view(Val value)
-              : value_(detail::move(value))
+            constexpr explicit single_view(T const &t)
+              : value_(t)
             {}
-            constexpr std::size_t size() const
+            constexpr explicit single_view(T &&t)
+              : value_(std::move(t))
+            {}
+            template<class... Args,
+                CONCEPT_REQUIRES_(Constructible<T, Args...>())>
+            constexpr single_view(in_place_t, Args&&... args)
+              : single_view{
+                    in_place,
+                    meta::bool_<(bool)SemiRegular<T>()>{},
+                    static_cast<Args &&>(args)...}
+            {}
+            RANGES_CXX14_CONSTEXPR T *begin() noexcept
             {
-                return 1;
+                return data();
+            }
+            constexpr T const *begin() const noexcept
+            {
+                return data();
+            }
+            RANGES_CXX14_CONSTEXPR T *end() noexcept
+            {
+                return data() + 1;
+            }
+            constexpr T const *end() const noexcept
+            {
+                return data() + 1;
+            }
+            constexpr static std::size_t size() noexcept
+            {
+                return 1u;
+            }
+            RANGES_CXX14_CONSTEXPR T *data() noexcept
+            {
+                return std::addressof(static_cast<T &>(value_));
+            }
+            constexpr T const *data() const noexcept
+            {
+                return std::addressof(static_cast<T const &>(value_));
             }
         };
+
+#if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
+        template<class T>
+        explicit single_view(T&&) -> single_view<detail::decay_t<T>>;
+#endif
 
         namespace view
         {

--- a/include/range/v3/view/sliding.hpp
+++ b/include/range/v3/view/sliding.hpp
@@ -49,7 +49,8 @@ namespace ranges
             sliding_view_detail::cache = sliding_view_detail::caching<Rng>::value>
         struct sliding_view;
 
-        namespace sliding_view_detail {
+        namespace sliding_view_detail
+        {
             template<typename Rng>
             using uncounted_t = decltype(
                 ranges::uncounted(std::declval<iterator_t<Rng>&>()));
@@ -120,7 +121,7 @@ namespace ranges
                 {
                     return size_(ranges::size(this->base()));
                 }
-                CONCEPT_REQUIRES(SizedRange<Rng>() && !SizedRange<Rng const>())
+                CONCEPT_REQUIRES(SizedRange<Rng>())
                 range_size_type_t<Rng> size()
                 {
                     return size_(ranges::size(this->base()));
@@ -132,7 +133,7 @@ namespace ranges
                 {
                     return static_cast<cache_t&>(*this);
                 }
-                optional<iterator_t<Rng>> const &cache() const&
+                optional<iterator_t<Rng>> const &cache() const &
                 {
                     return static_cast<cache_t const&>(*this);
                 }
@@ -179,7 +180,7 @@ namespace ranges
                 range_difference_type_t<Rng> n_ = {};
             public:
                 adaptor() = default;
-                adaptor(sliding_view<Rng> const &v)
+                adaptor(sliding_view &v)
                   : base_t{v.base()}
                   , n_{v.n_}
                 {}
@@ -214,7 +215,7 @@ namespace ranges
             {
                 return {*this};
             }
-            meta::if_<BoundedRange<Rng>, adaptor, adaptor_base> end_adaptor() const
+            meta::if_<BoundedRange<Rng>, adaptor, adaptor_base> end_adaptor()
             {
                 return {*this};
             }
@@ -248,7 +249,7 @@ namespace ranges
                 range_difference_type_t<Rng> n_ = {};
             public:
                 adaptor() = default;
-                adaptor(sliding_view<Rng> const &v)
+                adaptor(sliding_view &v)
                   : n_{v.n_}
                 {}
                 iterator_t<Rng> end(sliding_view &v)
@@ -262,7 +263,7 @@ namespace ranges
                 }
             };
 
-            adaptor begin_adaptor() const
+            adaptor begin_adaptor()
             {
                 return {*this};
             }
@@ -281,41 +282,54 @@ namespace ranges
         private:
             friend range_access;
 
-            iterator_t<Rng> get_last() const
-            {
-                auto const sz = ranges::distance(this->base());
-                auto const offset = this->n_ - 1 < sz ? this->n_ - 1 : sz;
-                return ranges::begin(this->base()) + (sz - offset);
-            }
-
+            template<bool Const>
             struct adaptor
               : adaptor_base
             {
             private:
-                range_difference_type_t<Rng> n_ = {};
+                friend struct adaptor<!Const>;
+                using CRng = meta::const_if_c<Const, Rng>;
+                range_difference_type_t<Rng> n_ = 0;
             public:
                 adaptor() = default;
-                adaptor(sliding_view<Rng> const &v)
-                  : n_{v.n_}
+                adaptor(range_difference_type_t<Rng> n)
+                  : n_(n)
                 {}
-                iterator_t<Rng> end(sliding_view const &v) const
+                template<bool Other,
+                    CONCEPT_REQUIRES_(Const && !Other)>
+                adaptor(adaptor<Other> that)
+                  : n_(that.n_)
+                {}
+                iterator_t<CRng> end(meta::const_if_c<Const, sliding_view> &v) const
                 {
-                    return v.get_last();
+                    auto const sz = ranges::distance(v.base());
+                    auto const offset = n_ - 1 < sz ? n_ - 1 : sz;
+                    return ranges::begin(v.base()) + (sz - offset);
                 }
-                auto read(iterator_t<Rng> const &it) const ->
+                auto read(iterator_t<CRng> const &it) const ->
                     decltype(view::counted(uncounted(it), n_))
                 {
                     return view::counted(uncounted(it), n_);
                 }
             };
 
-            adaptor begin_adaptor() const
+            adaptor<false> begin_adaptor()
             {
-                return {*this};
+                return {this->n_};
             }
-            adaptor end_adaptor() const
+            adaptor<false> end_adaptor()
             {
-                return {*this};
+                return {this->n_};
+            }
+            CONCEPT_REQUIRES(Range<Rng const>())
+            adaptor<true> begin_adaptor() const
+            {
+                return {this->n_};
+            }
+            CONCEPT_REQUIRES(Range<Rng const>())
+            adaptor<true> end_adaptor() const
+            {
+                return {this->n_};
             }
         public:
             using sliding_view::sv_base::sv_base;

--- a/include/range/v3/view/sliding.hpp
+++ b/include/range/v3/view/sliding.hpp
@@ -313,11 +313,11 @@ namespace ranges
                 }
             };
 
-            adaptor<false> begin_adaptor()
+            adaptor<simple_view<Rng>()> begin_adaptor()
             {
                 return {this->n_};
             }
-            adaptor<false> end_adaptor()
+            adaptor<simple_view<Rng>()> end_adaptor()
             {
                 return {this->n_};
             }

--- a/include/range/v3/view/tail.hpp
+++ b/include/range/v3/view/tail.hpp
@@ -55,6 +55,13 @@ namespace ranges
         private:
             Rng rng_;
             using size_type_ = range_size_type_t<Rng>;
+            template<typename R>
+            static constexpr size_type_ size_(R &rng)
+            {
+                return range_cardinality<Rng>::value >= 0
+                  ? detail::prev_or_zero_((size_type_)range_cardinality<Rng>::value)
+                  : detail::prev_or_zero_(ranges::size(rng));
+            }
         public:
             using iterator = iterator_t<Rng>;
             using sentinel = sentinel_t<Rng>;
@@ -69,8 +76,9 @@ namespace ranges
             {
                 return next(ranges::begin(rng_), 1, ranges::end(rng_));
             }
-            CONCEPT_REQUIRES(Range<Rng const>())
-            iterator begin() const
+            template<class CRng = Rng const,
+                CONCEPT_REQUIRES_(Range<CRng>())>
+            iterator_t<CRng> begin() const
             {
                 return next(ranges::begin(rng_), 1, ranges::end(rng_));
             }
@@ -78,17 +86,21 @@ namespace ranges
             {
                 return ranges::end(rng_);
             }
-            CONCEPT_REQUIRES(Range<Rng const>())
-            sentinel end() const
+            template<class CRng = Rng const,
+                CONCEPT_REQUIRES_(Range<CRng>())>
+            sentinel_t<CRng> end() const
             {
                 return ranges::end(rng_);
             }
-            CONCEPT_REQUIRES(SizedView<Rng>())
+            CONCEPT_REQUIRES(SizedRange<Rng>())
+            RANGES_CXX14_CONSTEXPR size_type_ size()
+            {
+                return tail_view::size_(rng_);
+            }
+            CONCEPT_REQUIRES(SizedRange<Rng const>())
             constexpr size_type_ size() const
             {
-                return range_cardinality<Rng>::value >= 0
-                  ? detail::prev_or_zero_((size_type_)range_cardinality<Rng>::value)
-                  : detail::prev_or_zero_(ranges::size(rng_));
+                return tail_view::size_(rng_);
             }
             Rng & base()
             {

--- a/include/range/v3/view/take.hpp
+++ b/include/range/v3/view/take.hpp
@@ -48,6 +48,11 @@ namespace ranges
             template<bool IsConst>
             struct adaptor : adaptor_base
             {
+                adaptor() = default;
+                template<bool Other,
+                    CONCEPT_REQUIRES_(IsConst && !Other)>
+                adaptor(adaptor<Other>)
+                {}
                 CI<IsConst> begin(meta::const_if_c<IsConst, take_view> &rng) const
                 {
                     return {ranges::begin(rng.base()), rng.n_};
@@ -57,6 +62,11 @@ namespace ranges
             template<bool IsConst>
             struct sentinel_adaptor : adaptor_base
             {
+                sentinel_adaptor() = default;
+                template<bool Other,
+                    CONCEPT_REQUIRES_(IsConst && !Other)>
+                sentinel_adaptor(sentinel_adaptor<Other>)
+                {}
                 bool empty(CI<IsConst> const &that, S<IsConst> const &sent) const
                 {
                     return 0 == that.count() || sent == that.base();

--- a/include/range/v3/view/take.hpp
+++ b/include/range/v3/view/take.hpp
@@ -73,11 +73,11 @@ namespace ranges
                 }
             };
 
-            adaptor<false> begin_adaptor()
+            adaptor<simple_view<Rng>()> begin_adaptor()
             {
                 return {};
             }
-            sentinel_adaptor<false> end_adaptor()
+            sentinel_adaptor<simple_view<Rng>()> end_adaptor()
             {
                 return {};
             }

--- a/include/range/v3/view/take_exactly.hpp
+++ b/include/range/v3/view/take_exactly.hpp
@@ -110,7 +110,7 @@ namespace ranges
                 }
                 iterator_t<Rng> end()
                 {
-                    return next(ranges::begin(rng_), n_);
+                    return ranges::begin(rng_) + n_;
                 }
                 template<typename BaseRng = Rng,
                     CONCEPT_REQUIRES_(Range<BaseRng const>())>
@@ -122,7 +122,7 @@ namespace ranges
                     CONCEPT_REQUIRES_(Range<BaseRng const>())>
                 iterator_t<BaseRng const> end() const
                 {
-                    return next(ranges::begin(rng_), n_);
+                    return ranges::begin(rng_) + n_;
                 }
                 range_size_type_t<Rng> size() const
                 {

--- a/include/range/v3/view/tokenize.hpp
+++ b/include/range/v3/view/tokenize.hpp
@@ -27,6 +27,7 @@
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/static_const.hpp>
 #include <range/v3/view/all.hpp>
+#include <range/v3/view/view.hpp>
 
 namespace ranges
 {
@@ -62,9 +63,10 @@ namespace ranges
               , subs_(std::move(subs))
               , flags_(flags)
             {}
-            iterator_t<false> begin()
+            iterator_t<simple_view<Rng>()> begin()
             {
-                return {ranges::begin(rng_), ranges::end(rng_), rex_, subs_, flags_};
+                meta::const_if_c<simple_view<Rng>(), Rng> &rng = rng_;
+                return {ranges::begin(rng), ranges::end(rng), rex_, subs_, flags_};
             }
             template<bool Const = true,
                 CONCEPT_REQUIRES_(Range<Rng const>())>
@@ -72,7 +74,7 @@ namespace ranges
             {
                 return {ranges::begin(rng_), ranges::end(rng_), rex_, subs_, flags_};
             }
-            iterator_t<false> end()
+            iterator_t<simple_view<Rng>()> end()
             {
                 return {};
             }

--- a/include/range/v3/view/tokenize.hpp
+++ b/include/range/v3/view/tokenize.hpp
@@ -49,9 +49,10 @@ namespace ranges
             Regex rex_;
             SubMatchRange subs_;
             std::regex_constants::match_flag_type flags_;
+            template<bool Const>
+            using iterator_t =
+                std::regex_token_iterator<iterator_t<meta::const_if_c<Const, Rng>>>;
         public:
-            using iterator =
-                std::regex_token_iterator<iterator_t<Rng>>;
 
             tokenize_view() = default;
             tokenize_view(Rng rng, Regex rex, SubMatchRange subs,
@@ -61,16 +62,23 @@ namespace ranges
               , subs_(std::move(subs))
               , flags_(flags)
             {}
-            iterator begin()
+            iterator_t<false> begin()
             {
                 return {ranges::begin(rng_), ranges::end(rng_), rex_, subs_, flags_};
             }
-            CONCEPT_REQUIRES(Range<Rng const &>())
-            iterator begin() const
+            template<bool Const = true,
+                CONCEPT_REQUIRES_(Range<Rng const>())>
+            iterator_t<Const> begin() const
             {
                 return {ranges::begin(rng_), ranges::end(rng_), rex_, subs_, flags_};
             }
-            iterator end() const
+            iterator_t<false> end()
+            {
+                return {};
+            }
+            template<bool Const = true,
+                CONCEPT_REQUIRES_(Range<Rng const>())>
+            iterator_t<Const> end() const
             {
                 return {};
             }

--- a/include/range/v3/view/transform.hpp
+++ b/include/range/v3/view/transform.hpp
@@ -69,21 +69,28 @@ namespace ranges
             struct adaptor : adaptor_base
             {
             private:
+                friend struct adaptor<!IsConst>;
+                using CRng = meta::const_if_c<IsConst, Rng>;
                 using fun_ref_ = semiregular_ref_or_val_t<Fun, IsConst>;
                 fun_ref_ fun_;
             public:
                 using value_type =
-                    detail::decay_t<invoke_result_t<Fun&, copy_tag, iterator_t<Rng>>>;
+                    detail::decay_t<invoke_result_t<Fun&, copy_tag, iterator_t<CRng>>>;
                 adaptor() = default;
                 adaptor(fun_ref_ fun)
                   : fun_(std::move(fun))
                 {}
-                auto read(iterator_t<Rng> it) const
+                template<bool Other,
+                    CONCEPT_REQUIRES_(IsConst && !Other)>
+                adaptor(adaptor<Other> that)
+                  : fun_(std::move(that.fun_))
+                {}
+                auto read(iterator_t<CRng> it) const
                 RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
                 (
                     invoke(fun_, it)
                 )
-                auto iter_move(iterator_t<Rng> it) const
+                auto iter_move(iterator_t<CRng> it) const
                 RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
                 (
                     invoke(fun_, move_tag{}, it)
@@ -94,16 +101,18 @@ namespace ranges
             {
                 return {fun_};
             }
-            meta::if_<use_sentinel_t, adaptor_base, adaptor<false>> end_adaptor()
-            {
-                return {fun_};
-            }
-            CONCEPT_REQUIRES(Invocable<Fun const&, iterator_t<Rng>>())
+            template<typename CRng = Rng const,
+                CONCEPT_REQUIRES_(Range<CRng>() && Invocable<Fun const&, iterator_t<CRng>>())>
             adaptor<true> begin_adaptor() const
             {
                 return {fun_};
             }
-            CONCEPT_REQUIRES(Invocable<Fun const&, iterator_t<Rng>>())
+            meta::if_<use_sentinel_t, adaptor_base, adaptor<false>> end_adaptor()
+            {
+                return {fun_};
+            }
+            template<typename CRng = Rng const,
+                CONCEPT_REQUIRES_(Range<CRng>() && Invocable<Fun const&, iterator_t<CRng>>())>
             meta::if_<use_sentinel_t, adaptor_base, adaptor<true>> end_adaptor() const
             {
                 return {fun_};

--- a/include/range/v3/view/view.hpp
+++ b/include/range/v3/view/view.hpp
@@ -39,6 +39,29 @@ namespace ranges
         }
         /// \endcond
 
+        struct SimpleView
+        {
+            template<typename Rng>
+            auto requires_() -> decltype(
+                concepts::valid_expr(
+                    concepts::model_of<concepts::View, Rng>() &&
+                    concepts::model_of<concepts::Range, Rng const>() &&
+                    concepts::model_of<concepts::Same, iterator_t<Rng>, iterator_t<Rng const>>() &&
+                    concepts::model_of<concepts::Same, sentinel_t<Rng>, sentinel_t<Rng const>>()
+                ));
+        };
+
+        template<typename Rng>
+        constexpr bool simple_view()
+        {
+            return concepts::models<SimpleView, Rng>::value;
+        }
+
+        template<typename Rng>
+        using ViewableRange = meta::and_<
+            Range<Rng>,
+            meta::or_<std::is_lvalue_reference<Rng>, View<uncvref_t<Rng>>>>;
+
         namespace view
         {
             /// \addtogroup group-views
@@ -69,11 +92,6 @@ namespace ranges
             /// \ingroup group-views
             /// \sa make_view_fn
             RANGES_INLINE_VARIABLE(make_view_fn, make_view)
-
-            template<typename Rng>
-            using ViewableRange = meta::and_<
-                Range<Rng>,
-                meta::or_<std::is_lvalue_reference<Rng>, View<uncvref_t<Rng>>>>;
 
             template<typename View>
             struct view : pipeable<view<View>>

--- a/include/range/v3/view/zip_with.hpp
+++ b/include/range/v3/view/zip_with.hpp
@@ -145,38 +145,53 @@ namespace ranges
             using difference_type_ = common_type_t<range_difference_type_t<Rngs>...>;
             using size_type_ = meta::_t<std::make_unsigned<difference_type_>>;
 
+            template<bool Const>
             struct cursor;
 
+            template<bool Const>
             struct sentinel
             {
             private:
-                friend struct cursor;
-                std::tuple<sentinel_t<Rngs>...> ends_;
+                friend struct cursor<Const>;
+                friend struct sentinel<!Const>;
+                std::tuple<sentinel_t<meta::const_if_c<Const, Rngs>>...> ends_;
             public:
                 sentinel() = default;
-                sentinel(detail::any, std::tuple<sentinel_t<Rngs>...> ends)
+                sentinel(detail::any, std::tuple<sentinel_t<meta::const_if_c<Const, Rngs>>...> ends)
                   : ends_(std::move(ends))
+                {}
+                template<bool Other,
+                    CONCEPT_REQUIRES_(Const && !Other)>
+                sentinel(sentinel<Other> that)
+                  : ends_(std::move(that.ends_))
                 {}
             };
 
+            template<bool Const>
             struct cursor
             {
             private:
-                using fun_ref_ = semiregular_ref_or_val_t<Fun, true>;
+                friend struct cursor<!Const>;
+                using fun_ref_ = semiregular_ref_or_val_t<Fun, Const>;
                 fun_ref_ fun_;
-                std::tuple<iterator_t<Rngs>...> its_;
+                std::tuple<iterator_t<meta::const_if_c<Const, Rngs>>...> its_;
 
             public:
                 using difference_type =
-                    common_type_t<range_difference_type_t<Rngs>...>;
+                    common_type_t<range_difference_type_t<meta::const_if_c<Const, Rngs>>...>;
                 using single_pass =
-                    meta::or_c<(bool) SinglePass<iterator_t<Rngs>>()...>;
+                    meta::or_c<(bool) SinglePass<iterator_t<meta::const_if_c<Const, Rngs>>>()...>;
                 using value_type =
-                    detail::decay_t<decltype(invoke(fun_, copy_tag{}, iterator_t<Rngs>{}...))>;
+                    detail::decay_t<decltype(invoke(fun_, copy_tag{}, iterator_t<meta::const_if_c<Const, Rngs>>{}...))>;
 
                 cursor() = default;
-                cursor(fun_ref_ fun, std::tuple<iterator_t<Rngs>...> its)
+                cursor(fun_ref_ fun, std::tuple<iterator_t<meta::const_if_c<Const, Rngs>>...> its)
                   : fun_(std::move(fun)), its_(std::move(its))
+                {}
+                template<bool Other,
+                    CONCEPT_REQUIRES_(Const && !Other)>
+                cursor(cursor<Other> that)
+                  : fun_(std::move(that.fun_)), its_(std::move(that.its_))
                 {}
                 auto read() const
                 RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
@@ -187,7 +202,10 @@ namespace ranges
                 {
                     tuple_for_each(its_, detail::inc);
                 }
-                CONCEPT_REQUIRES(meta::and_c<(bool) Sentinel<iterator_t<Rngs>, iterator_t<Rngs>>()...>::value)
+                CONCEPT_REQUIRES(meta::and_c<
+                    (bool) Sentinel<
+                        iterator_t<meta::const_if_c<Const, Rngs>>,
+                        iterator_t<meta::const_if_c<Const, Rngs>>>()...>::value)
                 bool equal(cursor const &that) const
                 {
                     // By returning true if *any* of the iterators are equal, we allow
@@ -198,7 +216,7 @@ namespace ranges
                         false,
                         [](bool a, bool b) { return a || b; });
                 }
-                bool equal(sentinel const &s) const
+                bool equal(sentinel<Const> const &s) const
                 {
                     // By returning true if *any* of the iterators are equal, we allow
                     // zipped ranges to be of different lengths, stopping when the first
@@ -208,19 +226,23 @@ namespace ranges
                         false,
                         [](bool a, bool b) { return a || b; });
                 }
-                CONCEPT_REQUIRES(meta::and_c<(bool) BidirectionalRange<Rngs>()...>::value)
+                CONCEPT_REQUIRES(meta::and_c<
+                    (bool) BidirectionalRange<meta::const_if_c<Const, Rngs>>()...>::value)
                 void prev()
                 {
                     tuple_for_each(its_, detail::dec);
                 }
-                CONCEPT_REQUIRES(meta::and_c<(bool) RandomAccessRange<Rngs>()...>::value)
+                CONCEPT_REQUIRES(meta::and_c<
+                    (bool) RandomAccessRange<meta::const_if_c<Const, Rngs>>()...>::value)
                 void advance(difference_type n)
                 {
                     using std::placeholders::_1;
                     tuple_for_each(its_, std::bind(detail::advance_, _1, n));
                 }
                 CONCEPT_REQUIRES(meta::and_c<(bool)
-                    SizedSentinel<iterator_t<Rngs>, iterator_t<Rngs>>()...>::value)
+                    SizedSentinel<
+                        iterator_t<meta::const_if_c<Const, Rngs>>,
+                        iterator_t<meta::const_if_c<Const, Rngs>>>()...>::value)
                 difference_type distance_to(cursor const &that) const
                 {
                     // Return the smallest distance (in magnitude) of any of the iterator
@@ -252,29 +274,30 @@ namespace ranges
                 }
             };
 
+            template<bool Const>
             using end_cursor_t =
-                meta::if_<
-                    meta::and_c<
-                        meta::and_c<(bool) BoundedRange<Rngs>()...>::value,
-                        !SinglePass<iterator_t<Rngs>>()...>,
-                    cursor,
-                    sentinel>;
+                meta::if_c<
+                    meta::and_c<(bool) BoundedRange<meta::if_c<Const, Rngs const, Rngs>>()...>::value &&
+                      meta::and_c<!SinglePass<iterator_t<meta::if_c<Const, Rngs const, Rngs>>>()...>::value,
+                    cursor<Const>,
+                    sentinel<Const>>;
 
-            cursor begin_cursor()
+            cursor<false> begin_cursor()
             {
                 return {fun_, tuple_transform(rngs_, begin)};
             }
-            end_cursor_t end_cursor()
+            end_cursor_t<false> end_cursor()
             {
                 return {fun_, tuple_transform(rngs_, end)};
             }
             CONCEPT_REQUIRES(meta::and_c<(bool) Range<Rngs const>()...>::value)
-            cursor begin_cursor() const
+            cursor<true> begin_cursor() const
             {
                 return {fun_, tuple_transform(rngs_, begin)};
             }
-            CONCEPT_REQUIRES(meta::and_c<(bool) Range<Rngs const>()...>::value)
-            end_cursor_t end_cursor() const
+            template<bool Const = true,
+                CONCEPT_REQUIRES_(meta::and_c<(bool) Range<Rngs const>()...>::value)>
+            end_cursor_t<Const> end_cursor() const
             {
                 return {fun_, tuple_transform(rngs_, end)};
             }
@@ -288,7 +311,7 @@ namespace ranges
               : fun_(std::move(fun))
               , rngs_{std::move(rngs)...}
             {}
-            CONCEPT_REQUIRES(meta::and_c<(bool) SizedRange<Rngs>()...>::value)
+            CONCEPT_REQUIRES(meta::and_c<(bool) SizedRange<Rngs const>()...>::value)
             constexpr size_type_ size() const
             {
                 return range_cardinality<iter_zip_with_view>::value >= 0 ?

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -33,11 +33,11 @@ namespace ranges
         {
             template<typename Derived>
             using begin_adaptor_t =
-                detail::decay_t<decltype(range_access::begin_adaptor(std::declval<Derived &>(), 42))>;
+                detail::decay_t<decltype(range_access::begin_adaptor(std::declval<Derived &>()))>;
 
             template<typename Derived>
             using end_adaptor_t =
-                detail::decay_t<decltype(range_access::end_adaptor(std::declval<Derived &>(), 42))>;
+                detail::decay_t<decltype(range_access::end_adaptor(std::declval<Derived &>()))>;
 
             template<typename Derived>
             using adapted_iterator_t =
@@ -338,7 +338,7 @@ namespace ranges
                 return ranges::iter_move(first());
             }
             // If the adaptor does not have an iter_move function but overrides the read
-            // member function, apply std::move to the result of calling current.
+            // member function, apply std::move to the result of calling read.
             template<typename A = Adapt,
                 typename R = decltype(std::declval<A const &>().read(std::declval<BaseIter const &>())),
                 typename X = aux::move_t<R>>
@@ -405,9 +405,9 @@ namespace ranges
             static RANGES_CXX14_CONSTEXPR adaptor_cursor_t<D> begin_cursor_(D &d)
                 noexcept(noexcept(adaptor_cursor_t<D>{
                     std::declval<detail::begin_adaptor_t<D> &>().begin(d),
-                    range_access::begin_adaptor(d, 42)}))
+                    range_access::begin_adaptor(d)}))
             {
-                auto adapt = range_access::begin_adaptor(d, 42);
+                auto adapt = range_access::begin_adaptor(d);
                 auto pos = adapt.begin(d);
                 return {std::move(pos), std::move(adapt)};
             }
@@ -429,9 +429,9 @@ namespace ranges
             static RANGES_CXX14_CONSTEXPR adaptor_sentinel_t<D> end_cursor_(D &d)
                 noexcept(noexcept(adaptor_sentinel_t<D>{
                     std::declval<detail::end_adaptor_t<D> &>().end(d),
-                    range_access::end_adaptor(d, 42)}))
+                    range_access::end_adaptor(d)}))
             {
-                auto adapt = range_access::end_adaptor(d, 42);
+                auto adapt = range_access::end_adaptor(d);
                 auto pos = adapt.end(d);
                 return {std::move(pos), std::move(adapt)};
             }

--- a/include/range/v3/view_facade.hpp
+++ b/include/range/v3/view_facade.hpp
@@ -32,11 +32,11 @@ namespace ranges
         {
             template<typename Derived>
             using begin_cursor_t =
-                detail::decay_t<decltype(range_access::begin_cursor(std::declval<Derived &>(), 42))>;
+                detail::decay_t<decltype(range_access::begin_cursor(std::declval<Derived &>()))>;
 
             template<typename Derived>
             using end_cursor_t =
-                detail::decay_t<decltype(range_access::end_cursor(std::declval<Derived &>(), 42))>;
+                detail::decay_t<decltype(range_access::end_cursor(std::declval<Derived &>()))>;
 
             template<typename Derived>
             using facade_iterator_t = basic_iterator<begin_cursor_t<Derived>>;
@@ -85,14 +85,14 @@ namespace ranges
             detail::facade_iterator_t<D> begin()
             {
                 return detail::facade_iterator_t<D>{
-                    range_access::begin_cursor(derived(), 42)};
+                    range_access::begin_cursor(derived())};
             }
             /// \overload
             template<typename D = Derived, CONCEPT_REQUIRES_(Same<D, Derived>())>
             detail::facade_iterator_t<D const> begin() const
             {
                 return detail::facade_iterator_t<D const>{
-                    range_access::begin_cursor(derived(), 42)};
+                    range_access::begin_cursor(derived())};
             }
             /// Let `d` be `static_cast<Derived &>(*this)`. Let `e` be
             /// `std::as_const(d).end_cursor()` if that expression is well-formed;
@@ -104,14 +104,14 @@ namespace ranges
             detail::facade_sentinel_t<D> end()
             {
                 return static_cast<detail::facade_sentinel_t<D>>(
-                    range_access::end_cursor(derived(), 42));
+                    range_access::end_cursor(derived()));
             }
             /// \overload
             template<typename D = Derived, CONCEPT_REQUIRES_(Same<D, Derived>())>
             detail::facade_sentinel_t<D const> end() const
             {
                 return static_cast<detail::facade_sentinel_t<D const>>(
-                    range_access::end_cursor(derived(), 42));
+                    range_access::end_cursor(derived()));
             }
         };
 

--- a/test/view/cartesian_product.cpp
+++ b/test/view/cartesian_product.cpp
@@ -115,7 +115,7 @@ void test_empty_range()
         std::tuple<int, char>>());
     CONCEPT_ASSERT(std::is_same<
         range_reference_t<Rng>,
-        common_tuple<int &, char const &>>());
+        common_tuple<int &, char &>>());
 
     using CT = common_tuple<int, char>;
     std::initializer_list<CT> control = {};

--- a/test/view/reverse.cpp
+++ b/test/view/reverse.cpp
@@ -55,8 +55,7 @@ int main()
     models<concepts::View>(aux::copy(rng2));
     models<concepts::RandomAccessRange>(rng2);
     models<concepts::BoundedRange>(rng2);
-    models<concepts::SizedRange>(rng2);
-    CHECK(rng2.size() == 5u);
+    models_not<concepts::SizedRange>(rng2);
     auto const & crng2 = rng2;
     models_not<concepts::Range>(crng2);
     ::check_equal(rng2, {'o','l','l','e','h'});

--- a/test/view/tail.cpp
+++ b/test/view/tail.cpp
@@ -59,12 +59,12 @@ int main()
     }
 
     {
-        tail_view<empty_view<int>> rng(view::empty<int>());
+        tail_view<empty_view<int>> const rng(view::empty<int>());
         static_assert(0 == size(rng), "");
     }
 
     {
-        auto rng = view::single(1) | view::tail;
+        auto const rng = view::single(1) | view::tail;
         static_assert(0 == size(rng), "");
     }
 


### PR DESCRIPTION
* views no longer prefer const `(begin|end)_(cursor|adaptor)`
* ok to adapt views with different const and mutable iterators
* `reverse_view`, `single_view`, and `empty_view` conform with P0896
