### PR TITLE
generate_view: emplace instead of assign the stored value

### DIFF
--- a/include/range/v3/view/generate.hpp
+++ b/include/range/v3/view/generate.hpp
@@ -55,7 +55,7 @@ namespace ranges
                 result_t &&read() const
                 {
                     if (!view_->val_)
-                        view_->val_ = view_->gen_();
+                        view_->val_.emplace(view_->gen_());
                     return static_cast<result_t &&>(
                         static_cast<result_t &>(*view_->val_));
                 }


### PR DESCRIPTION
Which generates better code when the optimizer can't tell that the generator function doesn't modify the cache.