### PR TITLE
Update MSVC workaround database:

### DIFF
--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -213,6 +213,10 @@ namespace ranges
 
 #define RANGES_CXX_VER _MSVC_LANG
 
+#if _MSC_VER < 1923
+#define RANGES_WORKAROUND_MSVC_934330 // Deduction guide not correctly preferred to copy
+                                      // deduction candidate [No workaround]
+
 #if _MSC_VER < 1922
 #define RANGES_WORKAROUND_MSVC_756601 // constexpr friend non-template erroneously rejected
                                       // with C3615
@@ -227,26 +231,11 @@ namespace ranges
                                       // non-instantiated nested class template
 #define RANGES_WORKAROUND_MSVC_790554 // Assert for return type that uses dependent
                                       // default non-type template argument
-
-#if _MSC_VER < 1920
-#define RANGES_WORKAROUND_MSVC_DC338193 // https://developercommunity.visualstudio.com/content/problem/338193/sfinae-disabled-ref-qualified-function-collides-wi.html
-#define RANGES_WORKAROUND_MSVC_401490   // conversion of constant expressions with
-                                        // representable values is NOT narrowing
-#define RANGES_WORKAROUND_MSVC_589046 // hidden friends should not be visible to qualified
-                                      // name lookup
-#define RANGES_WORKAROUND_MSVC_699982 // Nasty context-sensitive alias expansion / SFINAE
-                                      // error
-#define RANGES_WORKAROUND_MSVC_701425 // Failure to deduce decltype(pointer-to-member)
-                                      // (gcc_bugs_bugs_bugs for MSVC)
-#define RANGES_WORKAROUND_MSVC_711347 // Assertion invoking constexpr member function as
-                                      // alias template argument
-#endif                                // _MSC_VER < 1920
 #endif                                // _MSC_VER < 1921
 #endif                                // _MSC_VER < 1922
+#endif                                // _MSC_VER < 1923
 
 #if 1 // Fixed in 1920, but more bugs hiding behind workaround
-#define RANGES_WORKAROUND_MSVC_620035 // Error when definition-context name binding finds
-                                      // only deleted function
 #define RANGES_WORKAROUND_MSVC_701385 // Yet another alias expansion error
 #endif
 
@@ -266,15 +255,10 @@ namespace ranges
                                       // to constexpr function
 #define RANGES_WORKAROUND_MSVC_835948 // Silent bad codegen destroying sized_generator [No
                                       // workaround]
+#define RANGES_WORKAROUND_MSVC_895622 // Error when phase 1 name binding finds only deleted
+                                      // function
 #define RANGES_WORKAROUND_MSVC_934264 // Explicitly-defaulted inherited default constructor
                                       // is not correctly implicitly constexpr
-#define RANGES_WORKAROUND_MSVC_934330 // Deduction guide not correctly preferred to copy
-                                      // deduction candidate [No workaround]
-
-// 15.9 doesn't define __cpp_coroutines even with /await (Fix not yet live)
-#if !defined(RANGES_CXX_COROUTINES) && defined(_RESUMABLE_FUNCTIONS_SUPPORTED)
-#define RANGES_CXX_COROUTINES RANGES_CXX_COROUTINES_TS1
-#endif
 
 #elif defined(__GNUC__) || defined(__clang__)
 #define RANGES_PRAGMA(X) _Pragma(#X)
@@ -672,8 +656,7 @@ namespace ranges
 #endif // RANGES_CONSTEXPR_IF
 
 #if !defined(RANGES_BROKEN_CPO_LOOKUP) && !defined(RANGES_DOXYGEN_INVOKED) && \
-    (defined(RANGES_WORKAROUND_GCC_UNFILED0) ||                               \
-     defined(RANGES_WORKAROUND_MSVC_589046) || defined(RANGES_WORKAROUND_MSVC_620035))
+    (defined(RANGES_WORKAROUND_GCC_UNFILED0) || defined(RANGES_WORKAROUND_MSVC_895622))
 #define RANGES_BROKEN_CPO_LOOKUP 1
 #endif
 #ifndef RANGES_BROKEN_CPO_LOOKUP

--- a/include/range/v3/iterator/access.hpp
+++ b/include/range/v3/iterator/access.hpp
@@ -184,7 +184,7 @@ namespace ranges
         template<typename T, typename U>
         nope iter_swap(T, U) = delete;
 
-#ifdef RANGES_WORKAROUND_MSVC_620035
+#ifdef RANGES_WORKAROUND_MSVC_895622
         nope iter_swap();
 #endif
 

--- a/include/range/v3/range/access.hpp
+++ b/include/range/v3/range/access.hpp
@@ -42,7 +42,7 @@ namespace ranges
         template<typename T>
         void begin(T &&) = delete;
 
-#ifdef RANGES_WORKAROUND_MSVC_620035
+#ifdef RANGES_WORKAROUND_MSVC_895622
         void begin();
 #endif
 
@@ -186,7 +186,7 @@ namespace ranges
         template<typename T>
         void end(T &&) = delete;
 
-#ifdef RANGES_WORKAROUND_MSVC_620035
+#ifdef RANGES_WORKAROUND_MSVC_895622
         void end();
 #endif
 

--- a/include/range/v3/range/primitives.hpp
+++ b/include/range/v3/range/primitives.hpp
@@ -36,7 +36,7 @@ namespace ranges
         template<typename T>
         void size(T &&) = delete;
 
