### PR TITLE
Adding a constexpr addressof to fix #1167.

### DIFF
--- a/include/range/v3/functional/reference_wrapper.hpp
+++ b/include/range/v3/functional/reference_wrapper.hpp
@@ -22,6 +22,7 @@
 
 #include <range/v3/functional/invoke.hpp>
 #include <range/v3/functional/pipeable.hpp>
+#include <range/v3/utility/addressof.hpp>
 #include <range/v3/utility/static_const.hpp>
 
 namespace ranges
@@ -38,7 +39,7 @@ namespace ranges
             T * t_ = nullptr;
             constexpr reference_wrapper_() = default;
             constexpr reference_wrapper_(T & t) noexcept
-              : t_(std::addressof(t))
+              : t_(detail::addressof(t))
             {}
             constexpr reference_wrapper_(T &&) = delete;
             constexpr T & get() const noexcept
@@ -57,7 +58,7 @@ namespace ranges
             T * t_ = nullptr;
             constexpr reference_wrapper_() = default;
             constexpr reference_wrapper_(T && t) noexcept
-              : t_(std::addressof(t))
+              : t_(detail::addressof(t))
             {}
             constexpr T && get() const noexcept
             {

--- a/include/range/v3/iterator/basic_iterator.hpp
+++ b/include/range/v3/iterator/basic_iterator.hpp
@@ -26,6 +26,7 @@
 #include <range/v3/detail/range_access.hpp>
 #include <range/v3/iterator/concepts.hpp>
 #include <range/v3/iterator/traits.hpp>
+#include <range/v3/utility/addressof.hpp>
 #include <range/v3/utility/box.hpp>
 #include <range/v3/utility/move.hpp>
 #include <range/v3/utility/semiregular.hpp>
@@ -588,7 +589,7 @@ namespace ranges
                     Same<typename detail::iterator_associated_types_base<C>::value_type,
                          uncvref_t<const_reference_t>>)
         {
-            return std::addressof(**this);
+            return detail::addressof(**this);
         }
 
         CPP_member

--- a/include/range/v3/iterator/insert_iterators.hpp
+++ b/include/range/v3/iterator/insert_iterators.hpp
@@ -19,6 +19,7 @@
 #include <range/v3/range_fwd.hpp>
 
 #include <range/v3/iterator/operations.hpp>
