### PR TITLE
view::transform iterator size optimisation.

### DIFF
--- a/include/range/v3/view/transform.hpp
+++ b/include/range/v3/view/transform.hpp
@@ -65,6 +65,7 @@ namespace ranges
             using use_sentinel_t =
                 meta::or_<meta::not_<BoundedRange<Rng>>, SinglePass<iterator_t<Rng>>>;
 
+            template<bool is_stateless_functor, class fun_ref_>
             struct adaptor_fun;
 
             // Do not use empty base class optimisation here. Return Fun{} each time.

--- a/test/view/transform.cpp
+++ b/test/view/transform.cpp
@@ -44,8 +44,36 @@ void bug_996()
     (void)rng;
 }
 
+void test_size()
+{
+    using namespace ranges;
+
+    std::vector<int> vec = {1,2,3};
+
+    // Test with functor, not lambda.
+    // Since lambda default constructible from C++20 only.
+    struct Op
+    {
+        int operator()(int a) const
+        {
+            return a > 3 ? a : 42;
+        }
+    };
+
+    auto t1 = vec | view::transform(Op{});
+    auto t2 = t1  | view::transform(Op{});
+    auto t3 = t2  | view::transform(Op{});
+
+    static_assert(
+        sizeof(t1.begin()) == sizeof(t2.begin()) &&
+        sizeof(t2.begin()) == sizeof(t3.begin()),
+        "iterators sizes should not grow!" );
+}
+
 int main()
 {
+    test_size();
+
     using namespace ranges;
 
     int rgi[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};

--- a/test/view/transform.cpp
+++ b/test/view/transform.cpp
@@ -56,13 +56,15 @@ void test_size()
     {
         int operator()(int a) const
         {
-            return a > 3 ? a : 42;
+            return a + 1;
         }
     };
 
     auto t1 = vec | view::transform(Op{});
     auto t2 = t1  | view::transform(Op{});
     auto t3 = t2  | view::transform(Op{});
+
+    ::check_equal(t3.front(), vec.front() + 3);
 
     static_assert(
         sizeof(t1.begin()) == sizeof(t2.begin()) &&

--- a/test/view/transform.cpp
+++ b/test/view/transform.cpp
@@ -67,8 +67,9 @@ void test_size()
     ::check_equal(t3.front(), vec.front() + 3);
 
     static_assert(
-        sizeof(t1.begin()) == sizeof(t2.begin()) &&
-        sizeof(t2.begin()) == sizeof(t3.begin()),
+        sizeof(vec.begin()) == sizeof(t1.begin()) &&
+        sizeof(t1.begin())  == sizeof(t2.begin()) &&
+        sizeof(t2.begin())  == sizeof(t3.begin()),
         "iterators sizes should not grow!" );
 }
 


### PR DESCRIPTION
Currently, each `view::transform` in composition chain increase iterator size on 1 ptr:
```cpp
auto t1 = vec | view::transform(Op{});
auto t2 = t1  | view::transform(Op{});
auto t3 = t2  | view::transform(Op{});

assert( sizeof(t1.begin) == 16);
assert( sizeof(t2.begin) == 24);
assert( sizeof(t3.begin) == 32);
```
This is **too** wasteful. This may be forgivable for views, but not for iterators itself - since they copied/constructed in tight loops, and designed to be small.

This PR eliminates size grow of iterators of `transform`s with stateless functors (empty sized + default constructible):
```cpp
assert( sizeof(t1.begin) == 8);
assert( sizeof(t2.begin) == 8);
assert( sizeof(t3.begin) == 8);
```
---
Pay attention, that empty base optimization / [[no_unique_address]] is not used here. This is due to the fact, that only distinct types may occupy the same "memory location" (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88865). Which means that with EBO we'd have this:
```cpp
auto t1 = vec | view::transform(Op{});   // 8 - ok
auto t2 = t1  | view::transform(Op{});   // 16 - growing
```
At least I got that in [my version with EBO](https://github.com/tower120/range-v3/tree/view_transform_size_optimisation_w_ebo) (ranges::box) [see diff](https://github.com/tower120/range-v3/compare/view_transform_size_optimisation_w_ebo..view_transform_size_optimisation?diff=split)

If you know better, and EBO should work here - please let me know.
Another example with "non-working" size optimization https://wandbox.org/permlink/xrVxwlq4JsLG9abz

UPDATE

That's what happens under the hood:
```cpp
struct payload{ void* v;};
struct base_adaptor{};
struct A: base_adaptor, private box<Op, Op> {};    // without base_adaptor - all ok
struct B: base_adaptor, private box<Op2, Op2> {};  // or if replace box with any other type

using P  = compressed_pair<A, payload>;    // sizeof(P) == 8
using P2 = compressed_pair<B, P>;          // sizeof(P2) == 16
```
It seems that at the end - `compressed_pair` does not play nicely with the `box` (being box itself)... 
Linked issue https://github.com/ericniebler/range-v3/issues/1093

---

The same optimization must be done to the view.