### PR TITLE
[FIX] iota-distance computation too strict

### DIFF
--- a/include/range/v3/view/iota.hpp
+++ b/include/range/v3/view/iota.hpp
@@ -129,12 +129,12 @@ namespace ranges
                 i -= static_cast<Int>(-n);
         }
 
-        template<typename I, typename S>
-        auto iota_distance_(I const &i, S const &s) ->
+        template<typename I>
+        auto iota_distance_(I const &i, I const &s) ->
             CPP_ret(iota_difference_t<I>)(
-                requires SizedSentinel<S, I>)
+                requires Advanceable_<I> && (!Integral<I>))
         {
-            return s - i;
+            return static_cast<iota_difference_t<I>>(s - i);
         }
 
         template<typename Int>


### PR DESCRIPTION
The changes in c9d18a1e405c8d588859c430951eefb5fe5ae1f0 made iota hard fail for us, because it could not find an appropriate overload for some of our types (that do model the respective concepts). I think the overload below was just too strict by requiring SizedSentinel.