### PR TITLE
Improve logic controlling the enabling of testing.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,13 @@
 cmake_minimum_required(VERSION 3.6)
 get_directory_property(is_subproject PARENT_DIRECTORY)
 
+# Having both `is_subproject` and `is_standalone` improves readability.
+if(NOT is_subproject)
+    set(is_standalone YES)
+else()
+    set(is_standalone NO)
+endif()
+
 project(Range-v3 CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
@@ -29,7 +36,6 @@ function(rv3_add_test TESTNAME EXENAME FIRSTSOURCE)
   add_test(${TESTNAME} ${EXENAME})
 endfunction(rv3_add_test)
 
-include(CTest) # invokes enable_testing() and defines BUILD_TESTING variable, defaulting to ON
 include(TestHeaders)
 include(ranges_options)
 include(ranges_env)
@@ -40,6 +46,9 @@ if(RANGE_V3_DOCS)
 endif()
 
 if(RANGE_V3_TESTS)
+  # The CTest module invokes enable_testing() and defines the
+  # BUILD_TESTING variable, defaulting to ON.
+  include(CTest)
   add_subdirectory(test)
 endif()
 

--- a/cmake/ranges_options.cmake
+++ b/cmake/ranges_options.cmake
@@ -30,22 +30,22 @@ endif()
 
 CMAKE_DEPENDENT_OPTION(RANGE_V3_TESTS
   "Build the Range-v3 tests and integrate with ctest"
-  "${BUILD_TESTING}" "${is_subproject}" OFF)
+  ON "${is_standalone}" "${BUILD_TESTING}")
 
 CMAKE_DEPENDENT_OPTION(RANGE_V3_HEADER_CHECKS
   "Build the Range-v3 header checks and integrate with ctest"
-  "${BUILD_TESTING}" "${is_subproject}" OFF)
+  ON "${is_standalone}" "${BUILD_TESTING}")
 
 CMAKE_DEPENDENT_OPTION(RANGE_V3_EXAMPLES
   "Build the Range-v3 examples and integrate with ctest"
-  ON "${is_subproject}" OFF)
+  ON "${is_standalone}" OFF)
 
 CMAKE_DEPENDENT_OPTION(RANGE_V3_PERF
   "Build the Range-v3 performance benchmarks"
-  ON "${is_subproject}" OFF)
+  ON "${is_standalone}" OFF)
 
 CMAKE_DEPENDENT_OPTION(RANGE_V3_DOCS
   "Build the Range-v3 documentation"
-  ON "${is_subproject}" OFF)
+  ON "${is_standalone}" OFF)
 
 mark_as_advanced(RANGE_V3_PERF)


### PR DESCRIPTION
When range-v3 is being used as a standalone project (i.e., not a
subproject) then behavior should stay the same, in that the building
of tests/examples/etc. is enabled by default, but still settable
by the user using the same variables.

However, if range-v3 is a subproject of a parent then we will attempt
to respect the parent's settings regarding testing.  In that situation:

  * Testing/header checks are disabled by default.
  * Examples/docs/perf targets are disabled by default.
  * Enable testing/header checks if the parent has already enabled
    testing.

Effectively this causes the range-v3 subproject to mirror the testing
status of its parent, but while still allowing customization using
the usual variables.

This change was tested with CMake 3.13 in the following configurations:

  1) range-v3 is a standalone project, verified that tests/examples
     are built by default.
  2) range-v3 is a subproject of a parent with testing disabled.
     Verified that range-v3 tests are not built.
  3) rnage-v3 is a subproject of a parent with testing enabled.
     Verified that range-v3 tests are built and runnable as part
     of the global collection of tests.

For reference: https://cmake.org/cmake/help/v3.0/module/CMakeDependentOption.html