### PR TITLE
mixin for adaptor (view_adaptor) v2

### DIFF
--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -203,6 +203,8 @@ namespace ranges
         {
         private:
             friend range_access;
+            friend basic_adaptor_mixin<Adapt, BaseIter>;
+
             using base_t = detail::adaptor_value_type_<BaseIter, Adapt>;
             using single_pass = meta::or_<
                 range_access::single_pass_t<Adapt>,

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -260,7 +260,7 @@ namespace ranges
             static meta::id<typename Adapt_::template mixin<basic_adaptor_mixin>> basic_adaptor_mixin_2_(int);
 
             struct basic_adaptor_mixin_
-                : decltype(basic_adaptor_mixin_2_<Adapt>(42))
+              : decltype(basic_adaptor_mixin_2_<Adapt>(42))
             {};
 
             using mixin = meta::_t<basic_adaptor_mixin_>;

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -213,32 +213,6 @@ namespace ranges
             using detail::adaptor_sentinel_<BaseSent, Adapt>::adaptor_sentinel_;
         };
 
-        template<typename Adapt, typename BaseIter>
-        struct basic_adaptor_mixin
-            : basic_mixin<adaptor_cursor<BaseIter, Adapt>>
-        {
-            basic_adaptor_mixin() = default;
-            using basic_mixin<adaptor_cursor<BaseIter, Adapt>>::basic_mixin;
-
-            // All iterators into adapted ranges have a base() member for fetching
-            // the underlying iterator.
-            BaseIter base() const
-            {
-                return this->get().first();
-            }
-
-        protected:
-            // Adaptor accessor
-            Adapt& adaptor()
-            {
-                return this->get().second();
-            }
-            const Adapt& adaptor() const
-            {
-                return this->get().second();
-            }
-        };
-
         // Build a cursor out of an iterator into the adapted range, and an
         // adaptor that customizes behavior.
         template<typename BaseIter, typename Adapt>
@@ -247,20 +221,44 @@ namespace ranges
         {
         private:
             friend range_access;
-            friend basic_adaptor_mixin<Adapt, BaseIter>;
-
             using base_t = detail::adaptor_value_type_<BaseIter, Adapt>;
             using single_pass = meta::or_<
                 range_access::single_pass_t<Adapt>,
                 SinglePass<BaseIter>>;
 
-            template<typename Adapt_, typename BaseIter_>
-            static meta::id<basic_adaptor_mixin<Adapt_, BaseIter_>> basic_adaptor_mixin_2_(long);
-            template<typename Adapt_, typename BaseIter_>
-            static meta::id<typename Adapt_::template mixin<basic_adaptor_mixin<Adapt_, BaseIter_>>> basic_adaptor_mixin_2_(int);
+            //template<typename Adapt, typename BaseIter>
+            struct basic_adaptor_mixin
+                : basic_mixin<adaptor_cursor<BaseIter, Adapt>>
+            {
+                basic_adaptor_mixin() = default;
+                using basic_mixin<adaptor_cursor<BaseIter, Adapt>>::basic_mixin;
+
+                // All iterators into adapted ranges have a base() member for fetching
+                // the underlying iterator.
+                BaseIter base() const
+                {
+                    return this->get().first();
+                }
+
+            protected:
+                // Adaptor accessor
+                Adapt& adaptor()
+                {
+                    return this->get().second();
+                }
+                const Adapt& adaptor() const
+                {
+                    return this->get().second();
+                }
+            };
+
+            template<typename Adapt_>
+            static meta::id<basic_adaptor_mixin> basic_adaptor_mixin_2_(long);
+            template<typename Adapt_>
+            static meta::id<typename Adapt_::template mixin<basic_adaptor_mixin>> basic_adaptor_mixin_2_(int);
 
             struct basic_adaptor_mixin_
-                : decltype(basic_adaptor_mixin_2_<Adapt, BaseIter>(42))
+                : decltype(basic_adaptor_mixin_2_<Adapt>(42))
             {};
 
             using mixin = meta::_t<basic_adaptor_mixin_>;

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -194,10 +194,10 @@ namespace ranges
 
         namespace detail {
             template<typename BaseSent, typename Adapt>
-            static meta::id<base_adaptor_sentinel<BaseSent, Adapt>> base_adaptor_sentinel_2_(long);
+            meta::id<base_adaptor_sentinel<BaseSent, Adapt>> base_adaptor_sentinel_2_(long);
 
             template<typename BaseSent, typename Adapt>
-            static meta::id<typename Adapt::template mixin<base_adaptor_sentinel<BaseSent, Adapt>>> base_adaptor_sentinel_2_(int);
+            meta::id<typename Adapt::template mixin<base_adaptor_sentinel<BaseSent, Adapt>>> base_adaptor_sentinel_2_(int);
 
             template<typename BaseSent, typename Adapt>
             struct base_adaptor_sentinel_

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -195,6 +195,7 @@ namespace ranges
                 return this->get().first();
             }
 
+        protected:
             // Adaptor accessor
             Adapt& adaptor()
             {

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -192,7 +192,8 @@ namespace ranges
             }
         };
 
