### PR TITLE
Adaptor mixin v3 bis

### DIFF
--- a/include/range/v3/utility/basic_iterator.hpp
+++ b/include/range/v3/utility/basic_iterator.hpp
@@ -382,11 +382,11 @@ namespace ranges
             using typename assoc_types_::const_reference_t;
             RANGES_CXX14_CONSTEXPR Cur &pos() noexcept
             {
-                return this->mixin_t::get();
+                return this->mixin_t::basic_mixin::get();
             }
             constexpr Cur const &pos() const noexcept
             {
-                return this->mixin_t::get();
+                return this->mixin_t::basic_mixin::get();
             }
 
         public:

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -182,11 +182,11 @@ namespace ranges
 
         protected:
             // Adaptor accessor
-            Adapt& adaptor()
+            Adapt& get()
             {
                 return second();
             }
-            const Adapt& adaptor() const
+            const Adapt& get() const
             {
                 return second();
             }
@@ -239,18 +239,17 @@ namespace ranges
                 // the underlying iterator.
                 BaseIter base() const
                 {
-                    return this->get().first();
+                    return basic_adaptor_mixin::basic_mixin::get().first();
                 }
 
             protected:
-                // Adaptor accessor
-                Adapt& adaptor()
+                Adapt& get()
                 {
-                    return this->get().second();
+                    return basic_adaptor_mixin::basic_mixin::get().second();
                 }
-                const Adapt& adaptor() const
+                const Adapt& get() const
                 {
-                    return this->get().second();
+                    return basic_adaptor_mixin::basic_mixin::get().second();
                 }
             };
 

--- a/test/view_adaptor.cpp
+++ b/test/view_adaptor.cpp
@@ -40,7 +40,7 @@ private:
 
             int base_plus_adaptor() const
             {
-                int y = this->adaptor().t;
+                int y = this->get().t;
                 return *this->base() + y;
             }
         };
@@ -111,7 +111,7 @@ struct my_delimited_range
 
             int adaptor_access_test() const
             {
-                int y = this->adaptor().t;
+                int y = this->get().t;
                 return y;
             }
         };


### PR DESCRIPTION
This https://github.com/ericniebler/range-v3/pull/1099

Making `adpator mixin` `basic_iterator mixin` conformant. 
Accessing to iterator guts with `get()` everywhere.