### PR TITLE
Projection support on view::filter and view::remove_if

### DIFF
--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -525,14 +525,6 @@ namespace ranges
             struct empty_fn;
         }
 
-        template<typename Rng, typename Pred>
-        struct filter_view;
-
-        namespace view
-        {
-            struct filter_fn;
-        }
-
         template<typename Rng, typename Fun>
         struct group_by_view;
 

--- a/include/range/v3/view/filter.hpp
+++ b/include/range/v3/view/filter.hpp
@@ -29,21 +29,21 @@ namespace ranges
             /// that satisfy the predicate.
             struct filter_fn
             {
-                template<typename Rng, typename Pred>
-                remove_if_view<all_t<Rng>, logical_negate<Pred>>
-                operator()(Rng && rng, Pred pred) const
+                template<typename Rng, typename Pred, typename Proj = ident>
+                remove_if_view<all_t<Rng>, logical_negate<Pred>, Proj>
+                operator()(Rng && rng, Pred pred, Proj proj = Proj{}) const
                 {
                     CONCEPT_ASSERT(Range<Rng>());
                     CONCEPT_ASSERT(IndirectPredicate<Pred, iterator_t<Rng>>());
-                    return {all(static_cast<Rng&&>(rng)), not_fn(std::move(pred))};
+                    return {all(static_cast<Rng&&>(rng)), not_fn(std::move(pred)), std::move(proj)};
                 }
-                template<typename Pred>
-                auto operator()(Pred pred) const ->
+                template<typename Pred, typename Proj = ident>
+                auto operator()(Pred pred, Proj proj = Proj{}) const ->
                     decltype(make_pipeable(std::bind(*this, std::placeholders::_1,
-                        protect(std::move(pred)))))
+                        protect(std::move(pred)), protect(std::move(proj)))))
                 {
                     return make_pipeable(std::bind(*this, std::placeholders::_1,
-                        protect(std::move(pred))));
+                        protect(std::move(pred)), protect(std::move(proj))));
                 }
             };
 

--- a/include/range/v3/view/filter.hpp
+++ b/include/range/v3/view/filter.hpp
@@ -25,10 +25,9 @@ namespace ranges
     {
         namespace view
         {
-            /// Given a source range and a unary predicate, filter the elements
-            /// that satisfy the predicate.
-            struct filter_fn : details::remove_if_fn_base<not_fn_fn>
-            {};
+            /// Given a source range, unary predicate, and optional projection,
+            /// present a view of the elements that satisfy the predicate.
+            using filter_fn = remove_if_fn_<not_fn_fn>;
 
             /// \relates filter_fn
             /// \ingroup group-views

--- a/include/range/v3/view/filter.hpp
+++ b/include/range/v3/view/filter.hpp
@@ -27,29 +27,12 @@ namespace ranges
         {
             /// Given a source range and a unary predicate, filter the elements
             /// that satisfy the predicate.
-            struct filter_fn
-            {
-                template<typename Rng, typename Pred, typename Proj = ident>
-                remove_if_view<all_t<Rng>, logical_negate<Pred>, Proj>
-                operator()(Rng && rng, Pred pred, Proj proj = Proj{}) const
-                {
-                    CONCEPT_ASSERT(Range<Rng>());
-                    CONCEPT_ASSERT(IndirectPredicate<Pred, iterator_t<Rng>>());
-                    return {all(static_cast<Rng&&>(rng)), not_fn(std::move(pred)), std::move(proj)};
-                }
-                template<typename Pred, typename Proj = ident>
-                auto operator()(Pred pred, Proj proj = Proj{}) const ->
-                    decltype(make_pipeable(std::bind(*this, std::placeholders::_1,
-                        protect(std::move(pred)), protect(std::move(proj)))))
-                {
-                    return make_pipeable(std::bind(*this, std::placeholders::_1,
-                        protect(std::move(pred)), protect(std::move(proj))));
-                }
-            };
+            struct filter_fn : details::remove_if_fn_base<not_fn_fn>
+            {};
 
             /// \relates filter_fn
             /// \ingroup group-views
-            RANGES_INLINE_VARIABLE(filter_fn, filter)
+            RANGES_INLINE_VARIABLE(view<filter_fn>, filter)
         }
     }
 }

