### PR TITLE
MSVC 1.0 updates (again)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 range-v3
 ========
 
-Range library for C++11/14/17. This code is the basis of [a formal proposal](https://ericniebler.github.io/std/wg21/D4128.html) to add range support to the C++ standard library.
+Range library for C++14/17. This code was the basis of [a formal proposal](https://ericniebler.github.io/std/wg21/D4128.html) to add range support to the C++ standard library. That proposal evolved through a Technical Specification, and finally into [P0896R4 "The One Ranges Proposal"](https://wg21.link/p0896r4) which was merged into the C++20 working drafts in November 2018.
 
 About:
 ------
 
 Why does C++ need another range library? Simply put, the existing solutions haven't kept up with the rapid evolution of C++. Range v3 is a library for the future C++. Not only does it work well with today's C++ -- move semantics, lambdas, automatically deduced types and all -- it also anticipates tomorrow's C++ with Concepts.
-
-Range v3 forms the basis of a proposal to add range support to the standard library ([N4128: Ranges for the Standard Library](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4128.html)). It also will be the reference implementation for an upcoming Technical Specification. These are the first steps toward turning ranges into an international standard.
 
 Documentation:
 --------------
@@ -55,6 +53,9 @@ The code is known to work on the following compilers:
 - clang 3.6.2 (or later)
 - GCC 4.9.1 (or later) (C++14 support requires GCC 5.2; C++14 "extended constexpr" support is poor before 6.1.)
 - Clang/LLVM 6 (or later) on Windows (older versions may work - we haven't tested.)
+- Visual Studio 2019 Preview 4 (or later) on Windows, with some caveats due to range-v3's strict conformance requirements:
+  - range-v3 needs `/std:c++17 /permissive-`
+  - range-v3 needs a fully conforming preprocessor, so `/experimental:preprocesor` is necessary. Note that the conforming preprocessor diagnoses `C5105` "macro expansion producing 'defined' has undefined behavior" in some of the Windows SDK headers, so you'll probably want to suppress that warning with `/wd5105`.
 
 [ Note: We've "retired" support for Clang/C2 with the VS2015 toolset (i.e., the `v140_clang_c2` toolset) which Microsoft no longer supports for C++ use. We no longer have CI runs, but haven't gone out of our way to break anything, so it will likely continue to work. ]
 

--- a/cmake/ranges_flags.cmake
+++ b/cmake/ranges_flags.cmake
@@ -30,7 +30,10 @@ if (RANGES_CXX_COMPILER_CLANGCL OR RANGES_CXX_COMPILER_MSVC)
   # Enable "normal" warnings and make them errors:
   ranges_append_flag(RANGES_HAS_W3 /W3)
   ranges_append_flag(RANGES_HAS_WX /WX)
+  # range-v3 needs MSVC's experimental actually-conforming preprocessor...
   ranges_append_flag(RANGES_HAS_EXPERIMENTAL_PREPROCESSOR /experimental:preprocessor)
+  # ...which warns about UB in macros in the UCRT headers =(
+  ranges_append_flag(RANGES_HAS_WD5105 /wd5105)
 else()
   ranges_append_flag(RANGES_HAS_CXXSTD "-std=c++${RANGES_CXX_STD}")
   set(RANGES_STD_FLAG "-std=c++${RANGES_CXX_STD}")

--- a/include/meta/meta_fwd.hpp
+++ b/include/meta/meta_fwd.hpp
@@ -39,9 +39,14 @@
 
 #elif defined(_MSC_VER)
 #define META_HAS_MAKE_INTEGER_SEQ 1
-#define META_WORKAROUND_MSVC_702792 // Fixed for VS2019, possibly 16.0?
-#define META_WORKAROUND_MSVC_703656 // Fixed for VS2019 16.0
+#if _MSC_VER < 1920
+#define META_WORKAROUND_MSVC_702792 // Bogus C4018 comparing constant expressions with dependent type
+#define META_WORKAROUND_MSVC_703656 // ICE with pack expansion inside decltype in alias template
+#endif
+
+#if _MSC_VER < 1921
 #define META_WORKAROUND_MSVC_756112 // fold expression + alias templates in template argument
+#endif
 
 #elif defined(__GNUC__)
 #define META_WORKAROUND_GCC_86356 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86356

--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -214,26 +214,34 @@ namespace ranges
 #if _MSC_VER < 1920
 #define RANGES_WORKAROUND_MSVC_DC338193 // https://developercommunity.visualstudio.com/content/problem/338193/sfinae-disabled-ref-qualified-function-collides-wi.html
 #define RANGES_WORKAROUND_MSVC_401490 // conversion of constant expressions with representable values is NOT narrowing
+#define RANGES_WORKAROUND_MSVC_589046 // hidden friends should not be visible to qualified name lookup
+#define RANGES_WORKAROUND_MSVC_699982 // Nasty context-sensitive alias expansion / SFINAE error
 #define RANGES_WORKAROUND_MSVC_701425 // Failure to deduce decltype(pointer-to-member) (gcc_bugs_bugs_bugs for MSVC)
+#define RANGES_WORKAROUND_MSVC_711347 // Assertion invoking constexpr member function as alias template argument
 #endif // _MSC_VER < 1920
 
-#define RANGES_WORKAROUND_MSVC_249830 // constexpr and arguments that aren't subject to lvalue-to-rvalue conversion
-#define RANGES_WORKAROUND_MSVC_573728 // rvalues of array types bind to lvalue references [no workaround]
-#define RANGES_WORKAROUND_MSVC_589046 // hidden friends should not be visible to qualified name lookup
-#define RANGES_WORKAROUND_MSVC_620035 // Error when definition-context name binding finds only deleted function (Fix not yet live)
-#define RANGES_WORKAROUND_MSVC_677925 // Bogus C2676 "binary '++': '_Ty' does not define this operator"
-#define RANGES_WORKAROUND_MSVC_683388 // decltype(*i) is incorrectly an rvalue reference for pointer-to-array i
-#define RANGES_WORKAROUND_MSVC_688606 // SFINAE failing to account for access control during specialization matching
-#define RANGES_WORKAROUND_MSVC_699982 // Nasty context-sensitive alias expansion / SFINAE error (Fix not yet live)
-#define RANGES_WORKAROUND_MSVC_701385 // Yet another alias expansion error (Fix not yet live)
-#define RANGES_WORKAROUND_MSVC_711347 // Assertion invoking constexpr member function as alias template argument (Fix not yet live)
-#define RANGES_WORKAROUND_MSVC_756601 // constexpr friend non-template erroneously rejected with C3615
-#define RANGES_WORKAROUND_MSVC_779708 // ADL for operands of function type [No workaround]
+#if 1 // Fixed in 1920, but more bugs hiding behind workaround
+#define RANGES_WORKAROUND_MSVC_620035 // Error when definition-context name binding finds only deleted function
+#define RANGES_WORKAROUND_MSVC_701385 // Yet another alias expansion error
+#endif
+
+#if _MSC_VER < 1921
 #define RANGES_WORKAROUND_MSVC_785522 // SFINAE failure for error in immediate context
-#define RANGES_WORKAROUND_MSVC_786312 // Yet another mixed-pack-expansion failure
 #define RANGES_WORKAROUND_MSVC_786376 // Assertion casting anonymous union member in trailing-return-type
 #define RANGES_WORKAROUND_MSVC_787074 // Over-eager substitution of dependent type in non-instantiated nested class template
 #define RANGES_WORKAROUND_MSVC_790554 // Assert for return type that uses dependent default non-type template argument
+#endif // _MSC_VER < 1921
+
+#define RANGES_WORKAROUND_MSVC_249830 // constexpr and arguments that aren't subject to lvalue-to-rvalue conversion
+#define RANGES_WORKAROUND_MSVC_573728 // rvalues of array types bind to lvalue references [no workaround]
+#define RANGES_WORKAROUND_MSVC_677925 // Bogus C2676 "binary '++': '_Ty' does not define this operator"
+#define RANGES_WORKAROUND_MSVC_683388 // decltype(*i) is incorrectly an rvalue reference for pointer-to-array i
+#define RANGES_WORKAROUND_MSVC_688606 // SFINAE failing to account for access control during specialization matching
+#define RANGES_WORKAROUND_MSVC_756601 // constexpr friend non-template erroneously rejected with C3615
+#define RANGES_WORKAROUND_MSVC_779708 // ADL for operands of function type [No workaround]
+#define RANGES_WORKAROUND_MSVC_786312 // Yet another mixed-pack-expansion failure
+#define RANGES_WORKAROUND_MSVC_792338 // Failure to match specialization enabled via call to constexpr function
+#define RANGES_WORKAROUND_MSVC_793042 // T[0] sometimes accepted as a valid type in SFINAE context
 
 // 15.9 doesn't define __cpp_coroutines even with /await (Fix not yet live)
 #if !defined(RANGES_CXX_COROUTINES) && defined(_RESUMABLE_FUNCTIONS_SUPPORTED)

--- a/include/range/v3/range/access.hpp
+++ b/include/range/v3/range/access.hpp
@@ -18,10 +18,10 @@
 #include <initializer_list>
 #include <iterator>
 #include <limits>
-#include <utility>
-#if defined(__cpp_lib_string_view) && __cpp_lib_string_view > 0
+#if __has_include(<string_view>)
 #include <string_view>
 #endif
+#include <utility>
 
 #include <range/v3/range_fwd.hpp>
 #include <range/v3/iterator/concepts.hpp>

--- a/include/std/iterator
+++ b/include/std/iterator
@@ -125,10 +125,17 @@ namespace ranges
                 // *i has the same type as *i++
                 int[RANGES_IS_SAME(decltype(**pi), decltype(*(*pi)++))],
                 // *i is a real reference to value_type
+#ifdef RANGES_WORKAROUND_MSVC_793042
+                enable_if_t<RANGES_IS_SAME(decltype(**pi), decltype(*pv)) ||
+                            RANGES_IS_SAME(decltype(**pi), decltype(*pcv)) ||
+                            RANGES_IS_SAME(decltype(**pi), typename readable_traits<I>::value_type &&) ||
+                            RANGES_IS_SAME(decltype(**pi), typename readable_traits<I>::value_type const &&)>
+#else // ^^^ workaround / no workaround vvv
                 int[RANGES_IS_SAME(decltype(**pi), decltype(*pv)) ||
                     RANGES_IS_SAME(decltype(**pi), decltype(*pcv)) ||
                     RANGES_IS_SAME(decltype(**pi), typename readable_traits<I>::value_type &&) ||
                     RANGES_IS_SAME(decltype(**pi), typename readable_traits<I>::value_type const &&)]
+#endif // RANGES_WORKAROUND_MSVC_793042
             > * = nullptr)
         {
             return cpp17_iterator_category_3_<I>(0);
@@ -246,7 +253,12 @@ RANGES_BEGIN_NAMESPACE_STD
     template<typename I>
     struct _Iterator_traits_base<
         I,
+#ifdef RANGES_WORKAROUND_MSVC_792338
+        ::ranges::detail::enable_if_t<decltype(bool_constant<
+            !::ranges::detail::has_iterator_typedefs_impl_<I>(0)>{})::value>>
+#else // ^^^ workaround / no workaround vvv
         ::ranges::detail::enable_if_t<!::ranges::detail::has_iterator_typedefs_impl_<I>(0)>>
+#endif // RANGES_WORKAROUND_MSVC_792338
       : decltype(::ranges::detail::std_iterator_traits_impl_<I>(0))
     {};
 #endif

--- a/test/iterator/iterator.cpp
+++ b/test/iterator/iterator.cpp
@@ -270,8 +270,8 @@ namespace std
     template <>
     struct iterator_traits<::WouldBeFwd>
     {
-        using value_type = typename ::WouldBeFwd::value_type;
-        using difference_type = typename ::WouldBeFwd::difference_type;
+        using value_type = ::WouldBeFwd::value_type;
+        using difference_type = ::WouldBeFwd::difference_type;
         using reference = iter_reference_t<::WouldBeFwd>;
         using pointer = add_pointer_t<reference>;
         // Explicit opt-out of stl2's ForwardIterator concept:
@@ -302,8 +302,8 @@ namespace std
     template <>
     struct iterator_traits<::WouldBeBidi>
     {
-        using value_type = typename ::WouldBeBidi::value_type;
-        using difference_type = typename ::WouldBeBidi::difference_type;
+        using value_type = ::WouldBeBidi::value_type;
+        using difference_type = ::WouldBeBidi::difference_type;
         using reference = value_type;
         using pointer = value_type*;
         using iterator_category = std::input_iterator_tag; // STL1-style iterator category
@@ -354,46 +354,45 @@ void deep_integration_test()
     static_assert(is_same<iter_difference_t<int* const>, ptrdiff_t>::value, "");
 
     static_assert(detail::is_std_iterator_traits_specialized_v<X>, "");
-    static_assert(is_same<typename iterator_traits<X>::value_type, int>::value, "");
+    static_assert(is_same<iterator_traits<X>::value_type, int>::value, "");
     static_assert(is_same<iter_value_t<X>, int>::value, "");
 
     static_assert(!detail::is_std_iterator_traits_specialized_v<Y>, "");
-    static_assert(is_same<typename iterator_traits<Y>::value_type, int>::value, "");
+    static_assert(is_same<iterator_traits<Y>::value_type, int>::value, "");
     static_assert(is_same<iter_value_t<Y>, int>::value, "");
 
     // libc++ has a broken std::iterator_traits primary template
     // https://bugs.llvm.org/show_bug.cgi?id=39619
 #ifndef _LIBCPP_VERSION
-    // iterator_traits uses specializations of ranges::value_type:
+    // iterator_traits uses specializations of ranges::readable_traits:
     static_assert(!detail::is_std_iterator_traits_specialized_v<Z>, "");
-    static_assert(is_same<typename iterator_traits<Z>::value_type, int>::value, "");
+    static_assert(is_same<iterator_traits<Z>::value_type, int>::value, "");
     static_assert(is_same<iter_value_t<Z>, int>::value, "");
-    static_assert(is_same<typename iterator_traits<Z>::iterator_category,
+    static_assert(is_same<iterator_traits<Z>::iterator_category,
                           std::bidirectional_iterator_tag>::value, "");
 #endif
 
     static_assert(ranges::InputIterator<WouldBeFwd>, "");
     static_assert(!ranges::ForwardIterator<WouldBeFwd>, "");
-    static_assert(is_same<typename iterator_traits<WouldBeFwd>::iterator_category,
+    static_assert(is_same<iterator_traits<WouldBeFwd>::iterator_category,
                            std::input_iterator_tag>::value, "");
 
     static_assert(ranges::ForwardIterator<WouldBeBidi>, "");
     static_assert(!ranges::BidirectionalIterator<WouldBeBidi>, "");
-    static_assert(is_same<typename iterator_traits<WouldBeBidi>::iterator_category,
+    static_assert(is_same<iterator_traits<WouldBeBidi>::iterator_category,
                           std::input_iterator_tag>::value, "");
 
     static_assert(ranges::Iterator<OutIter>, "");
     static_assert(!ranges::InputIterator<OutIter>, "");
-    static_assert(is_same<typename iterator_traits<OutIter>::difference_type,
+    static_assert(is_same<iterator_traits<OutIter>::difference_type,
                           std::ptrdiff_t>::value, "");
-    static_assert(is_same<typename iterator_traits<OutIter>::iterator_category,
+    static_assert(is_same<iterator_traits<OutIter>::iterator_category,
                           std::output_iterator_tag>::value, "");
 
-    static_assert(ranges::RandomAccessIterator<int volatile *>, "");
     static_assert(ranges::ContiguousIterator<int volatile *>, "");
 
     static_assert(ranges::ForwardIterator<bool_iterator>, "");
-    static_assert(is_same<typename iterator_traits<bool_iterator>::iterator_category,
+    static_assert(is_same<iterator_traits<bool_iterator>::iterator_category,
                           std::input_iterator_tag>::value, "");
     // static_assert(_Cpp98InputIterator<int volatile*>);
     // static_assert(_Cpp98InputIterator<bool_iterator>);

--- a/test/range/conversion.cpp
+++ b/test/range/conversion.cpp
@@ -48,7 +48,11 @@ template<
 void test_zip_to_map(Rng &&rng, int)
 {
     using namespace ranges;
+#ifdef RANGES_WORKAROUND_MSVC_779708
+    auto m = static_cast<Rng &&>(rng) | to<std::map>();
+#else // ^^^ workaround / no workaround vvv
     auto m = static_cast<Rng &&>(rng) | to<std::map>;
+#endif // RANGES_WORKAROUND_MSVC_779708
     CPP_assert(Same<decltype(m), std::map<int, int>>);
 }
 #endif
@@ -69,7 +73,7 @@ int main()
         ::check_equal(lst0, {0,1,4,9,16,25,36,49,64,81});
     }
 
-#ifndef RANGES_WORKAROUND_MSVC_779708 // "workaround" is a misnomer - there's no workaround.
+#ifndef RANGES_WORKAROUND_MSVC_779708 // "workaround" is a misnomer; there's no workaround.
     {
         auto lst1 = view::ints | view::transform([](int i){return i*i;}) | view::take(10)
             | to<std::list>;


### PR DESCRIPTION
* iter.iterator:
  * remove extraneous typename disambiguators applied to non-dependent types
  * don't redundantly test that contiguous iterator is random access

* Use `__has_include` to detect `<string_view>` in `range/access.hpp`

* Workaround VSO#792338 "Failure to match specialization enabled via call to constexpr function"
* Workaround VSO#793042 in `<iterator>`
* Workaround VSO#779708 again

* VS2019: Disable unneeded MSVC workarounds
* Update README

* Disable C5105 "macro expansion producing 'defined' has undefined behavior"