### PR TITLE
MSABI coroutine issues:

### DIFF
--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -239,6 +239,7 @@ namespace ranges
 #define RANGES_WORKAROUND_MSVC_786312 // Yet another mixed-pack-expansion failure
 #define RANGES_WORKAROUND_MSVC_792338 // Failure to match specialization enabled via call to constexpr function
 #define RANGES_WORKAROUND_MSVC_793042 // T[0] sometimes accepted as a valid type in SFINAE context
+#define RANGES_WORKAROUND_MSVC_835948 // Silent bad codegen destroying sized_generator [No workaround]
 
 // 15.9 doesn't define __cpp_coroutines even with /await (Fix not yet live)
 #if !defined(RANGES_CXX_COROUTINES) && defined(_RESUMABLE_FUNCTIONS_SUPPORTED)

--- a/include/range/v3/experimental/utility/generator.hpp
+++ b/include/range/v3/experimental/utility/generator.hpp
@@ -31,6 +31,19 @@
 #include <range/v3/iterator/default_sentinel.hpp>
 #include <range/v3/view/all.hpp>
 
+#if defined(_MSC_VER) && !defined(RANGES_SILENCE_COROUTINE_WARNING)
+#ifdef __clang__
+#pragma message("DANGER: clang doesn't (yet?) grok the MSVC coroutine ABI. " \
+    "Use at your own risk. " \
+    "(RANGES_SILENCE_COROUTINE_WARNING will silence this message.)")
+#elif defined RANGES_WORKAROUND_MSVC_835948
+#pragma message("DANGER: ranges::experimental::generator is fine, but this " \
+    "version of MSVC likely miscompiles ranges::experimental::sized_generator. " \
+    "Use the latter at your own risk. " \
+    "(RANGES_SILENCE_COROUTINE_WARNING will silence this message.)")
+#endif
+#endif // RANGES_SILENCE_COROUTINE_WARNINGS
+
 namespace ranges
 {
     /// \addtogroup group-view

--- a/test/experimental/utility/generator.cpp
+++ b/test/experimental/utility/generator.cpp
@@ -208,6 +208,7 @@ int main()
 
     auto even = [](int i){ return i % 2 == 0; };
 
+#ifndef RANGES_WORKAROUND_MSVC_835948
     {
         auto rng = ::iota_generator(0, 10);
         ::models<SizedRangeConcept>(rng);
@@ -278,6 +279,7 @@ int main()
         auto rng = f(20) | view::filter(even);
         ::check_equal(rng, {0,2,4,6,8,10,12,14,16,18});
     }
+#endif // RANGES_WORKAROUND_MSVC_835948
 
     {
         auto square = [](int i) { return i * i; };
@@ -286,8 +288,6 @@ int main()
         auto rng = ::transform(::filter(debug_input_view<int const>{some_ints}, even), square);
         ::check_equal(rng, {0,4,16,36});
     }
-
-    std::cout << f(8) << '\n';
 
     return ::test_result();
 }


### PR DESCRIPTION
* Avoid VSO#835948 "Silent bad codegen for sized_generator" in test.generator
* Warn that clang-cl doesn't speak coroutine
* Warn that MSVC miscompiles `sized_generator`