### PR TITLE
Update TestHeaders CMake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ else()
 endif()
 if(RANGE_V3_TESTS)
   add_header_test(test.rangev3.headers HEADERS ${RANGE_V3_PUBLIC_HEADERS})
-  target_link_dependencies(test.rangev3.headers PRIVATE range-v3)
+  target_link_libraries(test.rangev3.headers PRIVATE range-v3)
 endif()
 set_target_properties(headers
     PROPERTIES FOLDER "test/header"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,8 @@ else()
   add_custom_target(headers SOURCES ${RANGE_V3_PUBLIC_HEADERS_ABSOLUTE})
 endif()
 if(RANGE_V3_TESTS)
-  add_header_test(range_v3_headers HEADERS ${RANGE_V3_PUBLIC_HEADERS})
+  add_header_test(test.rangev3.headers HEADERS ${RANGE_V3_PUBLIC_HEADERS})
+  target_link_dependencies(test.rangev3.headers PRIVATE range-v3)
 endif()
 set_target_properties(headers
     PROPERTIES FOLDER "test/header"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,6 @@ function(rv3_add_test TESTNAME EXENAME FIRSTSOURCE)
   add_test(${TESTNAME} ${EXENAME})
 endfunction(rv3_add_test)
 
-include(TestHeaders)
 include(ranges_options)
 include(ranges_env)
 include(ranges_flags)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,8 +82,20 @@ if(RANGE_V3_HEADER_CHECKS)
                     "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp")
   # This header is not meant to be included directly:
   list(REMOVE_ITEM RANGE_V3_PUBLIC_HEADERS std/detail/associated_types.hpp)
+  # Deprecated headers
+  if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+    foreach(header "${RANGE_V3_PUBLIC_HEADERS}")
+      file(STRINGS "${header}" is_deprecated LIMIT_COUNT 1
+                               REGEX ".*RANGES_DEPRECATED_HEADER.*")
+      if(is_deprecated)
+        list(APPEND RANGE_V3_DEPRECATED_PUBLIC_HEADERS "${header}")
+      endif()
+    endforeach()
+  endif()
 
-  add_header_test(test.range.v3.headers HEADERS ${RANGE_V3_PUBLIC_HEADERS})
+  add_header_test(test.range.v3.headers
+    EXCLUDE ${RANGE_V3_DEPRECATED_PUBLIC_HEADERS}
+    HEADERS ${RANGE_V3_PUBLIC_HEADERS})
   target_link_libraries(test.range.v3.headers PRIVATE range-v3)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ if(RANGE_V3_HEADER_CHECKS)
   list(REMOVE_ITEM RANGE_V3_PUBLIC_HEADERS std/detail/associated_types.hpp)
   # Deprecated headers
   if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
-    foreach(header "${RANGE_V3_PUBLIC_HEADERS}")
+    foreach(header ${RANGE_V3_PUBLIC_HEADERS})
       file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/include/${header}" is_deprecated
            LIMIT_COUNT 1
            REGEX ".*RANGES_DEPRECATED_HEADER.*")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,30 +67,25 @@ if(RANGE_V3_PERF)
   add_subdirectory(perf)
 endif()
 
-# Test all headers
-file(GLOB_RECURSE RANGE_V3_PUBLIC_HEADERS
-                  RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/include"
-                  "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp")
-# This header is not meant to be included directly:
-list(REMOVE_ITEM RANGE_V3_PUBLIC_HEADERS std/detail/associated_types.hpp)
-
 # Add header files as sources to fix MSVS 2017 not finding source during debugging
 file(GLOB_RECURSE RANGE_V3_PUBLIC_HEADERS_ABSOLUTE
                   "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp")
+add_custom_target(headers SOURCES ${RANGE_V3_PUBLIC_HEADERS_ABSOLUTE})
+set_target_properties(headers PROPERTIES FOLDER "header")
 
-include(TestHeaders)
+# Test all headers
 if(RANGE_V3_HEADER_CHECKS)
-  add_custom_target(headers ALL SOURCES ${RANGE_V3_PUBLIC_HEADERS_ABSOLUTE})
-else()
-  add_custom_target(headers SOURCES ${RANGE_V3_PUBLIC_HEADERS_ABSOLUTE})
+  include(TestHeaders)
+
+  file(GLOB_RECURSE RANGE_V3_PUBLIC_HEADERS
+                    RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/include"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp")
+  # This header is not meant to be included directly:
+  list(REMOVE_ITEM RANGE_V3_PUBLIC_HEADERS std/detail/associated_types.hpp)
+
+  add_header_test(test.range.v3.headers HEADERS ${RANGE_V3_PUBLIC_HEADERS})
+  target_link_libraries(test.range.v3.headers PRIVATE range-v3)
 endif()
