### PR TITLE
Sentinal-based Ranges should also take end Sentinels

### DIFF
--- a/include/range/v3/view/unbounded.hpp
+++ b/include/range/v3/view/unbounded.hpp
@@ -34,6 +34,9 @@ namespace ranges
             constexpr explicit unbounded_view(I it)
               : it_(detail::move(it))
             {}
+            constexpr explicit unbounded_view(I it, unreachable)
+              : unbounded_view(detail::move(it))
+            {}
             constexpr I begin() const
             {
                 return it_;


### PR DESCRIPTION
This pull request engages in a usability question: why does an unbounded range not take a sentinel?

I think that unbounded ranges should take 2 iterators like the rest of the ranges and containers and views, even if the second iterator is unreachable. It helps users not have to `if constexpr` internally in their algorithms to check for double-iterator constructibility to use these kinds of ranges.

I don't know if this should be extended to other range and view types, but I think it makes sense for, at least, `unbounded`.  Thoughts?