### PR TITLE
[FIX-#1092] view::take has problems with GCC+ConceptsTS

### DIFF
--- a/include/range/v3/view/take.hpp
+++ b/include/range/v3/view/take.hpp
@@ -164,7 +164,12 @@ namespace ranges
                     return ranges::begin(base_);
                 else
                 {
+#if defined(__cpp_concepts) && __cpp_concepts <= 201507 // cannot always delegate to size() member on GCC with ConceptsTS
+                    auto s = ranges::min(static_cast<range_difference_t<Rng>>(count_),
+                                         static_cast<range_difference_t<Rng>>(ranges::size(base_)));
+#else
                     auto s = static_cast<range_difference_t<Rng>>(size());
+#endif
                     return make_counted_iterator(ranges::begin(base_), s);
                 }
             else


### PR DESCRIPTION
This fixes #1092 for me. The workaround would always work, but I have just activated it for ConceptsTS, because I don't know what your general policy for platform specific workarounds is.