### PR TITLE
Add include/std/* to the list of headers available through bazel rules

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -19,6 +19,16 @@ cc_library(
 )
 
 cc_library(
+  name = 'std',
+  hdrs = glob([
+    'include/std/**/*.hpp',
+  ]),
+  includes = [
+    "include",
+  ],
+)
+
+cc_library(
   name = 'range-v3',
   hdrs = glob([
     'include/range/v3/**/*.hpp',
@@ -27,5 +37,6 @@ cc_library(
   deps = [
     ':concepts',
     ':meta',
+    ':std',
   ],
 )


### PR DESCRIPTION
The commit abf16a6c6a1919cacc25645588922b1cebe9c879 added new headers to include/std, but these were not exposed in Bazel rules and caused the builds to break.