### PR TITLE
Oooh, look. MSVC things.

### DIFF
--- a/cmake/ranges_env.cmake
+++ b/cmake/ranges_env.cmake
@@ -22,6 +22,11 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
   if (RANGES_VERBOSE_BUILD)
     message("[range-v3]: compiler is gcc.")
   endif()
+elseif("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xMSVC")
+  set (RANGES_CXX_COMPILER_MSVC TRUE)
+  if (RANGES_VERBOSE_BUILD)
+    message("[range-v3]: compiler is msvc.")
+  endif()
 else()
   message("[range-v3 warning]: unknown compiler ${CMAKE_CXX_COMPILER_ID} !")
 endif()
@@ -45,9 +50,9 @@ else()
   message("[range-v3 warning]: unknown system ${CMAKE_SYSTEM_NAME} !")
 endif()
 
-# Clang-CL will blow up with various parts of the standard library
-# if compiling with -std less than c++14.
-if (RANGES_CXX_COMPILER_CLANGCL)
+# Clang-CL will blow up in the standard library if compiling with less than
+# C++14, and MSVC doesn't support less than C++14 at all.
+if (RANGES_CXX_COMPILER_CLANGCL OR RANGES_CXX_COMPILER_MSVC)
   if (RANGES_CXX_STD EQUAL 11)
     set(CMAKE_CXX_STANDARD 14)
     set(RANGES_CXX_STD 14)

--- a/cmake/ranges_flags.cmake
+++ b/cmake/ranges_flags.cmake
@@ -18,14 +18,19 @@ endmacro()
 # All compilation flags
 # Language flag: version of the C++ standard to use
 message("[range-v3]: C++ std=${RANGES_CXX_STD}")
-if (RANGES_CXX_COMPILER_CLANGCL)
+if (RANGES_CXX_COMPILER_CLANGCL OR RANGES_CXX_COMPILER_MSVC)
   ranges_append_flag(RANGES_HAS_CXXSTDCOLON "-std:c++${RANGES_CXX_STD}")
 else()
   ranges_append_flag(RANGES_HAS_CXXSTD "-std=c++${RANGES_CXX_STD}")
 endif()
 
+# Enable MSVC strict mode
+if (RANGES_CXX_COMPILER_MSVC)
+  ranges_append_flag(RANGES_HAS_PERMISSIVEMINUS "-permissive-")
+endif()
+
 # Enable "normal" warnings and make them errors:
-if (RANGES_CXX_COMPILER_CLANGCL)
+if (RANGES_CXX_COMPILER_CLANGCL OR RANGES_CXX_COMPILER_MSVC)
   ranges_append_flag(RANGES_HAS_W3 -W3)
   ranges_append_flag(RANGES_HAS_WX -WX)
 else()

--- a/include/meta/meta_fwd.hpp
+++ b/include/meta/meta_fwd.hpp
@@ -19,12 +19,17 @@
 
 #define META_CXX_STD_14 201402L
 
-#if defined(_MSC_VER) && defined(_MSVC_LANG)
+#if defined(_MSC_VER) && defined(_MSVC_LANG) && _MSVC_LANG > __cplusplus
 #define META_CXX_VER _MSVC_LANG
-#define META_HAS_MAKE_INTEGER_SEQ 1
 #else
 #define META_CXX_VER __cplusplus
 #endif
+
+#ifdef _MSC_VER
+#define META_HAS_MAKE_INTEGER_SEQ 1
+#define META_WORKAROUND_MSVC_702792
+#define META_WORKAROUND_MSVC_703656
+#endif // _MSC_VER
 
 #ifndef META_CXX_VARIABLE_TEMPLATES
 #ifdef __cpp_variable_templates

--- a/include/range/v3/begin_end.hpp
+++ b/include/range/v3/begin_end.hpp
@@ -41,6 +41,10 @@ namespace ranges
             template<typename T>
             void begin(T const &) = delete;
 
+#ifdef RANGES_WORKAROUND_MSVC_620035
+            void begin();
+#endif
+
 #if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 8 && __GNUC_MINOR__ < 2
             // Workaround https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85765
             template<typename T>
@@ -130,6 +134,10 @@ namespace ranges
             void end(T &) = delete;
             template<typename T>
             void end(T const &) = delete;
+
+#ifdef RANGES_WORKAROUND_MSVC_620035
+            void end();
+#endif
 
 #if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 8 && __GNUC_MINOR__ < 2
             // Workaround https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85765

--- a/include/range/v3/iterator_range.hpp
+++ b/include/range/v3/iterator_range.hpp
@@ -34,7 +34,7 @@ namespace ranges
         /// \addtogroup group-core
         /// @{
         template<typename I, typename S /*= I*/>
