### PR TITLE
cycled_view updates

### DIFF
--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -475,14 +475,6 @@ namespace ranges
         }
 
         template<typename Rng>
-        struct bounded_view;
-
-        namespace view
-        {
-            struct bounded_fn;
-        }
-
-        template<typename Rng>
         struct const_view;
 
         namespace view
@@ -507,7 +499,7 @@ namespace ranges
         using move_into_iterator =
             basic_iterator<detail::move_into_cursor<I>>;
 
-        template<typename Rng>
+        template<typename Rng, bool = (bool) is_infinite<Rng>()>
         struct cycled_view;
 
         namespace view
@@ -609,7 +601,15 @@ namespace ranges
             struct repeat_fn;
         }
 
-        template<typename Rng>
+        namespace detail
+        {
+            template<typename>
+            std::false_type double_reverse(long);
+            template<typename R, meta::if_<std::is_same<R, typename R::unreverse_me>>* = nullptr>
+            std::true_type double_reverse(int);
+        }
+
+        template<typename Rng, bool = decltype(detail::double_reverse<Rng>(42))::value>
         struct reverse_view;
 
         namespace view

--- a/include/range/v3/view/all.hpp
+++ b/include/range/v3/view/all.hpp
@@ -107,6 +107,32 @@ namespace ranges
             using all_t =
                 meta::_t<std::decay<decltype(all(std::declval<Rng>()))>>;
         }
+
+        template<typename Rng>
+        struct identity_adaptor
+          : Rng
+        {
+            CONCEPT_ASSERT(View<Rng>());
+
+            identity_adaptor() = default;
+            constexpr explicit identity_adaptor(Rng const &rng)
+              : Rng(rng)
+            {}
+            constexpr explicit identity_adaptor(Rng &&rng)
+              : Rng(detail::move(rng))
+            {}
+
+            using Rng::Rng;
+
+            RANGES_CXX14_CONSTEXPR Rng &base() noexcept
+            {
+                return *this;
+            }
+            constexpr Rng const &base() const noexcept
+            {
+                return *this;
+            }
+        };
         /// @}
     }
 }

