### PR TITLE
Add trim view

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -563,6 +563,8 @@ provides, and a blurb about how each is intended to be used.
   <DD>Given a source range and optionally a submatch specifier and a `std::regex_constants::match_flag_type`, return a `std::regex_token_iterator` to step through the regex submatches of the source range. The submatch specifier may be either a plain `int`, a `std::vector<int>`, or a `std::initializer_list<int>`.</DD>
 <DT>\link ranges::view::transform_fn `view::transform`\endlink</DT>
   <DD>Given a source range and a unary function, return a new range where each result element is the result of applying the unary function to a source element.</DD>
+<DT>\link ranges::view::trim_fn `view::trim`\endlink</DT>
+  <DD>Remove elements from the front and back of a bidirectional range that satisfy a unary predicate.</DD>
 <DT>\link ranges::view::unbounded_fn `view::unbounded`\endlink</DT>
   <DD>Given an iterator, return an infinite range that begins at that position.</DD>
 <DT>\link ranges::view::unique_fn `view::unique`\endlink</DT>

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -702,6 +702,14 @@ namespace ranges
         struct replace_if_fn;
     }
 
+    template<typename Rng, typename Pred>
+    struct trim_view;
+
+    namespace view
+    {
+        struct trim_fn;
+    }
+
     template<typename I>
     struct unbounded_view;
 

--- a/include/range/v3/view.hpp
+++ b/include/range/v3/view.hpp
@@ -78,6 +78,7 @@ RANGES_DISABLE_WARNINGS
 #include <range/v3/view/take_while.hpp>
 #include <range/v3/view/tokenize.hpp>
 #include <range/v3/view/transform.hpp>
+#include <range/v3/view/trim.hpp>
 #include <range/v3/view/unbounded.hpp>
 #include <range/v3/view/unique.hpp>
 #include <range/v3/view/view.hpp>

--- a/include/range/v3/view/trim.hpp
+++ b/include/range/v3/view/trim.hpp
@@ -50,7 +50,7 @@ namespace ranges
     public:
         CPP_assert(BidirectionalView<Rng> &&
             IndirectUnaryPredicate<Pred, iterator_t<Rng>> &&
-            std::is_object<Pred>::value);
+            CommonRange<Rng>);
 
         trim_view() = default;
         trim_view(Rng rng, Pred pred)
@@ -112,7 +112,7 @@ namespace ranges
                 CPP_ret(trim_view<all_t<Rng>, Pred>)(
                     requires ViewableRange<Rng> && BidirectionalRange<Rng> &&
                         IndirectUnaryPredicate<Pred, iterator_t<Rng>> &&
-                        std::is_object<Pred>::value)
+                        CommonRange<Rng>)
             {
                 return {all(static_cast<Rng &&>(rng)), std::move(pred)};
             }