--- a/include/range/v3/view/remove_if.hpp
+++ b/include/range/v3/view/remove_if.hpp
@@ -37,24 +37,18 @@ namespace ranges
     {
         /// \addtogroup group-views
         /// @{
-        template<typename Rng, typename Pred, typename Proj>
+        template<typename Rng, typename Pred>
         struct RANGES_EMPTY_BASES remove_if_view
           : view_adaptor<
-                remove_if_view<Rng, Pred, Proj>,
+                remove_if_view<Rng, Pred>,
                 Rng,
                 is_finite<Rng>::value ? finite : range_cardinality<Rng>::value>
-          , private box<semiregular_t<Pred>, struct predicate_tag>
-          , private box<semiregular_t<Proj>, struct projection_tag>
+          , private box<semiregular_t<Pred>>
         {
-        private:
-            using predicate_box = box<semiregular_t<Pred>, struct predicate_tag>;
-            using projection_box = box<semiregular_t<Proj>, struct projection_tag>;
-        public:
             remove_if_view() = default;
-            constexpr remove_if_view(Rng rng, Pred pred, Proj proj = Proj{})
+            constexpr remove_if_view(Rng rng, Pred pred)
               : remove_if_view::view_adaptor{detail::move(rng)}
-              , predicate_box(detail::move(pred))
-              , projection_box(detail::move(proj))
+              , remove_if_view::box(detail::move(pred))
             {}
         private:
             friend range_access;
@@ -104,22 +98,20 @@ namespace ranges
             RANGES_CXX14_CONSTEXPR void satisfy_forward(iterator_t<Rng> &it)
             {
                 auto const last = ranges::end(this->base());
-                auto &pred = this->predicate_box::get();
-                auto &proj = this->projection_box::get();
-                while (it != last && invoke(pred, invoke(proj, *it)))
+                auto &pred = this->remove_if_view::box::get();
+                while (it != last && invoke(pred, *it))
                     ++it;
             }
             RANGES_CXX14_CONSTEXPR void satisfy_reverse(iterator_t<Rng> &it)
             {
                 RANGES_ASSERT(begin_);
                 auto const &first = *begin_;
-                auto &pred = this->predicate_box::get();
-                auto &proj = this->projection_box::get();
+                auto &pred = this->remove_if_view::box::get();
                 do
                 {
                     RANGES_ASSERT(it != first); (void)first;
                     --it;
-                } while(invoke(pred, invoke(proj, *it)));
+                } while(invoke(pred, *it));
             }
 
             RANGES_CXX14_CONSTEXPR void cache_begin()
@@ -135,49 +127,89 @@ namespace ranges
 
         namespace view
         {
-            struct remove_if_fn
+            /// \cond
+            namespace details
             {
-            private:
-                friend view_access;
-                template<typename Pred, typename Proj = ident>
-                static auto bind(remove_if_fn remove_if, Pred pred, Proj proj = Proj{})
-                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
-                (
-                    make_pipeable(std::bind(remove_if, std::placeholders::_1,
-                        protect(std::move(pred)), protect(std::move(proj))))
-                )
-            public:
-                template<typename Rng, typename Pred, typename Proj>
-                using Constraint = meta::and_<
-                    InputRange<Rng>,
-                    IndirectPredicate<Pred, projected<iterator_t<Rng>, Proj>>>;
 
-                template<typename Rng, typename Pred, typename Proj = ident,
-                    CONCEPT_REQUIRES_(Constraint<Rng, Pred, Proj>())>
-                RANGES_CXX14_CONSTEXPR auto operator()(Rng &&rng, Pred pred, Proj proj = Proj{}) const
-                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
-                (
-                    remove_if_view<all_t<Rng>, Pred, Proj>{
-                        all(static_cast<Rng &&>(rng)), std::move(pred), std::move(proj)}
-                )
-            #ifndef RANGES_DOXYGEN_INVOKED
-                template<typename Rng, typename Pred, typename Proj = ident,
-                    CONCEPT_REQUIRES_(!Constraint<Rng, Pred, Proj>())>
-                void operator()(Rng &&, Pred, Proj = Proj{}) const
+                template<typename Modifier>
+                struct remove_if_fn_base
                 {
-                    CONCEPT_ASSERT_MSG(InputRange<Rng>(),
-                        "The first argument to view::remove_if must be a model of the "
-                        "InputRange concept");
-                    using Itr = iterator_t<Rng>;
-                    CONCEPT_ASSERT_MSG(IndirectInvocable<Proj, Itr>(),
-                        "The projection function must accept objects of the iterator's value type, "
-                        "reference type, and common reference type.");
-                    CONCEPT_ASSERT_MSG(IndirectPredicate<Pred, projected<Itr, Proj>>(),
-                        "The second argument to view::remove_if must accept objects returned "
-                        "by the projection function, or of the range's value type if no projection "
-                        "is specified.");
-                }
-            #endif
+                private:
+                    friend view_access;
+                    template<typename Pred>
+                    static auto bind(remove_if_fn_base remove_if, Pred pred)
+                    RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                    (
+                        make_pipeable(std::bind(remove_if, std::placeholders::_1,
+                            protect(std::move(pred))))
+                    )
+
+                    template<typename Pred, typename Proj>
+                    static auto bind(remove_if_fn_base remove_if, Pred pred, Proj proj)
+                    RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                    (
+                        make_pipeable(std::bind(remove_if, std::placeholders::_1,
+                            protect(std::move(pred)), protect(std::move(proj))))
+                    )
+                public:
+                    template<typename Rng, typename Pred, typename Proj = ident>
+                    using Constraint = meta::and_<
+                        InputRange<Rng>,
+                        IndirectPredicate<Pred, projected<iterator_t<Rng>, Proj>>>;
+
+                    template<typename Rng, typename Pred,
+                        CONCEPT_REQUIRES_(Constraint<Rng, Pred>())>
+                    RANGES_CXX14_CONSTEXPR auto operator()(Rng &&rng, Pred pred) const
+                    RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                    (
+                        remove_if_view<all_t<Rng>, detail::decay_t<invoke_result_t<Modifier &, Pred>>>{
+                            all(static_cast<Rng &&>(rng)), Modifier{}(std::move(pred))}
+                    )
+
+                    template<typename Rng, typename Pred, typename Proj,
+                        CONCEPT_REQUIRES_(Constraint<Rng, Pred, Proj>())>
+                    RANGES_CXX14_CONSTEXPR auto operator()(Rng &&rng, Pred pred, Proj proj) const
+                    RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                    (
+                        remove_if_view<all_t<Rng>, composed<detail::decay_t<invoke_result_t<Modifier &, Pred>>, Proj>>{
+                            all(static_cast<Rng &&>(rng)), compose(Modifier{}(std::move(pred)), std::move(proj))}
+                    )
+
+                #ifndef RANGES_DOXYGEN_INVOKED
+                    template<typename Rng, typename Pred,
+                        CONCEPT_REQUIRES_(!Constraint<Rng, Pred>())>
+                    void operator()(Rng &&, Pred) const
+                    {
+                        CONCEPT_ASSERT_MSG(InputRange<Rng>(),
+                            "The first argument to view::remove_if/filter must be a model of the "
+                            "InputRange concept");
+                        using Itr = iterator_t<Rng>;
+                        CONCEPT_ASSERT_MSG(IndirectPredicate<Pred, Itr>(),
+                            "The second argument to view::remove_if/filter must accept arguments "
+                            "of the range's value type.");
+                    }
+
+                    template<typename Rng, typename Pred, typename Proj,
+                        CONCEPT_REQUIRES_(!Constraint<Rng, Pred, Proj>())>
+                    void operator()(Rng &&, Pred, Proj) const
+                    {
+                        CONCEPT_ASSERT_MSG(InputRange<Rng>(),
+                            "The first argument to view::remove_if/filter must be a model of the "
+                            "InputRange concept");
+                        using Itr = iterator_t<Rng>;
+                        CONCEPT_ASSERT_MSG(IndirectInvocable<Proj, Itr>(),
+                            "The projection function must accept arguments of the iterator's value type, "
+                            "reference type, and common reference type.");
+                        CONCEPT_ASSERT_MSG(IndirectPredicate<Pred, projected<Itr, Proj>>(),
+                            "The second argument to view::remove_if/filter must accept values returned "
+                            "by the projection function.");
+                    }
+                #endif
+                };
+            }
+
+            struct remove_if_fn : details::remove_if_fn_base<ident>
+            {
             };
 
             /// \relates remove_if_fn

--- a/include/range/v3/view/remove_if.hpp
+++ b/include/range/v3/view/remove_if.hpp
@@ -26,7 +26,7 @@
 #include <range/v3/utility/box.hpp>
 #include <range/v3/utility/optional.hpp>
 #include <range/v3/utility/semiregular.hpp>
-#include <range/v3/utility/static_const.hpp>
+#include <range/v3/utility/static_const.hpp>    
 #include <range/v3/view/view.hpp>
 
 RANGES_DISABLE_WARNINGS
@@ -37,18 +37,24 @@ namespace ranges
     {
         /// \addtogroup group-views
         /// @{
-        template<typename Rng, typename Pred>
+        template<typename Rng, typename Pred, typename Proj>
         struct RANGES_EMPTY_BASES remove_if_view
           : view_adaptor<
-                remove_if_view<Rng, Pred>,
+                remove_if_view<Rng, Pred, Proj>,
                 Rng,
                 is_finite<Rng>::value ? finite : range_cardinality<Rng>::value>
-          , private box<semiregular_t<Pred>>
+          , private box<semiregular_t<Pred>, struct predicate_tag>
+          , private box<semiregular_t<Proj>, struct projection_tag>
         {
+        private:
+            using predicate_box = box<semiregular_t<Pred>, struct predicate_tag>;
+            using projection_box = box<semiregular_t<Proj>, struct projection_tag>;
+        public:
             remove_if_view() = default;
-            constexpr remove_if_view(Rng rng, Pred pred)
+            constexpr remove_if_view(Rng rng, Pred pred, Proj proj)
               : remove_if_view::view_adaptor{detail::move(rng)}
-              , remove_if_view::box(detail::move(pred))
+              , predicate_box(detail::move(pred))
+              , projection_box(detail::move(proj))
             {}
         private:
             friend range_access;
@@ -98,20 +104,22 @@ namespace ranges
             RANGES_CXX14_CONSTEXPR void satisfy_forward(iterator_t<Rng> &it)
             {
                 auto const last = ranges::end(this->base());
-                auto &pred = this->remove_if_view::box::get();
-                while (it != last && invoke(pred, *it))
+                auto &pred = this->predicate_box::get();
+                auto &proj = this->projection_box::get();
+                while (it != last && invoke(pred, invoke(proj, *it)))
                     ++it;
             }
             RANGES_CXX14_CONSTEXPR void satisfy_reverse(iterator_t<Rng> &it)
             {
                 RANGES_ASSERT(begin_);
                 auto const &first = *begin_;
-                auto &pred = this->remove_if_view::box::get();
+                auto &pred = this->predicate_box::get();
+                auto &proj = this->projection_box::get();
                 do
                 {
                     RANGES_ASSERT(it != first); (void)first;
                     --it;
-                } while(invoke(pred, *it));
+                } while(invoke(pred, invoke(proj, *it)));
             }
 
             RANGES_CXX14_CONSTEXPR void cache_begin()
@@ -131,39 +139,43 @@ namespace ranges
             {
             private:
                 friend view_access;
-                template<typename Pred>
-                static auto bind(remove_if_fn remove_if, Pred pred)
+                template<typename Pred, typename Proj = ident>
+                static auto bind(remove_if_fn remove_if, Pred pred, Proj proj = Proj{})
                 RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
                 (
                     make_pipeable(std::bind(remove_if, std::placeholders::_1,
-                        protect(std::move(pred))))
+                        protect(std::move(pred)), protect(std::move(proj))))
                 )
             public:
-                template<typename Rng, typename Pred>
+                template<typename Rng, typename Pred, typename Proj>
                 using Constraint = meta::and_<
                     InputRange<Rng>,
-                    IndirectPredicate<Pred, iterator_t<Rng>>>;
+                    IndirectPredicate<Pred, projected<iterator_t<Rng>, Proj>>>;
 
-                template<typename Rng, typename Pred,
-                    CONCEPT_REQUIRES_(Constraint<Rng, Pred>())>
-                RANGES_CXX14_CONSTEXPR auto operator()(Rng &&rng, Pred pred) const
+                template<typename Rng, typename Pred, typename Proj = ident,
+                    CONCEPT_REQUIRES_(Constraint<Rng, Pred, Proj>())>
+                RANGES_CXX14_CONSTEXPR auto operator()(Rng &&rng, Pred pred, Proj proj = Proj{}) const
                 RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
                 (
-                    remove_if_view<all_t<Rng>, Pred>{
-                        all(static_cast<Rng &&>(rng)), std::move(pred)}
+                    remove_if_view<all_t<Rng>, Pred, Proj>{
+                        all(static_cast<Rng &&>(rng)), std::move(pred), std::move(proj)}
                 )
             #ifndef RANGES_DOXYGEN_INVOKED
-                template<typename Rng, typename Pred,
-                    CONCEPT_REQUIRES_(!Constraint<Rng, Pred>())>
+                template<typename Rng, typename Pred, typename Proj = ident,
+                    CONCEPT_REQUIRES_(!Constraint<Rng, Pred, Proj>())>
                 void operator()(Rng &&, Pred) const
                 {
                     CONCEPT_ASSERT_MSG(InputRange<Rng>(),
                         "The first argument to view::remove_if must be a model of the "
                         "InputRange concept");
-                    CONCEPT_ASSERT_MSG(IndirectPredicate<Pred, iterator_t<Rng>>(),
-                        "The second argument to view::remove_if must be callable with "
-                        "a value of the range, and the return type must be convertible "
-                        "to bool");
+                    using Itr = iterator_t<Rng>;
+                    CONCEPT_ASSERT_MSG(IndirectInvocable<Proj, Itr>(),
+                        "The projection function must accept objects of the iterator's value type, "
+                        "reference type, and common reference type.");
+                    CONCEPT_ASSERT_MSG(IndirectPredicate<Pred, projected<Itr, Proj>>(),
+                        "The second argument to view::remove_if must accept objects returned "
+                        "by the projection function, or of the range's value type if no projection "
+                        "is specified.");
                 }
             #endif
             };

