### PR TITLE
Improve check of -Wno-* compiler flags

### DIFF
--- a/cmake/ranges_flags.cmake
+++ b/cmake/ranges_flags.cmake
@@ -8,10 +8,14 @@
 
 # Compilation flags
 include(CheckCXXCompilerFlag)
-macro(ranges_append_flag testname flag ${ARGN})
-    check_cxx_compiler_flag("${flag} ${ARGN}" ${testname})
+macro(ranges_append_flag testname flag)
+    # As -Wno-* flags do not lead to build failure when there are no other
+    # diagnostics, we check positive option to determine their applicability.
+    # Of course, we set the original flag that is requested in the parameters.
+    string(REGEX REPLACE "^-Wno-" "-W" alt ${flag})
+    check_cxx_compiler_flag(${alt} ${testname})
     if (${testname})
-        add_compile_options(${flag} ${ARGN})
+        add_compile_options(${flag})
     endif()
 endmacro()
 


### PR DESCRIPTION
The GCC documentation says that unrecognized warning options in the `-Wno-*` form do not cause errors unless other diagnostics are issued. And thus unsupported flags may be appended. This results in a failed
build when there are some false positive warnings.

https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html