### PR TITLE
view::split and action::split refactorization

### DIFF
--- a/include/concepts/concepts.hpp
+++ b/include/concepts/concepts.hpp
@@ -127,7 +127,7 @@ CPP_PP_IGNORE_CXX2A_COMPAT_BEGIN
     /**/
 
 #define CPP_assert(...)                                                         \
-    static_assert((bool) (__VA_ARGS__),                                         \
+    static_assert(static_cast<bool>(__VA_ARGS__),                               \
         "Concept assertion failed : " #__VA_ARGS__)                             \
     /**/
 #define CPP_assert_msg static_assert
@@ -373,7 +373,7 @@ CPP_PP_IGNORE_CXX2A_COMPAT_BEGIN
     bool (&CPP_true)(::concepts::detail::Nil) =                                 \
         ::concepts::detail::CPP_true,                                           \
     ::concepts::detail::enable_if_t<int,                                        \
-        (bool)(CPP_PP_CAT(CPP_TEMPLATE_AUX_3_, __VA_ARGS__)) &&                 \
+        static_cast<bool>(CPP_PP_CAT(CPP_TEMPLATE_AUX_3_, __VA_ARGS__)) &&      \
         CPP_true(::concepts::detail::Nil{})> = 0>                               \
     /**/
 #define CPP_TEMPLATE_AUX_3_requires
@@ -401,14 +401,14 @@ CPP_PP_IGNORE_CXX2A_COMPAT_BEGIN
 #define CPP_CTOR_REQUIRES_0(...)                                                \
     ::concepts::detail::enable_if_t<                                            \
         ::concepts::detail::Nil,                                                \
-        (bool)(CPP_PP_CAT(CPP_TEMPLATE_AUX_3_, __VA_ARGS__)) &&                 \
+        static_cast<bool>(CPP_PP_CAT(CPP_TEMPLATE_AUX_3_, __VA_ARGS__)) &&      \
             CPP_true(::concepts::detail::Nil{})> = {})                          \
     /**/
 // Yes noexcept-clause:
 #define CPP_CTOR_REQUIRES_1(...)                                                \
     ::concepts::detail::enable_if_t<                                            \
         ::concepts::detail::Nil,                                                \
-        (bool)(CPP_PP_CAT(CPP_TEMPLATE_AUX_3_, CPP_PP_CAT(                      \
+        static_cast<bool>(CPP_PP_CAT(CPP_TEMPLATE_AUX_3_, CPP_PP_CAT(           \
                 CPP_CTOR_EAT_NOEXCEPT_, __VA_ARGS__))) &&                       \
             CPP_true(::concepts::detail::Nil{})> = {})                          \
         CPP_PP_EXPAND(                                                          \
@@ -435,7 +435,7 @@ CPP_PP_IGNORE_CXX2A_COMPAT_BEGIN
     /**/
 #define CPP_TEMPLATE_AUX_2_requires
 #define CPP_BROKEN_FRIEND_RETURN_TYPE_AUX_3_(...)                               \
-    (bool)(__VA_ARGS__) && CPP_true(::concepts::detail::Nil{})>                 \
+    static_cast<bool>(__VA_ARGS__) && CPP_true(::concepts::detail::Nil{})>      \
     /**/
 #define CPP_broken_friend_member                                                \
     template<bool (&CPP_true)(::concepts::detail::Nil) =                        \

--- a/include/range/v3/action.hpp
+++ b/include/range/v3/action.hpp
@@ -28,6 +28,7 @@
 #include <range/v3/action/slice.hpp>
 #include <range/v3/action/sort.hpp>
 #include <range/v3/action/split.hpp>
+#include <range/v3/action/split_with.hpp>
 #include <range/v3/action/stable_sort.hpp>
 #include <range/v3/action/stride.hpp>
 #include <range/v3/action/take.hpp>

--- a/include/range/v3/range_access.hpp
+++ b/include/range/v3/range_access.hpp
@@ -146,7 +146,7 @@ namespace ranges
             decltype(range_access::distance_to(std::declval<Cur>(), std::declval<Cur>()));
 
         template<typename T>
-        static std::ptrdiff_t cursor_difference_2_(detail::any);
+        static std::ptrdiff_t cursor_difference_2_(detail::ignore_t);
         template<typename T>
         static sized_cursor_difference_t<T> cursor_difference_2_(long);
         template<typename T>

--- a/include/range/v3/range_concepts.hpp
+++ b/include/range/v3/range_concepts.hpp
@@ -218,10 +218,11 @@ namespace ranges
         concept SizedRange,
             requires (T &t)
             (
-                ranges::size(t),
-                concepts::requires_<Integral<decltype(ranges::size(t))>>
+                ranges::size(t)
             ) &&
-            Range<T> && !disable_sized_range<uncvref_t<T>>
+            Range<T> &&
+            Integral<range_size_t<T>> &&
+            !disable_sized_range<uncvref_t<T>>
     );
 
     /// \cond
@@ -322,6 +323,8 @@ namespace ranges
             enable_view<T>
     );
 
+    /// \cond
+    // Non-standard, avoid using
     CPP_def
     (
         template(typename T, typename V)
@@ -340,7 +343,7 @@ namespace ranges
     (
         template(typename T)
         concept ForwardView,
-            View<T> && ForwardRange<T>
+            View<T> && Copyable<T> && ForwardRange<T>
     );
 
     CPP_def
@@ -363,6 +366,7 @@ namespace ranges
         concept ContiguousView,
             RandomAccessView<T> && ContiguousRange<T>
     );
+    /// \endcond
 
     // Additional concepts for checking additional orthogonal properties
     CPP_def

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -170,24 +170,18 @@ namespace ranges
     /// \cond
     namespace detail
     {
-        template<typename T = void>
-        struct any_
+        struct ignore_t
         {
-            any_() = default;
-            any_(T &&)
-            {}
-        };
-
-        template<>
-        struct any_<void>
-        {
-            any_() = default;
+            ignore_t() = default;
             template<typename T>
-            any_(T &&)
+            constexpr ignore_t(T &&) noexcept
             {}
+            template<typename T>
+            constexpr ignore_t const &operator=(T &&) const noexcept
+            {
+                return *this;
+            }
         };
-
-        using any = any_<>;
 
         struct value_init
         {
@@ -199,20 +193,6 @@ namespace ranges
         };
 
         struct make_compressed_pair_fn;
-
-        template<typename T>
-        constexpr T &&forward(meta::_t<std::remove_reference<T>> & t) noexcept
-        {
-            return static_cast<T &&>(t);
-        }
-
-        template<typename T>
-        constexpr T &&forward(meta::_t<std::remove_reference<T>> && t) noexcept
-        {
-            // This is to catch way sketchy stuff like: forward<int const &>(42)
-            static_assert(!std::is_lvalue_reference<T>::value, "You didn't just do that!");
-            return static_cast<T &&>(t);
-        }
 
         template<typename T>
         constexpr meta::_t<std::remove_reference<T>> &&
@@ -249,7 +229,7 @@ namespace ranges
 
         template<typename T, typename R = meta::_t<std::remove_reference<T>>>
         using as_cref_t =
-            meta::_t<std::add_lvalue_reference<meta::_t<std::add_const<R>>>>;
+            meta::_t<std::add_lvalue_reference<R const>>;
 
         struct get_first;
         struct get_second;
@@ -633,13 +613,13 @@ namespace ranges
         struct slice_fn;
     }
 
-    template<typename Rng, typename Fun>
-    struct split_view;
+    // template<typename Rng, typename Fun>
+    // struct split_view;
 
-    namespace view
-    {
-        struct split_fn;
-    }
+    // namespace view
+    // {
+    //     struct split_fn;
+    // }
 
     template<typename Rng>
     struct single_view;

--- a/include/range/v3/utility/common_iterator.hpp
+++ b/include/range/v3/utility/common_iterator.hpp
@@ -88,7 +88,7 @@ namespace ranges
         {
             return p;
         }
-        template<typename J, typename = detail::arrow_type_<J const>>
+        template<typename J, typename = detail::iter_arrow_t<J const>>
         static J operator_arrow_(J const &j, int) noexcept(noexcept(J(j)))
         {
             return j;
@@ -185,7 +185,7 @@ namespace ranges
         template<typename I_ = I>
         friend constexpr /*c++14*/
         auto iter_move(common_iterator const &i)
-            noexcept(detail::has_nothrow_iter_move<I>::value) ->
+            noexcept(detail::has_nothrow_iter_move_v<I>) ->
             CPP_broken_friend_ret(iter_rvalue_reference_t<I>)(
                 requires InputIterator<I_>)
         {
@@ -211,7 +211,7 @@ namespace ranges
         template<typename I, typename S>
         constexpr /*c++14*/
         auto iter_move(common_iterator<I, S> const &i)
-            noexcept(detail::has_nothrow_iter_move<I>::value) ->
+            noexcept(detail::has_nothrow_iter_move_v<I>) ->
             CPP_broken_friend_ret(iter_rvalue_reference_t<I>)(
                 requires InputIterator<I>)
         {
@@ -308,7 +308,7 @@ namespace ranges
             using difference_type = iter_difference_t<I>;
             using value_type = iter_value_t<I>;
             using reference = iter_reference_t<I>;
-            using pointer = meta::_t<detail::pointer_type_<I>>;
+            using pointer = detail::iter_pointer_t<I>;
             using iterator_concept =
                 if_then_t<
                     (bool) ForwardIterator<I>,

--- a/include/range/v3/utility/counted_iterator.hpp
+++ b/include/range/v3/utility/counted_iterator.hpp
@@ -250,7 +250,7 @@ namespace ranges
         CPP_broken_friend_member
         friend constexpr /*c++14*/
         auto iter_move(counted_iterator const &i)
-            noexcept(detail::has_nothrow_iter_move<I>::value) ->
+            noexcept(detail::has_nothrow_iter_move_v<I>) ->
             CPP_broken_friend_ret(iter_rvalue_reference_t<I>)(
                 requires InputIterator<I>)
         {
@@ -282,7 +282,7 @@ namespace ranges
         template<typename I>
         constexpr /*c++14*/
         auto iter_move(counted_iterator<I> const &i)
-            noexcept(detail::has_nothrow_iter_move<I>::value) ->
+            noexcept(detail::has_nothrow_iter_move_v<I>) ->
             CPP_broken_friend_ret(iter_rvalue_reference_t<I>)(
                 requires InputIterator<I>)
         {

--- a/include/range/v3/utility/invoke.hpp
+++ b/include/range/v3/utility/invoke.hpp
@@ -67,7 +67,7 @@ namespace ranges
     private:
         template<typename MemberFunctionPtr, typename First, typename... Rest>
         static constexpr auto CPP_auto_fun(invoke_member_fn)(
-            std::true_type, detail::any, MemberFunctionPtr fn, First &&first, Rest &&... rest)
+            std::true_type, detail::ignore_t, MemberFunctionPtr fn, First &&first, Rest &&... rest)
         (
             return (static_cast<First &&>(first).*fn)(static_cast<Rest &&>(rest)...)
         )
@@ -86,7 +86,7 @@ namespace ranges
 
         template<typename MemberDataPtr, typename First>
         static constexpr auto CPP_auto_fun(invoke_member_data)(
-            std::true_type, detail::any, MemberDataPtr ptr, First &&first)
+            std::true_type, detail::ignore_t, MemberDataPtr ptr, First &&first)
         (
             return static_cast<First &&>(first).*ptr
         )

--- a/include/range/v3/utility/iterator.hpp
+++ b/include/range/v3/utility/iterator.hpp
@@ -1218,7 +1218,7 @@ namespace ranges
             }
             template<typename II = I const>
             constexpr /*c++14*/
-            auto move() const noexcept(has_nothrow_iter_move<II>::value) ->
+            auto move() const noexcept(has_nothrow_iter_move_v<II>) ->
                 CPP_ret(iter_rvalue_reference_t<II>)(
                     requires Same<I const, II> && Readable<II>)
             {

--- a/include/range/v3/utility/iterator_concepts.hpp
+++ b/include/range/v3/utility/iterator_concepts.hpp
@@ -576,8 +576,8 @@ namespace ranges
 
     CPP_def
     (
-        template(typename I1, typename I2)
-        concept IndirectlySwappable,
+        template(typename I1, typename I2 = I1)
+        (concept IndirectlySwappable)(I1, I2),
             requires (I1 && i1, I2 && i2)
             (
                 ranges::iter_swap((I1 &&) i1, (I2 &&) i2),

--- a/include/range/v3/utility/iterator_traits.hpp
+++ b/include/range/v3/utility/iterator_traits.hpp
@@ -67,9 +67,8 @@ namespace ranges
         using iter_rvalue_reference_t = R;
 
         template<typename I>
-        struct has_nothrow_iter_move
-          : meta::bool_<noexcept(iter_rvalue_reference_t<I>(ranges::iter_move(std::declval<I &>())))>
-        {};
+        constexpr bool has_nothrow_iter_move_v =
+            noexcept(iter_rvalue_reference_t<I>(ranges::iter_move(std::declval<I &>())));
     } // namespace detail
     /// \endcond
 
@@ -81,7 +80,8 @@ namespace ranges
     using iter_rvalue_reference_t = detail::iter_rvalue_reference_t<I>;
 
     template<typename I>
-    using iter_common_reference_t = common_reference_t<iter_reference_t<I>, iter_value_t<I> &>;
+    using iter_common_reference_t =
+        common_reference_t<iter_reference_t<I>, iter_value_t<I> &>;
     /// @}
 
     /// \cond
@@ -89,28 +89,25 @@ namespace ranges
     using size_type_t
         RANGES_DEPRECATED("size_type_t is deprecated.") =
             meta::_t<std::make_unsigned<iter_difference_t<I>>>;
-    /// \endcond
 
-    /// \cond
     template<typename I>
     using rvalue_reference_t
-        RANGES_DEPRECATED("iter_rvalue_reference_t is deprecated; use iter_rvalue_reference_t instead") =
-            detail::iter_rvalue_reference_t<I>;
+        RANGES_DEPRECATED("rvalue_reference_t is deprecated; "
+                          "use iter_rvalue_reference_t instead") =
+            iter_rvalue_reference_t<I>;
     /// \endcond
 
     /// \cond
     namespace detail
     {
         template<typename I>
-        using arrow_type_ = decltype(std::declval<I &>().operator->());
+        using iter_arrow_t = decltype(std::declval<I &>().operator->());
 
         template<typename I>
-        struct pointer_type_
-          : meta::if_<
-                meta::is_trait<meta::defer<arrow_type_, I>>,
-                meta::defer<arrow_type_, I>,
-                std::add_pointer<iter_reference_t<I>>>
-        {};
+        using iter_pointer_t = meta::_t<if_then_t<
+            meta::is_trait<meta::defer<iter_arrow_t, I>>::value,
+            meta::defer<iter_arrow_t, I>,
+            std::add_pointer<iter_reference_t<I>>>>;
     }
     /// \endcond
 }

--- a/include/range/v3/view.hpp
+++ b/include/range/v3/view.hpp
@@ -63,6 +63,7 @@ RANGES_DISABLE_WARNINGS
 #include <range/v3/view/slice.hpp>
 #include <range/v3/view/sliding.hpp>
 #include <range/v3/view/split.hpp>
+#include <range/v3/view/split_with.hpp>
 #include <range/v3/view/stride.hpp>
 #include <range/v3/view/tail.hpp>
 #include <range/v3/view/take.hpp>

--- a/include/range/v3/view/all.hpp
+++ b/include/range/v3/view/all.hpp
@@ -36,7 +36,7 @@ namespace ranges
         private:
             /// If it's a view already, pass it though.
             template<typename T>
-            static auto from_range_(T &&t, std::true_type, detail::any, detail::any)
+            static auto from_range_(T &&t, std::true_type, detail::ignore_t, detail::ignore_t)
             {
                 return static_cast<T &&>(t);
             }
@@ -44,7 +44,7 @@ namespace ranges
             /// If it is container-like, turn it into a view, being careful
             /// to preserve the Sized-ness of the range.
             template<typename T>
-            static auto from_range_(T &&t, std::false_type, std::true_type, detail::any)
+            static auto from_range_(T &&t, std::false_type, std::true_type, detail::ignore_t)
             {
                 return ranges::view::ref(t);
             }

--- a/include/range/v3/view/drop.hpp
+++ b/include/range/v3/view/drop.hpp
@@ -62,7 +62,7 @@ namespace ranges
             CPP_assert(RandomAccessRange<Rng>);
             return next(ranges::begin(rng_), n_, ranges::end(rng_));
         }
-        iterator_t<Rng> get_begin_(std::false_type, detail::any)
+        iterator_t<Rng> get_begin_(std::false_type, detail::ignore_t)
         {
             CPP_assert(!RandomAccessRange<Rng>);
             using cache_t = detail::non_propagating_cache<

--- a/include/range/v3/view/join.hpp
+++ b/include/range/v3/view/join.hpp
@@ -80,7 +80,7 @@ namespace ranges
             {
                 return (inner_ = view::all(static_cast<Inner &&>(inner)));
             }
-            constexpr view::all_t<Inner> &get_inner_(any) noexcept
+            constexpr view::all_t<Inner> &get_inner_(ignore_t) noexcept
             {
                 return inner_;
             }

--- a/include/range/v3/view/split.hpp
+++ b/include/range/v3/view/split.hpp
@@ -22,162 +22,534 @@
 #include <range/v3/begin_end.hpp>
 #include <range/v3/range_traits.hpp>
 #include <range/v3/range_concepts.hpp>
-#include <range/v3/view_facade.hpp>
-#include <range/v3/utility/iterator.hpp>
-#include <range/v3/utility/functional.hpp>
-#include <range/v3/utility/semiregular.hpp>
+#include <range/v3/algorithm/mismatch.hpp>
 #include <range/v3/utility/static_const.hpp>
-#include <range/v3/algorithm/adjacent_find.hpp>
 #include <range/v3/view/view.hpp>
 #include <range/v3/view/all.hpp>
-#include <range/v3/view/iota.hpp>
-#include <range/v3/view/indirect.hpp>
-#include <range/v3/view/take_while.hpp>
-#include <range/v3/algorithm/find_if_not.hpp>
+#include <range/v3/view/single.hpp>
 
 namespace ranges
 {
     /// \addtogroup group-views
     /// @{
-    template<typename Rng, typename Fun>
-    struct split_view
-      : view_facade<
-            split_view<Rng, Fun>,
-            is_finite<Rng>::value ? finite : range_cardinality<Rng>::value>
-    {
-    private:
-        friend range_access;
-        Rng rng_;
-        semiregular_t<Fun> fun_;
 
-        template<bool IsConst>
-        struct cursor
+    /// \cond
+    namespace detail
+    {
+        template<typename T, T>
+        struct require_constant;
+
+        CPP_def
+        (
+            template(typename R)
+            concept tiny_range,
+                SizedRange<R> &&
+                Type<require_constant<decltype(std::remove_reference_t<R>::size()),
+                                      std::remove_reference_t<R>::size()>> &&
+                (std::remove_reference_t<R>::size() <= 1)
+        );
+    } // namespace detail
+
+    template<typename V, typename Pattern>
+#if CPP_CXX_CONCEPTS
+        requires InputRange<V> && ForwardRange<Pattern> && View<V> && View<Pattern> &&
+            IndirectlyComparable<iterator_t<V>, iterator_t<Pattern>, ranges::equal_to> &&
+            (ForwardRange<V> || detail::tiny_range<Pattern>)
+#endif
+    struct split_view;
+
+    namespace detail
+    {
+        struct there
+        {
+            template<typename T>
+            static decltype(auto) current_(T &t) noexcept
+            {
+                return (t.curr_);
+            }
+        };
+
+        template<typename It>
+        struct here
+        {
+            It curr_ = It();
+            It &current_(ignore_t) noexcept
+            {
+                return curr_;
+            }
+            It const &current_(ignore_t) const noexcept
+            {
+                return curr_;
+            }
+        };
+
+        template<bool>
+        struct here_or_there_
+        {
+            template<typename>
+            using invoke = there;
+        };
+
+        template<>
+        struct here_or_there_<true>
+        {
+            template<typename It>
+            using invoke = here<It>;
+        };
+
+        template<typename It>
+        using split_view_base =
+            meta::invoke<here_or_there_<!ForwardIterator<It>>, It>;
+
+        template<typename JoinView, bool Const>
+        struct split_outer_iterator;
+
+        template<typename JoinView, bool Const>
+        struct split_inner_iterator;
+
+        template<typename V, typename Pattern, bool Const>
+        struct split_inner_iterator<split_view<V, Pattern>, Const>
         {
         private:
-            friend range_access;
-            friend split_view;
-            friend struct cursor<!IsConst>;
-            bool zero_;
-            using CRng = meta::const_if_c<IsConst, Rng>;
-            iterator_t<CRng> cur_;
-            sentinel_t<CRng> last_;
-            using fun_ref_t = semiregular_ref_or_val_t<Fun, IsConst>;
-            fun_ref_t fun_;
-
-            struct search_pred
+            using Outer = split_outer_iterator<split_view<V, Pattern>, Const>;
+            using Base = meta::const_if_c<Const, V>;
+            using BaseIterCategory =
+                typename std::iterator_traits<iterator_t<Base>>::iterator_category;
+            Outer i_ = Outer();
+            bool incremented_ = false;
+            constexpr decltype(auto) current_() noexcept { return i_.current_(); }
+            constexpr decltype(auto) current_() const noexcept { return i_.current_(); }
+            constexpr bool done_() const
             {
-                bool zero_;
-                iterator_t<CRng> first_;
-                sentinel_t<CRng> last_;
-                fun_ref_t fun_;
-                bool operator()(iterator_t<CRng> cur) const
+                auto cur = current_();
+                auto end = ranges::end(i_.parent_->base_);
+                if(cur == end)
+                    return true;
+                auto pcur = ranges::begin(i_.parent_->pattern_);
+                auto pend = ranges::end(i_.parent_->pattern_);
+                if (pcur == pend)
+                    return incremented_;
+                do
                 {
-                    return (zero_ && cur == first_) || (cur != last_ && !invoke(fun_, cur, last_).first);
+                    if(*cur != *pcur)
+                        return false;
+                    if(++pcur == pend)
+                        return true;
+                } while (++cur != end);
+                return false;
+            }
+#if RANGES_CXX_IF_CONSTEXPR < RANGES_CXX_IF_CONSTEXPR_17
+            constexpr void pre_inc(std::true_type) // Forward
+            {
+                ++current_();
+            }
+            constexpr void pre_inc(std::false_type) // Input
+            {
+                if RANGES_CONSTEXPR_IF (Pattern::size() != 0)
+                    ++current_();
+            }
+            constexpr split_inner_iterator post_inc(std::true_type) // Forward
+            {
+                auto tmp = *this;
+                pre_inc(std::true_type{});
+                return tmp;
+            }
+            constexpr void post_inc(std::false_type) // Input
+            {
+                pre_inc(std::false_type{});
+            }
+#endif
+        public:
+            using iterator_concept = typename Outer::iterator_concept;
+            using iterator_category =
+                if_then_t<
+                    DerivedFrom<BaseIterCategory, ranges::forward_iterator_tag>,
+                    ranges::forward_iterator_tag,
+                    ranges::input_iterator_tag>;
+            using value_type = range_value_t<Base>;
+            using difference_type = range_difference_t<Base>;
+            using reference = range_reference_t<Base>; // Not to spec
+            using pointer = iter_pointer_t<iterator_t<Base>>; // Not to spec
+
+            split_inner_iterator() = default;
+
+            constexpr explicit split_inner_iterator(Outer i)
+              : i_(std::move(i))
+            {}
+
+            constexpr decltype(auto) operator*() const
+            {
+                return *current_();
+            }
+
+            constexpr split_inner_iterator &operator++()
+            {
+                incremented_ = true;
+#if RANGES_CXX_IF_CONSTEXPR >= RANGES_CXX_IF_CONSTEXPR_17
+                if constexpr (!ForwardRange<Base>)
+                    if constexpr (Pattern::size() == 0)
+                        return *this;
+                ++current_();
+#else
+                pre_inc(meta::bool_<ForwardRange<Base>>{});
+#endif
+                return *this;
+            }
+
+            constexpr decltype(auto) operator++(int)
+            {
+#if RANGES_CXX_IF_CONSTEXPR >= RANGES_CXX_IF_CONSTEXPR_17
+                if constexpr (ForwardRange<V>)
+                {
+                    auto tmp = *this;
+                    ++*this;
+                    return tmp;
+                }
+                else
+                    ++*this;
+#else
+                return post_inc(meta::bool_<ForwardRange<V>>{});
+#endif
+            }
+
+            CPP_broken_friend_member
+            friend constexpr
+            auto operator==(split_inner_iterator const &x, split_inner_iterator const &y) ->
+                CPP_broken_friend_ret(bool)(
+                    requires ForwardRange<Base>)
+            {
+                return x.i_.curr_ == y.i_.curr_;
+            }
+            CPP_broken_friend_member
+            friend constexpr
+            auto operator!=(split_inner_iterator const &x, split_inner_iterator const &y) ->
+                CPP_broken_friend_ret(bool)(
+                    requires ForwardRange<Base>)
+            {
+                return x.i_.curr_ != y.i_.curr_;
+            }
+            friend constexpr bool operator==(split_inner_iterator const &x, default_sentinel_t)
+            {
+                return x.done_();
+            }
+            friend constexpr bool operator==(default_sentinel_t, split_inner_iterator const &x)
+            {
+                return x.done_();
+            }
+            friend constexpr bool operator!=(split_inner_iterator const &x, default_sentinel_t)
+            {
+                return !x.done_();
+            }
+            friend constexpr bool operator!=(default_sentinel_t, split_inner_iterator const &x)
+            {
+                return !x.done_();
+            }
+            friend constexpr
+            decltype(auto) iter_move(split_inner_iterator const &i)
+                noexcept(noexcept(ranges::iter_move(i.current_())))
+            {
+                return ranges::iter_move(i.current_());
+            }
+            CPP_broken_friend_member
+            friend constexpr
+            auto iter_swap(split_inner_iterator const &x, split_inner_iterator const &y)
+                noexcept(noexcept(ranges::iter_swap(x.current_(), y.current_()))) ->
+                CPP_broken_friend_ret(void)(
+                    requires IndirectlySwappable<iterator_t<Base>>)
+            {
+                ranges::iter_swap(x.current_(), y.current_());
+            }
+        };
+
+        template<typename It>
+        using split_outer_iterator_base =
+            meta::invoke<here_or_there_<ForwardIterator<It>>, It>;
+
+        template<typename JoinView, bool Const>
+        struct split_outer_iterator;
+
+        template<typename V, typename Pattern, bool Const>
+        struct split_outer_iterator<split_view<V, Pattern>, Const>
+          : split_outer_iterator_base<iterator_t<meta::const_if_c<Const, V>>>
+        {
+        private:
+            friend struct split_inner_iterator<split_view<V, Pattern>, Const>;
+            using Parent = meta::const_if_c<Const, split_view<V, Pattern>>;
+            using Base = meta::const_if_c<Const, V>;
+            using Current = split_outer_iterator_base<iterator_t<Base>>;
+
+            Parent* parent_ = nullptr;
+            constexpr decltype(auto) current_() noexcept
+            {
+                return parent_->current_(*this);
+            }
+            constexpr decltype(auto) current_() const noexcept
+            {
+                return parent_->current_(*this);
+            }
+            constexpr decltype(auto) base_() const noexcept
+            {
+                return (parent_->base_);
+            }
+#if RANGES_CXX_IF_CONSTEXPR < RANGES_CXX_IF_CONSTEXPR_17
+            constexpr split_outer_iterator post_inc(std::true_type) // Forward
+            {
+                auto tmp = *this;
+                ++*this;
+                return tmp;
+            }
+            constexpr void post_inc(std::false_type) // Input
+            {
+                ++*this;
+            }
+#endif
+
+        public:
+            using iterator_concept = if_then_t<
+                ForwardRange<Base>,
+                ranges::forward_iterator_tag,
+                ranges::input_iterator_tag>;
+            using iterator_category = ranges::input_iterator_tag;
+            struct value_type
+            {
+            private:
+                split_outer_iterator i_ = split_outer_iterator();
+            public:
+                value_type() = default;
+                constexpr explicit value_type(split_outer_iterator i)
+                  : i_(std::move(i))
+                {}
+                constexpr split_inner_iterator<split_view<V, Pattern>, Const> begin() const
+                {
+                    return split_inner_iterator<split_view<V, Pattern>, Const>(i_);
+                }
+                constexpr default_sentinel_t end() const
+                {
+                    return default_sentinel;
                 }
             };
-            using reference_ =
-                indirect_view<take_while_view<iota_view<iterator_t<CRng>>, search_pred>>;
-            reference_ read() const
-            {
-                return reference_{{view::iota(cur_), {zero_, cur_, last_, fun_}}};
-            }
-            void next()
-            {
-                RANGES_EXPECT(cur_ != last_);
-                // If the last match consumed zero elements, bump the position.
-                advance(cur_, (int)zero_, last_);
-                zero_ = false;
-                for(; cur_ != last_; ++cur_)
-                {
-                    auto p = invoke(fun_, cur_, last_);
-                    if(p.first)
-                    {
-                        zero_ = (cur_ == p.second);
-                        cur_ = p.second;
-                        return;
-                    }
-                }
-            }
-            bool equal(default_sentinel_t) const
-            {
-                return cur_ == last_;
-            }
-            bool equal(cursor const &that) const
-            {
-                return cur_ == that.cur_;
-            }
-            cursor(fun_ref_t fun, iterator_t<CRng> first, sentinel_t<CRng> last)
-              : cur_(first), last_(last), fun_(fun)
-            {
-                // For skipping an initial zero-length match
-                auto p = invoke(fun, first, ranges::next(first));
-                zero_ = p.first && first == p.second;
-            }
-        public:
-            cursor() = default;
-            template<bool Other>
-            CPP_ctor(cursor)(cursor<Other> that)(
-                requires IsConst && (!Other))
-              : cursor{std::move(that.cur_), std::move(that.last_), std::move(that.fun_)}
+            using difference_type = range_difference_t<Base>;
+            using reference = value_type; // Not to spec
+            using pointer = value_type *; // Not to spec
+
+            split_outer_iterator() = default;
+
+            CPP_member
+            constexpr explicit CPP_ctor(split_outer_iterator)(Parent &parent)(
+                requires (!ForwardRange<Base>))
+              : parent_(&parent)
             {}
+
+            CPP_member
+            constexpr CPP_ctor(split_outer_iterator)(Parent &parent, iterator_t<Base> current)(
+                requires ForwardRange<Base>)
+              : Current{std::move(current)}
+              , parent_(&parent)
+            {}
+
+            template<bool Other>
+            constexpr CPP_ctor(split_outer_iterator)(
+                split_outer_iterator<split_view<V, Pattern>, Other> i)(
+                requires Const && (!Other) && ConvertibleTo<iterator_t<V>, iterator_t<Base>>)
+              : Current{std::move(i.curr_)}
+              , parent_(i.parent_)
+            {}
+
+            constexpr value_type operator*() const
+            {
+                return value_type{*this};
+            }
+
+            constexpr split_outer_iterator &operator++()
+            {
+                auto &current = current_();
+                const auto end = ranges::end(base_());
+                if(current == end)
+                    return *this;
+                auto const pbegin = ranges::begin(parent_->pattern_);
+                auto const pend = ranges::end(parent_->pattern_);
+                if(pbegin == pend)
+                    ++current;
+                else do
+                {
+                    const auto ret = ranges::mismatch(current, end, pbegin, pend);
+                    if(ret.in2 == pend)
+                    {
+                        current = ret.in1; // The pattern matched; skip it
+                        break;
+                    }
+                } while(++current != end);
+                return *this;
+            }
+
+            constexpr decltype(auto) operator++(int)
+            {
+#if RANGES_CXX_IF_CONSTEXPR >= RANGES_CXX_IF_CONSTEXPR_17
+                if constexpr (ForwardRange<Base>)
+                {
+                    auto tmp = *this;
+                    ++*this;
+                    return tmp;
+                }
+                else
+                    ++*this;
+#else
+                return post_inc(meta::bool_<ForwardRange<Base>>{});
+#endif
+            }
+
+            CPP_broken_friend_member
+            friend constexpr
+            auto operator==(split_outer_iterator const &x, split_outer_iterator const &y) ->
+                CPP_broken_friend_ret(bool)(
+                    requires ForwardRange<Base>)
+            {
+                return x.curr_ == y.curr_;
+            }
+            CPP_broken_friend_member
+            friend constexpr
+            auto operator!=(split_outer_iterator const &x, split_outer_iterator const &y) ->
+                CPP_broken_friend_ret(bool)(
+                    requires ForwardRange<Base>)
+            {
+                return x.curr_ != y.curr_;
+            }
+            friend constexpr bool operator==(split_outer_iterator const &x, default_sentinel_t)
+            {
+                return x.current_() == ranges::end(x.base_());
+            }
+            friend constexpr bool operator==(default_sentinel_t, split_outer_iterator const &x)
+            {
+                return x.current_() == ranges::end(x.base_());
+            }
+            friend constexpr bool operator!=(split_outer_iterator const &x, default_sentinel_t)
+            {
+                return x.current_() != ranges::end(x.base_());
+            }
+            friend constexpr bool operator!=(default_sentinel_t, split_outer_iterator const &x)
+            {
+                return x.current_() != ranges::end(x.base_());
+            }
         };
-        cursor<false> begin_cursor()
+    } // namespace detail
+    /// \endcond
+
+    template<typename V, typename Pattern>
+#if CPP_CXX_CONCEPTS
+        requires InputRange<V> && ForwardRange<Pattern> && View<V> && View<Pattern> &&
+            IndirectlyComparable<iterator_t<V>, iterator_t<Pattern>, ranges::equal_to> &&
+            (ForwardRange<V> || detail::tiny_range<Pattern>)
+#endif
+    struct RANGES_EMPTY_BASES split_view
+      : view_interface<split_view<V, Pattern>>
+      , private detail::split_view_base<iterator_t<V>>
+    {
+    private:
+        template<typename, bool> friend struct detail::split_outer_iterator;
+        template<typename, bool> friend struct detail::split_inner_iterator;
+
+        V base_ = V();
+        Pattern pattern_ = Pattern();
+        template<bool Const>
+        using outer_iterator = detail::split_outer_iterator<split_view, Const>;
+
+#if RANGES_CXX_IF_CONSTEXPR < RANGES_CXX_IF_CONSTEXPR_17
+        outer_iterator<simple_view<V>()> begin_(std::true_type)
         {
-            return {fun_, ranges::begin(rng_), ranges::end(rng_)};
+            return outer_iterator<simple_view<V>()>{*this, ranges::begin(base_)};
         }
-        template<typename CRng = Rng const>
-        auto begin_cursor() const -> CPP_ret(cursor<true>)(
-            requires Range<CRng> &&
-                Invocable<Fun const&, iterator_t<CRng>, sentinel_t<CRng>>)
+        outer_iterator<false> begin_(std::false_type)
         {
-            return {fun_, ranges::begin(rng_), ranges::end(rng_)};
+            this->curr_ = ranges::begin(base_);
+            return outer_iterator<false>{*this};
         }
+
+        outer_iterator<simple_view<V>()> end_(std::true_type) const
+        {
+            return outer_iterator<true>{*this, ranges::end(base_)};
+        }
+        default_sentinel_t end_(std::false_type) const
+        {
+            return default_sentinel;
+        }
+#endif
+
     public:
         split_view() = default;
-        split_view(Rng rng, Fun fun)
-          : rng_(std::move(rng))
-          , fun_(std::move(fun))
+
+        constexpr split_view(V base, Pattern pattern)
+          : base_((V &&) base)
+          , pattern_((Pattern &&) pattern)
         {}
+
+        CPP_member
+        constexpr CPP_ctor(split_view)(V base, range_value_t<V> e) (
+            requires Constructible<Pattern, range_value_t<V>>)
+          : base_(std::move(base))
+          , pattern_(e)
+        {}
+
+        constexpr V base() const
+        {
+            return base_;
+        }
+
+        constexpr auto begin()
+        {
+#if RANGES_CXX_IF_CONSTEXPR >= RANGES_CXX_IF_CONSTEXPR_17
+            if constexpr (ForwardRange<V>)
+                return outer_iterator<simple_view<V>()>{*this, ranges::begin(base_)};
+            else
+            {
+                this->curr_ = ranges::begin(base_);
+                return outer_iterator<false>{*this};
+            }
+#else
+            return begin_(meta::bool_<ForwardRange<V>>{});
+#endif
+        }
+        CPP_member
+        constexpr auto begin() const -> CPP_ret(outer_iterator<true>)(
+            requires ForwardRange<V> && ForwardRange<const V>)
+        {
+            return {*this, ranges::begin(base_)};
+        }
+        CPP_member
+        constexpr auto end() -> CPP_ret(outer_iterator<simple_view<V>()>)(
+            requires ForwardRange<V> && CommonRange<V>)
+        {
+            return outer_iterator<simple_view<V>()>{*this, ranges::end(base_)};
+        }
+        constexpr auto end() const
+        {
+#if RANGES_CXX_IF_CONSTEXPR >= RANGES_CXX_IF_CONSTEXPR_17
+            if constexpr (ForwardRange<V> && ForwardRange<const V> && CommonRange<const V>)
+                return outer_iterator<true>{*this, ranges::end(base_)};
+            else
+                return default_sentinel;
+#else
+            return end_(meta::bool_<ForwardRange<V> && ForwardRange<const V> &&
+                CommonRange<const V>>{});
+#endif
+        }
     };
+
+#if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
+    CPP_template(typename R, typename P)(
+        requires InputRange<R> && ForwardRange<P> && ViewableRange<R> && ViewableRange<P> &&
+            IndirectlyComparable<iterator_t<R>, iterator_t<P>, ranges::equal_to> &&
+            (ForwardRange<R> || detail::tiny_range<P>))
+    split_view(R &&, P &&) ->
+        split_view<view::all_t<R>, view::all_t<P>>;
+
+    CPP_template(typename R)(
+        requires InputRange<R>)
+    split_view(R &&, range_value_t<R>) ->
+        split_view<view::all_t<R>, single_view<range_value_t<R>>>;
+#endif
 
     namespace view
     {
-        CPP_def
-        (
-            template(typename Rng, typename Fun)
-            concept SplitOnFunction,
-                ForwardRange<Rng> &&
-                Invocable<Fun&, iterator_t<Rng>, sentinel_t<Rng>> &&
-                Invocable<Fun&, iterator_t<Rng>, iterator_t<Rng>> &&
-                CopyConstructible<Fun> &&
-                ConvertibleTo<
-                    invoke_result_t<Fun&, iterator_t<Rng>, sentinel_t<Rng>>,
-                    std::pair<bool, iterator_t<Rng>>>
-        );
-        CPP_def
-        (
-            template(typename Rng, typename Fun)
-            concept SplitOnPredicate,
-                ForwardRange<Rng> &&
-                Predicate<Fun const&, range_reference_t<Rng>> &&
-                CopyConstructible<Fun>
-        );
-        CPP_def
-        (
-            template(typename Rng)
-            concept SplitOnElement,
-                ForwardRange<Rng> &&
-                Regular<range_value_t<Rng>>
-        );
-        CPP_def
-        (
-            template(typename Rng, typename Sub)
-            concept SplitOnSubRange,
-                ForwardRange<Rng> &&
-                ForwardRange<Sub> &&
-                EqualityComparableWith<range_value_t<Rng>, range_value_t<Sub>>
-        );
-
         struct split_fn
         {
         private:
@@ -188,95 +560,25 @@ namespace ranges
                 return make_pipeable(std::bind(split, std::placeholders::_1,
                     bind_forward<T>(t)));
             }
-            template<typename Rng, typename Pred>
-            struct predicate_pred
-            {
-                semiregular_t<Pred> pred_;
-
-                template<typename S>
-                auto operator()(iterator_t<Rng> cur, S end) const ->
-                    CPP_ret(std::pair<bool, iterator_t<Rng>>)(
-                        requires Sentinel<S, iterator_t<Rng>>)
-                {
-                    auto where = ranges::find_if_not(cur, end, std::ref(pred_));
-                    return std::pair<bool, iterator_t<Rng>>{cur != where, where};
-                }
-            };
-            template<typename Rng>
-            struct element_pred
-            {
-                range_value_t<Rng> val_;
-
-                template<typename S>
-                auto operator()(iterator_t<Rng> cur, S end) const ->
-                    CPP_ret(std::pair<bool, iterator_t<Rng>>)(
-                        requires Sentinel<S, iterator_t<Rng>>)
-                {
-                    RANGES_EXPECT(cur != end);
-                    bool const match = *cur == val_;
-                    if (match) ++cur;
-                    return std::pair<bool, iterator_t<Rng>>{match, cur};
-                }
-            };
-            template<typename Rng, typename Sub>
-            struct subrange_pred
-            {
-                all_t<Sub> sub_;
-                range_difference_t<Sub> len_;
-
-                subrange_pred() = default;
-                subrange_pred(Sub &&sub)
-                  : sub_(all(static_cast<Sub &&>(sub))), len_(distance(sub_))
-                {}
-                template<typename S>
-                auto operator()(iterator_t<Rng> cur, S end) const ->
-                    CPP_ret(std::pair<bool, iterator_t<Rng>>)(
-                        requires Sentinel<S, iterator_t<Rng>>)
-                {
-                    using P = std::pair<bool, iterator_t<Rng>>;
-                    RANGES_EXPECT(cur != end);
-                    if((bool) SizedSentinel<S, iterator_t<Rng>> && distance(cur, end) < len_)
-                        return P{false, cur};
-                    auto pat_cur = ranges::begin(sub_);
-                    auto pat_end = ranges::end(sub_);
-                    for(;; ++cur, ++pat_cur)
-                    {
-                        if(pat_cur == pat_end)
-                            return P{true, cur};
-                        if(cur == end || !(*cur == *pat_cur))
-                            return P{false, cur};
-                    }
-                }
-            };
         public:
-            template<typename Rng, typename Fun>
-            auto operator()(Rng &&rng, Fun fun) const ->
-                CPP_ret(split_view<all_t<Rng>, Fun>)(
-                    requires ViewableRange<Rng> && SplitOnFunction<Rng, Fun>)
-            {
-                return {all(static_cast<Rng &&>(rng)), std::move(fun)};
-            }
-            template<typename Rng, typename Fun>
-            auto operator()(Rng &&rng, Fun fun) const ->
-                CPP_ret(split_view<all_t<Rng>, predicate_pred<Rng, Fun>>)(
-                    requires ViewableRange<Rng> && SplitOnPredicate<Rng, Fun>)
-            {
-                return {all(static_cast<Rng &&>(rng)),
-                        predicate_pred<Rng, Fun>{std::move(fun)}};
-            }
             template<typename Rng>
-            auto operator()(Rng &&rng, range_value_t<Rng> val) const ->
-                CPP_ret(split_view<all_t<Rng>, element_pred<Rng>>)(
-                    requires ViewableRange<Rng> && SplitOnElement<Rng>)
+            constexpr auto operator()(Rng &&rng, range_value_t<Rng> val) const ->
+                CPP_ret(split_view<all_t<Rng>, single_view<range_value_t<Rng>>>)(
+                    requires ViewableRange<Rng> && InputRange<Rng> &&
+                        IndirectlyComparable<iterator_t<Rng>, range_value_t<Rng> const *, ranges::equal_to>)
             {
-                return {all(static_cast<Rng &&>(rng)), {std::move(val)}};
+                return {all(static_cast<Rng &&>(rng)), single(std::move(val))};
             }
-            template<typename Rng, typename Sub>
-            auto operator()(Rng &&rng, Sub &&sub) const ->
-                CPP_ret(split_view<all_t<Rng>, subrange_pred<Rng, Sub>>)(
-                    requires ViewableRange<Rng> && SplitOnSubRange<Rng, Sub>)
+
+            template<typename Rng, typename Pattern>
+            constexpr auto operator()(Rng &&rng, Pattern &&pattern) const ->
+                CPP_ret(split_view<all_t<Rng>, all_t<Pattern>>)(
+                    requires ViewableRange<Rng> && InputRange<Rng> &&
+                        ViewableRange<Pattern> && ForwardRange<Pattern> &&
+                        IndirectlyComparable<iterator_t<Rng>, iterator_t<Pattern>, ranges::equal_to> &&
+                        (ForwardRange<Rng> || detail::tiny_range<Pattern>))
             {
-                return {all(static_cast<Rng &&>(rng)), {static_cast<Sub &&>(sub)}};
+                return {all((Rng &&) rng), all((Pattern &&) pattern)};
             }
         };
 

--- a/include/range/v3/view/split_with.hpp
+++ b/include/range/v3/view/split_with.hpp
@@ -1,0 +1,201 @@
+/// \file
+// Range v3 library
+//
+//  Copyright Eric Niebler 2013-present
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#ifndef RANGES_V3_VIEW_SPLIT_WITH_HPP
+#define RANGES_V3_VIEW_SPLIT_WITH_HPP
+
+#include <utility>
+#include <type_traits>
+#include <meta/meta.hpp>
+#include <range/v3/detail/satisfy_boost_range.hpp>
+#include <range/v3/range_fwd.hpp>
+#include <range/v3/begin_end.hpp>
+#include <range/v3/range_traits.hpp>
+#include <range/v3/range_concepts.hpp>
+#include <range/v3/view_facade.hpp>
+#include <range/v3/algorithm/find_if_not.hpp>
+#include <range/v3/utility/static_const.hpp>
+#include <range/v3/view/view.hpp>
+#include <range/v3/view/all.hpp>
+#include <range/v3/view/indirect.hpp>
+#include <range/v3/view/iota.hpp>
+#include <range/v3/view/take_while.hpp>
+
+namespace ranges
+{
+    /// \addtogroup group-views
+    /// @{
+
+    template<typename Rng, typename Fun>
+    struct split_with_view
+      : view_facade<
+            split_with_view<Rng, Fun>,
+            is_finite<Rng>::value ? finite : range_cardinality<Rng>::value>
+    {
+    private:
+        friend range_access;
+        Rng rng_;
+        semiregular_t<Fun> fun_;
+
+        template<bool IsConst>
+        struct cursor
+        {
+        private:
+            friend range_access;
+            friend split_with_view;
+            friend struct cursor<!IsConst>;
+            bool zero_;
+            using CRng = meta::const_if_c<IsConst, Rng>;
+            iterator_t<CRng> cur_;
+            sentinel_t<CRng> last_;
+            using fun_ref_t = semiregular_ref_or_val_t<Fun, IsConst>;
+            fun_ref_t fun_;
+
+            struct search_pred
+            {
+                bool zero_;
+                iterator_t<CRng> first_;
+                sentinel_t<CRng> last_;
+                fun_ref_t fun_;
+                bool operator()(iterator_t<CRng> cur) const
+                {
+                    return (zero_ && cur == first_) || (cur != last_ && !invoke(fun_, cur, last_).first);
+                }
+            };
+            using reference_ =
+                indirect_view<take_while_view<iota_view<iterator_t<CRng>>, search_pred>>;
+            reference_ read() const
+            {
+                return reference_{{view::iota(cur_), {zero_, cur_, last_, fun_}}};
+            }
+            void next()
+            {
+                RANGES_EXPECT(cur_ != last_);
+                // If the last match consumed zero elements, bump the position.
+                advance(cur_, (int)zero_, last_);
+                zero_ = false;
+                for(; cur_ != last_; ++cur_)
+                {
+                    auto p = invoke(fun_, cur_, last_);
+                    if(p.first)
+                    {
+                        zero_ = (cur_ == p.second);
+                        cur_ = p.second;
+                        return;
+                    }
+                }
+            }
+            bool equal(default_sentinel_t) const
+            {
+                return cur_ == last_;
+            }
+            bool equal(cursor const &that) const
+            {
+                return cur_ == that.cur_;
+            }
+            cursor(fun_ref_t fun, iterator_t<CRng> first, sentinel_t<CRng> last)
+              : cur_(first), last_(last), fun_(fun)
+            {
+                // For skipping an initial zero-length match
+                auto p = invoke(fun, first, ranges::next(first));
+                zero_ = p.first && first == p.second;
+            }
+        public:
+            cursor() = default;
+            template<bool Other>
+            CPP_ctor(cursor)(cursor<Other> that)(
+                requires IsConst && (!Other))
+              : cursor{std::move(that.cur_), std::move(that.last_), std::move(that.fun_)}
+            {}
+        };
+        cursor<false> begin_cursor()
+        {
+            return {fun_, ranges::begin(rng_), ranges::end(rng_)};
+        }
+        template<typename CRng = Rng const>
+        auto begin_cursor() const -> CPP_ret(cursor<true>)(
+            requires Range<CRng> &&
+                Invocable<Fun const&, iterator_t<CRng>, sentinel_t<CRng>>)
+        {
+            return {fun_, ranges::begin(rng_), ranges::end(rng_)};
+        }
+    public:
+        split_with_view() = default;
+        split_with_view(Rng rng, Fun fun)
+          : rng_(std::move(rng))
+          , fun_(std::move(fun))
+        {}
+    };
+
+    namespace view
+    {
+        struct split_with_fn
+        {
+        private:
+            friend view_access;
+            template<typename T>
+            static auto bind(split_with_fn split_with, T &&t)
+            {
+                return make_pipeable(std::bind(split_with, std::placeholders::_1,
+                    bind_forward<T>(t)));
+            }
+            template<typename Pred>
+            struct predicate_pred
+            {
+                semiregular_t<Pred> pred_;
+
+                template<typename I, typename S>
+                auto operator()(I cur, S end) const ->
+                    CPP_ret(std::pair<bool, I>)(
+                        requires Sentinel<S, I>)
+                {
+                    auto where = ranges::find_if_not(cur, end, std::ref(pred_));
+                    return {cur != where, where};
+                }
+            };
+        public:
+            template<typename Rng, typename Fun>
+            auto operator()(Rng &&rng, Fun fun) const ->
+                CPP_ret(split_with_view<all_t<Rng>, Fun>)(
+                    requires ViewableRange<Rng> && ForwardRange<Rng> &&
+                        Invocable<Fun&, iterator_t<Rng>, sentinel_t<Rng>> &&
+                        Invocable<Fun&, iterator_t<Rng>, iterator_t<Rng>> &&
+                        CopyConstructible<Fun> &&
+                        ConvertibleTo<
+                            invoke_result_t<Fun&, iterator_t<Rng>, sentinel_t<Rng>>,
+                            std::pair<bool, iterator_t<Rng>>>)
+            {
+                return {all(static_cast<Rng &&>(rng)), std::move(fun)};
+            }
+            template<typename Rng, typename Fun>
+            auto operator()(Rng &&rng, Fun fun) const ->
+                CPP_ret(split_with_view<all_t<Rng>, predicate_pred<Fun>>)(
+                    requires ViewableRange<Rng> && ForwardRange<Rng> &&
+                        Predicate<Fun const&, range_reference_t<Rng>> &&
+                        CopyConstructible<Fun>)
+            {
+                return {all(static_cast<Rng &&>(rng)),
+                        predicate_pred<Fun>{std::move(fun)}};
+            }
+        };
+
+        /// \relates split_with_fn
+        /// \ingroup group-views
+        RANGES_INLINE_VARIABLE(view<split_with_fn>, split_with)
+    }
+    /// @}
+}
+
+RANGES_SATISFY_BOOST_RANGE(::ranges::split_with_view)
+
+#endif

--- a/include/range/v3/view/take.hpp
+++ b/include/range/v3/view/take.hpp
@@ -106,7 +106,7 @@ namespace ranges
         {
             return ranges::begin(take.base_) + static_cast<range_difference_t<Rng>>(take.size());
         }
-        static auto end_random_access_(detail::any, std::false_type)
+        static auto end_random_access_(detail::ignore_t, std::false_type)
         {
             return default_sentinel;
         }
@@ -117,7 +117,7 @@ namespace ranges
                 take,
                 meta::bool_<RandomAccessRange<decltype((take.base_))>>{});
         }
-        static auto end_sized_(detail::any, std::false_type, std::true_type) // infinite
+        static auto end_sized_(detail::ignore_t, std::false_type, std::true_type) // infinite
         {
             return default_sentinel;
         }

--- a/include/range/v3/view/transform.hpp
+++ b/include/range/v3/view/transform.hpp
@@ -176,7 +176,7 @@ namespace ranges
             sentinel_t<Rng2> end2_;
         public:
             sentinel() = default;
-            sentinel(detail::any, sentinel_t<Rng1> end1, sentinel_t<Rng2> end2)
+            sentinel(detail::ignore_t, sentinel_t<Rng1> end1, sentinel_t<Rng2> end2)
               : end1_(std::move(end1)), end2_(std::move(end2))
             {}
         };

--- a/include/range/v3/view/zip_with.hpp
+++ b/include/range/v3/view/zip_with.hpp
@@ -173,7 +173,7 @@ namespace ranges
             std::tuple<sentinel_t<meta::const_if_c<Const, Rngs>>...> ends_;
         public:
             sentinel() = default;
-            sentinel(detail::any, std::tuple<sentinel_t<meta::const_if_c<Const, Rngs>>...> ends)
+            sentinel(detail::ignore_t, std::tuple<sentinel_t<meta::const_if_c<Const, Rngs>>...> ends)
               : ends_(std::move(ends))
             {}
             template<bool Other>

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -111,7 +111,7 @@ namespace ranges
         adaptor_base &operator=(adaptor_base &&) = default;
         adaptor_base &operator=(adaptor_base const &) = default;
 
-        adaptor_base(detail::any, detail::any = {}, detail::any = {})
+        adaptor_base(detail::ignore_t, detail::ignore_t = {}, detail::ignore_t = {})
         {}
         template<typename Rng>
         static constexpr auto CPP_auto_fun(begin)(Rng &rng)
@@ -363,7 +363,7 @@ namespace ranges
         template<typename A = Adapt,
             typename R = decltype(std::declval<A const &>().read(std::declval<BaseIter const &>())),
             typename X = aux::move_t<R>>
-        X iter_move_(detail::any) const
+        X iter_move_(detail::ignore_t) const
             noexcept(noexcept(X(static_cast<X &&>(
                 std::declval<A const &>().read(std::declval<BaseIter const &>())))))
         {

--- a/test/action/split.cpp
+++ b/test/action/split.cpp
@@ -14,6 +14,7 @@
 #include <range/v3/view/c_str.hpp>
 #include <range/v3/algorithm/move.hpp>
 #include <range/v3/action/split.hpp>
+#include <range/v3/action/split_with.hpp>
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 
@@ -28,7 +29,7 @@ int main()
     ::check_equal(rgv[1], {11,12,13,14,15,16,17,18,19,20});
 
     using I = std::vector<int>::iterator;
-    std::vector<std::vector<int>> rgv2 = action::split(v, [](I b, I){return std::make_pair(0 == (*b)%2,next(b));});
+    std::vector<std::vector<int>> rgv2 = action::split_with(v, [](I b, I){return std::make_pair(0 == (*b)%2,next(b));});
     CHECK(rgv2.size() == 10u);
     ::check_equal(rgv2[0], {1});
     ::check_equal(rgv2[1], {3});
@@ -57,7 +58,7 @@ int main()
 
     {
         std::string str("now  is \t the\ttime");
-        auto toks = action::split(str, (int(*)(int))&std::isspace);
+        auto toks = action::split_with(str, (int(*)(int))&std::isspace);
         static_assert(std::is_same<decltype(toks), std::vector<std::string>>::value, "");
         CHECK(toks.size() == 4u);
         if(toks.size() == 4u)

--- a/test/view/join.cpp
+++ b/test/view/join.cpp
@@ -18,6 +18,7 @@
 #include <range/v3/view/generate_n.hpp>
 #include <range/v3/view/repeat_n.hpp>
 #include <range/v3/view/concat.hpp>
+#include <range/v3/view/iota.hpp>
 #include <range/v3/view/single.hpp>
 #include <range/v3/view/transform.hpp>
 #include <range/v3/view/filter.hpp>

--- a/test/view/split.cpp
+++ b/test/view/split.cpp
@@ -11,17 +11,24 @@
 
 #include <string>
 #include <cctype>
+#include <sstream>
 #include <range/v3/core.hpp>
 #include <range/v3/view/counted.hpp>
 #include <range/v3/view/c_str.hpp>
 #include <range/v3/view/empty.hpp>
 #include <range/v3/view/remove_if.hpp>
 #include <range/v3/view/split.hpp>
+#include <range/v3/view/split_with.hpp>
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
 
 RANGES_DIAGNOSTIC_IGNORE_SIGN_CONVERSION
+
+#if defined(__clang__) && __clang_major__ < 6
+// Workaround https://bugs.llvm.org/show_bug.cgi?id=33314
+RANGES_DIAGNOSTIC_IGNORE_UNDEFINED_FUNC_TEMPLATE
+#endif
 
 namespace
 {
@@ -38,6 +45,230 @@ namespace
     ranges::subrange<char const*> c_str(char const (&sz)[N])
     {
         return {&sz[0], &sz[N-1]};
+    }
+}
+
+void moar_tests()
+{
+    using namespace ranges;
+    std::string greeting = "now is the time";
+    std::string pattern = " ";
+
+    {
+#if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
+        split_view sv{greeting, pattern};
+#else
+        split_view<view::all_t<std::string&>, view::all_t<std::string&>> sv{greeting, pattern};
+#endif
+        auto i = sv.begin();
+        check_equal(*i, {'n','o','w'});
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, {'i','s'});
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, {'t','h','e'});
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, {'t','i','m','e'});
+        ++i;
+        CHECK(i == sv.end());
+
+        using R = decltype(sv);
+        CPP_assert(ForwardRange<R>);
+        CPP_assert(ForwardRange<R const>);
+    }
+
+    {
+#if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
+        split_view sv{greeting, ' '};
+#else
+        split_view<view::all_t<std::string&>, single_view<char>> sv{greeting, ' '};
+#endif
+        auto i = sv.begin();
+        CHECK(i != sv.end());
+        check_equal(*i, {'n','o','w'});
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, {'i','s'});
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, {'t','h','e'});
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, {'t','i','m','e'});
+        ++i;
+        CHECK(i == sv.end());
+
+        using R = decltype(sv);
+        CPP_assert(ForwardRange<R>);
+        CPP_assert(ForwardRange<R const>);
+    }
+
+    {
+        std::stringstream sin{greeting};
+#if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
+        auto rng = subrange{
+            std::istreambuf_iterator<char>{sin},
+            std::istreambuf_iterator<char>{}};
+#else
+        auto rng = make_subrange(
+            std::istreambuf_iterator<char>{sin},
+            std::istreambuf_iterator<char>{});
+#endif
+
+        auto sv = view::split(rng, ' ');
+        auto i = sv.begin();
+        CHECK(i != sv.end());
+        check_equal(*i, {'n','o','w'});
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, {'i','s'});
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, {'t','h','e'});
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, {'t','i','m','e'});
+        ++i;
+        CHECK(i == sv.end());
+
+        using R = decltype(sv);
+        CPP_assert(InputRange<R>);
+        CPP_assert(!ForwardRange<R>);
+        CPP_assert(!InputRange<R const>);
+    }
+
+    {
+        std::string list{"eggs,milk,,butter"};
+        auto sv = view::split(list, ',');
+        auto i = sv.begin();
+        CHECK(i != sv.end());
+        check_equal(*i, {'e','g','g','s'});
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, {'m','i','l','k'});
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, view::empty<char>);
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, {'b','u','t','t','e','r'});
+        ++i;
+        CHECK(i == sv.end());
+    }
+
+    {
+        std::string list{"eggs,milk,,butter"};
+        std::stringstream sin{list};
+        auto rng = make_subrange(
+            std::istreambuf_iterator<char>{sin},
+            std::istreambuf_iterator<char>{});
+        auto sv = rng | view::split(',');
+        auto i = sv.begin();
+        CHECK(i != sv.end());
+        check_equal(*i, {'e','g','g','s'});
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, {'m','i','l','k'});
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, view::empty<char>);
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, {'b','u','t','t','e','r'});
+        ++i;
+        CHECK(i == sv.end());
+    }
+
+    {
+        std::string hello("hello");
+        auto sv = view::split(hello, view::empty<char>);
+        auto i = sv.begin();
+        CHECK(i != sv.end());
+        check_equal(*i, single_view<char>{'h'});
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, single_view<char>{'e'});
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, single_view<char>{'l'});
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, single_view<char>{'l'});
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, single_view<char>{'o'});
+        ++i;
+        CHECK(i == sv.end());
+    }
+
+    {
+        std::string hello{"hello"};
+        std::stringstream sin{hello};
+        auto rng = make_subrange(
+            std::istreambuf_iterator<char>{sin},
+            std::istreambuf_iterator<char>{});
+        auto sv = view::split(rng, view::empty<char>);
+        auto i = sv.begin();
+        CHECK(i != sv.end());
+        check_equal(*i, single_view<char>{'h'});
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, single_view<char>{'e'});
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, single_view<char>{'l'});
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, single_view<char>{'l'});
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, single_view<char>{'o'});
+        ++i;
+        CHECK(i == sv.end());
+    }
+
+    {
+        std::string hello{"hello"};
+        auto sv = view::split(hello, view::empty<char>);
+        auto i = sv.begin();
+        CHECK(i != sv.end());
+        ++i;
+        CHECK(i != sv.end());
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, single_view<char>{'l'});
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, single_view<char>{'l'});
+        ++i;
+        CHECK(i != sv.end());
+        ++i;
+        CHECK(i == sv.end());
+    }
+
+    {
+        std::string hello{"hello"};
+        std::stringstream sin{hello};
+        auto rng = make_subrange(
+            std::istreambuf_iterator<char>{sin},
+            std::istreambuf_iterator<char>{});
+        auto sv = view::split(rng, view::empty<char>);
+        auto i = sv.begin();
+        CHECK(i != sv.end());
+        ++i;
+        CHECK(i != sv.end());
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, single_view<char>{'l'});
+        ++i;
+        CHECK(i != sv.end());
+        check_equal(*i, single_view<char>{'l'});
+        ++i;
+        CHECK(i != sv.end());
+        ++i;
+        CHECK(i == sv.end());
     }
 }
 
