### PR TITLE
[MSVC] Support for solution folders in CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ project(Range-v3 CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON) # Export compilation data-base
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 add_library(meta INTERFACE)
 target_include_directories(meta INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>)
@@ -71,6 +72,9 @@ else()
   add_custom_target(headers SOURCES ${RANGE_V3_PUBLIC_HEADERS_ABSOLUTE})
 endif()
 generate_standalone_header_tests(EXCLUDE_FROM_ALL MASTER_TARGET headers HEADERS ${RANGE_V3_PUBLIC_HEADERS})
+set_target_properties(headers
+    PROPERTIES FOLDER "test/header"
+)
 
 # Grab the range-v3 version numbers:
 include(${CMAKE_CURRENT_SOURCE_DIR}/Version.cmake)

--- a/cmake/TestHeaders.cmake
+++ b/cmake/TestHeaders.cmake
@@ -127,6 +127,9 @@ int main() { }
             ${ARGS_EXCLUDE_FROM_ALL}
             "${CMAKE_CURRENT_BINARY_DIR}/headers/${directory}/${filename}.cpp"
         )
+        set_target_properties(test.header.${target}
+            PROPERTIES FOLDER "test/header"
+        )
         target_include_directories(test.header.${target} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
         if (ARGS_LINK_LIBRARIES)
             target_link_libraries(test.header.${target} ${ARGS_LINK_LIBRARIES})

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -8,11 +8,16 @@ if (NOT DOXYGEN_FOUND)
     return()
 endif()
 
+set(CMAKE_FOLDER "doc")
+
 configure_file(Doxyfile.in Doxyfile @ONLY)
 add_custom_target(doc.check
     COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile
     COMMENT "Running Doxygen to validate the documentation"
     VERBATIM
+)
+set_target_properties(doc.check
+    PROPERTIES FOLDER ${CMAKE_FOLDER}
 )
 
 # if (NOT TARGET benchmarks)
@@ -30,6 +35,9 @@ add_custom_target(doc
 #     DEPENDS benchmarks
     VERBATIM
 )
+set_target_properties(doc
+    PROPERTIES FOLDER ${CMAKE_FOLDER}
+)
 
 if (NOT GIT_FOUND)
     message(STATUS
@@ -45,6 +53,9 @@ add_custom_target(gh-pages.clean
     COMMENT "Cleaning up doc/gh-pages"
     VERBATIM
 )
+set_target_properties(gh-pages.clean
+    PROPERTIES FOLDER ${CMAKE_FOLDER}
+)
 
 add_custom_target(gh-pages.copy
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_BINARY_DIR}/html ${CMAKE_CURRENT_LIST_DIR}/gh-pages
@@ -52,6 +63,9 @@ add_custom_target(gh-pages.copy
     COMMENT "Copying the documentation from ${CMAKE_CURRENT_BINARY_DIR}/html to doc/gh-pages"
     DEPENDS doc gh-pages.clean
     VERBATIM
+)
+set_target_properties(gh-pages.copy
+    PROPERTIES FOLDER ${CMAKE_FOLDER}
 )
 
 execute_process(
@@ -67,4 +81,7 @@ add_custom_target(gh-pages.update
     COMMENT "Updating the gh-pages branch with freshly built documentation"
     DEPENDS gh-pages.copy
     VERBATIM
+)
+set_target_properties(gh-pages.update
+    PROPERTIES FOLDER ${CMAKE_FOLDER}
 )

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_FOLDER "example")
+
 # examples use a less draconian set of compiler warnings
 ranges_append_flag(RANGES_HAS_WNO_MISSING_BRACES -Wno-missing-braces)
 ranges_append_flag(RANGES_HAS_WNO_SHORTEN_64_TO_32 -Wno-shorten-64-to-32)

--- a/perf/CMakeLists.txt
+++ b/perf/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_FOLDER "perf")
+
 add_executable(counted_insertion_sort counted_insertion_sort.cpp)
 target_link_libraries(counted_insertion_sort range-v3)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,7 @@
 include(../cmake/ranges_diagnostics.cmake)
 
+set(CMAKE_FOLDER "test")
+
 add_library(rv3-tests INTERFACE)
 target_link_libraries(rv3-tests INTERFACE range-v3)
 if(NOT RANGE_V3_TRY_THREAD)

--- a/test/action/CMakeLists.txt
+++ b/test/action/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_FOLDER "${CMAKE_FOLDER}/action")
+
 rv3_add_test(test.act.concepts act.concepts cont_concepts.cpp)
 rv3_add_test(test.act.drop act.drop drop.cpp)
 rv3_add_test(test.act.drop_while act.drop_while drop_while.cpp)

--- a/test/algorithm/CMakeLists.txt
+++ b/test/algorithm/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_FOLDER "${CMAKE_FOLDER}/algorithm")
+
 rv3_add_test(test.alg.adjacent_find alg.adjacent_find adjacent_find.cpp)
 rv3_add_test(test.alg.all_of alg.all_of all_of.cpp)
 rv3_add_test(test.alg.any_of alg.any_of any_of.cpp)

--- a/test/experimental/CMakeLists.txt
+++ b/test/experimental/CMakeLists.txt
@@ -1,2 +1,4 @@
+set(CMAKE_FOLDER "${CMAKE_FOLDER}/experimental")
+
 add_subdirectory(utility)
 add_subdirectory(view)

--- a/test/experimental/utility/CMakeLists.txt
+++ b/test/experimental/utility/CMakeLists.txt
@@ -1,1 +1,3 @@
+set(CMAKE_FOLDER "${CMAKE_FOLDER}/utility")
+
 rv3_add_test(test.generator generator generator.cpp)

--- a/test/experimental/view/CMakeLists.txt
+++ b/test/experimental/view/CMakeLists.txt
@@ -1,1 +1,3 @@
+set(CMAKE_FOLDER "${CMAKE_FOLDER}/view")
+
 rv3_add_test(test.view.shared view.shared shared.cpp)

--- a/test/numeric/CMakeLists.txt
+++ b/test/numeric/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_FOLDER "${CMAKE_FOLDER}/numeric")
+
 rv3_add_test(test.num.accumulate num.accumulate accumulate.cpp)
 rv3_add_test(test.num.adjacent_difference num.adjacent_difference adjacent_difference.cpp)
 rv3_add_test(test.num.inner_product num.inner_product inner_product.cpp)

--- a/test/utility/CMakeLists.txt
+++ b/test/utility/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_FOLDER "${CMAKE_FOLDER}/utility")
+
 rv3_add_test(test.utility.basic_iterator utility.basic_iterator basic_iterator.cpp)
 rv3_add_test(test.utility.concepts utility.concepts concepts.cpp)
 rv3_add_test(test.utility.common_type utility.common_type common_type.cpp)

--- a/test/view/CMakeLists.txt
+++ b/test/view/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_FOLDER "${CMAKE_FOLDER}/view")
+
 rv3_add_test(test.view.adjacent_remove_if view.adjacent_remove_if adjacent_remove_if.cpp)
 rv3_add_test(test.view.all view.all all.cpp)
 rv3_add_test(test.view.any_view view.any_view any_view.cpp)


### PR DESCRIPTION
This PR is just a nice-to-have feature for people that use MSVC.
It adds support for solution folders (grouping together different targets).

It works only partially with CMake < 3.12, because of the use of `CMAKE_FOLDER` variable which is not recognized these earlier versions (https://cmake.org/cmake/help/v3.12/variable/CMAKE_FOLDER.html)
Supporting those seems to me as an unnecessary maintenance burden (each target would need to set its `FOLDER` property instead of setting it once by filesystem folder/cmakelists.txt).