### PR TITLE
[partial_sum] Fix horrible bugginess due to defaulting the binary ope…

### DIFF
--- a/include/range/v3/view/partial_sum.hpp
+++ b/include/range/v3/view/partial_sum.hpp
@@ -141,6 +141,14 @@ namespace ranges
                     make_pipeable(std::bind(partial_sum, std::placeholders::_1,
                         protect(std::move(fun))))
                 )
+                template<typename Fun = plus>
+                RANGES_DEPRECATED("Use \"ranges::view::partial_sum\" instead of \"ranges::view::partial_sum()\".")
+                static auto bind(partial_sum_fn partial_sum)
+                RANGES_DECLTYPE_AUTO_RETURN
+                (
+                    make_pipeable(std::bind(partial_sum, std::placeholders::_1,
+                        Fun{}))
+                )
             public:
                 template<typename Rng, typename Fun>
                 using Concept = meta::and_<
@@ -157,6 +165,7 @@ namespace ranges
                 {
                     return {all(static_cast<Rng&&>(rng)), std::move(fun)};
                 }
+
             #ifndef RANGES_DOXYGEN_INVOKED
                 template<typename Rng, typename Fun = plus,
                     CONCEPT_REQUIRES_(!Concept<Rng, Fun>())>

--- a/include/range/v3/view/partial_sum.hpp
+++ b/include/range/v3/view/partial_sum.hpp
@@ -134,8 +134,8 @@ namespace ranges
             {
             private:
                 friend view_access;
-                template<typename Fun = plus>
-                static auto bind(partial_sum_fn partial_sum, Fun fun = {})
+                template<typename Fun>
+                static auto bind(partial_sum_fn partial_sum, Fun fun)
                 RANGES_DECLTYPE_AUTO_RETURN
                 (
                     make_pipeable(std::bind(partial_sum, std::placeholders::_1,
@@ -151,16 +151,16 @@ namespace ranges
                             range_common_reference_t<Rng>>,
                         range_value_type_t<Rng>>>;
 
-                template<typename Rng, typename Fun,
+                template<typename Rng, typename Fun = plus,
                     CONCEPT_REQUIRES_(Concept<Rng, Fun>())>
-                partial_sum_view<all_t<Rng>, Fun> operator()(Rng && rng, Fun fun) const
+                partial_sum_view<all_t<Rng>, Fun> operator()(Rng && rng, Fun fun = {}) const
                 {
                     return {all(static_cast<Rng&&>(rng)), std::move(fun)};
                 }
             #ifndef RANGES_DOXYGEN_INVOKED
-                template<typename Rng, typename Fun,
+                template<typename Rng, typename Fun = plus,
                     CONCEPT_REQUIRES_(!Concept<Rng, Fun>())>
-                void operator()(Rng &&, Fun) const
+                void operator()(Rng &&, Fun = {}) const
                 {
                     CONCEPT_ASSERT_MSG(InputRange<Rng>(),
                         "The first argument passed to view::partial_sum must be a model of the "

--- a/test/view/CMakeLists.txt
+++ b/test/view/CMakeLists.txt
@@ -27,6 +27,7 @@ rv3_add_test(test.view.linear_distribute view.linear_distribute linear_distribut
 rv3_add_test(test.view.map view.map keys_value.cpp)
 rv3_add_test(test.view.move view.move move.cpp)
 rv3_add_test(test.view.partial_sum view.partial_sum partial_sum.cpp)
+rv3_add_test(test.view.partial_sum_depr view.partial_sum_depr partial_sum_depr.cpp)
 rv3_add_test(test.view.repeat view.repeat repeat.cpp)
 rv3_add_test(test.view.remove_if view.remove_if remove_if.cpp)
 rv3_add_test(test.view.replace view.replace replace.cpp)

--- a/test/view/partial_sum.cpp
+++ b/test/view/partial_sum.cpp
@@ -9,13 +9,13 @@
 //
 // Project home: https://github.com/ericniebler/range-v3
 
-#include <iterator>
 #include <functional>
+#include <iterator>
 #include <range/v3/core.hpp>
-#include <range/v3/view/partial_sum.hpp>
-#include <range/v3/view/counted.hpp>
-#include <range/v3/view/reverse.hpp>
 #include <range/v3/utility/copy.hpp>
+#include <range/v3/view/counted.hpp>
+#include <range/v3/view/partial_sum.hpp>
+#include <range/v3/view/reverse.hpp>
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 
@@ -25,7 +25,7 @@ int main()
 
     int rgi[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
-    auto && rng = rgi | view::partial_sum();
+    auto && rng = rgi | view::partial_sum;
     has_type<int &>(*begin(rgi));
     has_type<int>(*begin(rng));
     models<concepts::SizedView>(aux::copy(rng));
@@ -52,8 +52,15 @@ int main()
     CONCEPT_ASSERT(!View<decltype(mutable_rng) const>());
 
     {
-        auto rng = debug_input_view<int const>{rgi} | view::partial_sum();
+        auto rng = debug_input_view<int const>{rgi} | view::partial_sum;
         ::check_equal(rng, {1, 3, 6, 10, 15, 21, 28, 36, 45, 55});
+    }
+
+    {
+        static int const some_ints[] = {0,1,2,3,4};
+        auto t1 = ranges::view::partial_sum(some_ints);
+        auto t2 = some_ints | ranges::view::partial_sum;
+        ::check_equal(t1, t2);
     }
 
     return test_result();

--- a/test/view/partial_sum_depr.cpp
+++ b/test/view/partial_sum_depr.cpp
@@ -1,0 +1,25 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014-present
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+
+#include <range/v3/core.hpp>
+RANGES_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS
+#include <range/v3/view/partial_sum.hpp>
+#include "../simple_test.hpp"
+#include "../test_utils.hpp"
+
+int main()
+{
+    static int const some_ints[] = {0,1,2,3,4};
+    auto rng = some_ints | ranges::view::partial_sum();
+    ::check_equal(rng, {0,1,3,6,10});
+
+    return ::test_result();
+}


### PR DESCRIPTION
…ration in `bind` instead of `operator()`

NOTE: THIS CHANGE IS SOURCE-BREAKING. `view::partial_sum()` previously yielded a closure that held `plus`, despite that `operator()` did *not* default its function argument to `plus`. The new state is that `view::partial_sum()` is ill-formed and should be replaced with `view::partial_sum`, and `operator()` defaults its second argument to `plus{}`.

As a result, this program fragment:
```c++
static int const some_ints[] = {0,1,2,3,4};
auto t1 = ranges::view::partial_sum(some_ints);
auto t2 = some_ints | ranges::view::partial_sum;
::check_equal(t1, t2);
```
Now works as intended, whereas previously `ranges::view::partial_sum(some_ints)` yielded a closure object waiting for a range to sum with the "binary operation" `make_iterator_range(some_ints)`.