### PR TITLE
view::generate_n cache update optimisation

### DIFF
--- a/include/range/v3/view/generate_n.hpp
+++ b/include/range/v3/view/generate_n.hpp
@@ -59,7 +59,7 @@ namespace ranges
                 result_t &&read() const
                 {
                     if (!rng_->val_)
-                        rng_->val_ = rng_->gen_();
+                        rng_->val_.emplace(rng_->gen_());
                     return static_cast<result_t &&>(
                         static_cast<result_t &>(*rng_->val_));
                 }


### PR DESCRIPTION
This small change makes generate_n as fast as plain for-loop. 8x speed up with generated monotonically increasing int sequence (in compare to current version).

`emplace` has less branches then =. Because operator= also supports move assign value. This will never happens in `generate_n`.