### PR TITLE
[zip] Correctly zip no ranges

### DIFF
--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -213,7 +213,6 @@ namespace ranges
 #define RANGES_WORKAROUND_MSVC_701425 // Failure to deduce decltype(pointer-to-member) (gcc_bugs_bugs_bugs for MSVC)
 #endif
 
-#define RANGES_WORKAROUND_MSVC_125882 // Multiple defaulted copy constructors/assignment operators are not supported
 #define RANGES_WORKAROUND_MSVC_249830 // constexpr and arguments that aren't subject to lvalue-to-rvalue conversion
 #define RANGES_WORKAROUND_MSVC_620035 // Error when definition-context name binding finds only deleted function
 #define RANGES_WORKAROUND_MSVC_677925 // Bogus C2676 "binary '++': '_Ty' does not define this operator"

--- a/test/view/cartesian_product.cpp
+++ b/test/view/cartesian_product.cpp
@@ -45,13 +45,13 @@ struct printer {
     }
 };
 
-namespace ranges {
+namespace std {
     template<typename... Ts>
     std::ostream &operator<<(std::ostream &os, std::tuple<Ts...> const &t)
     {
         os << '(';
         auto first = true;
-        tuple_for_each(t, printer{os, first});
+        ::ranges::tuple_for_each(t, ::printer{os, first});
         os << ')';
         return os;
     }
@@ -75,7 +75,7 @@ void test_empty_set()
         std::tuple<>>());
     CONCEPT_ASSERT(std::is_same<
         range_reference_t<Rng>,
-        common_tuple<>>());
+        std::tuple<>&>());
 
     std::initializer_list<common_tuple<>> control{};
     ::check_equal(rng, control);
@@ -83,7 +83,7 @@ void test_empty_set()
 
     auto const first = begin(rng);
     auto const last = end(rng);
-    CHECK((last - first) == size(rng));
+    CHECK(decltype(size(rng))(last - first) == size(rng));
     for(auto i = 0; i <= distance(rng); ++i)
     {
         for(auto j = 0; j <= distance(rng); ++j)

--- a/test/view/zip.cpp
+++ b/test/view/zip.cpp
@@ -235,5 +235,16 @@ int main()
         ::check_equal(rng, {P{0,4},P{1,5}, P{2,6}, P{3,7}});
     }
 
+    {
+        // Test with no ranges
+        auto rng = view::zip();
+        using R = decltype(rng);
+        CONCEPT_ASSERT(Same<range_value_type_t<R>, std::tuple<>>());
+        CONCEPT_ASSERT(ContiguousRange<R>());
+        static_assert(ranges::range_cardinality<R>::value == ranges::cardinality(0), "");
+        CHECK(ranges::begin(rng) == ranges::end(rng));
+        CHECK(ranges::size(rng) == 0u);
+    }
+
     return test_result();
 }


### PR DESCRIPTION
`ranges::view::zip()` is a contiguous range of no elements of type `std::tuple<>`.