@@ -97,7 +328,7 @@ int main()
 
     {
         std::string str("Now is the time for all ggood men to come to the aid of their country.");
-        auto rng = view::split(str, starts_with_g{});
+        auto rng = view::split_with(str, starts_with_g{});
         CHECK(distance(rng) == 3);
         if(distance(rng) == 3)
         {
@@ -110,7 +341,7 @@ int main()
     {
         std::string str("Now is the time for all ggood men to come to the aid of their country.");
         forward_iterator<std::string::iterator> i {str.begin()};
-        auto rng = view::counted(i, str.size()) | view::split(starts_with_g{});
+        auto rng = view::counted(i, str.size()) | view::split_with(starts_with_g{});
         CHECK(distance(rng) == 3);
         if(distance(rng) == 3)
         {
@@ -134,18 +365,18 @@ int main()
     }
 
     {
-      int a[] = {0, 2, 3, 1, 4, 5, 1, 6, 7};
-      auto rng = a | view::remove_if([](int i) { return i % 2 == 0; });
-      auto srng = view::split(rng, 1);
-      CHECK(distance(srng) == 3);
-      check_equal(*begin(srng), {3});
-      check_equal(*next(begin(srng), 1), {5});
-      check_equal(*next(begin(srng), 2), {7});
+        int a[] = {0, 2, 3, 1, 4, 5, 1, 6, 7};
+        auto rng = a | view::remove_if([](int i) { return i % 2 == 0; });
+        auto srng = view::split(rng, 1);
+        CHECK(distance(srng) == 3);
+        check_equal(*begin(srng), {3});
+        check_equal(*next(begin(srng), 1), {5});
+        check_equal(*next(begin(srng), 2), {7});
     }
 
     {
         std::string str("now  is \t the\ttime");
-        auto rng = view::split(str, (int(*)(int))&std::isspace);
+        auto rng = view::split_with(str, (int(*)(int))&std::isspace);
         CHECK(distance(rng) == 4);
         if(distance(rng) == 4)
         {
@@ -161,6 +392,8 @@ int main()
         auto rng = view::c_str(str) | view::split(' ');
         CPP_assert(ForwardRange<decltype(rng)>);
     }
+
+    moar_tests();
 
     return test_result();
 }


### PR DESCRIPTION
* break `view::split` and `action::split` into `split` and `split_with`
* `view::split` conforms to C++20