-if(RANGE_V3_TESTS)
-  add_header_test(test.rangev3.headers HEADERS ${RANGE_V3_PUBLIC_HEADERS})
-  target_link_libraries(test.rangev3.headers PRIVATE range-v3)
-endif()
-set_target_properties(headers
-    PROPERTIES FOLDER "test/header"
-)
 
 # Grab the range-v3 version numbers:
 include(${CMAKE_CURRENT_SOURCE_DIR}/Version.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,9 @@ if(RANGE_V3_HEADER_CHECKS)
   # Deprecated headers
   if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
     foreach(header "${RANGE_V3_PUBLIC_HEADERS}")
-      file(STRINGS "${header}" is_deprecated LIMIT_COUNT 1
-                               REGEX ".*RANGES_DEPRECATED_HEADER.*")
+      file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/include/${header}" is_deprecated
+           LIMIT_COUNT 1
+           REGEX ".*RANGES_DEPRECATED_HEADER.*")
       if(is_deprecated)
         list(APPEND RANGE_V3_DEPRECATED_PUBLIC_HEADERS "${header}")
       endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ if(RANGE_V3_HEADER_CHECKS)
 else()
   add_custom_target(headers SOURCES ${RANGE_V3_PUBLIC_HEADERS_ABSOLUTE})
 endif()
