### PR TITLE
More detailed view_adaptor doc

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -478,7 +478,7 @@ Sometimes, you can use the same adaptor for both `begin_adaptor` and `end_adapto
     adaptor end_adaptor()   const { return {100}; }
 ~~~~~~~
 
-Note that all the data that you store in the adaptor will become part of the iterator.
+Note, that all the data, that you store in the adaptor, will become part of the iterator.
 
 If you will not "override" `begin_adaptor()` or/and `end_adaptor()` in your view_adaptor, default ones will be used.
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -480,7 +480,7 @@ Sometimes, you can use the same adaptor for both `begin_adaptor` and `end_adapto
 
 Pay attentention that all data, that you'll store in adaptor - will become part of iterator payload.
 
-If you will not "override" `begin_adaptor()` or/and `end_adaptor()` in your view_adaptor - default ones will be used.
+If you will not "override" `begin_adaptor()` or/and `end_adaptor()` in your view_adaptor, default ones will be used.
 
 ## Create Custom Iterators
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -478,7 +478,7 @@ Sometimes, you can use the same adaptor for both `begin_adaptor` and `end_adapto
     adaptor end_adaptor()   const { return {100}; }
 ~~~~~~~
 
-Pay attentention that all data, that you'll store in adaptor - will become part of iterator payload.
+Note that all the data that you store in the adaptor will become part of the iterator.
 
 If you will not "override" `begin_adaptor()` or/and `end_adaptor()` in your view_adaptor, default ones will be used.
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -316,7 +316,7 @@ to inject things into the public interface of the iterator:
               // everything inside this class will be accessible from iterator
               using base_mixin::base_mixin;
 
-              decltype(auto) base_value() const
+              auto& base_value() const
               {
                   return *this->base();
               }
@@ -341,14 +341,14 @@ Iterator/sentinel adaptor may "override" following members:
     {
         // !For begin_adaptor only!
         template<typename Rng>
-        constexpr decltype(auto) begin(Rng &rng)
+        constexpr auto begin(Rng &rng)
         {
             return ranges::begin(rng.base());
         }       
 
         // !For end_adaptor only!
         template<typename Rng>
-        constexpr decltype(auto) end(Rng &rng)
+        constexpr auto end(Rng &rng)
         {
             return ranges::end(rng.base());
         }       

--- a/doc/index.md
+++ b/doc/index.md
@@ -333,7 +333,7 @@ to inject things into the public interface of the iterator:
 
 From within mixin you can call:
 * `get()` - to access adaptor internals 
-* `base()` - to access adopted iterator
+* `base()` - to access adaptable iterator
 
 Iterator/sentinel adaptor may "override" following members:
 ~~~~~~~{.cpp}


### PR DESCRIPTION
By the way, why `empty()` is needed? `equal()` could accept sentinel instead...