### PR TITLE
Conan recipe/packaging fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,6 @@ install(EXPORT range-v3-targets FILE range-v3-config.cmake DESTINATION lib/cmake
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/range-v3-config-version.cmake
   DESTINATION lib/cmake/range-v3)
-install(DIRECTORY include/ DESTINATION include FILES_MATCHING PATTERN "*.hpp")
+install(DIRECTORY include/ DESTINATION include FILES_MATCHING PATTERN "*")
 
 export(EXPORT range-v3-targets FILE range-v3-config.cmake)

--- a/conanfile.py
+++ b/conanfile.py
@@ -18,12 +18,9 @@ class Rangev3Conan(ConanFile):
     license = "Boost Software License - Version 1.0 - August 17th, 2003"
     url = "https://github.com/ericniebler/range-v3"
     description = """Experimental range library for C++11/14/17"""
-    settings = "compiler", "arch"
+    # No settings/options are necessary, this is header only
     exports_sources = "include*", "LICENSE.txt", "CMakeLists.txt", "cmake/*", "Version.cmake", "version.hpp.in"
-    build_policy = "missing"
-
-    def build(self):
-        pass
+    no_copy_source = True
 
     def package(self):
         cmake = CMake(self)
@@ -36,6 +33,3 @@ class Rangev3Conan(ConanFile):
         cmake.install()
 
         self.copy("LICENSE.txt", dst="licenses", ignore_case=True, keep_path=False)
-
-    def package_id(self):
-        self.info.header_only()

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -20,4 +20,5 @@ add_executable(example example.cpp)
 
 target_link_libraries(example ${CONAN_LIBS})
 
-target_compile_features(example PRIVATE cxx_range_for)
+set_property(TARGET example PROPERTY CXX_STANDARD 17)
+target_compile_options(example PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/experimental:preprocessor /wd5105>)


### PR DESCRIPTION
— Remove `settings` property, `build_policy = "missing"`, `build()` and `package_info()` methods, add `no_copy_source` as per https://docs.conan.io/en/latest/howtos/header_only.html
— Fix CMake install pattern to include modulemap/std headers that don't have an extension
— Fix test_package compilation