### PR TITLE
min,max,minmax: properly accept initializer_lists

### DIFF
--- a/include/range/v3/algorithm/max.hpp
+++ b/include/range/v3/algorithm/max.hpp
@@ -59,12 +59,12 @@ namespace ranges
         }
 
         template<typename T, typename C = less, typename P = identity>
-        constexpr /*c++14*/ auto operator()(std::initializer_list<T> rng, C pred = C{},
+        constexpr /*c++14*/ auto operator()(std::initializer_list<T> const &&rng, C pred = C{},
                 P proj = P{}) const ->
             CPP_ret(T)(
                 requires Copyable<T> && IndirectStrictWeakOrder<C, projected<T const *, P>>)
         {
-            return (*this)(rng.begin(), rng.end(), std::move(pred), std::move(proj));
+            return (*this)(rng, std::move(pred), std::move(proj));
         }
     };
 

--- a/include/range/v3/algorithm/min.hpp
+++ b/include/range/v3/algorithm/min.hpp
@@ -59,12 +59,12 @@ namespace ranges
         }
 
         template<typename T, typename C = less, typename P = identity>
-        constexpr /*c++14*/ auto operator()(std::initializer_list<T> rng, C pred = C{},
+        constexpr /*c++14*/ auto operator()(std::initializer_list<T> const &&rng, C pred = C{},
                 P proj = P{}) const ->
             CPP_ret(T)(
                 requires Copyable<T> && IndirectStrictWeakOrder<C, projected<T const *, P>>)
         {
-            return (*this)(rng.begin(), rng.end(), std::move(pred), std::move(proj));
+            return (*this)(rng, std::move(pred), std::move(proj));
         }
     };
 

--- a/include/range/v3/algorithm/minmax.hpp
+++ b/include/range/v3/algorithm/minmax.hpp
@@ -97,12 +97,12 @@ namespace ranges
         }
 
         template<typename T, typename C = less, typename P = identity>
-        constexpr /*c++14*/ auto operator()(std::initializer_list<T> rng, C pred = C{},
+        constexpr /*c++14*/ auto operator()(std::initializer_list<T> const &&rng, C pred = C{},
                 P proj = P{}) const ->
             CPP_ret(minmax_result<T>)(
                 requires Copyable<T> && IndirectStrictWeakOrder<C, projected<T const *, P>>)
         {
-            return (*this)(rng.begin(), rng.end(), std::move(pred), std::move(proj));
+            return (*this)(rng, std::move(pred), std::move(proj));
         }
     };
 

--- a/test/algorithm/max.cpp
+++ b/test/algorithm/max.cpp
@@ -135,5 +135,8 @@ int main()
     S v = ranges::max(s, std::less<int>{}, &S::i);
     CHECK(v.i == 40);
 
+    // Works with initializer_lists? (Regression test for #1004)
+    CHECK(ranges::max({4,3,1,2,6,5}) == 6);
+
     return test_result();
 }

--- a/test/algorithm/min.cpp
+++ b/test/algorithm/min.cpp
@@ -134,5 +134,8 @@ int main()
     S v = ranges::min(s, std::less<int>{}, &S::i);
     CHECK(v.i == -4);
 
+    // Works with initializer_lists? (Regression test for #1004)
+    CHECK(ranges::min({4,3,1,2,6,5}) == 1);
+
     return test_result();
 }

--- a/test/algorithm/minmax.cpp
+++ b/test/algorithm/minmax.cpp
@@ -164,5 +164,8 @@ int main()
     CHECK(res.max.value == 40);
     CHECK(res.max.index == 7);
 
+    // Works with initializer_lists? (Regression test for #1004)
+    CHECK(ranges::minmax({4,3,1,2,6,5}) == ranges::minmax_result<int>{1,6});
+
     return test_result();
 }


### PR DESCRIPTION
... instead of trying to return the min/max/minmax iterator values.

Fixes #1004.