### PR TITLE
mixin for adaptor (view_adaptor)

### DIFF
--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -203,6 +203,8 @@ namespace ranges
         {
         private:
             friend range_access;
+            friend basic_adaptor_mixin<Adapt, BaseIter>;
+
             using base_t = detail::adaptor_value_type_<BaseIter, Adapt>;
             using single_pass = meta::or_<
                 range_access::single_pass_t<Adapt>,

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -195,6 +195,7 @@ namespace ranges
                 return this->get().first();
             }
 
+        protected:
             // Adaptor accessor
             Adapt& adaptor()
             {

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -187,11 +187,22 @@ namespace ranges
         {
             basic_adaptor_mixin() = default;
             using basic_mixin<adaptor_cursor<BaseIter, Adapt>>::basic_mixin;
+
             // All iterators into adapted ranges have a base() member for fetching
             // the underlying iterator.
             BaseIter base() const
             {
                 return this->get().first();
+            }
+
+            // Adaptor accessor
+            Adapt& adaptor()
+            {
+                return this->get().second();
+            }
+            const Adapt& adaptor() const
+            {
+                return this->get().second();
             }
         };
 

--- a/test/view_adaptor.cpp
+++ b/test/view_adaptor.cpp
@@ -38,11 +38,14 @@ private:
 
             int mixin_int = 120;
 
-            int base_plus_one() const
+            int base_plus_adaptor() const
             {
-                return *this->base() + 1;
+                int y = this->adaptor().t;
+                return *this->base() + y;
             }
         };
+
+        int t = 20;
 
         // Cross-wire begin and end.
         base_iterator_t begin(my_reverse_view const &rng) const
@@ -107,7 +110,7 @@ int main()
     ::check_equal(retro, {4, 3, 2, 1});
     CHECK( retro.begin().mixin_int == 120 );
     CHECK( *((retro.begin()+1).base()) == 4 );
-    CHECK( (retro.begin()+1).base_plus_one() == 5 );
+    CHECK( (retro.begin()+1).base_plus_adaptor() == 24 );
 
     std::list<int> l{1, 2, 3, 4};
     my_reverse_view<std::list<int>& > retro2{l};

--- a/test/view_adaptor.cpp
+++ b/test/view_adaptor.cpp
@@ -31,11 +31,17 @@ private:
     struct adaptor : ranges::adaptor_base
     {
         template<class iter_t /* iter_t can be iterator_t<BidiRange> or sentinel_t<BidiRange> */>
-        struct mixin : ranges::basic_adaptor_mixin<adaptor, iter_t>{
+        struct mixin : ranges::basic_adaptor_mixin<adaptor, iter_t>
+        {
             mixin() = default;
             using ranges::basic_adaptor_mixin<adaptor, iter_t>::basic_adaptor_mixin;
 
             int mixin_int = 120;
+
+            int base_plus_one() const
+            {
+                return *this->base() + 1;
+            }
         };
 
         // Cross-wire begin and end.
@@ -99,8 +105,9 @@ int main()
     ::models<concepts::BoundedView>(aux::copy(retro));
     ::models<concepts::RandomAccessIterator>(retro.begin());
     ::check_equal(retro, {4, 3, 2, 1});
-    CHECK(retro.begin().mixin_int == 120);
-    CHECK(*((retro.begin()+1).base()) == 4);
+    CHECK( retro.begin().mixin_int == 120 );
+    CHECK( *((retro.begin()+1).base()) == 4 );
+    CHECK( (retro.begin()+1).base_plus_one() == 5 );
 
     std::list<int> l{1, 2, 3, 4};
     my_reverse_view<std::list<int>& > retro2{l};

--- a/test/view_adaptor.cpp
+++ b/test/view_adaptor.cpp
@@ -30,6 +30,14 @@ private:
 
     struct adaptor : ranges::adaptor_base
     {
+        template<class iter_t /* iter_t can be iterator_t<BidiRange> or sentinel_t<BidiRange> */>
+        struct mixin : ranges::basic_adaptor_mixin<adaptor, iter_t>{
+            mixin() = default;
+            using ranges::basic_adaptor_mixin<adaptor, iter_t>::basic_adaptor_mixin;
+
+            int mixin_int = 120;
+        };
+
         // Cross-wire begin and end.
         base_iterator_t begin(my_reverse_view const &rng) const
         {
@@ -91,6 +99,7 @@ int main()
     ::models<concepts::BoundedView>(aux::copy(retro));
     ::models<concepts::RandomAccessIterator>(retro.begin());
     ::check_equal(retro, {4, 3, 2, 1});
+    CHECK(retro.begin().mixin_int == 120);
 
     std::list<int> l{1, 2, 3, 4};
     my_reverse_view<std::list<int>& > retro2{l};

--- a/test/view_adaptor.cpp
+++ b/test/view_adaptor.cpp
@@ -100,6 +100,7 @@ int main()
     ::models<concepts::RandomAccessIterator>(retro.begin());
     ::check_equal(retro, {4, 3, 2, 1});
     CHECK(retro.begin().mixin_int == 120);
+    CHECK(*((retro.begin()+1).base()) == 4);
 
     std::list<int> l{1, 2, 3, 4};
     my_reverse_view<std::list<int>& > retro2{l};


### PR DESCRIPTION
This PR adds ability to use mixin in adaptor.
Interface is following (same as with cursor's mixin, but have additional base_iterator template parameter):

```cpp
class adaptor : public ::ranges::adaptor_base{
     template<class base_iter_t /* can be iterator_t<base_rng> or sentinel_t<base_rng> */>
     struct mixin : ranges::basic_adaptor_mixin<adaptor, base_iter_t>{
          mixin() = default;
          using ranges::basic_adaptor_mixin<adaptor, base_iter_t>::basic_adaptor_mixin;
     };
};
```

See `/test/view_adaptor.cpp` for example.

Accessing adaptor guts through `adaptor`, not `get`.
