### PR TITLE
use modern concept definition

### DIFF
--- a/include/concepts/concepts.hpp
+++ b/include/concepts/concepts.hpp
@@ -224,13 +224,13 @@ CPP_PP_IGNORE_CXX2A_COMPAT_BEGIN
 #ifdef CPP_DOXYGEN_INVOKED
 #define CPP_PP_DECL_DEF_IMPL(TPARAM, NAME, ARGS, ...)                           \
     CPP_PP_CAT(CPP_PP_DEF_, TPARAM)                                             \
-    concept bool NAME = CPP_PP_DEF_IMPL(__VA_ARGS__,)(__VA_ARGS__)              \
+    META_CONCEPT NAME = CPP_PP_DEF_IMPL(__VA_ARGS__,)(__VA_ARGS__)              \
     /**/
 #else
 #define CPP_PP_DECL_DEF_IMPL(TPARAM, NAME, ARGS, ...)                           \
     inline namespace _eager_ {                                                  \
         CPP_PP_CAT(CPP_PP_DEF_, TPARAM)                                         \
-        concept bool NAME = CPP_PP_DEF_IMPL(__VA_ARGS__,)(__VA_ARGS__);         \
+        META_CONCEPT NAME = CPP_PP_DEF_IMPL(__VA_ARGS__,)(__VA_ARGS__);         \
     }                                                                           \
     struct CPP_PP_CAT(NAME, Concept) {                                          \
         CPP_PP_CAT(CPP_PP_DEF_, TPARAM)                                         \


### PR DESCRIPTION
The standard only allows the following syntax 

```c++
template <typename t>
concept AnyType = true; // gcc >= 9 and clang
```

but ranges currently uses 

```c++
template <typename t>
concept bool AnyType = true; // only way to define concepts gcc<9
```

-----

clang will not allow the additional `bool`.

This PR will add the concept definition without the `bool` and uses it in the same manner as it is already handled in the meta library, see

https://github.com/ericniebler/range-v3/blob/75d96cfeabf6366012090594382bda635b6cfb38/include/meta/meta_fwd.hpp#L138-L153

Open Questions:
* Would it also be okay to use `META_CONCEPT` instead if redefining it? Or do you want to make the definitions of the meta library independent of the ones in ranges?
* Do you have a better name for `CPP_CXX_CONCEPT`? Or is it okay?