### PR TITLE
make semiregular copy constructor be conditionally noexcept

### DIFF
--- a/include/range/v3/utility/semiregular.hpp
+++ b/include/range/v3/utility/semiregular.hpp
@@ -116,6 +116,7 @@ namespace ranges
                 this->construct_from(detail::move(that.data_));
         }
         semiregular(semiregular const &that)
+            noexcept(std::is_nothrow_copy_constructible<T>::value)
         {
             if (that.engaged_)
                 this->construct_from(that.data_);


### PR DESCRIPTION
I got some broken-ness through changing to v1.0-beta which this little patch resolves. I assume the conditional noexcept was just forgotten?