--- a/include/range/v3/view/remove_if.hpp
+++ b/include/range/v3/view/remove_if.hpp
@@ -128,89 +128,94 @@ namespace ranges
         namespace view
         {
             /// \cond
-            namespace details
+            template<typename Modifier>
+            struct remove_if_fn_
             {
+            private:
+                friend view_access;
+                template<typename Pred>
+                static auto bind(remove_if_fn_ remove_if, Pred pred)
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                (
+                    make_pipeable(std::bind(remove_if, std::placeholders::_1,
+                        protect(std::move(pred))))
+                )
 
-                template<typename Modifier>
-                struct remove_if_fn_base
+                template<typename Pred, typename Proj>
+                static auto bind(remove_if_fn_ remove_if, Pred pred, Proj proj)
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                (
+                    make_pipeable(std::bind(remove_if, std::placeholders::_1,
+                        protect(std::move(pred)), protect(std::move(proj))))
+                )
+            public:
+                template<typename Rng, typename Pred, typename Proj = ident>
+                using Constraint = meta::and_<
+                    InputRange<Rng>,
+                    IndirectPredicate<Pred, projected<iterator_t<Rng>, Proj>>>;
+
+                template<typename Rng, typename Pred,
+                    typename M = detail::decay_t<invoke_result_t<Modifier, Pred>>,
+                    CONCEPT_REQUIRES_(Constraint<Rng, Pred>())>
+                RANGES_CXX14_CONSTEXPR
+                auto operator()(Rng &&rng, Pred&& pred) const
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                (
+                    remove_if_view<all_t<Rng>, M>{
+                        all(static_cast<Rng &&>(rng)),
+                        Modifier{}(std::move(pred))
+                    }
+                )
+
+                template<typename Rng, typename Pred, typename Proj,
+                    typename M = detail::decay_t<invoke_result_t<Modifier, Pred>>,
+                    CONCEPT_REQUIRES_(Constraint<Rng, Pred, Proj>())>
+                RANGES_CXX14_CONSTEXPR
+                auto operator()(Rng &&rng, Pred pred, Proj proj) const
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                (
+                    remove_if_view<all_t<Rng>, composed<M, Proj>>{
+                        all(static_cast<Rng &&>(rng)),
+                        compose(Modifier{}(std::move(pred)), std::move(proj))
+                    }
+                )
+
+            #ifndef RANGES_DOXYGEN_INVOKED
+                template<typename Rng, typename Pred,
+                    CONCEPT_REQUIRES_(!Constraint<Rng, Pred>())>
+                void operator()(Rng &&, Pred) const
                 {
-                private:
-                    friend view_access;
-                    template<typename Pred>
-                    static auto bind(remove_if_fn_base remove_if, Pred pred)
-                    RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
-                    (
-                        make_pipeable(std::bind(remove_if, std::placeholders::_1,
-                            protect(std::move(pred))))
-                    )
+                    CONCEPT_ASSERT_MSG(InputRange<Rng>(),
+                        "The first argument to view::remove_if/filter must "
+                        "be a model of the InputRange concept");
+                    using Itr = iterator_t<Rng>;
+                    CONCEPT_ASSERT_MSG(IndirectPredicate<Pred, Itr>(),
+                        "The second argument to view::remove_if/filter must "
+                        "accept arguments of the range's value type.");
+                }
 
-                    template<typename Pred, typename Proj>
-                    static auto bind(remove_if_fn_base remove_if, Pred pred, Proj proj)
-                    RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
-                    (
-                        make_pipeable(std::bind(remove_if, std::placeholders::_1,
-                            protect(std::move(pred)), protect(std::move(proj))))
-                    )
-                public:
-                    template<typename Rng, typename Pred, typename Proj = ident>
-                    using Constraint = meta::and_<
-                        InputRange<Rng>,
-                        IndirectPredicate<Pred, projected<iterator_t<Rng>, Proj>>>;
-
-                    template<typename Rng, typename Pred,
-                        CONCEPT_REQUIRES_(Constraint<Rng, Pred>())>
-                    RANGES_CXX14_CONSTEXPR auto operator()(Rng &&rng, Pred pred) const
-                    RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
-                    (
-                        remove_if_view<all_t<Rng>, detail::decay_t<invoke_result_t<Modifier &, Pred>>>{
-                            all(static_cast<Rng &&>(rng)), Modifier{}(std::move(pred))}
-                    )
-
-                    template<typename Rng, typename Pred, typename Proj,
-                        CONCEPT_REQUIRES_(Constraint<Rng, Pred, Proj>())>
-                    RANGES_CXX14_CONSTEXPR auto operator()(Rng &&rng, Pred pred, Proj proj) const
-                    RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
-                    (
-                        remove_if_view<all_t<Rng>, composed<detail::decay_t<invoke_result_t<Modifier &, Pred>>, Proj>>{
-                            all(static_cast<Rng &&>(rng)), compose(Modifier{}(std::move(pred)), std::move(proj))}
-                    )
-
-                #ifndef RANGES_DOXYGEN_INVOKED
-                    template<typename Rng, typename Pred,
-                        CONCEPT_REQUIRES_(!Constraint<Rng, Pred>())>
-                    void operator()(Rng &&, Pred) const
-                    {
-                        CONCEPT_ASSERT_MSG(InputRange<Rng>(),
-                            "The first argument to view::remove_if/filter must be a model of the "
-                            "InputRange concept");
-                        using Itr = iterator_t<Rng>;
-                        CONCEPT_ASSERT_MSG(IndirectPredicate<Pred, Itr>(),
-                            "The second argument to view::remove_if/filter must accept arguments "
-                            "of the range's value type.");
-                    }
-
-                    template<typename Rng, typename Pred, typename Proj,
-                        CONCEPT_REQUIRES_(!Constraint<Rng, Pred, Proj>())>
-                    void operator()(Rng &&, Pred, Proj) const
-                    {
-                        CONCEPT_ASSERT_MSG(InputRange<Rng>(),
-                            "The first argument to view::remove_if/filter must be a model of the "
-                            "InputRange concept");
-                        using Itr = iterator_t<Rng>;
-                        CONCEPT_ASSERT_MSG(IndirectInvocable<Proj, Itr>(),
-                            "The projection function must accept arguments of the iterator's value type, "
-                            "reference type, and common reference type.");
-                        CONCEPT_ASSERT_MSG(IndirectPredicate<Pred, projected<Itr, Proj>>(),
-                            "The second argument to view::remove_if/filter must accept values returned "
-                            "by the projection function.");
-                    }
-                #endif
-                };
-            }
-
-            struct remove_if_fn : details::remove_if_fn_base<ident>
-            {
+                template<typename Rng, typename Pred, typename Proj,
+                    CONCEPT_REQUIRES_(!Constraint<Rng, Pred, Proj>())>
+                void operator()(Rng &&, Pred, Proj) const
+                {
+                    CONCEPT_ASSERT_MSG(InputRange<Rng>(),
+                        "The first argument to view::remove_if/filter must "
+                        "be a model of the InputRange concept");
+                    using Itr = iterator_t<Rng>;
+                    CONCEPT_ASSERT_MSG(IndirectInvocable<Proj, Itr>(),
+                        "The projection function must accept arguments of the iterator's "
+                        "value type, reference type, and common reference type.");
+                    CONCEPT_ASSERT_MSG(IndirectPredicate<Pred, projected<Itr, Proj>>(),
+                        "The second argument to view::remove_if/filter must accept values "
+                        "returned by the projection function.");
+                }
+            #endif
             };