-        struct iterator_range
+        struct RANGES_EMPTY_BASES iterator_range
           : tagged_compressed_tuple<tag::begin(I), tag::end(S)>
           , view_interface<iterator_range<I, S>>
         {

--- a/include/range/v3/range_access.hpp
+++ b/include/range/v3/range_access.hpp
@@ -261,12 +261,6 @@ namespace ranges
             template<typename T>
             static typename T::difference_type cursor_difference_2_(int);
 
-            template<typename Cur>
-            struct cursor_difference
-            {
-                using type = decltype(range_access::cursor_difference_2_<Cur>(42));
-            };
-
             template<typename T>
             using cursor_reference_t = decltype(std::declval<T const &>().read());
 
@@ -275,17 +269,32 @@ namespace ranges
             template<typename T>
             static meta::id<typename T::value_type> cursor_value_2_(int);
 
+#ifdef RANGES_WORKAROUND_CWG_1554
+            template<typename Cur>
+            struct cursor_difference
+            {
+                using type = decltype(range_access::cursor_difference_2_<Cur>(42));
+            };
+
             template<typename Cur>
             struct cursor_value
               : decltype(range_access::cursor_value_2_<Cur>(42))
             {};
-
+#endif // RANGES_WORKAROUND_CWG_1554
         public:
+#ifdef RANGES_WORKAROUND_CWG_1554
             template<typename Cur>
-            using cursor_difference_t = typename cursor_difference<Cur>::type;
+            using cursor_difference_t = meta::_t<cursor_difference<Cur>>;
 
             template<typename Cur>
-            using cursor_value_t = typename cursor_value<Cur>::type;
+            using cursor_value_t = meta::_t<cursor_value<Cur>>;
+#else // ^^^ workaround ^^^ / vvv no workaround vvv
+            template<typename Cur>
+            using cursor_difference_t = decltype(range_access::cursor_difference_2_<Cur>(42));
+
+            template<typename Cur>
+            using cursor_value_t = meta::_t<decltype(range_access::cursor_value_2_<Cur>(42))>;
+#endif // RANGES_WORKAROUND_CWG_1554
 
             template<typename Cur>
             static RANGES_CXX14_CONSTEXPR Cur &pos(basic_iterator<Cur> &it) noexcept

--- a/include/range/v3/range_concepts.hpp
+++ b/include/range/v3/range_concepts.hpp
@@ -401,10 +401,17 @@ namespace ranges
             //  - It's derived from view_base
             template<typename T>
             struct view_predicate_
+#ifdef RANGES_WORKAROUND_MSVC_699982
+              : meta::if_<
+                    meta::is_trait<enable_view<T>>,
+                    enable_view<T>,
+                    meta::or_<view_like<T>, DerivedFrom<T, view_base>>>::type
+#else
               : meta::_t<meta::if_<
                     meta::is_trait<enable_view<T>>,
                     enable_view<T>,
                     meta::bool_<view_like<T>() || DerivedFrom<T, view_base>()>>>
+#endif
             {};
 
             template<typename T>

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -398,7 +398,7 @@ namespace ranges
         struct basic_mixin;
 
         template<typename Cur>
-        struct basic_iterator;
+        struct RANGES_EMPTY_BASES basic_iterator;
 
         template<cardinality>
         struct basic_view : view_base
@@ -440,7 +440,7 @@ namespace ranges
     #endif
 
         template<typename I, typename S = I>
-        struct iterator_range;
+        struct RANGES_EMPTY_BASES iterator_range;
 
         template<typename I, typename S = I>
         struct sized_iterator_range;
@@ -454,7 +454,7 @@ namespace ranges
         // Views
         //
         template<typename Rng, typename Pred>
-        struct adjacent_filter_view;
+        struct RANGES_EMPTY_BASES adjacent_filter_view;
 
         namespace view
         {
@@ -462,7 +462,7 @@ namespace ranges
         }
 
         template<typename Rng, typename Pred>
-        struct adjacent_remove_if_view;
+        struct RANGES_EMPTY_BASES adjacent_remove_if_view;
 
         namespace view
         {
@@ -500,7 +500,7 @@ namespace ranges
             basic_iterator<detail::move_into_cursor<I>>;
 
         template<typename Rng, bool = (bool) is_infinite<Rng>()>
-        struct cycled_view;
+        struct RANGES_EMPTY_BASES cycled_view;
 
         namespace view
         {
@@ -610,7 +610,7 @@ namespace ranges
         }
 
         template<typename Rng, bool = decltype(detail::double_reverse<Rng>(42))::value>
-        struct reverse_view;
+        struct RANGES_EMPTY_BASES reverse_view;
 
         namespace view
         {

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -475,14 +475,6 @@ namespace ranges
         }
 
         template<typename Rng>
-        struct bounded_view;
-
-        namespace view
-        {
-            struct bounded_fn;
-        }
-
-        template<typename Rng>
         struct const_view;
 
         namespace view
@@ -507,7 +499,7 @@ namespace ranges
         using move_into_iterator =
             basic_iterator<detail::move_into_cursor<I>>;
 
-        template<typename Rng>
+        template<typename Rng, bool = (bool) is_infinite<Rng>()>
         struct cycled_view;
 
         namespace view
@@ -609,7 +601,15 @@ namespace ranges
             struct repeat_fn;
         }
 
-        template<typename Rng>
+        namespace detail
+        {
+            template<typename>
+            std::false_type double_reverse(long);
+            template<typename R, meta::if_<std::is_same<R, typename R::unreverse_me>>* = nullptr>
+            std::true_type double_reverse(int);
+        }
+
+        template<typename Rng, bool = decltype(detail::double_reverse<Rng>(42))::value>
         struct reverse_view;
 
         namespace view

--- a/include/range/v3/size.hpp
+++ b/include/range/v3/size.hpp
@@ -34,6 +34,10 @@ namespace ranges
             template<typename T>
             void size(T const &) = delete;
 
+#ifdef RANGES_WORKAROUND_MSVC_620035
+            void size();
+#endif
+
             struct fn : iter_size_fn
             {
             private:

--- a/include/range/v3/span.hpp
+++ b/include/range/v3/span.hpp
@@ -108,7 +108,7 @@ namespace ranges
         /// \endcond
 
         template<typename T, detail::span_index_t N = dynamic_extent>
-        struct span
+        struct RANGES_EMPTY_BASES span
           : public view_interface<span<T, N>,
                 (N == dynamic_extent ? finite : static_cast<cardinality>(N))>,
             public detail::span_extent<N>
@@ -220,7 +220,7 @@ namespace ranges
                         data_ + Offset, Count == dynamic_extent ? size() - Offset : Count};
             }
             template<index_type Offset>
