### PR TITLE
Allow importing from existing CMake build tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,3 +128,5 @@ install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/range-v3-config-version.cmake
   DESTINATION lib/cmake/range-v3)
 install(DIRECTORY include/ DESTINATION include FILES_MATCHING PATTERN "*.hpp")
+
+export(EXPORT range-v3-targets FILE range-v3-config.cmake)


### PR DESCRIPTION
This change adds an additional way to consume Range-v3 with CMake, other than installing it to use with `find_package` or somehow making it available (say, git submodule or `FetchContent`) to use it with `add_subdirectory`. It permits pointing to an existing build tree of Range-v3 by setting `range-v3_DIR` variable to that directory, so that you can then use it with `find_package` as usual.

My intention is to allow my own libraries depending on Range-v3 to be used by defining their `_DIR` variable, as mentioned above, without needing Range-v3 to be installed.