### PR TITLE
More MSVC 1.0 work

### DIFF
--- a/include/concepts/concepts.hpp
+++ b/include/concepts/concepts.hpp
@@ -46,6 +46,7 @@
 #if defined(_MSC_VER) && !defined(__clang__)
 #define CPP_WORKAROUND_MSVC_779763 // FATAL_UNREACHABLE calling constexpr function via template parameter
 #define CPP_WORKAROUND_MSVC_780775 // Incorrect substitution in function template return type
+#define CPP_WORKAROUND_MSVC_784772 // Failure to invoke *explicit* bool conversion in a constant expression
 #endif
 
 #if !defined(CPP_CXX_CONCEPTS)
@@ -136,6 +137,12 @@ CPP_PP_IGNORE_CXX2A_COMPAT_BEGIN
         "Concept assertion failed : " #__VA_ARGS__)                             \
     /**/
 #define CPP_assert_msg static_assert
+
+#ifdef CPP_WORKAROUND_MSVC_784772
+#define CPP_EXPLICIT /**/
+#else
+#define CPP_EXPLICIT explicit
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // CPP_def
@@ -229,7 +236,7 @@ CPP_PP_IGNORE_CXX2A_COMPAT_BEGIN
         CPP_PP_CAT(CPP_PP_DEF_, TPARAM)                                         \
         struct Eval {                                                           \
             using Concept = CPP_PP_CAT(NAME, Concept);                          \
-            explicit constexpr operator bool() const noexcept {                 \
+            CPP_EXPLICIT constexpr operator bool() const noexcept {                 \
                 return (bool) _eager_::NAME<CPP_PP_EXPAND ARGS>;                \
             }                                                                   \
             constexpr auto operator!() const noexcept {                         \
@@ -292,7 +299,7 @@ CPP_PP_IGNORE_CXX2A_COMPAT_BEGIN
         struct Eval {                                                           \
             CPP_PP_DECL_DEF_IMPL_HACK(ARGS)                                     \
             static constexpr bool impl(long) noexcept { return false; }         \
-            explicit constexpr operator bool() const noexcept {                 \
+            CPP_EXPLICIT constexpr operator bool() const noexcept {                 \
                 return Eval::impl(0);                                           \
             }                                                                   \
             constexpr auto operator!() const noexcept {                         \
@@ -682,7 +689,7 @@ namespace concepts
         template<typename T>
         struct Not
         {
-            explicit constexpr operator bool() const noexcept
+            CPP_EXPLICIT constexpr operator bool() const noexcept
             {
                 return !(bool) T{};
             }
@@ -707,7 +714,7 @@ namespace concepts
             {
                 return (bool) U{};
             }
-            explicit constexpr operator bool() const noexcept
+            CPP_EXPLICIT constexpr operator bool() const noexcept
             {
                 return And::impl(bool_<(bool) T{}>{});
             }

--- a/include/concepts/concepts.hpp
+++ b/include/concepts/concepts.hpp
@@ -146,7 +146,7 @@ CPP_PP_IGNORE_CXX2A_COMPAT_BEGIN
 
 ////////////////////////////////////////////////////////////////////////////////
 // CPP_def
-//   For defining concepts with a syntax symilar to C++20. For example:
+//   For defining concepts with a syntax similar to C++20. For example:
 //
 //     CPP_def(
 //         // The Assignable concept from the C++20

--- a/include/range/v3/view/transform.hpp
+++ b/include/range/v3/view/transform.hpp
@@ -383,9 +383,9 @@ namespace ranges
           , rng1_(std::move(rng1))
           , rng2_(std::move(rng2))
         {}
-        CPP_member
-        static constexpr auto size() -> CPP_ret(size_type_)(
+        CPP_template(int = 42)(
             requires my_cardinality >= 0)
+        static constexpr size_type_ size()
         {
             return static_cast<size_type_>(my_cardinality);
         }


### PR DESCRIPTION
* [NFC] Remove unused `_concepts_int_` type alias
* Workaround MSVC's aversion to `explicit operator bool` in constant expressions.

This raises the bar from 6% tests passing to 32% (With VS2019 + not-yet-released bugfix)