### PR TITLE
ranges::base

### DIFF
--- a/include/range/v3/base.hpp
+++ b/include/range/v3/base.hpp
@@ -1,0 +1,144 @@
+/// \file
+// Range v3 library
+//
+//  Copyright Andrey Diduh 2019
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#ifndef RANGE_V3_BASE_HPP
+#define RANGE_V3_BASE_HPP
+
+#include <range/v3/range_concepts.hpp>
+#include <range/v3/view/all.hpp>
+
+namespace ranges
+{
+    inline namespace v3
+    {
+        namespace details
+        {
+            template<class V>
+            RANGES_CXX14_CONSTEXPR auto base_loop(V&& v, std::integral_constant<int, 1>)
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+            (
+                v.base()
+            )
+            template<int N, class V>
+            RANGES_CXX14_CONSTEXPR auto base_loop(V&& v, std::integral_constant<int, N>)
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+            (
+                base_loop( v.base(), std::integral_constant<int, N-1>{})
+            )
+            template<int N, class V>
+            RANGES_CXX14_CONSTEXPR auto base_loop(V&& v)
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+            (
+                base_loop(std::forward<V>(v), std::integral_constant<int, N>{})
+            )
+
+            template<typename Target, bool found>
+            struct loop_to_t;
+
+            template<typename Target, class V>
+            RANGES_CXX14_CONSTEXPR auto loop_to(V&& v)
+            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+            (
+                loop_to_t<
+                    Target,
+                    std::is_same< detail::decay_t<V>, detail::decay_t<Target> >::value
+                >{}(std::forward<V>(v))
+            )
+
+            template<typename Target>
+            struct loop_to_t<Target, true>
+            {
+                template<class V>
+                RANGES_CXX14_CONSTEXPR auto operator()(V&& v)
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                (
+                    std::forward<V>(v)
+                )
+            };
+
+            template<typename Target>
+            struct loop_to_t<Target, false>
+            {
+                template<class V>
+                RANGES_CXX14_CONSTEXPR auto operator()(V&& v)
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                (
+                    loop_to<Target>(v.base())
+                )
+            };
+        }
+
+        // for iterators
+        template<typename I,
+            CONCEPT_REQUIRES_(Iterator<I>())>
+        RANGES_CXX14_CONSTEXPR auto base(I&& iter)
+        RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+        (
+            iter.base()
+        )
+
+        // TODO: static_assert(N >= 1)
+        template<int N, typename I,
+            CONCEPT_REQUIRES_(Iterator<I>())>
+        RANGES_CXX14_CONSTEXPR auto base(I&& iter)
+        RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+        (
+            details::base_loop<N>(std::forward<I>(iter))
+        )
+        template<typename BaseIterator, typename I,
+            CONCEPT_REQUIRES_(Iterator<I>() && Iterator<BaseIterator>())>
+        RANGES_CXX14_CONSTEXPR BaseIterator base(I&& iter)
+        {
+            return details::loop_to<BaseIterator>(std::forward<I>(iter));
+        }
+        template<typename BaseRange, typename I,
+            CONCEPT_REQUIRES_(Iterator<I>() && Range<BaseRange>())>
+        RANGES_CXX14_CONSTEXPR auto base(I&& iter)
+        RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+        (
+            base<iterator_t<BaseRange>>(std::forward<I>(iter))
+        )
+        template<typename BaseRange, typename I,
+            CONCEPT_REQUIRES_(Iterator<I>() && Range<BaseRange>())>
+        RANGES_CXX14_CONSTEXPR auto base(I&& iter, BaseRange&&)
+        RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+        (
+            base<iterator_t<BaseRange>>(std::forward<I>(iter))
+        )
+
+        // for ranges
+        template<typename R,
+            CONCEPT_REQUIRES_(Range<R>())>
+        RANGES_CXX14_CONSTEXPR auto base(R&& range)
+        RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+        (
+            range.base()
+        )
+        template<int N, typename R,
+            CONCEPT_REQUIRES_(Range<R>())>
+        RANGES_CXX14_CONSTEXPR auto base(R&& range)
+        RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+        (
+            details::base_loop<N>(std::forward<R>(range))
+        )
+        template<typename BaseRange, typename R,
+            CONCEPT_REQUIRES_(Range<R>() && Range<BaseRange>())>
+        RANGES_CXX14_CONSTEXPR auto base(R&& range)
+        RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+        (
+            details::loop_to<view::all_t<BaseRange>>(view::all(std::forward<R>(range)))
+        )
+    }
+}
+
+#endif //RANGE_V3_BASE_HPP

