### PR TITLE
semiregular: converting constructor should be conditionally explicit

### DIFF
--- a/include/range/v3/utility/semiregular.hpp
+++ b/include/range/v3/utility/semiregular.hpp
@@ -123,8 +123,16 @@ namespace ranges
         template<typename U>
         explicit constexpr CPP_ctor(semiregular)(U &&u)(
             noexcept(std::is_nothrow_constructible<T, U>::value)
-                requires not defer::Same<uncvref_t<U>, semiregular> &&
+                requires (not defer::Same<uncvref_t<U>, semiregular>) &&
                     defer::Constructible<T, U>)
+          : semiregular(in_place, static_cast<U &&>(u))
+        {}
+        template<typename U>
+        constexpr CPP_ctor(semiregular)(U &&u)(
+            noexcept(std::is_nothrow_constructible<T, U>::value)
+                requires (not defer::Same<uncvref_t<U>, semiregular>) &&
+                    defer::Constructible<T, U> &&
+                    defer::ConvertibleTo<U, T>)
           : semiregular(in_place, static_cast<U &&>(u))
         {}
         CPP_template(typename... Args)(

--- a/test/view/split.cpp
+++ b/test/view/split.cpp
@@ -162,5 +162,10 @@ int main()
         CPP_assert(ForwardRange<decltype(rng)>);
     }
 
+    {   // Regression test for #986
+        std::string s;
+        s | ranges::view::split([](char) { return true; });
+    }
+
     return test_result();
 }


### PR DESCRIPTION
Drive-by: parenthesize non-primary-expression in requires-clause

Fixes #986.