### PR TITLE
split_when_view: fix bogus initial-zero-match check in cursor constructor

### DIFF
--- a/include/range/v3/view/split_when.hpp
+++ b/include/range/v3/view/split_when.hpp
@@ -84,8 +84,11 @@ namespace ranges
             {
                 RANGES_EXPECT(cur_ != last_);
                 // If the last match consumed zero elements, bump the position.
-                advance(cur_, (int)zero_, last_);
-                zero_ = false;
+                if(zero_)
+                {
+                    zero_ = false;
+                    ++cur_;
+                }
                 for(; cur_ != last_; ++cur_)
                 {
                     auto p = invoke(fun_, cur_, last_);
@@ -109,7 +112,7 @@ namespace ranges
               : cur_(first), last_(last), fun_(fun)
             {
                 // For skipping an initial zero-length match
-                auto p = invoke(fun, first, ranges::next(first));
+                auto p = invoke(fun, first, last);
                 zero_ = p.first && first == p.second;
             }
         public:

--- a/test/view/split.cpp
+++ b/test/view/split.cpp
@@ -400,5 +400,18 @@ int main()
 
     moar_tests();
 
+    {   // Regression test for #1041
+        auto is_escape = [](auto first, auto last) {
+            return std::make_pair(next(first) != last, first);
+        };
+
+        auto escapes = view::split_when(view::c_str(R"(\t)"), is_escape);
+        CPP_assert(ForwardRange<decltype(escapes)>);
+
+        auto const first = begin(escapes);
+        CHECK(first != end(escapes));
+        CHECK(first != next(first));
+    }
+
     return test_result();
 }


### PR DESCRIPTION
Drive-by: simplify `zero_` handling in `cursor::next`

Fixes #1041.