-            constexpr span<T, N >= Offset ? N - Offset : dynamic_extent> subspan() const noexcept
+            constexpr span<T, (N >= Offset ? N - Offset : dynamic_extent)> subspan() const noexcept
             {
                 static_assert(Offset >= 0,
                     "Offset of first element to extract cannot be negative.");

--- a/include/range/v3/utility/any.hpp
+++ b/include/range/v3/utility/any.hpp
@@ -61,7 +61,14 @@ namespace ranges
         template<typename T>
         T const * any_cast(any const *) noexcept;
 
+#if defined(RANGES_WORKAROUND_MSVC_589046) && !defined(RANGES_DOXYGEN_INVOKED)
+        namespace _any_ { struct adl_hook {}; }
+#endif
+
         struct any
+#if defined(RANGES_WORKAROUND_MSVC_589046) && !defined(RANGES_DOXYGEN_INVOKED)
+          : private _any_::adl_hook
+#endif
         {
         private:
             template<typename T>
@@ -153,11 +160,24 @@ namespace ranges
             {
                 ptr_.swap(that.ptr_);
             }
+
+#if !defined(RANGES_WORKAROUND_MSVC_589046) || defined(RANGES_DOXYGEN_INVOKED)
             friend void swap(any &x, any &y) noexcept
             {
                 x.swap(y);
             }
+#endif
         };
+
+#if defined(RANGES_WORKAROUND_MSVC_589046) && !defined(RANGES_DOXYGEN_INVOKED)
+        namespace _any_
+        {
+            void swap(any &x, any &y) noexcept
+            {
+                x.swap(y);
+            }
+        }
+#endif
 
         /// \throw bad_any_cast
         template<typename T>

--- a/include/range/v3/utility/associated_types.hpp
+++ b/include/range/v3/utility/associated_types.hpp
@@ -78,7 +78,15 @@ namespace ranges
         namespace detail
         {
             template<typename I,
+#ifdef RANGES_WORKAROUND_MSVC_683388
+                typename R = meta::if_<
+                    meta::and_<std::is_pointer<uncvref_t<I>>,
+                        std::is_array<std::remove_pointer_t<uncvref_t<I>>>>,
+                    std::add_lvalue_reference_t<std::remove_pointer_t<uncvref_t<I>>>,
+                    decltype(*std::declval<I &>())>,
+#else
                 typename R = decltype(*std::declval<I &>()),
+#endif
                 typename = R&>
             using reference_t_ = R;
         }

--- a/include/range/v3/utility/basic_iterator.hpp
+++ b/include/range/v3/utility/basic_iterator.hpp
@@ -125,7 +125,7 @@ namespace ranges
             // as the return type of operator* when the cursor type has a set() member
             // function of the correct signature (i.e., if it can accept a value_type &&).
             template<typename Cur, bool Readable = (bool) ReadableCursor<Cur>()>
-            struct basic_proxy_reference
+            struct RANGES_EMPTY_BASES basic_proxy_reference
               : cursor_traits<Cur>
                 // The following adds conversion operators to the common reference
                 // types, so that basic_proxy_reference can model Readable
@@ -363,7 +363,7 @@ namespace ranges
 #endif
 
         template<typename Cur>
-        struct basic_iterator
+        struct RANGES_EMPTY_BASES basic_iterator
           : detail::iterator_associated_types_base<Cur>
 #if RANGES_BROKEN_CPO_LOOKUP
           , private _basic_iterator_::adl_hook<basic_iterator<Cur>>

--- a/include/range/v3/utility/box.hpp
+++ b/include/range/v3/utility/box.hpp
@@ -124,7 +124,7 @@ namespace ranges
             {
                 return box_compress::ebo;
             }
-#ifndef _MSC_VER
+#ifndef RANGES_WORKAROUND_MSVC_249830
             // MSVC pukes passing non-constant-expression objects to constexpr
             // functions, so do not coalesce.
             template<typename T, typename = meta::if_<

--- a/include/range/v3/utility/common_iterator.hpp
+++ b/include/range/v3/utility/common_iterator.hpp
@@ -155,12 +155,21 @@ namespace ranges
                 ++ranges::get<0>(data_);
                 return *this;
             }