--- a/include/range/v3/view/cycle.hpp
+++ b/include/range/v3/view/cycle.hpp
@@ -48,7 +48,7 @@ namespace ranges
                 iterator_t<Rng>, cycled_view<Rng>, !BoundedRange<Rng>()>
         {
         private:
-            CONCEPT_ASSERT(ForwardRange<Rng>());
+            CONCEPT_ASSERT(ForwardRange<Rng>() && !is_infinite<Rng>::value);
             friend range_access;
             Rng rng_;
 
@@ -64,12 +64,11 @@ namespace ranges
                 using constify_if = meta::const_if_c<IsConst, T>;
                 using cycled_view_t = constify_if<cycled_view>;
                 using CRng = constify_if<Rng>;
-                using difference_type_ = range_difference_type_t<Rng>;
                 using iterator = iterator_t<CRng>;
 
                 cycled_view_t *rng_{};
                 iterator it_{};
-                std::ptrdiff_t n_ = 0;
+                std::intmax_t n_ = 0;
 
                 iterator get_end_(std::true_type, bool = false) const
                 {
@@ -140,10 +139,8 @@ namespace ranges
                     --it_;
                 }
                 CONCEPT_REQUIRES(RandomAccessRange<CRng>())
-                void advance(difference_type_ n)
+                void advance(std::intmax_t n)
                 {
-                    if (is_infinite<Rng>::value)
-                        return void(it_ += n);
                     auto const begin = ranges::begin(rng_->rng_);
                     auto const end = this->get_end_(BoundedRange<CRng>(), meta::bool_<true>());
                     auto const dist = end - begin;
@@ -151,14 +148,13 @@ namespace ranges
                     auto const off = (d + n) % dist;
                     n_ += (d + n) / dist;
                     RANGES_EXPECT(n_ >= 0);
-                    it_ = begin + (off < 0 ? off + dist : off);
+                    using D = range_difference_type_t<Rng>;
+                    it_ = begin + static_cast<D>(off < 0 ? off + dist : off);
                 }
                 CONCEPT_REQUIRES(SizedSentinel<iterator, iterator>())
-                difference_type_ distance_to(cursor const &that) const
+                std::intmax_t distance_to(cursor const &that) const
                 {
                     RANGES_EXPECT(that.rng_ == rng_);
-                    if (is_infinite<Rng>::value)
-                        return that.it_ - it_;
                     auto const begin = ranges::begin(rng_->rng_);
                     auto const end = this->get_end_(BoundedRange<Rng>(), meta::bool_<true>());
                     auto const dist = end - begin;
@@ -192,26 +188,47 @@ namespace ranges
             /// range.
             struct cycle_fn
             {
-            private:
-                friend view_access;
-                template<class T>
-                using Concept = ForwardRange<T>;
-
-            public:
+#if RANGES_CXX_IF_CONSTEXPR >= RANGES_CXX_IF_CONSTEXPR_17
                 /// \pre <tt>!empty(rng)</tt>
-                template<typename Rng, CONCEPT_REQUIRES_(Concept<Rng>())>
-                cycled_view<all_t<Rng>> operator()(Rng &&rng) const
+                template<typename Rng, CONCEPT_REQUIRES_(ForwardRange<Rng>())>
+                auto operator()(Rng &&rng) const
                 {
+                    if constexpr(is_infinite<Rng>::value)
+                        return all(static_cast<Rng&&>(rng));
+                    else
+                        return cycled_view<all_t<Rng>>{all(static_cast<Rng&&>(rng))};
+                }
+#else // ^^^ Use "if constexpr" / Use tag dispatch vvv
+            private:
+                template<typename Rng>
+                static all_t<Rng> impl_(Rng &&rng, std::true_type)
+                {
+                    CONCEPT_ASSERT(is_infinite<Rng>::value);
+                    return all(static_cast<Rng&&>(rng));
+                }
+                template<typename Rng>
+                static cycled_view<all_t<Rng>> impl_(Rng &&rng, std::false_type)
+                {
+                    CONCEPT_ASSERT(!is_infinite<Rng>::value);
                     return cycled_view<all_t<Rng>>{all(static_cast<Rng&&>(rng))};
                 }
+            public:
+                /// \pre <tt>!empty(rng)</tt>
+                template<typename Rng, CONCEPT_REQUIRES_(ForwardRange<Rng>())>
+                auto operator()(Rng &&rng) const
+                RANGES_DECLTYPE_AUTO_RETURN
+                (
+                    impl_(static_cast<Rng&&>(rng), is_infinite<Rng>{})
+                )
+#endif // "if constexpr" switch
 
 #ifndef RANGES_DOXYGEN_INVOKED
-                template<typename Rng, CONCEPT_REQUIRES_(!Concept<Rng>())>
+                template<typename Rng, CONCEPT_REQUIRES_(!ForwardRange<Rng>())>
                 void operator()(Rng &&) const
                 {
                     CONCEPT_ASSERT_MSG(ForwardRange<Rng>(),
-                        "The object on which view::cycle operates must be a "
-                        "model of the ForwardRange concept.");
+                        "The object on which view::cycle operates must model "
+                        "the ForwardRange concept.");
                 }
 #endif
             };

--- a/include/range/v3/view/reverse.hpp
+++ b/include/range/v3/view/reverse.hpp
@@ -28,6 +28,7 @@
 #include <range/v3/utility/iterator.hpp>
 #include <range/v3/utility/optional.hpp>
 #include <range/v3/utility/static_const.hpp>
+#include <range/v3/view/all.hpp>
 #include <range/v3/view/view.hpp>
 
 namespace ranges
@@ -36,7 +37,7 @@ namespace ranges
     {
         /// \addtogroup group-views
         /// @{
-        template<typename Rng>
+        template<typename Rng, bool /* = decltype(detail::double_reverse<Rng>(42))::value */>
         struct reverse_view
           : view_interface<reverse_view<Rng>, range_cardinality<Rng>::value>
           , private detail::non_propagating_cache<
@@ -44,7 +45,9 @@ namespace ranges
         {
         private:
             CONCEPT_ASSERT(BidirectionalRange<Rng>());
+
             Rng rng_;
+
             RANGES_CXX14_CONSTEXPR
             reverse_iterator<iterator_t<Rng>> begin_(std::true_type)
             {
@@ -104,6 +107,21 @@ namespace ranges
             {
                 return ranges::size(rng_);
             }
+
+            using unreverse_me = reverse_view;
+        };
+
+        template<typename Rng_>
+        struct reverse_view<Rng_, true>
+          : identity_adaptor<decltype(std::declval<Rng_ &>().base())>
+        {
+            using Rng = decltype(std::declval<Rng_ &>().base());
+            CONCEPT_ASSERT(BidirectionalRange<Rng>());
+
+            reverse_view() = default;
+            explicit constexpr reverse_view(Rng_ rng)
+              : identity_adaptor<Rng>(rng.base())
+            {}
         };
 
         namespace view

--- a/test/view/reverse.cpp
+++ b/test/view/reverse.cpp
@@ -36,6 +36,8 @@ int main()
     CHECK(rng0.size() == 10u);
     ::check_equal(rng0, {9,8,7,6,5,4,3,2,1,0});
     ::check_equal(rng0 | view::reverse, {0,1,2,3,4,5,6,7,8,9});
+    ::check_equal(rng0 | view::reverse | view::reverse, {9,8,7,6,5,4,3,2,1,0});
+    ::check_equal(rng0 | view::reverse | view::reverse | view::reverse, {0,1,2,3,4,5,6,7,8,9});
 
     // Reverse another random-access, non-bounded, sized range
     auto cnt = view::counted(rgv.begin(), 10);


### PR DESCRIPTION
* Prefer `std::intmax_t` to `std::ptrdiff_t` for "really large signed integer", which matters for 32-bit platforms.

* Don't bother to inefficiently adapt infinite ranges.