-        namespace detail {
+        namespace detail
+        {
             template<typename BaseSent, typename Adapt>
             meta::id<base_adaptor_sentinel<BaseSent, Adapt>> base_adaptor_sentinel_2_(long);
 

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -202,7 +202,7 @@ namespace ranges
 
             template<typename BaseSent, typename Adapt>
             struct base_adaptor_sentinel_
-                : decltype(base_adaptor_sentinel_2_<BaseSent, Adapt>(42))
+              : decltype(base_adaptor_sentinel_2_<BaseSent, Adapt>(42))
             {};
 
             template<typename BaseSent, typename Adapt>

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -210,7 +210,9 @@ namespace ranges
         }
 
         template<typename BaseSent, typename Adapt>
-        struct adaptor_sentinel : detail::adaptor_sentinel_<BaseSent, Adapt>{
+        struct adaptor_sentinel
+          : detail::adaptor_sentinel_<BaseSent, Adapt>
+        {
             using detail::adaptor_sentinel_<BaseSent, Adapt>::adaptor_sentinel_;
         };
 

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -187,11 +187,22 @@ namespace ranges
         {
             basic_adaptor_mixin() = default;
             using basic_mixin<adaptor_cursor<BaseIter, Adapt>>::basic_mixin;
+
             // All iterators into adapted ranges have a base() member for fetching
             // the underlying iterator.
             BaseIter base() const
             {
                 return this->get().first();
+            }
+
+            // Adaptor accessor
+            Adapt& adaptor()
+            {
+                return this->get().second();
+            }
+            const Adapt& adaptor() const
+            {
+                return this->get().second();
             }
         };
 

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -226,7 +226,6 @@ namespace ranges
                 range_access::single_pass_t<Adapt>,
                 SinglePass<BaseIter>>;
 
-            //template<typename Adapt, typename BaseIter>
             struct basic_adaptor_mixin
                 : basic_mixin<adaptor_cursor<BaseIter, Adapt>>
             {

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -95,7 +95,7 @@ namespace ranges
         struct adaptor_cursor;
 
         template<typename BaseSent, typename Adapt>
-        struct adaptor_sentinel;
+        struct base_adaptor_sentinel;
 
         struct adaptor_base
         {
@@ -161,7 +161,7 @@ namespace ranges
         // Build a sentinel out of a sentinel into the adapted range, and an
         // adaptor that customizes behavior.
         template<typename BaseSent, typename Adapt>
-        struct adaptor_sentinel
+        struct base_adaptor_sentinel
           : private compressed_pair<BaseSent, Adapt>
         {
         private:
@@ -179,6 +179,38 @@ namespace ranges
             {
                 return first();
             }
+
+        protected:
+            // Adaptor accessor
+            Adapt& adaptor()
+            {
+                return second();
+            }
+            const Adapt& adaptor() const
+            {
+                return second();
+            }
+        };
+
+        namespace detail {
+            template<typename BaseSent, typename Adapt>
+            static meta::id<base_adaptor_sentinel<BaseSent, Adapt>> base_adaptor_sentinel_2_(long);
+
+            template<typename BaseSent, typename Adapt>
+            static meta::id<typename Adapt::template mixin<base_adaptor_sentinel<BaseSent, Adapt>>> base_adaptor_sentinel_2_(int);
+
+            template<typename BaseSent, typename Adapt>
+            struct base_adaptor_sentinel_
+                : decltype(base_adaptor_sentinel_2_<BaseSent, Adapt>(42))
+            {};
+
+            template<typename BaseSent, typename Adapt>
+            using adaptor_sentinel_ = meta::_t<base_adaptor_sentinel_<BaseSent, Adapt>>;
+        }
+
+        template<typename BaseSent, typename Adapt>
+        struct adaptor_sentinel : detail::adaptor_sentinel_<BaseSent, Adapt>{
+            using detail::adaptor_sentinel_<BaseSent, Adapt>::adaptor_sentinel_;
         };
 
         template<typename Adapt, typename BaseIter>
@@ -225,7 +257,7 @@ namespace ranges
             template<typename Adapt_, typename BaseIter_>
             static meta::id<basic_adaptor_mixin<Adapt_, BaseIter_>> basic_adaptor_mixin_2_(long);
             template<typename Adapt_, typename BaseIter_>
-            static meta::id<typename Adapt_::template mixin<BaseIter_>> basic_adaptor_mixin_2_(int);
+            static meta::id<typename Adapt_::template mixin<basic_adaptor_mixin<Adapt_, BaseIter_>>> basic_adaptor_mixin_2_(int);
 
             struct basic_adaptor_mixin_
                 : decltype(basic_adaptor_mixin_2_<Adapt, BaseIter>(42))

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -230,7 +230,7 @@ namespace ranges
                 SinglePass<BaseIter>>;
 
             struct basic_adaptor_mixin
-                : basic_mixin<adaptor_cursor<BaseIter, Adapt>>
+              : basic_mixin<adaptor_cursor>
             {
                 basic_adaptor_mixin() = default;
                 using basic_mixin<adaptor_cursor<BaseIter, Adapt>>::basic_mixin;

--- a/test/view_adaptor.cpp
+++ b/test/view_adaptor.cpp
@@ -38,11 +38,14 @@ private:
 
             int mixin_int = 120;
 
-            int base_plus_one() const
+            int base_plus_adaptor() const
             {
-                return *this->base() + 1;
+                int y = this->adaptor().t;
+                return *this->base() + y;
             }
         };
+
+        int t = 20;
 
         // Cross-wire begin and end.
         base_iterator_t begin(my_reverse_view const &rng) const
@@ -107,7 +110,7 @@ int main()
     ::check_equal(retro, {4, 3, 2, 1});
     CHECK( retro.begin().mixin_int == 120 );
     CHECK( *((retro.begin()+1).base()) == 4 );
-    CHECK( (retro.begin()+1).base_plus_one() == 5 );
+    CHECK( (retro.begin()+1).base_plus_adaptor() == 24 );
 
     std::list<int> l{1, 2, 3, 4};
     my_reverse_view<std::list<int>& > retro2{l};

--- a/test/view_adaptor.cpp
+++ b/test/view_adaptor.cpp
@@ -31,11 +31,17 @@ private:
     struct adaptor : ranges::adaptor_base
     {
         template<class iter_t /* iter_t can be iterator_t<BidiRange> or sentinel_t<BidiRange> */>
-        struct mixin : ranges::basic_adaptor_mixin<adaptor, iter_t>{
+        struct mixin : ranges::basic_adaptor_mixin<adaptor, iter_t>
+        {
             mixin() = default;
             using ranges::basic_adaptor_mixin<adaptor, iter_t>::basic_adaptor_mixin;
 
             int mixin_int = 120;
+
+            int base_plus_one() const
+            {
+                return *this->base() + 1;
+            }
         };
 
         // Cross-wire begin and end.
@@ -99,8 +105,9 @@ int main()
     ::models<concepts::BoundedView>(aux::copy(retro));
     ::models<concepts::RandomAccessIterator>(retro.begin());
     ::check_equal(retro, {4, 3, 2, 1});
-    CHECK(retro.begin().mixin_int == 120);
-    CHECK(*((retro.begin()+1).base()) == 4);
+    CHECK( retro.begin().mixin_int == 120 );
+    CHECK( *((retro.begin()+1).base()) == 4 );
+    CHECK( (retro.begin()+1).base_plus_one() == 5 );
 
     std::list<int> l{1, 2, 3, 4};
     my_reverse_view<std::list<int>& > retro2{l};

--- a/test/view_adaptor.cpp
+++ b/test/view_adaptor.cpp
@@ -30,6 +30,14 @@ private:
 
     struct adaptor : ranges::adaptor_base
     {
+        template<class iter_t /* iter_t can be iterator_t<BidiRange> or sentinel_t<BidiRange> */>
+        struct mixin : ranges::basic_adaptor_mixin<adaptor, iter_t>{
+            mixin() = default;
+            using ranges::basic_adaptor_mixin<adaptor, iter_t>::basic_adaptor_mixin;
+
+            int mixin_int = 120;
+        };
+
         // Cross-wire begin and end.
         base_iterator_t begin(my_reverse_view const &rng) const
         {
@@ -91,6 +99,7 @@ int main()
     ::models<concepts::BoundedView>(aux::copy(retro));
     ::models<concepts::RandomAccessIterator>(retro.begin());
     ::check_equal(retro, {4, 3, 2, 1});
+    CHECK(retro.begin().mixin_int == 120);
 
     std::list<int> l{1, 2, 3, 4};
     my_reverse_view<std::list<int>& > retro2{l};

--- a/test/view_adaptor.cpp
+++ b/test/view_adaptor.cpp
@@ -99,7 +99,6 @@ struct my_delimited_range
 {
     using view_adaptor::view_adaptor;
 
-
     struct adaptor : ranges::adaptor_base
     {
         template<class base_mixin>

--- a/test/view_adaptor.cpp
+++ b/test/view_adaptor.cpp
@@ -123,7 +123,8 @@ struct my_delimited_range
     {
         return {};
     }
-    adaptor end_adaptor() const {
+    adaptor end_adaptor() const
+    {
         return {};
     }
 };

--- a/test/view_adaptor.cpp
+++ b/test/view_adaptor.cpp
@@ -30,11 +30,11 @@ private:
 
     struct adaptor : ranges::adaptor_base
     {
-        template<class iter_t /* iter_t can be iterator_t<BidiRange> or sentinel_t<BidiRange> */>
-        struct mixin : ranges::basic_adaptor_mixin<adaptor, iter_t>
+        template<class base_mixin>
+        struct mixin : base_mixin
         {
             mixin() = default;
-            using ranges::basic_adaptor_mixin<adaptor, iter_t>::basic_adaptor_mixin;
+            using base_mixin::base_mixin;
 
             int mixin_int = 120;
 
@@ -98,6 +98,34 @@ struct my_delimited_range
         ranges::delimit_view<ranges::istream_range<int>, int>>
 {
     using view_adaptor::view_adaptor;
+
+
+    struct adaptor : ranges::adaptor_base
+    {
+        template<class base_mixin>
+        struct mixin : base_mixin
+        {
+            mixin() = default;
+            using base_mixin::base_mixin;
+
+            int mixin_int = 120;
+
+            int base_access_test() const
+            {
+                int y = this->adaptor().t;
+                return y;
+            }
+        };
+
+        int t = 20;
+    };
+    adaptor begin_adaptor() const
+    {
+        return {};
+    }
+    adaptor end_adaptor() const {
+        return {};
+    }
 };
 
 int main()
@@ -108,6 +136,8 @@ int main()
     ::models<concepts::BoundedView>(aux::copy(retro));
     ::models<concepts::RandomAccessIterator>(retro.begin());
     ::check_equal(retro, {4, 3, 2, 1});
+
+    // test cursor mixin
     CHECK( retro.begin().mixin_int == 120 );
     CHECK( *((retro.begin()+1).base()) == 4 );
     CHECK( (retro.begin()+1).base_plus_adaptor() == 24 );
@@ -126,6 +156,10 @@ int main()
     ::models<concepts::InputIterator>(r.begin());
     ::models_not<concepts::ForwardIterator>(r.begin());
     ::check_equal(r, {1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4});
+
+    // test sentinel mixin
+    CHECK(r.end().mixin_int == 120);
+    CHECK(r.end().base_access_test() == 20);
 
     return ::test_result();
 }

--- a/test/view_adaptor.cpp
+++ b/test/view_adaptor.cpp
@@ -110,7 +110,7 @@ struct my_delimited_range
 
             int mixin_int = 120;
 
-            int base_access_test() const
+            int adaptor_access_test() const
             {
                 int y = this->adaptor().t;
                 return y;
@@ -159,7 +159,7 @@ int main()
 
     // test sentinel mixin
     CHECK(r.end().mixin_int == 120);
-    CHECK(r.end().base_access_test() == 20);
+    CHECK(r.end().adaptor_access_test() == 20);
 
     return ::test_result();
 }

--- a/test/view_adaptor.cpp
+++ b/test/view_adaptor.cpp
@@ -100,6 +100,7 @@ int main()
     ::models<concepts::RandomAccessIterator>(retro.begin());
     ::check_equal(retro, {4, 3, 2, 1});
     CHECK(retro.begin().mixin_int == 120);
+    CHECK(*((retro.begin()+1).base()) == 4);
 
     std::list<int> l{1, 2, 3, 4};
     my_reverse_view<std::list<int>& > retro2{l};


### PR DESCRIPTION
This PR adds ability to use mixin in adaptor.
Interface:

```cpp
class adaptor : public ::ranges::adaptor_base
{
     template<class base_mixin>
     struct mixin : base_mixin
     {
          mixin() = default;
          using base_mixin::base_mixin;

          decltype(auto) base_value() const
          {
              return *base.value();
          }

          int get_i() const
          {
              return this->adaptor().i;
          }
     };

     int i = 100;
};
```

`adaptor()` is only visible from inside mixin.
`base()` - visible everywhere.

Work for both - cursor and sentinel adaptor versions.