+#include <range/v3/utility/addressof.hpp>
 
 namespace ranges
 {
@@ -32,7 +33,7 @@ namespace ranges
 
         constexpr back_insert_iterator() = default;
         explicit constexpr back_insert_iterator(Container & x)
-          : container_(std::addressof(x))
+          : container_(detail::addressof(x))
         {}
         back_insert_iterator & operator=(typename Container::value_type const & value)
         {
@@ -81,7 +82,7 @@ namespace ranges
 
         constexpr front_insert_iterator() = default;
         explicit constexpr front_insert_iterator(Container & x)
-          : container_(std::addressof(x))
+          : container_(detail::addressof(x))
         {}
         front_insert_iterator & operator=(typename Container::value_type const & value)
         {
@@ -130,7 +131,7 @@ namespace ranges
 
         constexpr insert_iterator() = default;
         explicit constexpr insert_iterator(Container & x, typename Container::iterator w)
-          : container_(std::addressof(x))
+          : container_(detail::addressof(x))
           , where_(w)
         {}
         insert_iterator & operator=(typename Container::value_type const & value)

--- a/include/range/v3/range/primitives.hpp
+++ b/include/range/v3/range/primitives.hpp
@@ -20,6 +20,7 @@
 
 #include <range/v3/iterator/concepts.hpp>
 #include <range/v3/range/access.hpp>
+#include <range/v3/utility/addressof.hpp>
 #include <range/v3/utility/static_const.hpp>
 
 namespace ranges
@@ -176,13 +177,13 @@ namespace ranges
             static constexpr auto impl_(R && r, detail::priority_tag<0>) noexcept(
                 noexcept(ranges::begin((R &&) r) == ranges::end((R &&) r)
                              ? nullptr
-                             : std::addressof(*ranges::begin((R &&) r))))
-                -> CPP_ret(decltype(std::addressof(*ranges::begin((R &&) r))))( //
+                             : detail::addressof(*ranges::begin((R &&) r))))
+                -> CPP_ret(decltype(detail::addressof(*ranges::begin((R &&) r))))( //
                     requires ContiguousIterator<_begin_::_t<R>>)
             {
                 return ranges::begin((R &&) r) == ranges::end((R &&) r)
                            ? nullptr
-                           : std::addressof(*ranges::begin((R &&) r));
+                           : detail::addressof(*ranges::begin((R &&) r));
             }
 
         public:

--- a/include/range/v3/utility/addressof.hpp
+++ b/include/range/v3/utility/addressof.hpp
@@ -14,9 +14,12 @@
 
 #include <memory>
 #include <type_traits>
+
 #include <concepts/concepts.hpp>
-#include <range/v3/detail/config.hpp>
+
 #include <range/v3/range_fwd.hpp>
+
+#include <range/v3/detail/config.hpp>
 
 namespace ranges
 {
@@ -26,38 +29,42 @@ namespace ranges
 #ifdef __cpp_lib_addressof_constexpr
         using std::addressof;
 #else
-        namespace check_addressof {
-            inline ignore_t operator&(ignore_t) { return {}; }
-            template <typename T>
-            auto addressof(T& t) {
+        namespace check_addressof
+        {
+            inline ignore_t operator&(ignore_t)
+            {
+                return {};
+            }
+            template<typename T>
+            auto addressof(T & t)
+            {
                 return &t;
             }
         }
 
-        template <typename T>
-        constexpr bool has_bad_addressof() {
+        template<typename T>
+        constexpr bool has_bad_addressof()
+        {
             return !std::is_scalar<T>::value &&
-                !RANGES_IS_SAME(
-                    decltype(check_addressof::addressof(*(T*)nullptr)),
-                    ignore_t);
+                   !RANGES_IS_SAME(decltype(check_addressof::addressof(*(T *)nullptr)),
+                                   ignore_t);
         }
 
-        template <typename T>
-        auto addressof(T& arg) noexcept
-            -> CPP_ret(T*)(requires has_bad_addressof<T>())
+        template<typename T>
+        auto addressof(T & arg) noexcept -> CPP_ret(T *)(requires has_bad_addressof<T>())
         {
             return std::addressof(arg);
         }
 
-        template <typename T>
-        constexpr auto addressof(T& arg) noexcept
-            -> CPP_ret(T*)(requires !has_bad_addressof<T>())
+        template<typename T>
+        constexpr auto addressof(T & arg) noexcept
+            -> CPP_ret(T *)(requires !has_bad_addressof<T>())
         {
             return &arg;
         }
 
-        template <typename T>
-        T const* addressof(T const&&) = delete;
+        template<typename T>
+        T const * addressof(T const &&) = delete;
 #endif
     }
     /// \endcond

--- a/include/range/v3/utility/addressof.hpp
+++ b/include/range/v3/utility/addressof.hpp
@@ -26,7 +26,7 @@ namespace ranges
 #else
         namespace test {
             struct ignore {
-                template <typename T> ignore(T&&);
+                template <typename T> ignore(T&&) { }
             };
 
             ignore operator&(ignore);

--- a/include/range/v3/utility/addressof.hpp
+++ b/include/range/v3/utility/addressof.hpp
@@ -13,6 +13,7 @@
 #define RANGES_V3_UTLITY_ADDRESSOF_HPP
 
 #include <memory>
+#include <type_traits>
 #include <range/v3/detail/config.hpp>
 
 namespace ranges
@@ -36,20 +37,23 @@ namespace ranges
         }
 
         template <typename T>
-        using has_bad_addressof = meta::bool_<
-            !std::is_scalar<T>::value &&
-            !RANGES_IS_SAME(decltype(test::addressof(*(T*)0)), test::ignore)>;
+        constexpr bool has_bad_addressof() {
+            return !std::is_scalar<T>::value &&
+                !RANGES_IS_SAME(
+                    decltype(test::addressof(*(T*)0)),
+                    test::ignore)>;
+        }
 
         template <typename T>
         auto addressof(T& arg) noexcept
-            -> CPP_ret(T*)(requires has_bad_addressof<T>::value)
+            -> CPP_ret(T*)(requires has_bad_addressof<T>())
         {
             return std::addressof(arg);
         }
 
         template <typename T>
         constexpr auto addressof(T& arg) noexcept
-            -> CPP_ret(T*)(requires !has_bad_addressof<T>::value)
+            -> CPP_ret(T*)(requires !has_bad_addressof<T>())
         {
             return &arg;
         }

--- a/include/range/v3/utility/addressof.hpp
+++ b/include/range/v3/utility/addressof.hpp
@@ -1,0 +1,40 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2013-present
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+//
+#ifndef RANGES_V3_UTLITY_ADDRESSOF_HPP
+#define RANGES_V3_UTLITY_ADDRESSOF_HPP
+
+#ifdef __cpp_lib_addressof_constexpr
+#include <memory>
+#endif
+
+namespace ranges
+{
+    /// \cond
+    namespace detail
+    {
+        template <typename T>
+        constexpr T* addressof(T& arg) noexcept
+        {
+            #ifdef __cpp_lib_addressof_constexpr
+            return std::addressof(arg);
+            #else
+            return &arg;
+            #endif
+        }
+
+        template <typename T>
+        T const* addressof(T const&&) = delete;
+    }
+    /// \endcond
+}
+
+#endif

--- a/include/range/v3/utility/addressof.hpp
+++ b/include/range/v3/utility/addressof.hpp
@@ -16,6 +16,7 @@
 #include <type_traits>
 #include <concepts/concepts.hpp>
 #include <range/v3/detail/config.hpp>
+#include <range/v3/range_fwd.hpp>
 
 namespace ranges
 {
@@ -25,12 +26,8 @@ namespace ranges
 #ifdef __cpp_lib_addressof_constexpr
         using std::addressof;
 #else
-        namespace test {
-            struct ignore {
-                template <typename T> ignore(T&&) { }
-            };
-
-            ignore operator&(ignore);
+        namespace check_addressof {
+            inline ignore_t operator&(ignore_t) { return {}; }
             template <typename T>
             auto addressof(T& t) {
                 return &t;
@@ -41,8 +38,8 @@ namespace ranges
         constexpr bool has_bad_addressof() {
             return !std::is_scalar<T>::value &&
                 !RANGES_IS_SAME(
-                    decltype(test::addressof(*(T*)nullptr)),
-                    test::ignore);
+                    decltype(check_addressof::addressof(*(T*)nullptr)),
+                    ignore_t);
         }
 
         template <typename T>

--- a/include/range/v3/utility/addressof.hpp
+++ b/include/range/v3/utility/addressof.hpp
@@ -13,6 +13,7 @@
 #define RANGES_V3_UTLITY_ADDRESSOF_HPP
 
 #include <memory>
+#include <range/v3/detail/config.hpp>
 
 namespace ranges
 {

--- a/include/range/v3/utility/addressof.hpp
+++ b/include/range/v3/utility/addressof.hpp
@@ -14,6 +14,7 @@
 
 #include <memory>
 #include <type_traits>
+#include <concepts/concepts.hpp>
 #include <range/v3/detail/config.hpp>
 
 namespace ranges

--- a/include/range/v3/utility/addressof.hpp
+++ b/include/range/v3/utility/addressof.hpp
@@ -41,7 +41,7 @@ namespace ranges
             return !std::is_scalar<T>::value &&
                 !RANGES_IS_SAME(
                     decltype(test::addressof(*(T*)0)),
-                    test::ignore)>;
+                    test::ignore);
         }
 
         template <typename T>

--- a/include/range/v3/utility/addressof.hpp
+++ b/include/range/v3/utility/addressof.hpp
@@ -40,7 +40,7 @@ namespace ranges
         constexpr bool has_bad_addressof() {
             return !std::is_scalar<T>::value &&
                 !RANGES_IS_SAME(
-                    decltype(test::addressof(*(T*)0)),
+                    decltype(test::addressof(*(T*)nullptr)),
                     test::ignore);
         }
 

--- a/include/range/v3/utility/optional.hpp
+++ b/include/range/v3/utility/optional.hpp
@@ -23,6 +23,7 @@
 
 #include <range/v3/detail/config.hpp>
 #include <range/v3/utility/in_place.hpp>
+#include <range/v3/utility/addressof.hpp>
 #include <range/v3/utility/static_const.hpp>
 #include <range/v3/utility/swap.hpp>
 
@@ -189,11 +190,11 @@ namespace ranges
                 }
                 constexpr T * operator->() noexcept
                 {
-                    return RANGES_EXPECT(engaged_), std::addressof(data_);
+                    return RANGES_EXPECT(engaged_), detail::addressof(data_);
                 }
                 constexpr T const * operator->() const noexcept
                 {
-                    return RANGES_EXPECT(engaged_), std::addressof(data_);
+                    return RANGES_EXPECT(engaged_), detail::addressof(data_);
                 }
                 CPP_member
                 constexpr auto swap(optional_base & that) noexcept(
@@ -233,7 +234,7 @@ namespace ranges
                         data_ = *static_cast<U &&>(that);
                     else
                     {
-                        auto const address = static_cast<void *>(std::addressof(data_));
+                        auto const address = static_cast<void *>(detail::addressof(data_));
                         ::new(address) T(*static_cast<U &&>(that));
                         engaged_ = true;
                     }
@@ -275,7 +276,7 @@ namespace ranges
                 constexpr explicit CPP_ctor(optional_base)(in_place_t, Arg && arg)( //
                     noexcept(true)                                                  //
                     requires Constructible<T &, Arg>)
-                  : ptr_(std::addressof(arg))
+                  : ptr_(detail::addressof(arg))
                 {}
                 constexpr bool has_value() const noexcept
                 {
@@ -310,7 +311,7 @@ namespace ranges
                     requires ConvertibleTo<U &, T &>)
                 {
                     RANGES_EXPECT(!ptr_);
-                    ptr_ = std::addressof(ref);
+                    ptr_ = detail::addressof(ref);
                     return *ptr_;
                 }
                 template<typename U>

--- a/include/range/v3/utility/optional.hpp
+++ b/include/range/v3/utility/optional.hpp
@@ -22,8 +22,8 @@
 #include <concepts/concepts.hpp>
 
 #include <range/v3/detail/config.hpp>
-#include <range/v3/utility/in_place.hpp>
 #include <range/v3/utility/addressof.hpp>
+#include <range/v3/utility/in_place.hpp>
 #include <range/v3/utility/static_const.hpp>
 #include <range/v3/utility/swap.hpp>
 
@@ -234,7 +234,8 @@ namespace ranges
                         data_ = *static_cast<U &&>(that);
                     else
                     {
-                        auto const address = static_cast<void *>(detail::addressof(data_));
+                        auto const address =
+                            static_cast<void *>(detail::addressof(data_));
                         ::new(address) T(*static_cast<U &&>(that));
                         engaged_ = true;
                     }

--- a/include/range/v3/view/addressof.hpp
+++ b/include/range/v3/view/addressof.hpp
@@ -19,9 +19,9 @@
 
 #include <meta/meta.hpp>
 
+#include <range/v3/utility/addressof.hpp>
 #include <range/v3/view/transform.hpp>
 #include <range/v3/view/view.hpp>
-#include <range/v3/utility/addressof.hpp>
 
 namespace ranges
 {

--- a/include/range/v3/view/addressof.hpp
+++ b/include/range/v3/view/addressof.hpp
@@ -21,6 +21,7 @@
 
 #include <range/v3/view/transform.hpp>
 #include <range/v3/view/view.hpp>
+#include <range/v3/utility/addressof.hpp>
 
 namespace ranges
 {
@@ -36,7 +37,7 @@ namespace ranges
                 template<typename V>
                 constexpr V * operator()(V & value) const noexcept
                 {
-                    return std::addressof(value);
+                    return detail::addressof(value);
                 }
             };
 

--- a/include/range/v3/view/any_view.hpp
+++ b/include/range/v3/view/any_view.hpp
@@ -25,6 +25,7 @@
 #include <range/v3/range/access.hpp>
 #include <range/v3/range/concepts.hpp>
 #include <range/v3/range/traits.hpp>
+#include <range/v3/utility/addressof.hpp>
 #include <range/v3/utility/memory.hpp>
 #include <range/v3/view/all.hpp>
 #include <range/v3/view/facade.hpp>
@@ -120,7 +121,7 @@ namespace ranges
             any_ref() = default;
             template<typename T>
             constexpr any_ref(T & obj) noexcept
-              : obj_(std::addressof(obj))
+              : obj_(detail::addressof(obj))
 #ifndef NDEBUG
               , info_(&typeid(rtti_tag<T>))
 #endif
@@ -216,7 +217,7 @@ namespace ranges
 
             any_input_cursor() = default;
             constexpr any_input_cursor(any_input_view_interface<Ref> & view) noexcept
-              : view_{std::addressof(view)}
+              : view_{detail::addressof(view)}
             {}
             Ref read() const
             {

--- a/include/range/v3/view/partial_sum.hpp
+++ b/include/range/v3/view/partial_sum.hpp
@@ -28,6 +28,7 @@
 #include <range/v3/range/access.hpp>
 #include <range/v3/range/primitives.hpp>
 #include <range/v3/range/traits.hpp>
+#include <range/v3/utility/addressof.hpp>
 #include <range/v3/utility/semiregular.hpp>
 #include <range/v3/utility/static_const.hpp>
 #include <range/v3/view/all.hpp>
@@ -88,7 +89,7 @@ namespace ranges
 
             cursor() = default;
             constexpr explicit cursor(Parent & rng)
-              : parent_{std::addressof(rng)}
+              : parent_{detail::addressof(rng)}
               , current_(ranges::begin(rng.base_))
             {
                 if(current_ != ranges::end(rng.base_))

--- a/include/range/v3/view/ref.hpp
+++ b/include/range/v3/view/ref.hpp
@@ -21,9 +21,9 @@
 #include <range/v3/range/access.hpp>
 #include <range/v3/range/primitives.hpp>
 #include <range/v3/range/traits.hpp>
+#include <range/v3/utility/addressof.hpp>
 #include <range/v3/view/interface.hpp>
 #include <range/v3/view/view.hpp>
-#include <range/v3/utility/addressof.hpp>
 
 RANGES_DISABLE_WARNINGS
 

--- a/include/range/v3/view/ref.hpp
+++ b/include/range/v3/view/ref.hpp
@@ -23,6 +23,7 @@
 #include <range/v3/range/traits.hpp>
 #include <range/v3/view/interface.hpp>
 #include <range/v3/view/view.hpp>
+#include <range/v3/utility/addressof.hpp>
 
 RANGES_DISABLE_WARNINGS
 
@@ -77,7 +78,7 @@ namespace ranges
     public:
         constexpr ref_view() noexcept = default;
         constexpr ref_view(Rng & rng) noexcept
-          : rng_(std::addressof(rng))
+          : rng_(detail::addressof(rng))
         {}
         constexpr Rng & base() const noexcept
         {

--- a/include/range/v3/view/single.hpp
+++ b/include/range/v3/view/single.hpp
@@ -24,6 +24,7 @@
 #include <range/v3/range/access.hpp>
 #include <range/v3/range/concepts.hpp>
 #include <range/v3/range/traits.hpp>
+#include <range/v3/utility/addressof.hpp>
 #include <range/v3/utility/optional.hpp>
 #include <range/v3/utility/semiregular.hpp>
 #include <range/v3/utility/static_const.hpp>
@@ -87,11 +88,11 @@ namespace ranges
         }
         constexpr T * data() noexcept
         {
-            return std::addressof(static_cast<T &>(value_));
+            return detail::addressof(static_cast<T &>(value_));
         }
         constexpr T const * data() const noexcept
         {
-            return std::addressof(static_cast<T const &>(value_));
+            return detail::addressof(static_cast<T const &>(value_));
         }
     };
 

--- a/test/constexpr_core.cpp
+++ b/test/constexpr_core.cpp
@@ -16,6 +16,7 @@
 #include <range/v3/range/access.hpp>
 #include <range/v3/range/operations.hpp>
 #include <range/v3/range/primitives.hpp>
+#include <range/v3/utility/addressof.hpp>
 #include "array.hpp"
 #include "test_iterators.hpp"
 
@@ -248,6 +249,42 @@ constexpr /*c++14*/ auto test_init_list() -> bool
     }
 
     return true;
+}
+
+#ifdef __cpp_lib_addressof_constexpr
+#define ADDR_CONSTEXPR constexpr
+#else
+#define ADDR_CONSTEXPR
+#endif
+
+namespace addr {
+    struct Good { };
+    struct Bad { void operator&() const; };
+    struct Bad2 { friend void operator&(Bad2); };
+}
+
+void test_constexpr_addressof() {
+    static constexpr int i = 0;
+    static constexpr int const* pi = ranges::detail::addressof(i);
+    static_assert(&i == pi, "");
+
+    static constexpr addr::Good g = {};
+    static constexpr addr::Good const* pg = ranges::detail::addressof(g);
+    static_assert(&g == pg, "");
+
+    static constexpr addr::Bad b = {};
+    static ADDR_CONSTEXPR addr::Bad const* pb = ranges::detail::addressof(b);
+
+    static constexpr addr::Bad2 b2 = {};
+    static ADDR_CONSTEXPR addr::Bad2 const* pb2 = ranges::detail::addressof(b2);
+
+#ifdef __cpp_lib_addressof_constexpr
+    static_assert(std::addressof(b) == pb, "");
+    static_assert(std::addressof(b2) == pb2, "");
+#else
+    (void)pb;
+    (void)pb2;
+#endif
 }
 
 int main()

--- a/test/constexpr_core.cpp
+++ b/test/constexpr_core.cpp
@@ -17,6 +17,7 @@
 #include <range/v3/range/operations.hpp>
 #include <range/v3/range/primitives.hpp>
 #include <range/v3/utility/addressof.hpp>
+
 #include "array.hpp"
 #include "test_iterators.hpp"
 


### PR DESCRIPTION
I'm going on the principle here that it's more important for `constexpr` to work than to handle overloaded unary `operator&()`. This fixes #1167 

If you all disagree, I can instead do something like:
```cpp
#ifdef __cpp_lib_address_constexpr
#define RANGES_ADDRESSOF_CONSTEXPR constexpr
#else
#define RANGES_ADDRESSOF_CONSTEXPR
#endif
```
and changes all the appropriate functions from `constexpr` to `RANGES_ADDRESSOF_CONSTEXPR`.