+#ifdef RANGES_WORKAROUND_MSVC_677925
+            template<typename I2 = I, CONCEPT_REQUIRES_(!ForwardIterator<I2>())>
+            auto operator++(int)
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+            (
+                ((I2 &) ranges::get<0>(data_))++
+            )
+#else // ^^^ workaround ^^^ / vvv no workaround vvv
             CONCEPT_REQUIRES(!ForwardIterator<I>())
             auto operator++(int)
             RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (
                 ranges::get<0>(data_)++
             )
+#endif // RANGES_WORKAROUND_MSVC_677925
             CONCEPT_REQUIRES(ForwardIterator<I>())
             common_iterator operator++(int)
             {

--- a/include/range/v3/utility/compressed_pair.hpp
+++ b/include/range/v3/utility/compressed_pair.hpp
@@ -38,7 +38,7 @@ namespace ranges
 
             template<typename List, typename Indices> struct compressed_tuple_;
             template<typename... Ts, std::size_t... Is>
-            struct compressed_tuple_<meta::list<Ts...>, meta::index_sequence<Is...>>
+            struct RANGES_EMPTY_BASES compressed_tuple_<meta::list<Ts...>, meta::index_sequence<Is...>>
               : storage<Ts, Is, Ts...>...
             {
                 static_assert(Same<meta::index_sequence<Is...>,

--- a/include/range/v3/utility/concepts.hpp
+++ b/include/range/v3/utility/concepts.hpp
@@ -104,7 +104,8 @@ namespace ranges
             auto models_(any) ->
                 std::false_type;
 
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ == 5 && __GNUC_MINOR__ < 5
+#if (defined(__GNUC__) && !defined(__clang__) && __GNUC__ == 5 && __GNUC_MINOR__ < 5) || \
+    defined(RANGES_WORKAROUND_MSVC_701425)
             template<typename T>
             T gcc_bugs_bugs_bugs(T);
 

--- a/include/range/v3/utility/counted_iterator.hpp
+++ b/include/range/v3/utility/counted_iterator.hpp
@@ -144,8 +144,14 @@ namespace ranges
                 return *this;
             }
 
+#ifdef RANGES_WORKAROUND_MSVC_677925
+            template<typename I2 = I,
+                CONCEPT_REQUIRES_(!ForwardIterator<I2>())>
+            auto operator++(int) -> decltype(std::declval<I2 &>()++)
+#else // ^^^ workaround ^^^ / vvv no workaround vvv
             CONCEPT_REQUIRES(!ForwardIterator<I>())
             auto operator++(int) -> decltype(current_++)
+#endif // RANGES_WORKAROUND_MSVC_677925
             {
                 RANGES_EXPECT(cnt_ > 0);
                 return post_increment_(std::is_void<decltype(current_++)>());

--- a/include/range/v3/utility/functional.hpp
+++ b/include/range/v3/utility/functional.hpp
@@ -626,7 +626,7 @@ namespace ranges
         namespace detail
         {
             template<typename Bind>
-            struct pipeable_binder
+            struct RANGES_EMPTY_BASES pipeable_binder
               : Bind
               , pipeable<pipeable_binder<Bind>>
             {

--- a/include/range/v3/utility/invoke.hpp
+++ b/include/range/v3/utility/invoke.hpp
@@ -207,6 +207,30 @@ namespace ranges
             }
         };
 
+#ifdef RANGES_WORKAROUND_MSVC_701385
+        /// \cond
+        namespace detail
+        {
+            template<typename Void, typename Fun, typename...Args>
+            struct _invoke_result_
+            {};
+
+            template<typename Fun, typename...Args>
+            struct _invoke_result_<
+                meta::void_<decltype(invoke(std::declval<Fun>(), std::declval<Args>()...))>,
+                Fun, Args...>
+            {
+                using type = decltype(invoke(std::declval<Fun>(), std::declval<Args>()...));
+            };
+        }
+        /// \endcond
+
+        template<typename Fun, typename...Args>
+        using invoke_result = detail::_invoke_result_<void, Fun, Args...>;
+
+        template<typename Fun, typename...Args>
+        using invoke_result_t = meta::_t<invoke_result<Fun, Args...>>;
+#else // RANGES_WORKAROUND_MSVC_701385
         template<typename Fun, typename...Args>
         using invoke_result_t =
             decltype(invoke(std::declval<Fun>(), std::declval<Args>()...));
@@ -215,6 +239,7 @@ namespace ranges
         struct invoke_result
           : meta::defer<invoke_result_t, Fun, Args...>
         {};
+#endif // RANGES_WORKAROUND_MSVC_701385
 
         template<typename Sig>
         struct result_of

--- a/include/range/v3/utility/iterator.hpp
+++ b/include/range/v3/utility/iterator.hpp
@@ -35,6 +35,10 @@ namespace ranges
         /// @{
         namespace adl_advance_detail
         {
+#ifdef RANGES_WORKAROUND_MSVC_620035
+            void advance();
+#endif
+
             template<typename I, typename D>
             void advance(I&, D) = delete;
 

--- a/include/range/v3/utility/swap.hpp
+++ b/include/range/v3/utility/swap.hpp
@@ -86,6 +86,10 @@ namespace ranges
             template<typename T, std::size_t N>
             void swap(T (&)[N], T (&)[N]) = delete;
 
+#ifdef RANGES_WORKAROUND_MSVC_620035
+            void swap();
+#endif
+
             template<typename T, typename U,
                 typename = decltype(swap(std::declval<T>(), std::declval<U>()))>
             std::true_type try_adl_swap_(int);
@@ -212,6 +216,10 @@ namespace ranges
             // (possibly) unconstrained.
             template<typename T>
             void iter_swap(T, T) = delete;
+
+#ifdef RANGES_WORKAROUND_MSVC_620035
+            void iter_swap();
+#endif
 
             template<typename T, typename U,
                 typename = decltype(iter_swap(std::declval<T>(), std::declval<U>()))>

--- a/include/range/v3/utility/tagged_pair.hpp
+++ b/include/range/v3/utility/tagged_pair.hpp
@@ -56,7 +56,7 @@ namespace ranges
         /// \endcond
 
         template<typename Base, typename...Tags>
-        class tagged
+        class RANGES_EMPTY_BASES tagged
           : public meta::_t<_tagged_::chain<Base, 0, Tags...>>
 #if RANGES_BROKEN_CPO_LOOKUP
           , private _tagged_::adl_hook<tagged<Base, Tags...>>

--- a/include/range/v3/view/adjacent_filter.hpp
+++ b/include/range/v3/view/adjacent_filter.hpp
@@ -48,7 +48,7 @@ namespace ranges
         /// \addtogroup group-views
         /// @{
         template<typename Rng, typename Pred>
-        struct adjacent_filter_view
+        struct RANGES_EMPTY_BASES adjacent_filter_view
           : view_adaptor<
                 adjacent_filter_view<Rng, Pred>,
                 Rng,

--- a/include/range/v3/view/adjacent_remove_if.hpp
+++ b/include/range/v3/view/adjacent_remove_if.hpp
@@ -35,7 +35,7 @@ namespace ranges
         /// \addtogroup group-views
         /// @{
         template<typename Rng, typename Pred>
-        struct adjacent_remove_if_view
+        struct RANGES_EMPTY_BASES adjacent_remove_if_view
           : view_adaptor<
                 adjacent_remove_if_view<Rng, Pred>,
                 Rng,

--- a/include/range/v3/view/all.hpp
+++ b/include/range/v3/view/all.hpp
@@ -107,6 +107,32 @@ namespace ranges
             using all_t =
                 meta::_t<std::decay<decltype(all(std::declval<Rng>()))>>;
         }
+
+        template<typename Rng>
+        struct identity_adaptor
+          : Rng
+        {
+            CONCEPT_ASSERT(View<Rng>());
+
+            identity_adaptor() = default;
+            constexpr explicit identity_adaptor(Rng const &rng)
+              : Rng(rng)
+            {}
+            constexpr explicit identity_adaptor(Rng &&rng)
+              : Rng(detail::move(rng))
+            {}
+
+            using Rng::Rng;
+
+            RANGES_CXX14_CONSTEXPR Rng &base() noexcept
+            {
+                return *this;
+            }
+            constexpr Rng const &base() const noexcept
+            {
+                return *this;
+            }
+        };
         /// @}
     }
 }

--- a/include/range/v3/view/any_view.hpp
+++ b/include/range/v3/view/any_view.hpp
@@ -224,7 +224,7 @@ namespace ranges
             };
 
             template<typename Rng, typename Ref, bool Sized = false>
