### PR TITLE
Workaround valgrind Travis failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -251,8 +251,13 @@ install:
   # Workaround for valgrind bug: https://bugs.kde.org/show_bug.cgi?id=326469.
   # It is fixed in valgrind 3.10 so this won't be necessary if someone
   # replaces the current valgrind (3.7) with valgrind-3.10
-  - if [ "$USE_VALGRIND" == "On" ]; then sed -i 's/march=native/msse4.2/' cmake/ranges_flags.cmake; fi
-
+  - |
+    if [ "$USE_VALGRIND" == "On" ]; then
+      sed -i 's/march=native/msse4.2/' cmake/ranges_flags.cmake
+      # We need to explicitly initialize std::random_device on libstdc++ to avoid using RDRAND
+      # since valgrind doesn't understand the instruction.
+      CXX_FLAGS="${CXX_FLAGS} -DRANGES_WORKAROUND_VALGRIND_RDRAND"
+    fi
   - if [ "$GCC_VERSION" == "5" ]; then CXX_FLAGS="${CXX_FLAGS} -DRANGES_CXX_CONSTEXPR=RANGES_CXX_CONSTEXPR11"; fi
   - |
     if [ "$LIBCXX" == "On" ]; then

--- a/include/range/v3/utility/random.hpp
+++ b/include/range/v3/utility/random.hpp
@@ -108,7 +108,11 @@ namespace ranges
                     std::array<std::uint32_t, 8> seeds;
 
                     // Hopefully high-quality entropy from random_device.
-                    std::random_device rd{};
+#if defined(__GLIBCXX__) && defined(RANGES_WORKAROUND_VALGRIND_RDRAND)
+                    std::random_device rd{"/dev/urandom"};
+#else
+                    std::random_device rd;
+#endif
                     std::uniform_int_distribution<std::uint32_t> dist{};
                     ranges::generate(seeds, [&] { return dist(rd); });
 

--- a/test/action/unstable_remove_if.cpp
+++ b/test/action/unstable_remove_if.cpp
@@ -112,7 +112,11 @@ void logic_test()
 class fuzzy_test_fn
 {
     int size;
+#if defined(__GLIBCXX__) && defined(RANGES_WORKAROUND_VALGRIND_RDRAND)
+    std::random_device rd{"/dev/urandom"};
+#else
     std::random_device rd;
+#endif
     std::mt19937 eng{rd()};
     std::uniform_int_distribution<int> distr;
 


### PR DESCRIPTION
`valgrind` doesn't grok `RDRAND` (https://bugs.launchpad.net/ubuntu/+source/valgrind/+bug/1501545), so we must explicitly initialize `std::random_device{"/dev/urandom"}` to avoid using the instruction in valgrind runs on Travis.