@@ -121,7 +121,7 @@ namespace ranges
                 CPP_ret(trim_view<all_t<Rng>, composed<Pred, Proj>>)(
                     requires ViewableRange<Rng> && BidirectionalRange<Rng> &&
                         IndirectUnaryPredicate<composed<Pred, Proj>, iterator_t<Rng>> &&
-                        std::is_object<Pred>::value && std::is_object<Proj>::value)
+                        CommonRange<Rng>)
             {
                 return {
                     all(static_cast<Rng &&>(rng)),

--- a/include/range/v3/view/trim.hpp
+++ b/include/range/v3/view/trim.hpp
@@ -1,0 +1,147 @@
+/// \file
+// Range v3 library
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#ifndef RANGES_V3_VIEW_TRIM_HPP
+#define RANGES_V3_VIEW_TRIM_HPP
+
+#include <functional>
+#include <type_traits>
+#include <utility>
+#include <concepts/concepts.hpp>
+#include <range/v3/algorithm/find_if_not.hpp>
+#include <range/v3/detail/config.hpp>
+#include <range/v3/iterator/concepts.hpp>
+#include <range/v3/functional/bind.hpp>
+#include <range/v3/functional/compose.hpp>
+#include <range/v3/functional/pipeable.hpp>
+#include <range/v3/range/access.hpp>
+#include <range/v3/range/concepts.hpp>
+#include <range/v3/range/primitives.hpp>
+#include <range/v3/utility/optional.hpp>
+#include <range/v3/utility/semiregular.hpp>
+#include <range/v3/view/all.hpp>
+#include <range/v3/view/interface.hpp>
+#include <range/v3/view/reverse.hpp>
+#include <range/v3/view/view.hpp>
+
+namespace ranges
+{
+    /// \addtogroup group-views
+    /// @{
+    template<typename Rng, typename Pred>
+    struct trim_view : view_interface<trim_view<Rng, Pred>>
+    {
+    private:
+        Rng rng_;
+        semiregular_t<Pred> pred_;
+        detail::non_propagating_cache<iterator_t<Rng>> begin_;
+        detail::non_propagating_cache<iterator_t<Rng>> end_;
+
+    public:
+        CPP_assert(BidirectionalView<Rng> &&
+            IndirectUnaryPredicate<Pred, iterator_t<Rng>> &&
+            std::is_object<Pred>::value);
+
+        trim_view() = default;
+        trim_view(Rng rng, Pred pred)
+          : rng_(std::move(rng)), pred_(std::move(pred))
+        {}
+        CPP_template(typename R)(
+            requires BidirectionalRange<R> && ViewableRange<R> &&
+                Constructible<Rng, view::all_t<R>>)
+        trim_view(R &&rng, Pred pred)
+          : rng_(view::all(static_cast<R &&>(rng))), pred_(std::move(pred))
+        {}
+
+        iterator_t<Rng> begin()
+        {
+            if(!begin_)
+                begin_ = find_if_not(rng_, std::ref(pred_));
+            return *begin_;
+        }
+        iterator_t<Rng> end()
+        {
+            if(!end_)
+            {
+                auto rbase = view::reverse(rng_);
+                end_= find_if_not(rbase, std::ref(pred_)).base();
+            }
+            return *end_;
+        }
+
+        Rng base() const
+        {
+            return rng_;
+        }
+    };
+
+#if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
+    template<typename Rng, typename Pred>
+    trim_view(Rng &&, Pred) -> trim_view<view::all_t<Rng>, Pred>;
+#endif
+
+    template<typename Rng, typename Pred>
+    RANGES_INLINE_VAR constexpr bool disable_sized_range<trim_view<Rng, Pred>> = true;
+
+    namespace view
+    {
+        struct trim_fn
+        {
+        private:
+            friend view_access;
+            template<typename Pred>
+            static auto bind(trim_fn trim, Pred pred)
+            {
+                return make_pipeable(
+                    std::bind(trim, std::placeholders::_1, protect(std::move(pred))));
+            }
+            template<typename Pred, typename Proj>
+            static auto bind(trim_fn trim, Pred pred, Proj proj)
+            {
+                return make_pipeable(
+                    std::bind(trim, std::placeholders::_1, protect(std::move(pred)),
+                    protect(std::move(proj))));
+            }
+        public:
+            template<typename Rng, typename Pred>
+            auto operator()(Rng &&rng, Pred pred) const ->
+                CPP_ret(trim_view<all_t<Rng>, Pred>)(
+                    requires ViewableRange<Rng> && BidirectionalRange<Rng> &&
+                        IndirectUnaryPredicate<Pred, iterator_t<Rng>> &&
+                        std::is_object<Pred>::value)
+            {
+                return {all(static_cast<Rng &&>(rng)), std::move(pred)};
+            }
+            template<typename Rng, typename Pred, typename Proj>
+            auto operator()(Rng &&rng, Pred pred, Proj proj) const ->
+                CPP_ret(trim_view<all_t<Rng>, composed<Pred, Proj>>)(
+                    requires ViewableRange<Rng> && BidirectionalRange<Rng> &&
+                        IndirectUnaryPredicate<composed<Pred, Proj>, iterator_t<Rng>> &&
+                        std::is_object<Pred>::value && std::is_object<Proj>::value)
+            {
+                return {
+                    all(static_cast<Rng &&>(rng)),
+                    compose(std::move(pred), std::move(proj))
+                };
+            }
+        };
+
+        /// \relates trim_fn
+        /// \ingroup group-views
+        RANGES_INLINE_VARIABLE(view<trim_fn>, trim)
+    }
+    /// @}
+}
+
+#include <range/v3/detail/satisfy_boost_range.hpp>
+RANGES_SATISFY_BOOST_RANGE(::ranges::trim_view)
+
+#endif // RANGES_V3_VIEW_TRIM_HPP

--- a/include/range/v3/view/trim.hpp
+++ b/include/range/v3/view/trim.hpp
@@ -31,6 +31,7 @@
 #include <range/v3/view/all.hpp>
 #include <range/v3/view/interface.hpp>
 #include <range/v3/view/reverse.hpp>
+#include <range/v3/view/subrange.hpp>
 #include <range/v3/view/view.hpp>
 
 namespace ranges
@@ -66,7 +67,7 @@ namespace ranges
         {
             if(!end_)
             {
-                auto rbase = view::reverse(rng_);
+                auto rbase = view::reverse(make_subrange(begin(), ranges::end(rng_)));
                 end_= find_if_not(rbase, std::ref(pred_)).base();
             }
             return *end_;

--- a/include/range/v3/view/trim.hpp
+++ b/include/range/v3/view/trim.hpp
@@ -15,7 +15,6 @@
 #define RANGES_V3_VIEW_TRIM_HPP
 
 #include <functional>
-#include <type_traits>
 #include <utility>
 #include <concepts/concepts.hpp>
 #include <range/v3/algorithm/find_if_not.hpp>

--- a/include/range/v3/view/trim.hpp
+++ b/include/range/v3/view/trim.hpp
@@ -22,7 +22,6 @@
 #include <range/v3/iterator/concepts.hpp>
 #include <range/v3/functional/bind.hpp>
 #include <range/v3/functional/compose.hpp>
-#include <range/v3/functional/invoke.hpp>
 #include <range/v3/functional/pipeable.hpp>
 #include <range/v3/range/access.hpp>
 #include <range/v3/range/concepts.hpp>
@@ -31,6 +30,7 @@
 #include <range/v3/utility/semiregular.hpp>
 #include <range/v3/view/all.hpp>
 #include <range/v3/view/interface.hpp>
+#include <range/v3/view/reverse.hpp>
 #include <range/v3/view/view.hpp>
 
 namespace ranges
@@ -66,12 +66,8 @@ namespace ranges
         {
             if(!end_)
             {
-                auto const first = begin();
-                auto last = ranges::end(rng_);
-
-                while (last != first && invoke(pred_, *--last))
-                {}
-                end_ = ++last;
+                auto rbase = view::reverse(rng_);
+                end_= find_if_not(rbase, std::ref(pred_)).base();
             }
             return *end_;
         }

--- a/include/range/v3/view/trim.hpp
+++ b/include/range/v3/view/trim.hpp
@@ -23,6 +23,7 @@
 #include <range/v3/iterator/concepts.hpp>
 #include <range/v3/functional/bind.hpp>
 #include <range/v3/functional/compose.hpp>
+#include <range/v3/functional/invoke.hpp>
 #include <range/v3/functional/pipeable.hpp>
 #include <range/v3/range/access.hpp>
 #include <range/v3/range/concepts.hpp>
@@ -31,7 +32,6 @@
 #include <range/v3/utility/semiregular.hpp>
 #include <range/v3/view/all.hpp>
 #include <range/v3/view/interface.hpp>
-#include <range/v3/view/reverse.hpp>
 #include <range/v3/view/view.hpp>
 
 namespace ranges
@@ -67,8 +67,12 @@ namespace ranges
         {
             if(!end_)
             {
-                auto rbase = view::reverse(rng_);
-                end_= find_if_not(rbase, std::ref(pred_)).base();
+                auto const first = begin();
+                auto last = ranges::end(rng_);
+
+                while (last != first && invoke(pred_, *--last))
+                {}
+                end_ = ++last;
             }
             return *end_;
         }

--- a/include/range/v3/view/trim.hpp
+++ b/include/range/v3/view/trim.hpp
@@ -56,12 +56,6 @@ namespace ranges
         trim_view(Rng rng, Pred pred)
           : rng_(std::move(rng)), pred_(std::move(pred))
         {}
-        CPP_template(typename R)(
-            requires BidirectionalRange<R> && ViewableRange<R> &&
-                Constructible<Rng, view::all_t<R>>)
-        trim_view(R &&rng, Pred pred)
-          : rng_(view::all(static_cast<R &&>(rng))), pred_(std::move(pred))
-        {}
 
         iterator_t<Rng> begin()
         {

--- a/include/range/v3/view/trim.hpp
+++ b/include/range/v3/view/trim.hpp
@@ -1,6 +1,8 @@
 /// \file
 // Range v3 library
 //
+//  Copyright Johel Guerrero 2019
+//
 //  Use, modification and distribution is subject to the
 //  Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at

--- a/include/range/v3/view/trim.hpp
+++ b/include/range/v3/view/trim.hpp
@@ -22,6 +22,7 @@
 #include <range/v3/iterator/concepts.hpp>
 #include <range/v3/functional/bind.hpp>
 #include <range/v3/functional/compose.hpp>
+#include <range/v3/functional/invoke.hpp>
 #include <range/v3/functional/pipeable.hpp>
 #include <range/v3/range/access.hpp>
 #include <range/v3/range/concepts.hpp>
@@ -30,8 +31,6 @@
 #include <range/v3/utility/semiregular.hpp>
 #include <range/v3/view/all.hpp>
 #include <range/v3/view/interface.hpp>
-#include <range/v3/view/reverse.hpp>
-#include <range/v3/view/subrange.hpp>
 #include <range/v3/view/view.hpp>
 
 namespace ranges
@@ -67,8 +66,15 @@ namespace ranges
         {
             if(!end_)
             {
-                auto rbase = view::reverse(make_subrange(begin(), ranges::end(rng_)));
-                end_= find_if_not(rbase, std::ref(pred_)).base();
+                const auto first = begin();
+                auto last = ranges::end(rng_);
+                while (last != first)
+                    if (!invoke(pred_, *--last))
+                    {
+                        ++last;
+                        break;
+                    }
+                end_ = std::move(last);
             }
             return *end_;
         }

--- a/test/view/CMakeLists.txt
+++ b/test/view/CMakeLists.txt
@@ -58,6 +58,7 @@ rv3_add_test(test.view.take_exactly view.take_exactly take_exactly.cpp)
 rv3_add_test(test.view.take_while view.take_while take_while.cpp)
 rv3_add_test(test.view.tokenize view.tokenize tokenize.cpp)
 rv3_add_test(test.view.transform view.transform transform.cpp)
+rv3_add_test(test.view.trim view.trim trim.cpp)
 rv3_add_test(test.view.unique view.unique unique.cpp)
 rv3_add_test(test.view.zip view.zip zip.cpp)
 

--- a/test/view/trim.cpp
+++ b/test/view/trim.cpp
@@ -1,0 +1,43 @@
+// Range v3 library
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#include <list>
+
+#include <range/v3/range/concepts.hpp>
+#include <range/v3/utility/copy.hpp>
+#include <range/v3/view/counted.hpp>
+#include <range/v3/view/trim.hpp>
+
+#include "../test_utils.hpp"
+
+int main()
+{
+    using namespace ranges;
+
+    auto is_space = [](char c) {
+        return c == ' ' || c == '\t' || c == '\0';
+    };
+    auto _42 = view::trim(" \t42\t  \t", is_space);
+
+    check_equal(_42, {'4', '2'});
+    // Always models the most refined range concept
+    // modeled by the underlying range.
+    models<ContiguousViewConcept>(aux::copy(_42));
+    std::list<char> l;
+    models<BidirectionalViewConcept>(view::trim(l, is_space));
+    models_not<RandomAccessViewConcept>(view::trim(l, is_space));
+    // Always models `CommonRange`.
+    models<CommonRangeConcept>(aux::copy(_42));
+    models<CommonRangeConcept>(view::trim(view::counted("", 0), is_space));
+    // Never models `SizedRange`.
+    models_not<SizedRangeConcept>(aux::copy(_42));
+
+    return test_result();
+}

--- a/test/view/trim.cpp
+++ b/test/view/trim.cpp
@@ -1,5 +1,7 @@
 // Range v3 library
 //
+//  Copyright Johel Guerrero 2019
+//
 //  Use, modification and distribution is subject to the
 //  Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at

--- a/test/view/trim.cpp
+++ b/test/view/trim.cpp
@@ -14,7 +14,6 @@
 
 #include <range/v3/range/concepts.hpp>
 #include <range/v3/utility/copy.hpp>
-#include <range/v3/view/counted.hpp>
 #include <range/v3/view/trim.hpp>
 
 #include "../test_utils.hpp"
@@ -35,9 +34,6 @@ int main()
     std::list<char> l;
     models<BidirectionalViewConcept>(view::trim(l, is_space));
     models_not<RandomAccessViewConcept>(view::trim(l, is_space));
-    // Always models `CommonRange`.
-    models<CommonRangeConcept>(aux::copy(_42));
-    models<CommonRangeConcept>(view::trim(view::counted("", 0), is_space));
     // Never models `SizedRange`.
     models_not<SizedRangeConcept>(aux::copy(_42));
 

--- a/test/view/trim.cpp
+++ b/test/view/trim.cpp
@@ -10,32 +10,82 @@
 // Project home: https://github.com/ericniebler/range-v3
 //
 
-#include <list>
-
-#include <range/v3/range/concepts.hpp>
+#include <concepts/concepts.hpp>
+#include <range/v3/iterator/operations.hpp>
+#include <range/v3/range/operations.hpp>
+#include <range/v3/range/primitives.hpp>
+#include <range/v3/range_fwd.hpp>
 #include <range/v3/utility/copy.hpp>
+#include <range/v3/view/addressof.hpp>
+#include <range/v3/view/drop.hpp>
+#include <range/v3/view/drop_while.hpp>
+#include <range/v3/view/reverse.hpp>
+#include <range/v3/view/subrange.hpp>
+#include <range/v3/view/tail.hpp>
 #include <range/v3/view/trim.hpp>
 
+#include "../test_iterators.hpp"
 #include "../test_utils.hpp"
 
 int main()
 {
     using namespace ranges;
+    int ia[] = {0, 1, 2, 3, 4, 3, 2, 1, 2, 3, 4, 3, 2, 1, 0};
+    int ib[] =             {4, 3, 2, 1, 2, 3, 4};
+    constexpr auto bs = distance(ib);
+    auto p = [](int i) { return i < 4; };
 
-    auto is_space = [](char c) {
-        return c == ' ' || c == '\t' || c == '\0';
-    };
-    auto _42 = view::trim(" \t42\t  \t", is_space);
+    auto && rng = view::trim(ia, p);
+    static_assert(Same<iterator_t<decltype(rng)>, iterator_t<decltype(ia)>>, "");
+    models<ContiguousViewConcept>(aux::copy(rng));
+    models<CommonRangeConcept>(aux::copy(rng));
+    models_not<SizedRangeConcept>(aux::copy(rng));
+    check_equal(rng, ib);
 
-    check_equal(_42, {'4', '2'});
-    // Always models the most refined range concept
-    // modeled by the underlying range.
-    models<ContiguousViewConcept>(aux::copy(_42));
-    std::list<char> l;
-    models<BidirectionalViewConcept>(view::trim(l, is_space));
-    models_not<RandomAccessViewConcept>(view::trim(l, is_space));
-    // Never models `SizedRange`.
-    models_not<SizedRangeConcept>(aux::copy(_42));
+    auto && rng2 = view::trim(ib, p);
+    check_equal(view::addressof(rng2), view::addressof(ib));
+
+    auto && rng3 = ia | view::drop(4) | view::trim(p);
+    static_assert(Same<iterator_t<decltype(rng3)>, iterator_t<decltype(rng3.base())>>, "");
+    models<ContiguousViewConcept>(aux::copy(rng3));
+    models<CommonRangeConcept>(aux::copy(rng3));
+    models_not<SizedRangeConcept>(aux::copy(rng3));
+    check_equal(rng3, ib);
+
+    auto && rng4 = ia | view::reverse | view::drop(4) | view::trim(p);
+    static_assert(Same<iterator_t<decltype(rng4)>, iterator_t<decltype(rng4.base())>>, "");
+    models<RandomAccessViewConcept>(aux::copy(rng4));
+    models<CommonRangeConcept>(aux::copy(rng4));
+    models_not<SizedRangeConcept>(aux::copy(rng4));
+    check_equal(rng4, ib);
+
+    check_equal(view::trim(ia, p), ia | view::drop_while(p) | view::reverse | view::drop_while(p));
+
+    auto && rng5 = make_subrange(ib + 1, ib + bs - 1) | view::trim(p);
+    static_assert(Same<iterator_t<decltype(rng5)>, iterator_t<decltype(rng5.base())>>, "");
+    models<ContiguousViewConcept>(aux::copy(rng5));
+    models<CommonRangeConcept>(aux::copy(rng5));
+    models_not<SizedRangeConcept>(aux::copy(rng5));
+    CHECK(empty(rng5));
+
+    auto && rng6 = make_subrange(ib, ib + bs - 1) | view::trim(p);
+    CHECK(distance(rng6) == 1);
+    check_equal(&front(rng6), ib);
+
+    auto && rng7 = ib | view::tail | view::trim(p);
+    static_assert(Same<iterator_t<decltype(rng7)>, iterator_t<decltype(rng7.base())>>, "");
+    models<ContiguousViewConcept>(aux::copy(rng7));
+    models<CommonRangeConcept>(aux::copy(rng7));
+    models_not<SizedRangeConcept>(aux::copy(rng7));
+    CHECK(distance(rng7) == 1);
+    check_equal(&front(rng7), ib + bs - 1);
+
+    auto && rng8 = make_subrange(bidirectional_iterator<const int*>(ia),
+        bidirectional_iterator<const int*>(ia + distance(ia))) | view::trim(p);
+    static_assert(Same<iterator_t<decltype(rng8)>, iterator_t<decltype(rng8.base())>>, "");
+    models<BidirectionalViewConcept>(aux::copy(rng8));
+    models<CommonRangeConcept>(aux::copy(rng8));
+    models_not<SizedRangeConcept>(aux::copy(rng8));
 
     return test_result();
 }


### PR DESCRIPTION
I hope this is within scope. I thought I'd try getting this in so that it's available for the broader public rather than stuffing it in a library of mine. I'm looking forward to the review comments.

The current implementation is simple thanks to the bidirectional range requirement. Looking at #1112, it should be possible to do with a forward range. But I believe it'd be simpler to add a complementing `drop_last_while` and implement `view::trim` in terms of it and `drop_while`. This possibility makes me wonder if this is okay as is.