### PR TITLE
Fix shadow variable warnings in variant.hpp

### DIFF
--- a/include/range/v3/detail/variant.hpp
+++ b/include/range/v3/detail/variant.hpp
@@ -706,8 +706,8 @@ namespace ranges
         {
             using elem_t = meta::_t<std::remove_reference<meta::at_c<meta::list<Ts...>, N>>>;
             elem_t *elem = nullptr;
-            auto &data = detail::variant_core_access::data(var);
-            detail::variant_visit_(var.index(), data, detail::get_fn<elem_t, N>{&elem});
+            auto &var_data = detail::variant_core_access::data(var);
+            detail::variant_visit_(var.index(), var_data, detail::get_fn<elem_t, N>{&elem});
             return detail::variant_deref_(elem);
         }
 
@@ -717,8 +717,8 @@ namespace ranges
         {
             using elem_t = meta::_t<std::remove_reference<meta::at_c<meta::list<Ts...>, N> const>>;
             elem_t *elem = nullptr;
-            auto &data = detail::variant_core_access::data(var);
-            detail::variant_visit_(var.index(), data, detail::get_fn<elem_t, N>{&elem});
+            auto &var_data = detail::variant_core_access::data(var);
+            detail::variant_visit_(var.index(), var_data, detail::get_fn<elem_t, N>{&elem});
             return detail::variant_deref_(elem);
         }
 
@@ -728,8 +728,8 @@ namespace ranges
         {
             using elem_t = meta::_t<std::remove_reference<meta::at_c<meta::list<Ts...>, N>>>;
             elem_t *elem = nullptr;
-            auto &data = detail::variant_core_access::data(var);
-            detail::variant_visit_(var.index(), data, detail::get_fn<elem_t, N>{&elem});
+            auto &var_data = detail::variant_core_access::data(var);
+            detail::variant_visit_(var.index(), var_data, detail::get_fn<elem_t, N>{&elem});
             using res_t = meta::_t<std::add_rvalue_reference<meta::at_c<meta::list<Ts...>, N>>>;
             return static_cast<res_t>(detail::variant_deref_(elem));
         }


### PR DESCRIPTION
Related: #939
Fixes variant.hpp(706,1): warning C4459:  declaration of 'data' hides global declaration on MSVC 2019 /W4
 
1> \range-v3\include\range\v3\detail\variant.hpp(706,1): warning C4459:  declaration of 'data' hides global declaration
1> \range-v3\include\range\v3\detail\variant.hpp(706,1): warning C4459:         {
1> \range-v3\include\range\v3\detail\variant.hpp(706,1): warning C4459: ^
1> \range-v3\include\range\v3\data.hpp(84,13): message :  see declaration of 'ranges::v3::CPOs::data'
1> \range-v3\include\range\v3\data.hpp(84,13): message :             RANGES_INLINE_VARIABLE(data_detail::data_fn, data)
1> \range-v3\include\range\v3\data.hpp(84,13): message :             ^