-            struct any_input_view_impl
+            struct RANGES_EMPTY_BASES any_input_view_impl
               : any_input_view_interface<Ref, Sized>
               , private tagged_compressed_tuple<tag::range(Rng),
                     tag::current(iterator_t<Rng>)>
@@ -465,7 +465,7 @@ namespace ranges
                 cloneable<any_view_interface<Ref, Cat>>;
 
             template<typename Rng, typename Ref, category Cat>
-            struct any_view_impl
+            struct RANGES_EMPTY_BASES any_view_impl
               : any_cloneable_view_interface<Ref, Cat>
               , private box<Rng, any_view_impl<Rng, Ref, Cat>>
               , private any_view_sentinel_impl<Rng>

--- a/include/range/v3/view/cycle.hpp
+++ b/include/range/v3/view/cycle.hpp
@@ -48,7 +48,7 @@ namespace ranges
                 iterator_t<Rng>, cycled_view<Rng>, !BoundedRange<Rng>()>
         {
         private:
-            CONCEPT_ASSERT(ForwardRange<Rng>());
+            CONCEPT_ASSERT(ForwardRange<Rng>() && !is_infinite<Rng>::value);
             friend range_access;
             Rng rng_;
 
@@ -64,12 +64,11 @@ namespace ranges
                 using constify_if = meta::const_if_c<IsConst, T>;
                 using cycled_view_t = constify_if<cycled_view>;
                 using CRng = constify_if<Rng>;
-                using difference_type_ = range_difference_type_t<Rng>;
                 using iterator = iterator_t<CRng>;
 
                 cycled_view_t *rng_{};
                 iterator it_{};
-                std::ptrdiff_t n_ = 0;
+                std::intmax_t n_ = 0;
 
                 iterator get_end_(std::true_type, bool = false) const
                 {
@@ -140,10 +139,8 @@ namespace ranges
                     --it_;
                 }
                 CONCEPT_REQUIRES(RandomAccessRange<CRng>())
-                void advance(difference_type_ n)
+                void advance(std::intmax_t n)
                 {
-                    if (is_infinite<Rng>::value)
-                        return void(it_ += n);
                     auto const begin = ranges::begin(rng_->rng_);
                     auto const end = this->get_end_(BoundedRange<CRng>(), meta::bool_<true>());
                     auto const dist = end - begin;
@@ -151,14 +148,13 @@ namespace ranges
                     auto const off = (d + n) % dist;
                     n_ += (d + n) / dist;
                     RANGES_EXPECT(n_ >= 0);
-                    it_ = begin + (off < 0 ? off + dist : off);
+                    using D = range_difference_type_t<Rng>;
+                    it_ = begin + static_cast<D>(off < 0 ? off + dist : off);
                 }
                 CONCEPT_REQUIRES(SizedSentinel<iterator, iterator>())
-                difference_type_ distance_to(cursor const &that) const
+                std::intmax_t distance_to(cursor const &that) const
                 {
                     RANGES_EXPECT(that.rng_ == rng_);
-                    if (is_infinite<Rng>::value)
-                        return that.it_ - it_;
                     auto const begin = ranges::begin(rng_->rng_);
                     auto const end = this->get_end_(BoundedRange<Rng>(), meta::bool_<true>());
                     auto const dist = end - begin;
@@ -192,26 +188,47 @@ namespace ranges
             /// range.
             struct cycle_fn
             {
-            private:
-                friend view_access;
-                template<class T>
-                using Concept = ForwardRange<T>;
-
-            public:
+#if RANGES_CXX_IF_CONSTEXPR >= RANGES_CXX_IF_CONSTEXPR_17
                 /// \pre <tt>!empty(rng)</tt>
-                template<typename Rng, CONCEPT_REQUIRES_(Concept<Rng>())>
-                cycled_view<all_t<Rng>> operator()(Rng &&rng) const
+                template<typename Rng, CONCEPT_REQUIRES_(ForwardRange<Rng>())>
+                auto operator()(Rng &&rng) const
                 {
+                    if constexpr(is_infinite<Rng>::value)
+                        return all(static_cast<Rng&&>(rng));
+                    else
+                        return cycled_view<all_t<Rng>>{all(static_cast<Rng&&>(rng))};
+                }
+#else // ^^^ Use "if constexpr" / Use tag dispatch vvv
+            private:
+                template<typename Rng>
+                static all_t<Rng> impl_(Rng &&rng, std::true_type)
+                {
+                    CONCEPT_ASSERT(is_infinite<Rng>::value);
+                    return all(static_cast<Rng&&>(rng));
+                }
+                template<typename Rng>
+                static cycled_view<all_t<Rng>> impl_(Rng &&rng, std::false_type)
+                {
+                    CONCEPT_ASSERT(!is_infinite<Rng>::value);
                     return cycled_view<all_t<Rng>>{all(static_cast<Rng&&>(rng))};
                 }
+            public:
+                /// \pre <tt>!empty(rng)</tt>
+                template<typename Rng, CONCEPT_REQUIRES_(ForwardRange<Rng>())>
+                auto operator()(Rng &&rng) const
+                RANGES_DECLTYPE_AUTO_RETURN
+                (
+                    impl_(static_cast<Rng&&>(rng), is_infinite<Rng>{})
+                )
+#endif // "if constexpr" switch
 
 #ifndef RANGES_DOXYGEN_INVOKED
-                template<typename Rng, CONCEPT_REQUIRES_(!Concept<Rng>())>
+                template<typename Rng, CONCEPT_REQUIRES_(!ForwardRange<Rng>())>
                 void operator()(Rng &&) const
                 {
                     CONCEPT_ASSERT_MSG(ForwardRange<Rng>(),
-                        "The object on which view::cycle operates must be a "
-                        "model of the ForwardRange concept.");
+                        "The object on which view::cycle operates must model "
+                        "the ForwardRange concept.");
                 }
 #endif
             };

--- a/include/range/v3/view/cycle.hpp
+++ b/include/range/v3/view/cycle.hpp
@@ -42,7 +42,7 @@ namespace ranges
         /// \addtogroup group-views
         ///@{
         template<typename Rng, bool /* = (bool) is_infinite<Rng>() */>
-        struct cycled_view
+        struct RANGES_EMPTY_BASES cycled_view
           : view_facade<cycled_view<Rng>, infinite>
           , private detail::non_propagating_cache<
                 iterator_t<Rng>, cycled_view<Rng>, !BoundedRange<Rng>()>

--- a/include/range/v3/view/drop.hpp
+++ b/include/range/v3/view/drop.hpp
@@ -38,7 +38,7 @@ namespace ranges
         /// \addtogroup group-views
         /// @{
         template<typename Rng>
-        struct drop_view
+        struct RANGES_EMPTY_BASES drop_view
           : view_interface<drop_view<Rng>, is_finite<Rng>::value ? finite : range_cardinality<Rng>::value>
           , private detail::non_propagating_cache<
                 iterator_t<Rng>,

--- a/include/range/v3/view/drop_exactly.hpp
+++ b/include/range/v3/view/drop_exactly.hpp
@@ -37,7 +37,7 @@ namespace ranges
         /// \addtogroup group-views
         /// @{
         template<typename Rng>
-        struct drop_exactly_view
+        struct RANGES_EMPTY_BASES drop_exactly_view
           : view_interface<
                 drop_exactly_view<Rng>,
                 is_finite<Rng>::value ? finite : range_cardinality<Rng>::value>

--- a/include/range/v3/view/remove_if.hpp
+++ b/include/range/v3/view/remove_if.hpp
@@ -38,7 +38,7 @@ namespace ranges
         /// \addtogroup group-views
         /// @{
         template<typename Rng, typename Pred>
-        struct remove_if_view
+        struct RANGES_EMPTY_BASES remove_if_view
           : view_adaptor<
                 remove_if_view<Rng, Pred>,
                 Rng,

--- a/include/range/v3/view/reverse.hpp
+++ b/include/range/v3/view/reverse.hpp
@@ -28,6 +28,7 @@
 #include <range/v3/utility/iterator.hpp>
 #include <range/v3/utility/optional.hpp>
 #include <range/v3/utility/static_const.hpp>
+#include <range/v3/view/all.hpp>
 #include <range/v3/view/view.hpp>
 
 namespace ranges
@@ -36,7 +37,7 @@ namespace ranges
     {
         /// \addtogroup group-views
         /// @{
-        template<typename Rng>
+        template<typename Rng, bool /* = decltype(detail::double_reverse<Rng>(42))::value */>
         struct reverse_view
           : view_interface<reverse_view<Rng>, range_cardinality<Rng>::value>
           , private detail::non_propagating_cache<
@@ -44,7 +45,9 @@ namespace ranges
         {
         private:
             CONCEPT_ASSERT(BidirectionalRange<Rng>());
+
             Rng rng_;
+
             RANGES_CXX14_CONSTEXPR
             reverse_iterator<iterator_t<Rng>> begin_(std::true_type)
             {
@@ -104,6 +107,21 @@ namespace ranges
             {
                 return ranges::size(rng_);
             }
+
+            using unreverse_me = reverse_view;
+        };
+
+        template<typename Rng_>
+        struct reverse_view<Rng_, true>
+          : identity_adaptor<decltype(std::declval<Rng_ &>().base())>
+        {
+            using Rng = decltype(std::declval<Rng_ &>().base());
+            CONCEPT_ASSERT(BidirectionalRange<Rng>());
+
+            reverse_view() = default;
+            explicit constexpr reverse_view(Rng_ rng)
+              : identity_adaptor<Rng>(rng.base())
+            {}
         };
 
         namespace view

--- a/include/range/v3/view/reverse.hpp
+++ b/include/range/v3/view/reverse.hpp
@@ -38,7 +38,7 @@ namespace ranges
         /// \addtogroup group-views
         /// @{
         template<typename Rng, bool /* = decltype(detail::double_reverse<Rng>(42))::value */>
-        struct reverse_view
+        struct RANGES_EMPTY_BASES reverse_view
           : view_interface<reverse_view<Rng>, range_cardinality<Rng>::value>
           , private detail::non_propagating_cache<
                 iterator_t<Rng>, reverse_view<Rng>, !BoundedRange<Rng>()>

--- a/include/range/v3/view/sliding.hpp
+++ b/include/range/v3/view/sliding.hpp
@@ -98,7 +98,7 @@ namespace ranges
             };
 
             template<typename Rng>
-            class sv_base
+            class RANGES_EMPTY_BASES sv_base
               : public view_adaptor<
                     sliding_view<Rng>,
                     Rng,
@@ -171,7 +171,7 @@ namespace ranges
                 return *first;
             }
 
-            struct adaptor
+            struct RANGES_EMPTY_BASES adaptor
               : adaptor_base
               , sliding_view_detail::trailing<Rng>
             {

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -80,7 +80,11 @@ namespace ranges
               : compressed_pair<BaseIter, Adapt>
             {
                 using compressed_pair<BaseIter, Adapt>::compressed_pair;
+#ifdef RANGES_WORKAROUND_MSVC_688606
+                using value_type = value_type_t<Adapt>;
+#else // ^^^ workaround ^^^ / vvv no workaround vvv
                 using value_type = typename Adapt::value_type;
+#endif // RANGES_WORKAROUND_MSVC_688606
             };
         }
         /// \endcond

--- a/test/span.cpp
+++ b/test/span.cpp
@@ -506,7 +506,11 @@ RANGES_DIAGNOSTIC_IGNORE_UNDEFINED_FUNC_TEMPLATE
             CONCEPT_ASSERT(std::is_same<span<int, 5>, decltype(s)>::value);
         }
         {
-            span s{ranges::begin(arr), ranges::size(arr)};
+#ifdef RANGES_WORKAROUND_MSVC_401490
+            span s{ranges::data(arr), ranges::distance(arr)};
+#else // ^^^ workaround ^^^ / vvv no workaround vvv
+            span s{ranges::data(arr), ranges::size(arr)};
+#endif // RANGES_WORKAROUND_MSVC_401490
             CONCEPT_ASSERT(std::is_same<span<int>, decltype(s)>::value);
         }
         {

--- a/test/view/chunk.cpp
+++ b/test/view/chunk.cpp
@@ -92,8 +92,7 @@ int main()
     CHECK(it1 == ranges::end(rng1));
     ::check_equal(*ranges::next(it1, -3), {3,4,5});
     CHECK(size(rng1), 4u);
-    if (!ranges::v3::detail::broken_ebo)
-        CHECK(sizeof(rng1.begin()) == sizeof(v.begin()) * 2 + sizeof(std::ptrdiff_t) * 2);
+    CHECK(sizeof(rng1.begin()) == sizeof(v.begin()) * 2 + sizeof(std::ptrdiff_t) * 2);
 
     std::forward_list<int> l = view::iota(0,11);
     auto rng2 = l | view::chunk(3);
@@ -106,8 +105,7 @@ int main()
     ::check_equal(*it2++, {6,7,8});
     ::check_equal(*it2++, {9,10});
     CHECK(it2 == ranges::end(rng2));
-    if (!ranges::v3::detail::broken_ebo)
-        CHECK(sizeof(rng2.begin()) == sizeof(l.begin()) * 2 + sizeof(std::ptrdiff_t));
+    CHECK(sizeof(rng2.begin()) == sizeof(l.begin()) * 2 + sizeof(std::ptrdiff_t));
 
     {
         // An infinite, cyclic range with cycle length == 1

--- a/test/view/reverse.cpp
+++ b/test/view/reverse.cpp
@@ -36,6 +36,8 @@ int main()
     CHECK(rng0.size() == 10u);
     ::check_equal(rng0, {9,8,7,6,5,4,3,2,1,0});
     ::check_equal(rng0 | view::reverse, {0,1,2,3,4,5,6,7,8,9});
+    ::check_equal(rng0 | view::reverse | view::reverse, {9,8,7,6,5,4,3,2,1,0});
+    ::check_equal(rng0 | view::reverse | view::reverse | view::reverse, {0,1,2,3,4,5,6,7,8,9});
 
     // Reverse another random-access, non-bounded, sized range
     auto cnt = view::counted(rgv.begin(), 10);

--- a/test/view/sliding.cpp
+++ b/test/view/sliding.cpp
@@ -97,11 +97,7 @@ namespace
         CHECK(it == ranges::end(rng));
 
         test_prev(rng, it, BidirectionalRange<Base>());
-
-        if (!ranges::v3::detail::broken_ebo)
-        {
-            CHECK(sizeof(it) == sizeof(size_compare<Base>));
-        }
+        CHECK(sizeof(it) == sizeof(size_compare<Base>));
     }
 }
 


