### PR TITLE
Make v1.0-branch build with GCC9

### DIFF
--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -288,6 +288,9 @@ namespace ranges
 #if __GNUC__ < 6
 #define RANGES_WORKAROUND_GCC_UNFILED0 /* Workaround old GCC name lookup bug */
 #endif
+#if __GNUC__ >=9 && defined(__cpp_concepts)
+#define RANGES_WORKAROUND_GCC_89953
+#endif
 #endif
 
 #else

--- a/include/range/v3/range/access.hpp
+++ b/include/range/v3/range/access.hpp
@@ -90,6 +90,11 @@ namespace ranges
             template<typename R>
             using impl = impl_<HasMemberBegin<R>>;
 
+#ifdef RANGES_WORKAROUND_GCC_89953
+            template<typename R>
+            static constexpr impl<R> impl_v{};
+#endif
+
         public:
             template<typename R, std::size_t N>
             void operator()(R (&&)[N]) const = delete;
@@ -101,9 +106,15 @@ namespace ranges
             }
 
             template<typename R>
+#ifdef RANGES_WORKAROUND_GCC_89953
+            constexpr auto CPP_fun(operator())(R &&r) (const
+                noexcept(noexcept(impl_v<R>((R &&) r)))
+                requires (HasMemberBegin<R> || HasNonMemberBegin<R>))
+#else
             constexpr auto CPP_fun(operator())(R &&r) (const
                 noexcept(noexcept(impl<R>{}((R &&) r)))
                 requires (HasMemberBegin<R> || HasNonMemberBegin<R>))
+#endif
             {
                 return impl<R>{}((R &&) r);
             }
@@ -223,6 +234,11 @@ namespace ranges
             template<typename R>
             using impl = impl_<HasMemberEnd<R>>;
 
+#ifdef RANGES_WORKAROUND_GCC_89953
+            template<typename R>
+            static constexpr impl<R> impl_v{};
+#endif
+
         public:
             template<typename R, std::size_t N>
             void operator()(R (&&)[N]) const = delete;
@@ -234,9 +250,15 @@ namespace ranges
             }
 
             template<typename R>
+#ifdef RANGES_WORKAROUND_GCC_89953
+            constexpr auto CPP_fun(operator())(R &&r) (const
+                noexcept(noexcept(impl_v<R>((R &&) r)))
+                requires (HasMemberEnd<R> || HasNonMemberEnd<R>))
+#else
             constexpr auto CPP_fun(operator())(R &&r) (const
                 noexcept(noexcept(impl<R>{}((R &&) r)))
                 requires (HasMemberEnd<R> || HasNonMemberEnd<R>))
+#endif
             {
                 return impl<R>{}((R &&) r);
             }

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -161,8 +161,7 @@ public:
     {
         using S = meta::_t<sentinel_type<I>>;
         using R = decltype(algo_(begin, end, rest...));
-        Algo algo = algo_;
-        auto check_algo = [=](function_ref<void(R)> const & check)
+        auto check_algo = [algo = algo_, begin, end, rest...](function_ref<void(R)> const & check)
         {
             check(algo(begin, end, rest...));
             check(algo(begin, S{base(end)}, rest...));
@@ -195,8 +194,7 @@ public:
         using S1 = meta::_t<sentinel_type<I1>>;
         using S2 = meta::_t<sentinel_type<I2>>;
         using R = decltype(algo_(begin1, end1, begin2, end2, rest...));
-        Algo algo = algo_;
-        return checker<R>{[=](function_ref<void(R)> const & check)
+        return checker<R>{[algo = algo_, begin1, end1, begin2, end2, rest...](function_ref<void(R)> const & check)
         {
             check(algo(begin1, end1, begin2, end2, rest...));
             check(algo(begin1, S1{base(end1)}, begin2, S2{base(end2)}, rest...));


### PR DESCRIPTION
The first commit makes the test suite build with gcc9 (independent of `-fconcepts`). I think the changes *shouldn't* be necessary and that it is probably a GCC bug, but it only affects test suite code and not library code.

The second commit is a workaround for #1164. Note that although the example in #1164 seems rather trivial, the issue was not detected by the test suite. One should maybe create a test case, but I thought it was more important to get a fix in now since we have a bunch of other ICEs in GCC9 that we can't tackle without #1164 being out of the way.

P.S: I thought about creating a MACRO for the workaround, but since it involves code inside the other macros, it would involve more code than necessary. I can still change this or replace the alias template entirely with the variable template since one doesn't really need both. But the solution below was the one with the smallest diff that I could come up with.