-#ifdef RANGES_WORKAROUND_MSVC_620035
+#ifdef RANGES_WORKAROUND_MSVC_895622
         void size();
 #endif
 

--- a/include/range/v3/utility/any.hpp
+++ b/include/range/v3/utility/any.hpp
@@ -59,18 +59,7 @@ namespace ranges
     template<typename T>
     T const * any_cast(any const *) noexcept;
 
-#if defined(RANGES_WORKAROUND_MSVC_589046) && !defined(RANGES_DOXYGEN_INVOKED)
-    namespace _any_
-    {
-        struct adl_hook
-        {};
-    } // namespace _any_
-#endif
-
     struct any
-#if defined(RANGES_WORKAROUND_MSVC_589046) && !defined(RANGES_DOXYGEN_INVOKED)
-      : private _any_::adl_hook
-#endif
     {
     private:
         template<typename T>

--- a/include/range/v3/view/stride.hpp
+++ b/include/range/v3/view/stride.hpp
@@ -133,34 +133,23 @@ namespace ranges
         // stride_view const models Range if Rng const models Range, and
         // either (1) Rng is sized, so we can pre-calculate offset_, or (2)
         // Rng is !Bidirectional, so it does not need offset_.
-#ifdef RANGES_WORKAROUND_MSVC_711347
-        static constexpr bool const_iterable =
-            Range<Rng const> && (SizedRange<Rng const> || !BidirectionalRange<Rng const>);
-#else  // ^^^ workaround / no workaround vvv
         static constexpr bool const_iterable() noexcept
         {
             return Range<Rng const> &&
                    (SizedRange<Rng const> || !BidirectionalRange<Rng const>);
         }
-#endif // RANGES_WORKAROUND_MSVC_711347
 
         // If the underlying range doesn't model CommonRange, then we can't
         // decrement the end and there's no reason to adapt the sentinel. Strictly
         // speaking, we don't have to adapt the end iterator of Input and Forward
         // Ranges, but in the interests of making the resulting stride view model
         // CommonView, adapt it anyway.
-#ifdef RANGES_WORKAROUND_MSVC_711347
-        template<bool Const, class CRng = meta::const_if_c<Const, Rng>>
-        static constexpr bool can_bound = CommonRange<CRng> &&
-                                          (SizedRange<CRng> || !BidirectionalRange<CRng>);
-#else  // ^^^ workaround / no workaround vvv
         template<bool Const>
         static constexpr bool can_bound() noexcept
         {
             using CRng = meta::const_if_c<Const, Rng>;
             return CommonRange<CRng> && (SizedRange<CRng> || !BidirectionalRange<CRng>);
         }
-#endif // RANGES_WORKAROUND_MSVC_711347
 
         template<bool Const>
         struct adaptor : adaptor_base
@@ -258,33 +247,20 @@ namespace ranges
         }
         CPP_member
         constexpr auto begin_adaptor() const noexcept ->
-#ifdef RANGES_WORKAROUND_MSVC_711347
-            CPP_ret(adaptor<true>)(requires const_iterable)
-#else  // ^^^ workaround / no workaround vvv
             CPP_ret(adaptor<true>)(requires(const_iterable()))
-#endif // RANGES_WORKAROUND_MSVC_711347
         {
             return adaptor<true>{*this};
         }
 
         constexpr auto end_adaptor() noexcept ->
-#ifdef RANGES_WORKAROUND_MSVC_711347
-            meta::if_c<can_bound<false>, adaptor<false>, adaptor_base>
-#else  // ^^^ workaround / no workaround vvv
             meta::if_c<can_bound<false>(), adaptor<false>, adaptor_base>
-#endif // RANGES_WORKAROUND_MSVC_711347
         {
             return {*this};
         }
         CPP_member
         constexpr auto end_adaptor() const noexcept ->
-#ifdef RANGES_WORKAROUND_MSVC_711347
-            CPP_ret(meta::if_c<can_bound<true>, adaptor<true>, adaptor_base>)( //
-                requires const_iterable)
-#else  // ^^^ workaround / no workaround vvv
             CPP_ret(meta::if_c<can_bound<true>(), adaptor<true>, adaptor_base>)( //
                 requires(const_iterable()))
-#endif // RANGES_WORKAROUND_MSVC_711347
         {
             return {*this};
         }

--- a/test/view/span.cpp
+++ b/test/view/span.cpp
@@ -506,11 +506,7 @@ RANGES_DIAGNOSTIC_IGNORE_UNDEFINED_FUNC_TEMPLATE
             CPP_assert(std::is_same<span<int, 5>, decltype(s)>::value);
         }
         {
-#ifdef RANGES_WORKAROUND_MSVC_401490
-            span s{ranges::data(arr), ranges::distance(arr)};
-#else // ^^^ workaround ^^^ / vvv no workaround vvv
             span s{ranges::data(arr), ranges::size(arr)};
-#endif // RANGES_WORKAROUND_MSVC_401490
             CPP_assert(std::is_same<span<int>, decltype(s)>::value);
         }
         {


### PR DESCRIPTION
* VSO#934330 will be fixed in VS2019 16.3
* Despite that VSO#620035 was fixed in VS2019 16.0, the workarounds are still needed; I overreduced the repro. These workarounds are now tagged with the fresh new bug number VSO#895622.
* Remove workarounds for VS2017 bugs, which is no longer supported.