### PR TITLE
partial_sum_view refactor:

### DIFF
--- a/test/view/partial_sum.cpp
+++ b/test/view/partial_sum.cpp
@@ -25,7 +25,7 @@ int main()
 
     int rgi[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
-    auto && rng = rgi | view::partial_sum;
+    auto rng = rgi | view::partial_sum;
     has_type<int &>(*begin(rgi));
     has_type<int>(*begin(rng));
     models<SizedViewConcept>(aux::copy(rng));


### PR DESCRIPTION
* Replace bogus `ConvertibleTo<invoke_result_t, range_value_t>` constraint
* Don't use `view_adaptor`
* `RANGES_UNIQUE_ADDRESS` all the things
* Never model `CommonRange`. There's little to be gained by making a forward range common, and doing so harms perf on the benchmark (https://stackoverflow.com/questions/44413446/why-is-range-v3-slower-than-the-stl-in-this-example).

This brings the slowdown relative to STL in the benchmark down to 1.6x, which seems to be the best we can do: my "put everything in the iterator" investigations were actually slower. I'll let you decide if this is good enough to close #668.