### PR TITLE
Make conan package always compatible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,11 +145,18 @@ if(NOT RANGE_V3_NEW_VERSION_HPP STREQUAL RANGE_V3_OLD_VERSION_HPP)
 endif()
 
 include(CMakePackageConfigHelpers)
+
+# write_basic_package_version_file(...) gained ARCH_INDEPENDENT in CMake 3.14.
+# For CMake 3.6, this workaround makes the version file ARCH_INDEPENDENT
+# by making CMAKE_SIZEOF_VOID_P empty.
+set(OLD_CMAKE_SIZEOF_VOID_P ${CMAKE_SIZEOF_VOID_P})
+set(CMAKE_SIZEOF_VOID_P "")
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/range-v3-config-version.cmake
   VERSION ${RANGE_V3_VERSION}
   COMPATIBILITY ExactVersion
 )
+set(CMAKE_SIZEOF_VOID_P ${OLD_CMAKE_SIZEOF_VOID_P})
 
 install(TARGETS concepts meta range-v3 EXPORT range-v3-targets DESTINATION lib)
 install(EXPORT range-v3-targets FILE range-v3-config.cmake DESTINATION lib/cmake/range-v3)

--- a/conanfile.py
+++ b/conanfile.py
@@ -37,5 +37,5 @@ class Rangev3Conan(ConanFile):
 
         self.copy("LICENSE.txt", dst="licenses", ignore_case=True, keep_path=False)
 
-    def package_info(self):
+    def package_id(self):
         self.info.header_only()


### PR DESCRIPTION
Fixes #1212 

Changes:

- conanfile.py: Fix typo: `package_info` -> `package_id`. `package_info(self)` is for settings things like compiler flags and options, whereas `package_id(self)` is for determining package compatibility.
- CMakeLists.txt: `write_basic_package_version_file` has a hidden architecture check. Disable it via the workaround of unsetting `CMAKE_SIZEOF_VOID_P`, at least until an upgrade to CMake 3.14 is reasonable.