### PR TITLE
Implement detail::is_trivial

### DIFF
--- a/include/meta/meta_fwd.hpp
+++ b/include/meta/meta_fwd.hpp
@@ -158,8 +158,7 @@
 #endif
 
 #if (defined(__cpp_lib_type_trait_variable_templates) && \
-    __cpp_lib_type_trait_variable_templates > 0) || \
-    META_CXX_VER >= META_CXX_STD_17
+    __cpp_lib_type_trait_variable_templates > 0)
 #define META_CXX_TRAIT_VARIABLE_TEMPLATES 1
 #else
 #define META_CXX_TRAIT_VARIABLE_TEMPLATES 0

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -263,9 +263,14 @@ namespace ranges
         {};
 
         template<typename T>
-        RANGES_INLINE_VAR constexpr bool is_trivial_v =
+        using is_trivial = meta::bool_<
+#if META_CXX_TRAIT_VARIABLE_TEMPLATES
             std::is_trivially_copyable_v<T> &&
-            std::is_trivially_default_constructible_v<T>;
+            std::is_trivially_default_constructible_v<T>>;
+#else
+            std::is_trivially_copyable<T>::value &&
+            std::is_trivially_default_constructible<T>::value>;
+#endif
 
     #if defined(__clang__) && !defined(_LIBCPP_VERSION)
         template<typename T, typename... Args>

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -262,6 +262,11 @@ namespace ranges
         struct priority_tag<0>
         {};
 
+        template<typename T>
+        RANGES_INLINE_VAR constexpr bool is_trivial_v =
+            std::is_trivially_copyable_v<T> &&
+            std::is_trivially_default_constructible_v<T>;
+
     #if defined(__clang__) && !defined(_LIBCPP_VERSION)
         template<typename T, typename... Args>
         using is_trivially_constructible =

--- a/include/range/v3/utility/box.hpp
+++ b/include/range/v3/utility/box.hpp
@@ -133,7 +133,7 @@ namespace ranges
         // MSVC pukes passing non-constant-expression objects to constexpr
         // functions, so do not coalesce.
         template<typename T, typename = meta::if_<
-            meta::strict_and<std::is_empty<T>, detail::is_trivial_v<T>>>>
+            meta::strict_and<std::is_empty<T>, detail::is_trivial<T>>>>
         constexpr box_compress box_compression_(int)
         {
             return box_compress::coalesce;

--- a/include/range/v3/utility/box.hpp
+++ b/include/range/v3/utility/box.hpp
@@ -133,7 +133,7 @@ namespace ranges
         // MSVC pukes passing non-constant-expression objects to constexpr
         // functions, so do not coalesce.
         template<typename T, typename = meta::if_<
-            meta::strict_and<std::is_empty<T>, std::is_trivial<T>>>>
+            meta::strict_and<std::is_empty<T>, detail::is_trivial_v<T>>>>
         constexpr box_compress box_compression_(int)
         {
             return box_compress::coalesce;


### PR DESCRIPTION
Compilers' `is_trivial` intrinsics are not to be trusted (https://godbolt.org/z/8n_4OA).

Fixes #1196.