-generate_standalone_header_tests(EXCLUDE_FROM_ALL MASTER_TARGET headers HEADERS ${RANGE_V3_PUBLIC_HEADERS})
+add_header_test(EXCLUDE_FROM_ALL MASTER_TARGET headers HEADERS ${RANGE_V3_PUBLIC_HEADERS})
 set_target_properties(headers
     PROPERTIES FOLDER "test/header"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,9 @@ if(RANGE_V3_HEADER_CHECKS)
 else()
   add_custom_target(headers SOURCES ${RANGE_V3_PUBLIC_HEADERS_ABSOLUTE})
 endif()
-add_header_test(EXCLUDE_FROM_ALL MASTER_TARGET headers HEADERS ${RANGE_V3_PUBLIC_HEADERS})
+if(RANGE_V3_TESTS)
+  add_header_test(range_v3_headers HEADERS ${RANGE_V3_PUBLIC_HEADERS})
+endif()
 set_target_properties(headers
     PROPERTIES FOLDER "test/header"
 )

--- a/cmake/TestHeaders.cmake
+++ b/cmake/TestHeaders.cmake
@@ -1,34 +1,40 @@
-# Copyright Louis Dionne 2013-2016
+# Copyright Louis Dionne 2013-2017
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 #
 #
-# This CMake module provides a function generating unit tests to make sure
+# This CMake module provides a function generating a unit test to make sure
 # that every public header can be included on its own.
 #
 # When a C++ library or application has many header files, it can happen that
 # a header does not include all the other headers it depends on. When this is
 # the case, it can happen that including that header file on its own will
-# break the compilation. This CMake module generates a dummy unit test for
-# each header file considered public: this unit test is just a program of
-# the form
+# break the compilation. This CMake module generates a dummy executable
+# comprised of many .cpp files, each of which includes a header file that
+# is part of the public API. In other words, the executable is comprised
+# of .cpp files of the form:
 #
 #   #include <the/public/header.hpp>
-#   int main() { }
 #
-# If this succeeds to compile, it means that the header can be included on
-# its own, which is what clients expect. Otherwise, you have a problem.
-# Since writing these dumb unit tests by hand is tedious and repetitive,
-# you can use this CMake module to automate this task.
+# and then exactly one `main` function. If this succeeds to compile, it means
+# that the header can be included on its own, which is what clients expect.
+# Otherwise, you have a problem. Since writing these dumb unit tests by hand
+# is tedious and repetitive, you can use this CMake module to automate this
+# task.
 
+#   add_header_test(<target> [EXCLUDE_FROM_ALL] [EXCLUDE excludes...] HEADERS headers...)
+#
 # Generates header-inclusion unit tests for all the specified headers.
 #
-# For each specified header with path `xxx/yyy/zzz.hpp`, a target named
-# `test.header.xxx.yyy.zzz` is created. This target builds the unit test
-# including `xxx/yyy/zzz.hpp`.
+# This function creates a target which builds a dummy executable including
+# each specified header file individually. If this target builds successfully,
+# it means that all the specified header files can be included individually.
 #
 # Parameters
 # ----------
+# <target>:
+#   The name of the target to generate.
+#
 # HEADERS headers:
 #   A list of header files to generate the inclusion tests for. All headers
 #   in this list must be represented as relative paths from the root of the
@@ -70,25 +76,14 @@
 #   generated. Basically, any header in the list specified by the `HEADERS`
 #   argument that matches anything in `EXCLUDE` will be skipped.
 #
-# [MASTER_TARGET target]:
-#   An optional target name that will be made a dependent of all the generated
-#   targets. This can be used to create a target that will build all the
-#   header-inclusion tests.
-#
-# [LINK_LIBRARIES libraries]:
-#   An optional list of libraries that should be linked into each generated
-#   executable. The libraries are linked into the target using the usual
-#   `target_link_libraries`.
-#
 # [EXCLUDE_FROM_ALL]:
-#   If set to true, the generated targets are excluded from the 'all' target.
+#   If provided, the generated target is excluded from the 'all' target.
 #
-function(generate_standalone_header_tests)
+function(add_header_test target)
     cmake_parse_arguments(ARGS "EXCLUDE_FROM_ALL"             # options
-                               "MASTER_TARGET;LINK_LIBRARIES" # 1 value args
+                               ""                             # 1 value args
                                "HEADERS;EXCLUDE"              # multivalued args
                                ${ARGN})
-
     if (NOT ARGS_HEADERS)
         message(FATAL_ERROR "The `HEADERS` argument must be provided.")
     endif()
@@ -114,31 +109,20 @@ function(generate_standalone_header_tests)
         get_filename_component(filename "${header}" NAME_WE)
         get_filename_component(directory "${header}" DIRECTORY)
 
-        if (NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/headers/${directory}/${filename}.cpp")
-            file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/headers/${directory}/${filename}.cpp" "
-/* THIS FILE WAS AUTOMATICALLY GENERATED: DO NOT EDIT! */
-#include <${header}>
-int main() { }
-")
+        set(source "${CMAKE_CURRENT_BINARY_DIR}/headers/${directory}/${filename}.cpp")
+        if (NOT EXISTS "${source}")
+            file(WRITE "${source}" "#include <${header}>")
         endif()
-
-        string(REGEX REPLACE "/" "." target "${header}")
-        add_executable(test.header.${target}
-            ${ARGS_EXCLUDE_FROM_ALL}
-            "${CMAKE_CURRENT_BINARY_DIR}/headers/${directory}/${filename}.cpp"
-        )
-        set_target_properties(test.header.${target}
-            PROPERTIES FOLDER "test/header"
-        )
-        target_compile_definitions(test.header.${target}
-            PRIVATE RANGES_DISABLE_DEPRECATED_WARNINGS)
-        target_include_directories(test.header.${target} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
-        if (ARGS_LINK_LIBRARIES)
-            target_link_libraries(test.header.${target} ${ARGS_LINK_LIBRARIES})
-        endif()
-
-        if (ARGS_MASTER_TARGET)
-            add_dependencies(${ARGS_MASTER_TARGET} test.header.${target})
-        endif()
+        list(APPEND sources "${source}")
     endforeach()
+
+    set(standalone_main "${CMAKE_CURRENT_BINARY_DIR}/headers/_standalone_main.cpp")
+    if (NOT EXISTS "${standalone_main}")
+        file(WRITE "${standalone_main}" "int main() { }")
+    endif()
+    add_executable(${target}
+        ${ARGS_EXCLUDE_FROM_ALL}
+        ${sources}
+        "${CMAKE_CURRENT_BINARY_DIR}/headers/_standalone_main.cpp"
+    )
 endfunction()

--- a/cmake/ranges_options.cmake
+++ b/cmake/ranges_options.cmake
@@ -22,6 +22,9 @@ option(RANGES_PREFER_REAL_CONCEPTS
 option(RANGES_DEEP_STL_INTEGRATION
   "Hijacks the primary std::iterator_traits template to emulate the C++20 std::ranges:: behavior."
   OFF)
+option(RANGE_V3_HEADER_CHECKS
+  "Build the Range-v3 header checks and integrate with ctest"
+  OFF)
 set(RANGES_INLINE_THRESHOLD -1 CACHE STRING "Force a specific inlining threshold.")
 
 # Enable verbose configure when passing -Wdev to CMake
@@ -36,10 +39,6 @@ endif()
 
 CMAKE_DEPENDENT_OPTION(RANGE_V3_TESTS
   "Build the Range-v3 tests and integrate with ctest"
-  ON "${is_standalone}" OFF)
-
-CMAKE_DEPENDENT_OPTION(RANGE_V3_HEADER_CHECKS
-  "Build the Range-v3 header checks and integrate with ctest"
   ON "${is_standalone}" OFF)
 
 CMAKE_DEPENDENT_OPTION(RANGE_V3_EXAMPLES


### PR DESCRIPTION
This prevents the massive amount of generated targets from appearing in graphical contexts that overshadow the local project's targets.