### PR TITLE
Bit of cmake cleanup:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,28 +29,6 @@ include(ranges_options)
 include(ranges_env)
 include(ranges_flags)
 
-# Test for <thread>
-try_compile(RANGE_V3_TRY_THREAD ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/thread_test_code.cpp)
-
-# Test for coroutine TS support
-include(CheckCXXSourceCompiles)
-
-file(READ "${CMAKE_CURRENT_SOURCE_DIR}/cmake/coro_test_code.cpp" RANGE_V3_CORO_TEST_CODE)
-if (RANGES_CXX_COMPILER_MSVC)
-  set(CMAKE_REQUIRED_FLAGS "/await")
-  check_cxx_source_compiles("${RANGE_V3_CORO_TEST_CODE}" RANGES_HAS_AWAIT)
-  if (RANGES_HAS_AWAIT)
-    set(RANGE_V3_COROUTINE_FLAGS "/await")
-  endif()
-else()
-  set(CMAKE_REQUIRED_FLAGS "-fcoroutines-ts")
-  check_cxx_source_compiles("${RANGE_V3_CORO_TEST_CODE}" RANGES_HAS_FCOROUTINES_TS)
-  if (RANGES_HAS_FCOROUTINES_TS)
-    set(RANGE_V3_COROUTINE_FLAGS "-fcoroutines-ts")
-  endif()
-endif()
-unset(CMAKE_REQUIRED_FLAGS)
-
 if(RANGE_V3_DOCS)
   add_subdirectory(doc)
 endif()

--- a/cmake/aligned_new_probe.cpp
+++ b/cmake/aligned_new_probe.cpp
@@ -1,0 +1,6 @@
+#include <new>
+
+int main() {
+    struct alignas(__STDCPP_DEFAULT_NEW_ALIGNMENT__ * 4) S {};
+    (void) ::operator new(sizeof(S), std::align_val_t{alignof(S)});
+}

--- a/cmake/ranges_flags.cmake
+++ b/cmake/ranges_flags.cmake
@@ -20,6 +20,7 @@ endmacro()
 message("[range-v3]: C++ std=${RANGES_CXX_STD}")
 if (RANGES_CXX_COMPILER_CLANGCL OR RANGES_CXX_COMPILER_MSVC)
   ranges_append_flag(RANGES_HAS_CXXSTDCOLON "-std:c++${RANGES_CXX_STD}")
+  set(RANGES_STD_FLAG "-std:c++${RANGES_CXX_STD}")
   # Enable MSVC strict mode
   ranges_append_flag(RANGES_HAS_PERMISSIVEMINUS "-permissive-")
   # Enable "normal" warnings and make them errors:
@@ -27,6 +28,7 @@ if (RANGES_CXX_COMPILER_CLANGCL OR RANGES_CXX_COMPILER_MSVC)
   ranges_append_flag(RANGES_HAS_WX -WX)
 else()
   ranges_append_flag(RANGES_HAS_CXXSTD "-std=c++${RANGES_CXX_STD}")
+  set(RANGES_STD_FLAG "-std=c++${RANGES_CXX_STD}")
   # Enable "normal" warnings and make them errors:
   ranges_append_flag(RANGES_HAS_WALL -Wall)
   ranges_append_flag(RANGES_HAS_WEXTRA -Wextra)
@@ -163,6 +165,38 @@ if (RANGES_NATIVE)
   ranges_append_flag(RANGES_HAS_MARCH_NATIVE "-march=native")
   ranges_append_flag(RANGES_HAS_MTUNE_NATIVE "-mtune=native")
 endif()
+
+include(CheckCXXSourceCompiles)
+
+set(CMAKE_REQUIRED_FLAGS ${RANGES_STD_FLAG})
+# Probe for <thread>
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/cmake/thread_test_code.cpp" RANGE_V3_PROBE_CODE)
+check_cxx_source_compiles("${RANGE_V3_PROBE_CODE}" RANGE_V3_THREAD_PROBE)
+unset(RANGE_V3_PROBE_CODE)
+
+# Probe for library and compiler support for aligned new
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/cmake/aligned_new_probe.cpp" RANGE_V3_PROBE_CODE)
+check_cxx_source_compiles("${RANGE_V3_PROBE_CODE}" RANGE_V3_ALIGNED_NEW_PROBE)
+unset(RANGE_V3_PROBE_CODE)
+unset(CMAKE_REQUIRED_FLAGS)
+
+# Probe for coroutine TS support
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/cmake/coro_test_code.cpp" RANGE_V3_PROBE_CODE)
+if(RANGES_CXX_COMPILER_MSVC)
+  set(CMAKE_REQUIRED_FLAGS "/await")
+  check_cxx_source_compiles("${RANGE_V3_PROBE_CODE}" RANGES_HAS_AWAIT)
+  if(RANGES_HAS_AWAIT)
+    set(RANGE_V3_COROUTINE_FLAGS "/await")
+  endif()
+elseif(RANGES_CXX_COMPILER_CLANG)
+  set(CMAKE_REQUIRED_FLAGS "-fcoroutines-ts")
+  check_cxx_source_compiles("${RANGE_V3_PROBE_CODE}" RANGES_HAS_FCOROUTINES_TS)
+  if(RANGES_HAS_FCOROUTINES_TS)
+    set(RANGE_V3_COROUTINE_FLAGS "-fcoroutines-ts")
+  endif()
+endif()
+unset(CMAKE_REQUIRED_FLAGS)
+unset(RANGE_V3_PROBE_CODE)
 
 if (RANGES_VERBOSE_BUILD)
   message("[range-v3]: C++ flags: ${CMAKE_CXX_FLAGS}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_FOLDER "test")
 
 add_library(rv3-tests INTERFACE)
 target_link_libraries(rv3-tests INTERFACE range-v3)
-if (NOT RANGE_V3_TRY_THREAD)
+if (NOT RANGE_V3_THREAD_PROBE)
   target_compile_definitions(rv3-tests INTERFACE "RANGES_CXX_THREAD=0")
 endif()
 if (RANGE_V3_COROUTINE_FLAGS)


### PR DESCRIPTION
* Refer to `<thread>` and coroutine features checks as "probes"

* Add probe for C++17 aligned new support (since there's no feature detection macro for the library support)

* put the probes in `ranges_flags.cmake` instead of the top-level `CMakeLists.txt`