+            /// \endcond
+
+            /// Given a source range, unary predicate, and optional projection,
+            /// present a view of the elements that do not satisfy the predicate.
+            using remove_if_fn = remove_if_fn_<ident>;
 
             /// \relates remove_if_fn
             /// \ingroup group-views

--- a/include/range/v3/view/remove_if.hpp
+++ b/include/range/v3/view/remove_if.hpp
@@ -26,7 +26,7 @@
 #include <range/v3/utility/box.hpp>
 #include <range/v3/utility/optional.hpp>
 #include <range/v3/utility/semiregular.hpp>
-#include <range/v3/utility/static_const.hpp>    
+#include <range/v3/utility/static_const.hpp>
 #include <range/v3/view/view.hpp>
 
 RANGES_DISABLE_WARNINGS
@@ -51,7 +51,7 @@ namespace ranges
             using projection_box = box<semiregular_t<Proj>, struct projection_tag>;
         public:
             remove_if_view() = default;
-            constexpr remove_if_view(Rng rng, Pred pred, Proj proj)
+            constexpr remove_if_view(Rng rng, Pred pred, Proj proj = Proj{})
               : remove_if_view::view_adaptor{detail::move(rng)}
               , predicate_box(detail::move(pred))
               , projection_box(detail::move(proj))
