### PR TITLE
fix libcpp aligned new detection for iOS

### DIFF
--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -464,7 +464,8 @@ namespace ranges
 
 // Its not enough for the compiler to support this; the stdlib must support it too.
 #ifndef RANGES_CXX_ALIGNED_NEW
-#if (!defined(_LIBCPP_VERSION) || _LIBCPP_VERSION >= 4000) && \
+#if (!defined(_LIBCPP_VERSION) || \
+		(_LIBCPP_VERSION >= 4000 && !defined(_LIBCPP_HAS_NO_ALIGNED_ALLOCATION))) && \
     (!defined(__GLIBCXX__) || (defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE >= 7))
 #if defined(__cpp_aligned_new)
 #define RANGES_CXX_ALIGNED_NEW __cpp_aligned_new


### PR DESCRIPTION
Currently range-v3/master does not build when targeting iOS, due to iOS lacking support for aligned new.

This PR disables aligned new when `_LIBCPP_HAS_NO_ALIGNED_ALLOCATION` is defined which allows range-v3 to build for iOS targets.