### PR TITLE
linear_distribute_view: fix equal

### DIFF
--- a/include/range/v3/view/linear_distribute.hpp
+++ b/include/range/v3/view/linear_distribute.hpp
@@ -50,11 +50,13 @@ namespace ranges
                 RANGES_CXX14_CONSTEXPR
                 bool equal(linear_distribute_view const& other) const noexcept
                 {
+                    bool const eq = n_ == other.n_;
                     RANGES_DIAGNOSTIC_PUSH
                     RANGES_DIAGNOSTIC_IGNORE_FLOAT_EQUAL
-                    RANGES_EXPECT(from_ == other.from_ && to_ == other.to_);
+                    RANGES_EXPECT(to_ == other.to_);
+                    RANGES_EXPECT(!eq || from_ == other.from_);
                     RANGES_DIAGNOSTIC_POP
-                    return n_ == other.n_;
+                    return eq;
                 }
                 RANGES_CXX14_CONSTEXPR void next() noexcept
                 {
@@ -119,4 +121,3 @@ namespace ranges
 }
 
 #endif
-

--- a/test/view/linear_distribute.cpp
+++ b/test/view/linear_distribute.cpp
@@ -60,7 +60,7 @@ int main()
                              3.0},
                             float_eq));
     }
-    {  // empty interval
+    {   // empty interval
         auto irng = linear_distribute(0, 0, 1);
         CHECK(ranges::size(irng) == std::size_t{1});
         check_equal(irng, {0});
@@ -76,6 +76,13 @@ int main()
         auto frng = linear_distribute(0., 0., 3);
         CHECK(ranges::size(frng) == std::size_t{3});
         CHECK(ranges::equal(frng, {0.,0.,0.}, float_eq));
+    }
+
+    {   // regression test for #1088
+        auto ld = linear_distribute(1, 10, 10);
+        auto const first = ranges::begin(ld);
+        auto const i = ranges::next(first, 4);
+        CHECK(ranges::distance(first, i) == 4);
     }
 
     return test_result();


### PR DESCRIPTION
The `from_` values are only equal if the `n_` values are.

Fixes #1088.