--- a/include/range/v3/core.hpp
+++ b/include/range/v3/core.hpp
@@ -25,6 +25,7 @@
 #include <range/v3/range_for.hpp>
 #include <range/v3/index.hpp>
 #include <range/v3/at.hpp>
+#include <range/v3/base.hpp>
 #include <range/v3/back.hpp>
 #include <range/v3/front.hpp>
 #include <range/v3/istream_range.hpp>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,7 @@ add_subdirectory(utility)
 add_subdirectory(view)
 add_subdirectory(experimental)
 
+rv3_add_test(test.base base base.cpp)
 rv3_add_test(test.config config config.cpp)
 rv3_add_test(test.container_conversion container_conversion container_conversion.cpp)
 rv3_add_test(test.constexpr_core constexpr_core constexpr_core.cpp)

--- a/test/base.cpp
+++ b/test/base.cpp
@@ -1,0 +1,100 @@
+/// \file
+// Range v3 library
+//
+//  Copyright Andrey Diduh 2019
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+
+#include <vector>
+#include <iostream>
+
+#include <range/v3/base.hpp>
+#include <range/v3/view/transform.hpp>
+#include <range/v3/view/drop.hpp>
+#include <range/v3/view/take_exactly.hpp>
+#include <range/v3/view/const.hpp>
+
+#include "./simple_test.hpp"
+#include "./test_utils.hpp"
+
+using namespace ranges;
+
+struct Data
+{
+    int i;
+
+    bool operator==(const Data& other) const
+    {
+        return i == other.i;
+    }
+};
+using Vec = std::vector<Data>;
+using Iter = ranges::iterator_t<Vec>;
+
+void test_base_n()
+{
+    Vec vec = { {1}, {2}, {3}, {4} };
+    auto list = vec | view::transform(&Data::i) | view::const_;
+
+    // ITERATOR
+    // base()
+    {
+        check_equal( list.begin().base(), ranges::base(list.begin()) );
+    }
+    // base<N>()
+    {
+        check_equal( list.begin().base(), ranges::base<1>(list.begin()) );
+        check_equal( list.begin().base().base(), ranges::base<2>(list.begin()) );
+        check_equal( list.begin().base().base(), ranges::base(ranges::base(list.begin())) );
+        check_equal( vec.begin(), ranges::base<2>(list.begin()) );
+    }
+
+    // RANGE
+    // base()
+    {
+        check_equal( list.base(), ranges::base(list) );
+    }
+    // base<N>()
+    {
+        check_equal( list.base(), ranges::base<1>(list) );
+        check_equal( list.base().base(), ranges::base<2>(list) );
+        check_equal( list.base().base(), ranges::base(ranges::base(list)) );
+        check_equal( vec, ranges::base<2>(list) );
+    }
+}
+
+void test_base_of()
+{
+    Vec vec = { {1}, {2}, {3}, {4} };
+
+    auto list = vec | view::transform(&Data::i) | view::take_exactly(3);
+
+    // Not every view introduce new iterator, so:
+    // list.begin().base().base() != vec.begin()
+
+    // ITERATOR
+    {
+        check_equal( vec.begin(), ranges::base<Iter>(list.begin()) );
+        check_equal( vec.begin(), ranges::base<Vec>(list.begin()) );
+        check_equal( vec.begin(), ranges::base(list.begin(), vec) );
+    }
+
+    // RANGE
+    {
+        check_equal( vec, ranges::base<Vec>(list) );
+    }
+}
+
+int main()
+{
+    test_base_n();
+    test_base_of();
+
+    return test_result();
+}


### PR DESCRIPTION
### Abstract

This PR introduces `ranges::base` standalone function. It provides machinery for working with iterator/range base() chains (`base().base().base()....`).

### Motivation

```cpp
auto list = vec | view::transform(&Data::i) | view::take_exactly(3);
list.begin().base().base() != vec.begin();
```
You have to "guess" count of base() calls to the desired layer of iterator adaptor.
```cpp
auto list = vec | view::transform(&Data::i) | view::take_exactly(3);
base<iterator_t<Vec>>(list.begin()) == vec.begin();
```
Usage with algorithms:
```cpp
auto list  = vec | view::transform(&Data::i) | view::take_exactly(3);
iterator i = base<iterator>(find(list, 10));
```

### Interface

```cpp
// iterator

ragnes::base(iter);                     // iter.base()
ragnes::base<3>(iter);                  // iter.base().base().base()
ragnes::base<iterator_t<Range>>(iter);  // iter.base()...
ragnes::base<Range>(iter);              // ragnes::base<iterator_t<Range>>(iter)
ragnes::base(iter, range);              // ragnes::base<decltype(range)>(iter)

// range

ragnes::base(range);
ragnes::base<3>(range);
ragnes::base<List>(range);

```