@@ -163,7 +163,7 @@ namespace ranges
             #ifndef RANGES_DOXYGEN_INVOKED
                 template<typename Rng, typename Pred, typename Proj = ident,
                     CONCEPT_REQUIRES_(!Constraint<Rng, Pred, Proj>())>
-                void operator()(Rng &&, Pred) const
+                void operator()(Rng &&, Pred, Proj = Proj{}) const
                 {
                     CONCEPT_ASSERT_MSG(InputRange<Rng>(),
                         "The first argument to view::remove_if must be a model of the "

--- a/test/view/remove_if.cpp
+++ b/test/view/remove_if.cpp
@@ -15,6 +15,7 @@
 #include <functional>
 #include <range/v3/core.hpp>
 #include <range/v3/view/remove_if.hpp>
+#include <range/v3/view/filter.hpp>
 #include <range/v3/view/counted.hpp>
 #include <range/v3/view/concat.hpp>
 #include <range/v3/view/reverse.hpp>
@@ -116,10 +117,32 @@ int main()
     }
 
     {
-        // remove_if with projection
+        // with projection
         const std::vector<my_data> some_my_datas{{1}, {2}, {3}, {4}};
-        auto rng = some_my_datas | ranges::view::remove_if(is_even(), &my_data::i);
-        ::check_equal(rng, std::vector<my_data>{{1}, {3}});
+
+        {
+            // view::remove_if without pipe
+            auto rng = ranges::view::remove_if(some_my_datas, is_even(), &my_data::i);
+            ::check_equal(rng, std::vector<my_data>{{1}, {3}});
+        }
+
+        {
+            // view::remove_if with pipe
+            auto rng = some_my_datas | ranges::view::remove_if(is_even(), &my_data::i);
+            ::check_equal(rng, std::vector<my_data>{{1}, {3}});
+        }
+
+        {
+            // view::filter without pipe
+            auto rng = ranges::view::filter(some_my_datas, is_even(), &my_data::i);
+            ::check_equal(rng, std::vector<my_data>{{2}, {4}});
+        }
+
+        {
+            // view::filter with pipe
+            auto rng = some_my_datas | ranges::view::filter(is_even(), &my_data::i);
+            ::check_equal(rng, std::vector<my_data>{{2}, {4}});
+        }
     }
 
     return test_result();

--- a/test/view/remove_if.cpp
+++ b/test/view/remove_if.cpp
@@ -117,7 +117,7 @@ int main()
 
     {
         // remove_if with projection
-        const std::array<my_data, 4> some_my_datas{1, 2, 3, 4};
+        const std::vector<my_data> some_my_datas{{1}, {2}, {3}, {4}};
         auto rng = some_my_datas | ranges::view::remove_if(is_even(), &my_data::i);
         ::check_equal(rng, std::vector<my_data>{{1}, {3}});
     }

--- a/test/view/remove_if.cpp
+++ b/test/view/remove_if.cpp
@@ -39,6 +39,16 @@ struct is_even
     }
 };
 
+struct my_data
+{
+    int i;
+};
+
+bool operator==(my_data left, my_data right)
+{
+    return left.i == right.i;
+}
+
 int main()
 {
     using namespace ranges;
@@ -103,6 +113,13 @@ int main()
         int const some_ints[] = {1, 2, 3};
         auto a = some_ints | ranges::view::remove_if([](int val) { return val > 0; });
         CHECK(a.empty());
+    }
+
+    {
+        // remove_if with projection
+        const std::array<my_data, 4> some_my_datas{1, 2, 3, 4};
+        auto rng = some_my_datas | ranges::view::remove_if(is_even(), &my_data::i);
+        ::check_equal(rng, std::vector<my_data>{{1}, {3}});
     }
 
     return test_result();


### PR DESCRIPTION
I missed the same feature as described in #892.
My changes to the view::filter and view::remove_if are mostly based on the projection code used in action::remove_if.
If this patch is accepted, I will have a look on view::take_while.