### PR DESCRIPTION
Various notes in no particular order:
* This is currently based on #923, so don't be surprised to see those changes in this PR. Click the "Support building with MSVC" commit to see only the changes unrelated to #923.

* Don't bother trying to build this. The target compiler is 15.9, but some of the necessary bug fixes haven't yet flowed into preview releases.

* I've made no effort to integrate bug workarounds. They all look like:
  ```c++
  #ifdef NASTY_MSVC_BUG_WORKAROUND
  // Disgusting hacks 
  #else // ^^^ workaround / no workaround vvv
  // Pristine and perfect range-v3 code here.
  #endif // NASTY_MSVC_BUG_WORKAROUND
  ```
  I've even done this with the workarounds for Clang #37556. I'm fond of this "name-and-shame" approach to bug workarounds which makes it easy to know which garbage we can excise from the codebase when we drop support for what compiler version.

* I've tagged individual workarounds with bug numbers from the MSVC internal tracker. These numbers obviously aren't terribly useful except as opaque IDs and/or to communicate to people on the Visual C++ Team. (FWIW, I'll be checking this into the compiler test suite post-merge to replace the three-year-old range-v3 test suite that the compiler front-end team runs in their inner loop. Range-v3 will have some mighty good protection against regressions on MSVC.)

* I'm not adding CI support for MSVC yet. Firstly because AppVeyor doesn't have the unreleased compiler versions, and second because I suspect that other maintainers aren't interested in working around MSVC template metaprogramming bugs. I suppose we should say MSVC is "provisionally" supported until we have CI gating set up. I'm hoping to keep the Visual C++ team focused on stomping range-v3 bugs which are going to become everyone's bugs in C++20: the effort invested by everyone in VC++ over the last several months to get us here has been incredible.

