### PR TITLE
testing is disabled when subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@
 cmake_minimum_required(VERSION 3.6)
 get_directory_property(is_subproject PARENT_DIRECTORY)
 
-# Having both `is_subproject` and `is_standalone` improves readability.
 if(NOT is_subproject)
     set(is_standalone YES)
 else()
@@ -46,8 +45,6 @@ if(RANGE_V3_DOCS)
 endif()
 
 if(RANGE_V3_TESTS)
-  # The CTest module invokes enable_testing() and defines the
-  # BUILD_TESTING variable, defaulting to ON.
   include(CTest)
   add_subdirectory(test)
 endif()

--- a/cmake/ranges_options.cmake
+++ b/cmake/ranges_options.cmake
@@ -30,11 +30,11 @@ endif()
 
 CMAKE_DEPENDENT_OPTION(RANGE_V3_TESTS
   "Build the Range-v3 tests and integrate with ctest"
-  ON "${is_standalone}" "${BUILD_TESTING}")
+  ON "${is_standalone}" OFF)
 
 CMAKE_DEPENDENT_OPTION(RANGE_V3_HEADER_CHECKS
   "Build the Range-v3 header checks and integrate with ctest"
-  ON "${is_standalone}" "${BUILD_TESTING}")
+  ON "${is_standalone}" OFF)
 
 CMAKE_DEPENDENT_OPTION(RANGE_V3_EXAMPLES
   "Build the Range-v3 examples and integrate with ctest"


### PR DESCRIPTION
Removed some comments and changed testing defaults in ranges_options.cmake from `BUILD_TESTING` to `OFF`. This ensures that when range-v3 is a subproject and consumed with `add_subdirectory` that the tests will not build or register with ctest. 