### PR TITLE
Deprecate view->container conversions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -70,6 +70,8 @@
         "coroutine": "cpp",
         "ios": "cpp",
         "locale": "cpp",
-        "random": "cpp"
+        "random": "cpp",
+        "__node_handle": "cpp",
+        "__tree": "cpp"
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -73,5 +73,6 @@
         "random": "cpp",
         "__node_handle": "cpp",
         "__tree": "cpp"
-    }
+    },
+    "C_Cpp.configurationWarnings": "Disabled"
 }

--- a/example/calendar.cpp
+++ b/example/calendar.cpp
@@ -258,13 +258,13 @@ class interleave_view : public view_facade<interleave_view<Rngs>>
     struct cursor;
     cursor begin_cursor()
     {
-        return {0, &rngs_, view::transform(rngs_, ranges::begin)};
+        return {0, &rngs_, view::transform(rngs_, ranges::begin) | to<std::vector>};
     }
 
 public:
     interleave_view() = default;
     explicit interleave_view(Rngs rngs)
-      : rngs_(std::move(rngs))
+      : rngs_(std::move(rngs) | to<std::vector>)
     {}
 };
 

--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -455,7 +455,10 @@ namespace ranges
 #endif
 
 #if !defined(RANGES_DEPRECATED) && !defined(RANGES_DISABLE_DEPRECATED_WARNINGS)
-#if RANGES_CXX_ATTRIBUTE_DEPRECATED && \
+#if defined(__GNUC__) && !defined(__clang__)
+// GCC's support for [[deprecated("message")]] is unusably buggy.
+#define RANGES_DEPRECATED(MSG) __attribute__((deprecated(MSG)))
+#elif RANGES_CXX_ATTRIBUTE_DEPRECATED && \
     !((defined(__clang__) || defined(__GNUC__)) && RANGES_CXX_STD < RANGES_CXX_STD_14)
 #define RANGES_DEPRECATED(MSG) [[deprecated(MSG)]]
 #elif defined(__clang__) || defined(__GNUC__)

--- a/include/range/v3/range/conversion.hpp
+++ b/include/range/v3/range/conversion.hpp
@@ -127,8 +127,7 @@ namespace ranges
             template<typename Rng, typename ToContainer>
             friend auto operator|(Rng && rng, fn<ToContainer> (*)(to_container))
                 -> CPP_broken_friend_ret(container_t<ToContainer, Rng>)( //
-                    requires InputRange<Rng> &&
-                        ConvertibleToContainer<Rng, container_t<ToContainer, Rng>>)
+                    requires Invocable<fn<ToContainer>, Rng>)
             {
                 return fn<ToContainer>{}(static_cast<Rng &&>(rng));
             }

--- a/include/range/v3/range/conversion.hpp
+++ b/include/range/v3/range/conversion.hpp
@@ -191,7 +191,10 @@ namespace ranges
             concept ConvertibleToContainerImpl,
                 Range<Cont> && (!View<Cont>) && MoveConstructible<Cont> &&
                 Constructible<range_value_t<Cont>, range_reference_t<Rng>> &&
-                Constructible<Cont, range_cpp17_iterator_t<Rng>, range_cpp17_iterator_t<Rng>>
+                Constructible<
+                    Cont,
+                    range_cpp17_iterator_t<Rng>,
+                    range_cpp17_iterator_t<Rng>>
         );
 
         CPP_def
@@ -199,11 +202,17 @@ namespace ranges
             template(typename Rng, typename Cont)
             concept ConvertibleToContainerContainerImpl,
                 Range<Cont> && (!View<Cont>) && MoveConstructible<Cont> &&
-                Range<range_value_t<Cont>> && (!View<range_value_t<Cont>>) &&
+                True<ranges::defer::Range<range_value_t<Cont>> &&
+                    (!ranges::defer::View<range_value_t<Cont>>)> &&
                 // Test that each element of the input range can be ranges::to<>
                 // to the output container.
-                Invocable<to_container::fn<meta::id<range_value_t<Cont>>>, range_reference_t<Rng>> &&
-                Constructible<Cont, to_container_iterator<Rng, Cont>, to_container_iterator<Rng, Cont>>
+                Invocable<
+                    to_container::fn<meta::id<range_value_t<Cont>>>,
+                    range_reference_t<Rng>> &&
+                Constructible<
+                    Cont,
+                    to_container_iterator<Rng, Cont>,
+                    to_container_iterator<Rng, Cont>>
         );
 
         CPP_def
@@ -270,8 +279,8 @@ namespace ranges
             }
             template<typename Rng>
             auto operator()(Rng && rng) const -> CPP_ret(container_t<Rng>)( //
-                requires InputRange<Rng> &&
-                    (!ConvertibleToContainer<Rng, container_t<Rng>>) &&
+                requires InputRange<Rng> && //
+                    (!ConvertibleToContainer<Rng, container_t<Rng>>)&& //
                     ConvertibleToContainerContainer<Rng, container_t<Rng>>)
             {
                 static_assert(!is_infinite<Rng>::value,

--- a/include/range/v3/range/conversion.hpp
+++ b/include/range/v3/range/conversion.hpp
@@ -136,7 +136,7 @@ namespace ranges
                 it_ -= n;
                 return *this;
             }
-            CPP_member
+            CPP_broken_friend_member
             friend auto operator+(to_container_iterator i, difference_type n) //
                 -> CPP_broken_friend_ret(to_container_iterator)(
                     requires DerivedFrom<iterator_category,
@@ -144,7 +144,7 @@ namespace ranges
             {
                 return i += n;
             }
-            CPP_member
+            CPP_broken_friend_member
             friend auto operator-(to_container_iterator i, difference_type n) //
                 -> CPP_broken_friend_ret(to_container_iterator)(
                     requires DerivedFrom<iterator_category,
@@ -152,7 +152,7 @@ namespace ranges
             {
                 return i -= n;
             }
-            CPP_member
+            CPP_broken_friend_member
             friend auto operator-(difference_type n, to_container_iterator i) //
                 -> CPP_broken_friend_ret(to_container_iterator)(
                     requires DerivedFrom<iterator_category,
@@ -160,7 +160,7 @@ namespace ranges
             {
                 return i -= n;
             }
-            CPP_member
+            CPP_broken_friend_member
             friend auto operator-(to_container_iterator const & i,
                                   to_container_iterator const & j) //
                 -> CPP_broken_friend_ret(difference_type)(

--- a/include/range/v3/range/conversion.hpp
+++ b/include/range/v3/range/conversion.hpp
@@ -278,10 +278,10 @@ namespace ranges
                 return impl<cont_t, iter_t>(static_cast<Rng &&>(rng), use_reserve_t{});
             }
             template<typename Rng>
-            auto operator()(Rng && rng) const -> CPP_ret(container_t<Rng>)( //
-                requires InputRange<Rng> && //
-                    (!ConvertibleToContainer<Rng, container_t<Rng>>)&& //
-                    ConvertibleToContainerContainer<Rng, container_t<Rng>>)
+            auto operator()(Rng && rng) const -> CPP_ret(container_t<Rng>)(       //
+                requires InputRange<Rng> &&                                       //
+                    True<!defer::ConvertibleToContainer<Rng, container_t<Rng>> && //
+                         defer::ConvertibleToContainerContainer<Rng, container_t<Rng>>>)
             {
                 static_assert(!is_infinite<Rng>::value,
                               "Attempt to convert an infinite range to a container.");

--- a/include/range/v3/range/conversion.hpp
+++ b/include/range/v3/range/conversion.hpp
@@ -42,6 +42,141 @@ namespace ranges
     /// \cond
     namespace detail
     {
+        struct to_container
+        {
+            template<typename ToContainer>
+            struct fn;
+
+            template<typename ToContainer, typename Rng>
+            using container_t = meta::invoke<ToContainer, Rng>;
+
+            template<typename Rng, typename ToContainer>
+            friend auto operator|(Rng && rng, fn<ToContainer> (*)(to_container))
+                -> CPP_broken_friend_ret(container_t<ToContainer, Rng>)( //
+                    requires Invocable<fn<ToContainer>, Rng>)
+            {
+                return fn<ToContainer>{}(static_cast<Rng &&>(rng));
+            }
+        };
+
+        // A simple, light-weight transform iterator that applies ranges::to
+        // to each element in the range. Used by ranges::to to convers a range
+        // of ranges into a container of containers.
+        template<typename Rng, typename Cont>
+        struct to_container_iterator
+        {
+        private:
+            using I = range_cpp17_iterator_t<Rng>;
+            using ValueType = range_value_t<Cont>;
+            I it_;
+
+        public:
+            using difference_type = typename std::iterator_traits<I>::difference_type;
+            using value_type = ValueType;
+            using reference = ValueType;
+            using pointer = typename std::iterator_traits<I>::pointer;
+            using iterator_category = typename std::iterator_traits<I>::iterator_category;
+
+            to_container_iterator() = default;
+            template<typename OtherIt>
+            to_container_iterator(OtherIt it)
+              : it_(std::move(it))
+            {}
+            friend bool operator==(to_container_iterator const & a,
+                                   to_container_iterator const & b)
+            {
+                return a.it_ == b.it_;
+            }
+            friend bool operator!=(to_container_iterator const & a,
+                                   to_container_iterator const & b)
+            {
+                return !(a == b);
+            }
+            reference operator*() const
+            {
+                return to_container::fn<meta::id<ValueType>>{}(*it_);
+            }
+            to_container_iterator & operator++()
+            {
+                ++it_;
+                return *this;
+            }
+            to_container_iterator operator++(int)
+            {
+                auto tmp = *this;
+                ++it_;
+                return tmp;
+            }
+            CPP_member
+            auto operator--() -> CPP_ret(to_container_iterator &)(
+                requires DerivedFrom<iterator_category, std::bidirectional_iterator_tag>)
+            {
+                --it_;
+                return *this;
+            }
+            CPP_member
+            auto operator--(int) -> CPP_ret(to_container_iterator &)(
+                requires DerivedFrom<iterator_category, std::bidirectional_iterator_tag>)
+            {
+                auto tmp = *this;
+                ++it_;
+                return tmp;
+            }
+            CPP_member
+            auto operator+=(difference_type n) -> CPP_ret(to_container_iterator &)(
+                requires DerivedFrom<iterator_category, std::random_access_iterator_tag>)
+            {
+                it_ += n;
+                return *this;
+            }
+            CPP_member
+            auto operator-=(difference_type n) -> CPP_ret(to_container_iterator &)(
+                requires DerivedFrom<iterator_category, std::random_access_iterator_tag>)
+            {
+                it_ -= n;
+                return *this;
+            }
+            CPP_member
+            friend auto operator+(to_container_iterator i, difference_type n) //
+                -> CPP_broken_friend_ret(to_container_iterator)(
+                    requires DerivedFrom<iterator_category,
+                                         std::random_access_iterator_tag>)
+            {
+                return i += n;
+            }
+            CPP_member
+            friend auto operator-(to_container_iterator i, difference_type n) //
+                -> CPP_broken_friend_ret(to_container_iterator)(
+                    requires DerivedFrom<iterator_category,
+                                         std::random_access_iterator_tag>)
+            {
+                return i -= n;
+            }
+            CPP_member
+            friend auto operator-(difference_type n, to_container_iterator i) //
+                -> CPP_broken_friend_ret(to_container_iterator)(
+                    requires DerivedFrom<iterator_category,
+                                         std::random_access_iterator_tag>)
+            {
+                return i -= n;
+            }
+            CPP_member
+            friend auto operator-(to_container_iterator const & i,
+                                  to_container_iterator const & j) //
+                -> CPP_broken_friend_ret(difference_type)(
+                    requires DerivedFrom<iterator_category,
+                                         std::random_access_iterator_tag>)
+            {
+                return i.it_ - j.it_;
+            }
+            CPP_member
+            auto operator[](difference_type n) const -> CPP_ret(reference)(
+                requires DerivedFrom<iterator_category, std::random_access_iterator_tag>)
+            {
+                return *(*this + n);
+            }
+        };
+
         // clang-format off
         CPP_def
         (
@@ -55,8 +190,20 @@ namespace ranges
             template(typename Rng, typename Cont)
             concept ConvertibleToContainerImpl,
                 Range<Cont> && (!View<Cont>) && MoveConstructible<Cont> &&
-                ConvertibleTo<range_value_t<Rng>, range_value_t<Cont>> &&
+                Constructible<range_value_t<Cont>, range_reference_t<Rng>> &&
                 Constructible<Cont, range_cpp17_iterator_t<Rng>, range_cpp17_iterator_t<Rng>>
+        );
+
+        CPP_def
+        (
+            template(typename Rng, typename Cont)
+            concept ConvertibleToContainerContainerImpl,
+                Range<Cont> && (!View<Cont>) && MoveConstructible<Cont> &&
+                Range<range_value_t<Cont>> && (!View<range_value_t<Cont>>) &&
+                // Test that each element of the input range can be ranges::to<>
+                // to the output container.
+                Invocable<to_container::fn<meta::id<range_value_t<Cont>>>, range_reference_t<Rng>> &&
+                Constructible<Cont, to_container_iterator<Rng, Cont>, to_container_iterator<Rng, Cont>>
         );
 
         CPP_def
@@ -69,67 +216,71 @@ namespace ranges
 
         CPP_def
         (
-            template(typename C, typename R)
+            template(typename Rng, typename Cont)
+            concept ConvertibleToContainerContainer,
+                defer::HasAllocatorType<Cont> && // HACKHACK
+                defer::ConvertibleToContainerContainerImpl<Rng, Cont>
+        );
+
+        CPP_def
+        (
+            template(typename C, typename I, typename R)
             concept ToContainerReserve,
-                ReserveAndAssignable<C, range_cpp17_iterator_t<R>> &&
+                ReserveAndAssignable<C, I> &&
                 SizedRange<R>
         );
         // clang-format on
 
-        struct to_container
+        template<typename ToContainer>
+        struct to_container::fn : pipeable<fn<ToContainer>>
         {
-            template<typename ToContainer>
-            struct fn : pipeable<fn<ToContainer>>
+        private:
+            template<typename Cont, typename I, typename Rng>
+            static Cont impl(Rng && rng, std::false_type)
             {
-            private:
-                template<typename Cont, typename Rng>
-                static auto impl(Rng && rng) -> CPP_ret(Cont)( //
-                    requires(!ToContainerReserve<Cont, Rng>))
-                {
-                    using I = range_cpp17_iterator_t<Rng>;
-                    return Cont(I{ranges::begin(rng)}, I{ranges::end(rng)});
-                }
-
-                template<typename Cont, typename Rng>
-                static auto impl(Rng && rng) -> CPP_ret(Cont)( //
-                    requires ToContainerReserve<Cont, Rng>)
-                {
-                    Cont c;
-                    auto const rng_size = ranges::size(rng);
-                    using size_type = decltype(c.max_size());
-                    using C = common_type_t<range_size_t<Rng>, size_type>;
-                    RANGES_EXPECT(static_cast<C>(rng_size) <=
-                                  static_cast<C>(c.max_size()));
-                    c.reserve(static_cast<size_type>(rng_size));
-                    using I = range_cpp17_iterator_t<Rng>;
-                    c.assign(I{ranges::begin(rng)}, I{ranges::end(rng)});
-                    return c;
-                }
-
-                template<typename Rng>
-                using container_t = meta::invoke<ToContainer, Rng>;
-
-            public:
-                template<typename Rng>
-                auto operator()(Rng && rng) const -> CPP_ret(container_t<Rng>)( //
-                    requires InputRange<Rng> &&
-                        ConvertibleToContainer<Rng, container_t<Rng>>)
-                {
-                    static_assert(!is_infinite<Rng>::value,
-                                  "Attempt to convert an infinite range to a container.");
-                    return impl<container_t<Rng>>(static_cast<Rng &&>(rng));
-                }
-            };
-
-            template<typename ToContainer, typename Rng>
+                return Cont(I{ranges::begin(rng)}, I{ranges::end(rng)});
+            }
+            template<typename Cont, typename I, typename Rng>
+            static auto impl(Rng && rng, std::true_type)
+            {
+                Cont c;
+                auto const rng_size = ranges::size(rng);
+                using size_type = decltype(c.max_size());
+                using C = common_type_t<range_size_t<Rng>, size_type>;
+                RANGES_EXPECT(static_cast<C>(rng_size) <= static_cast<C>(c.max_size()));
+                c.reserve(static_cast<size_type>(rng_size));
+                c.assign(I{ranges::begin(rng)}, I{ranges::end(rng)});
+                return c;
+            }
+            template<typename Rng>
             using container_t = meta::invoke<ToContainer, Rng>;
 
-            template<typename Rng, typename ToContainer>
-            friend auto operator|(Rng && rng, fn<ToContainer> (*)(to_container))
-                -> CPP_broken_friend_ret(container_t<ToContainer, Rng>)( //
-                    requires Invocable<fn<ToContainer>, Rng>)
+        public:
+            template<typename Rng>
+            auto operator()(Rng && rng) const -> CPP_ret(container_t<Rng>)( //
+                requires InputRange<Rng> && ConvertibleToContainer<Rng, container_t<Rng>>)
             {
-                return fn<ToContainer>{}(static_cast<Rng &&>(rng));
+                static_assert(!is_infinite<Rng>::value,
+                              "Attempt to convert an infinite range to a container.");
+                using cont_t = container_t<Rng>;
+                using iter_t = range_cpp17_iterator_t<Rng>;
+                using use_reserve_t =
+                    meta::bool_<(bool)ToContainerReserve<cont_t, iter_t, Rng>>;
+                return impl<cont_t, iter_t>(static_cast<Rng &&>(rng), use_reserve_t{});
+            }
+            template<typename Rng>
+            auto operator()(Rng && rng) const -> CPP_ret(container_t<Rng>)( //
+                requires InputRange<Rng> &&
+                    (!ConvertibleToContainer<Rng, container_t<Rng>>) &&
+                    ConvertibleToContainerContainer<Rng, container_t<Rng>>)
+            {
+                static_assert(!is_infinite<Rng>::value,
+                              "Attempt to convert an infinite range to a container.");
+                using cont_t = container_t<Rng>;
+                using iter_t = to_container_iterator<Rng, cont_t>;
+                using use_reserve_t =
+                    meta::bool_<(bool)ToContainerReserve<cont_t, iter_t, Rng>>;
+                return impl<cont_t, iter_t>(static_cast<Rng &&>(rng), use_reserve_t{});
             }
         };
 

--- a/include/range/v3/view/interface.hpp
+++ b/include/range/v3/view/interface.hpp
@@ -440,18 +440,22 @@ namespace ranges
             return Slice{}(detail::move(derived()), offs.from, offs.to);
         }
         /// Implicit conversion to something that looks like a container.
-        CPP_template(typename Container, bool True = true)(              //
-            requires detail::ConvertibleToContainer<D<True>, Container>) //
-            constexpr
-            operator Container()
+        CPP_template(typename Container, bool True = true)( // clang-format off
+            requires detail::ConvertibleToContainer<D<True>, Container>)
+        RANGES_DEPRECATED(
+            "Implicit conversion from a view to a container is deprecated. "
+            "Please use ranges::to in <range/v3/range/conversion.hpp> instead.")
+        constexpr operator Container() // clang-format on
         {
             return ranges::to<Container>(derived());
         }
         /// \overload
-        CPP_template(typename Container, bool True = true)(                    //
-            requires detail::ConvertibleToContainer<D<True> const, Container>) //
-            constexpr
-            operator Container() const
+        CPP_template(typename Container, bool True = true)( // clang-format off
+            requires detail::ConvertibleToContainer<D<True> const, Container>)
+        RANGES_DEPRECATED(
+            "Implicit conversion from a view to a container is deprecated. "
+            "Please use ranges::to in <range/v3/range/conversion.hpp> instead.")
+        constexpr operator Container() const // clang-format on
         {
             return ranges::to<Container>(derived());
         }

--- a/test/action/adjacent_remove_if.cpp
+++ b/test/action/adjacent_remove_if.cpp
@@ -22,7 +22,7 @@ int main()
 {
     using namespace ranges;
 
-    std::vector<int> v = view::ints(1, 21);
+    auto v = view::ints(1,21) | to<std::vector>();
     auto & v2 = action::adjacent_remove_if(v, [](int x, int y){ return (x + y) % 3 == 0; });
     CHECK(std::addressof(v) == std::addressof(v2));
     check_equal(v, {2, 3, 5, 6, 8, 9, 11, 12, 14, 15, 17, 18, 20});

--- a/test/action/drop.cpp
+++ b/test/action/drop.cpp
@@ -19,7 +19,7 @@ int main()
 {
     using namespace ranges;
 
-    std::vector<int> v = view::ints(1,21);
+    auto v = view::ints(1,21) | to<std::vector>();
     auto & v2 = action::drop(v, 3);
     CHECK(&v2 == &v);
     CHECK(v.size() == 17u);

--- a/test/action/drop_while.cpp
+++ b/test/action/drop_while.cpp
@@ -20,7 +20,7 @@ int main()
     using namespace ranges;
     using namespace std::placeholders;
 
-    std::vector<int> v = view::ints(1,21);
+    auto v = view::ints(1,21) | to<std::vector>();
     auto & v2 = action::drop_while(v, std::bind(std::less<int>(), _1, 4));
     CHECK(&v2 == &v);
     CHECK(v.size() == 17u);

--- a/test/action/remove_if.cpp
+++ b/test/action/remove_if.cpp
@@ -20,7 +20,7 @@ int main()
 {
     using namespace ranges;
 
-    std::vector<int> v = view::ints(1,21);
+    auto v = view::ints(1,21) | to<std::vector>();
     auto & v2 = action::remove_if(v, [](int i){return i % 2 == 0;});
     CHECK(&v2 == &v);
     check_equal(v, {1,3,5,7,9,11,13,15,17,19});

--- a/test/action/reverse.cpp
+++ b/test/action/reverse.cpp
@@ -22,10 +22,10 @@ using namespace ranges;
 int main()
 {
     // [1,2,2,3,3,3,4,4,4,4,5,5,5,5,5,...]
-    std::vector<int> v =
+    auto v =
         view::for_each(view::ints(1,6), [](int i){
             return yield_from(view::repeat_n(i,i));
-        });
+        }) | to<std::vector>();
     check_equal(v, {1,2,2,3,3,3,4,4,4,4,5,5,5,5,5});
 
     v |= action::unique | action::reverse;

--- a/test/action/shuffle.cpp
+++ b/test/action/shuffle.cpp
@@ -27,7 +27,7 @@ int main()
     std::mt19937 gen;
 
     // "Ints" view vs. shuffled
-    std::vector<int> v = view::ints(0,100);
+    auto v = view::ints(0,100) | to<std::vector>();
     auto v2 = v | copy | action::shuffle(gen);
     CHECK(is_sorted(v));
     CHECK(!is_sorted(v2));
@@ -50,19 +50,19 @@ int main()
 
     // Container algorithms can also be called directly
     // in which case they take and return by reference
-    v = view::ints(0,100);
+    v = view::ints(0,100) | to<std::vector>();
     auto & v3 = action::shuffle(v, gen);
     CHECK(!is_sorted(v));
     CHECK(&v3 == &v);
 
     // Create and shuffle container reference
-    v = view::ints(0,100);
+    v = view::ints(0,100) | to<std::vector>();
     auto ref = view::ref(v);
     ref |= action::shuffle(gen);
     CHECK(!is_sorted(v));
 
     // Can pipe a view to a "container" algorithm.
-    v = view::ints(0,100);
+    v = view::ints(0,100) | to<std::vector>();
     v | view::stride(2) | action::shuffle(gen);
     CHECK(!is_sorted(v));
 

--- a/test/action/slice.cpp
+++ b/test/action/slice.cpp
@@ -23,7 +23,7 @@ int main()
 {
     using namespace ranges;
     {
-        std::vector<int> v = view::ints(0, 100);
+        auto v = view::ints(0, 100) | to<std::vector>();
 
         auto v2 = v | copy | action::slice(10, 20);
         CHECK(size(v2) == 10u);
@@ -42,7 +42,7 @@ int main()
     }
 
     {
-        std::vector<int> rng = view::ints(0, 100);
+        auto rng = view::ints(0, 100) | to<std::vector>();
 
         rng |= action::slice(20, end - 70);
         CHECK(size(rng) == 10u);
@@ -54,7 +54,7 @@ int main()
     }
 
     {
-        std::vector<int> rng = view::ints(0, 100);
+        auto rng = view::ints(0, 100) | to<std::vector>();
 
         auto &rng_copy = action::slice(rng, 90, end);
         CHECK(&rng_copy == &rng);

--- a/test/action/sort.cpp
+++ b/test/action/sort.cpp
@@ -29,7 +29,7 @@ int main()
     using namespace ranges;
     std::mt19937 gen;
 
-    std::vector<int> v = view::ints(0,100);
+    auto v = view::ints(0,100) | to<std::vector>();
     v |= action::shuffle(gen);
     CHECK(!is_sorted(v));
 

--- a/test/action/split.cpp
+++ b/test/action/split.cpp
@@ -24,7 +24,7 @@ int main()
     using namespace ranges;
 
     {
-        std::vector<int> v = view::ints(1,21);
+        auto v = view::ints(1,21) | to<std::vector>();
         std::vector<std::vector<int>> rgv = action::split(v, 10);
         CHECK(rgv.size() == 2u);
         ::check_equal(rgv[0], {1,2,3,4,5,6,7,8,9});

--- a/test/action/stable_sort.cpp
+++ b/test/action/stable_sort.cpp
@@ -43,7 +43,7 @@ int main()
     using namespace ranges;
     std::mt19937 gen;
 
-    std::vector<int> v = view::ints(0,100);
+    auto v = view::ints(0,100) | to<std::vector>();
     v |= action::shuffle(gen);
     CHECK(!is_sorted(v));
 

--- a/test/action/stride.cpp
+++ b/test/action/stride.cpp
@@ -22,7 +22,7 @@ int main()
 {
     using namespace ranges;
 
-    std::vector<int> v = view::ints(0,100);
+    auto v = view::ints(0,100) | to<std::vector>();
 
     auto v2 = v | copy | action::stride(10);
     CHECK(size(v2) == 10u);

--- a/test/action/take.cpp
+++ b/test/action/take.cpp
@@ -19,7 +19,7 @@ int main()
 {
     using namespace ranges;
 
-    std::vector<int> v = view::ints(1,21);
+    auto v = view::ints(1,21) | to<std::vector>();
     auto & v2 = action::take(v, 17);
     CHECK(&v2 == &v);
     CHECK(v.size() == 17u);

--- a/test/action/take_while.cpp
+++ b/test/action/take_while.cpp
@@ -20,7 +20,7 @@ int main()
     using namespace ranges;
     using namespace std::placeholders;
 
-    std::vector<int> v = view::ints(1,21);
+    auto v = view::ints(1,21) | to<std::vector>();
     auto & v2 = action::take_while(v, std::bind(std::less<int>(), _1, 18));
     CHECK(&v2 == &v);
     CHECK(v.size() == 17u);

--- a/test/action/transform.cpp
+++ b/test/action/transform.cpp
@@ -22,7 +22,7 @@ int main()
 {
     using namespace ranges;
 
-    std::vector<int> v = view::ints(0,10);
+    auto v = view::ints(0,10) | to<std::vector>();
 
     auto v0 = v | copy | action::transform([](int i){return i*i;});
     ::models<SameConcept>(v, v0);

--- a/test/action/unique.cpp
+++ b/test/action/unique.cpp
@@ -29,10 +29,10 @@ int main()
     std::mt19937 gen;
 
     // [1,2,2,3,3,3,4,4,4,4,5,5,5,5,5,...]
-    std::vector<int> v =
+    auto v =
         view::for_each(view::ints(1,100), [](int i){
             return yield_from(view::repeat_n(i,i));
-        });
+        }) | to<std::vector>();
     check_equal(view::take(v, 15), {1,2,2,3,3,3,4,4,4,4,5,5,5,5,5});
     v |= action::shuffle(gen);
     CHECK(!is_sorted(v));

--- a/test/algorithm/sort.cpp
+++ b/test/algorithm/sort.cpp
@@ -313,10 +313,10 @@ int main()
     // Check sorting a zip view, which uses iter_move
     {
         using namespace ranges;
-        std::vector<int> v0 =
+        auto v0 =
             view::for_each(view::ints(1,6) | view::reverse, [](int i){
                 return ranges::yield_from(view::repeat_n(i,i));
-            });
+            }) | to<std::vector>();
         auto v1 = ranges::to<std::vector<Int>>(
             {1,2,2,3,3,3,4,4,4,4,5,5,5,5,5});
         auto rng = view::zip(v0, v1);

--- a/test/range/conversion.cpp
+++ b/test/range/conversion.cpp
@@ -117,14 +117,12 @@ int main()
         auto r1 = view::indices( std::uintmax_t{ 100 } );
         auto r2 = view::zip( r1, r1 );
 
-        std::map<std::uintmax_t, std::uintmax_t> m = r2;
-        (void) m;
-
 #ifdef RANGES_WORKAROUND_MSVC_779708
-        (void)(r2 | ranges::to<std::map<std::uintmax_t, std::uintmax_t>>());
+        auto m = r2 | ranges::to<std::map<std::uintmax_t, std::uintmax_t>>();
 #else // ^^^ workaround / no workaround vvv
-        (void)(r2 | ranges::to<std::map<std::uintmax_t, std::uintmax_t>>);
+        auto m = r2 | ranges::to<std::map<std::uintmax_t, std::uintmax_t>>;
 #endif // RANGES_WORKAROUND_MSVC_779708
+        CPP_assert(Same<decltype(m), std::map<std::uintmax_t, std::uintmax_t>>);
     }
 
     test_zip_to_map(view::zip(view::ints, view::iota(0, 10)), 0);

--- a/test/range/conversion.cpp
+++ b/test/range/conversion.cpp
@@ -12,14 +12,16 @@
 #include <list>
 #include <map>
 #include <vector>
+
+#include <range/v3/action/sort.hpp>
 #include <range/v3/core.hpp>
 #include <range/v3/range/conversion.hpp>
-#include <range/v3/view/iota.hpp>
 #include <range/v3/view/indices.hpp>
-#include <range/v3/view/transform.hpp>
+#include <range/v3/view/iota.hpp>
 #include <range/v3/view/take.hpp>
+#include <range/v3/view/transform.hpp>
 #include <range/v3/view/zip.hpp>
-#include <range/v3/action/sort.hpp>
+
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 
@@ -42,16 +44,14 @@ struct vector_like : std::vector<T>
 };
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-template<
-    typename Rng,
-    typename CI = ranges::range_common_iterator_t<Rng>,
-    typename = decltype(std::map{CI{}, CI{}})>
-void test_zip_to_map(Rng &&rng, int)
+template<typename Rng, typename CI = ranges::range_common_iterator_t<Rng>,
+         typename = decltype(std::map{CI{}, CI{}})>
+void test_zip_to_map(Rng && rng, int)
 {
     using namespace ranges;
 #ifdef RANGES_WORKAROUND_MSVC_779708
     auto m = static_cast<Rng &&>(rng) | to<std::map>();
-#else // ^^^ workaround / no workaround vvv
+#else  // ^^^ workaround / no workaround vvv
     auto m = static_cast<Rng &&>(rng) | to<std::map>;
 #endif // RANGES_WORKAROUND_MSVC_779708
     CPP_assert(Same<decltype(m), std::map<int, int>>);
@@ -66,41 +66,44 @@ int main()
     using namespace ranges;
 
     {
-        auto lst0 = view::ints | view::transform([](int i){return i*i;}) | view::take(10)
-            | to<std::list>();
+        auto lst0 = view::ints | view::transform([](int i) { return i * i; }) |
+                    view::take(10) | to<std::list>();
         CPP_assert(Same<decltype(lst0), std::list<int>>);
-        ::check_equal(lst0, {0,1,4,9,16,25,36,49,64,81});
+        ::check_equal(lst0, {0, 1, 4, 9, 16, 25, 36, 49, 64, 81});
     }
 
-#ifndef RANGES_WORKAROUND_MSVC_779708 // "workaround" is a misnomer; there's no workaround.
+#ifndef RANGES_WORKAROUND_MSVC_779708 // "workaround" is a misnomer; there's no
+                                      // workaround.
     {
-        auto lst1 = view::ints | view::transform([](int i){return i*i;}) | view::take(10)
-            | to<std::list>;
+        auto lst1 = view::ints | view::transform([](int i) { return i * i; }) |
+                    view::take(10) | to<std::list>;
         CPP_assert(Same<decltype(lst1), std::list<int>>);
-        ::check_equal(lst1, {0,1,4,9,16,25,36,49,64,81});
+        ::check_equal(lst1, {0, 1, 4, 9, 16, 25, 36, 49, 64, 81});
     }
 #endif // RANGES_WORKAROUND_MSVC_779708
 
     {
-        auto vec0 = view::ints | view::transform([](int i){return i*i;}) | view::take(10)
-            | to_vector | action::sort(std::greater<int>{});
+        auto vec0 = view::ints | view::transform([](int i) { return i * i; }) |
+                    view::take(10) | to_vector | action::sort(std::greater<int>{});
         CPP_assert(Same<decltype(vec0), std::vector<int>>);
-        ::check_equal(vec0, {81,64,49,36,25,16,9,4,1,0});
+        ::check_equal(vec0, {81, 64, 49, 36, 25, 16, 9, 4, 1, 0});
     }
 
     {
-        auto vec1 = view::ints | view::transform([](int i){return i*i;}) | view::take(10)
-            | to<std::vector<long>>() | action::sort(std::greater<long>{});
+        auto vec1 = view::ints | view::transform([](int i) { return i * i; }) |
+                    view::take(10) | to<std::vector<long>>() |
+                    action::sort(std::greater<long>{});
         CPP_assert(Same<decltype(vec1), std::vector<long>>);
-        ::check_equal(vec1, {81,64,49,36,25,16,9,4,1,0});
+        ::check_equal(vec1, {81, 64, 49, 36, 25, 16, 9, 4, 1, 0});
     }
 
 #ifndef RANGES_WORKAROUND_MSVC_779708
     {
-        auto vec2 = view::ints | view::transform([](int i){return i*i;}) | view::take(10)
-            | to<std::vector<long>> | action::sort(std::greater<long>{});
+        auto vec2 = view::ints | view::transform([](int i) { return i * i; }) |
+                    view::take(10) | to<std::vector<long>> |
+                    action::sort(std::greater<long>{});
         CPP_assert(Same<decltype(vec2), std::vector<long>>);
-        ::check_equal(vec2, {81,64,49,36,25,16,9,4,1,0});
+        ::check_equal(vec2, {81, 64, 49, 36, 25, 16, 9, 4, 1, 0});
     }
 #endif // RANGES_WORKAROUND_MSVC_779708
 
@@ -114,8 +117,8 @@ int main()
 
     // https://github.com/ericniebler/range-v3/issues/1145
     {
-        auto r1 = view::indices( std::uintmax_t{ 100 } );
-        auto r2 = view::zip( r1, r1 );
+        auto r1 = view::indices(std::uintmax_t{100});
+        auto r2 = view::zip(r1, r1);
 
 #ifdef RANGES_WORKAROUND_MSVC_779708
         auto m = r2 | ranges::to<std::map<std::uintmax_t, std::uintmax_t>>();
@@ -123,6 +126,19 @@ int main()
         auto m = r2 | ranges::to<std::map<std::uintmax_t, std::uintmax_t>>;
 #endif // RANGES_WORKAROUND_MSVC_779708
         CPP_assert(Same<decltype(m), std::map<std::uintmax_t, std::uintmax_t>>);
+    }
+
+    // Transform a range-of-ranges into a container of containers
+    {
+        auto r = view::ints(1, 4) |
+                 view::transform([](int i) { return view::ints(i, i + 3); });
+
+        auto m = r | ranges::to<std::vector<std::vector<int>>>();
+        CPP_assert(Same<decltype(m), std::vector<std::vector<int>>>);
+        CHECK(m.size() == 3u);
+        check_equal(m[0], {1, 2, 3});
+        check_equal(m[1], {2, 3, 4});
+        check_equal(m[2], {3, 4, 5});
     }
 
     test_zip_to_map(view::zip(view::ints, view::iota(0, 10)), 0);

--- a/test/view/chunk.cpp
+++ b/test/view/chunk.cpp
@@ -80,7 +80,7 @@ namespace
 
 int main()
 {
-    std::vector<int> v = view::iota(0,11);
+    auto v = view::iota(0,11) | to<std::vector>();
     auto rng1 = v | view::chunk(3);
     ::models<RandomAccessRangeConcept>(rng1);
     ::models<SizedRangeConcept>(rng1);
@@ -94,7 +94,7 @@ int main()
     CHECK(size(rng1), 4u);
     CHECK(sizeof(rng1.begin()) == sizeof(v.begin()) * 2 + sizeof(std::ptrdiff_t) * 2);
 
-    std::forward_list<int> l = view::iota(0,11);
+    auto l = view::iota(0,11) | to<std::forward_list>();
     auto rng2 = l | view::chunk(3);
     ::models<ForwardRangeConcept>(rng2);
     ::models_not<BidirectionalRangeConcept>(rng2);

--- a/test/view/conversion.cpp
+++ b/test/view/conversion.cpp
@@ -36,61 +36,66 @@ int main()
 
     // 1-d vector
 
-    std::vector<int> v = view::ints | view::take(10);
+    auto v = view::ints | view::take(10) | to<std::vector>();
     ::check_equal(v, {0,1,2,3,4,5,6,7,8,9});
 
-    v = view::iota(10) | view::take(10) | view::reverse;
+    v = view::iota(10) | view::take(10) | view::reverse | to<std::vector>();
     ::check_equal(v, {19,18,17,16,15,14,13,12,11,10});
 
     // 1-d list
 
-    std::list<int> l = view::ints | view::take(10);
+    auto l = view::ints | view::take(10) | to<std::list>();
     ::check_equal(l, {0,1,2,3,4,5,6,7,8,9});
 
-    l = view::iota(10) | view::take(10) | view::reverse;
+    l = view::iota(10) | view::take(10) | view::reverse | to<std::list>();
     ::check_equal(l, {19,18,17,16,15,14,13,12,11,10});
 
     // 2-d vector
 
-    std::vector<std::vector<int>> vv = view::repeat_n(view::ints(0, 8), 10);
+    // TODO: make `| to<vector<vector<int>>` work
+    auto vv = view::repeat_n(view::ints(0, 8), 10) | view::transform(to<std::vector>()) |
+        to<std::vector>();
     ::check_equal(vv, std::vector<std::vector<int>>(10, {0,1,2,3,4,5,6,7}));
 
     // issue #556
 
     {
-      std::string s{"abc"};
-      any_view<any_view<char, category::random_access>, category::random_access> v1 =
-        view::single(s | view::drop(1));
-      any_view<any_view<char, category::random_access>, category::random_access> v2 =
-        view::single(s | view::drop(2));
-      auto v3 = view::concat(v1, v2);
+        std::string s{"abc"};
+        any_view<any_view<char, category::random_access>, category::random_access> v1 =
+            view::single(s | view::drop(1));
+        any_view<any_view<char, category::random_access>, category::random_access> v2 =
+            view::single(s | view::drop(2));
+        auto v3 = view::concat(v1, v2);
 
-      std::vector<std::vector<char>> owner1 = v3;
-      std::vector<std::string> owner2 = v3;
+        // TODO:
+        // auto owner1 = v3 | to<std::vector<std::vector<char>>>();
+        // auto owner2 = v3 | to<std::vector<std::string>>();
+        auto owner1 = v3 | view::transform(to<std::vector>()) | to<std::vector>();
+        auto owner2 = v3 | view::transform(to<std::string>()) | to<std::vector>();
 
-      ::check_equal(owner1, std::vector<std::vector<char>>{{'b', 'c'}, {'c'}});
-      ::check_equal(owner2, std::vector<std::string>{{"bc"}, {"c"}});
+        ::check_equal(owner1, std::vector<std::vector<char>>{{'b', 'c'}, {'c'}});
+        ::check_equal(owner2, std::vector<std::string>{{"bc"}, {"c"}});
     }
 
     // map
 
-    auto to_string = [](int i){ std::stringstream str; str << i; return str.str();};
-    std::map<int, std::string> m =
-        view::zip(view::ints, view::ints | view::transform(to_string)) | view::take(5);
+    auto to_string = [](int i){ std::stringstream str; str << i; return str.str(); };
+    auto m = view::zip(view::ints, view::ints | view::transform(to_string)) |
+        view::take(5) | to<std::map<int, std::string>>();
     using P = std::pair<int const, std::string>;
     ::check_equal(m, {P{0,"0"}, P{1,"1"}, P{2,"2"}, P{3,"3"}, P{4,"4"}});
 
     // Another way to say the same thing, but with a range comprehension:
     m = view::for_each(view::ints(0,5), [&](int i) {
             return yield(std::make_pair(i, to_string(i)));
-        });
+        }) | to<std::map<int, std::string>>();
     ::check_equal(m, {P{0,"0"}, P{1,"1"}, P{2,"2"}, P{3,"3"}, P{4,"4"}});
 
     // set
 
     CPP_assert(Range<std::set<int>>);
     CPP_assert(!View<std::set<int>>);
-    std::set<int> s = view::ints | view::take(10);
+    auto s = view::ints | view::take(10) | to<std::set<int>>();
     ::check_equal(s, {0,1,2,3,4,5,6,7,8,9});
 
     static_assert(!View<std::initializer_list<int>>, "");

--- a/test/view/conversion.cpp
+++ b/test/view/conversion.cpp
@@ -52,9 +52,7 @@ int main()
 
     // 2-d vector
 
-    // TODO: make `| to<vector<vector<int>>` work
-    auto vv = view::repeat_n(view::ints(0, 8), 10) | view::transform(to<std::vector>()) |
-        to<std::vector>();
+    auto vv = view::repeat_n(view::ints(0, 8), 10) | to<std::vector<std::vector<int>>>();
     ::check_equal(vv, std::vector<std::vector<int>>(10, {0,1,2,3,4,5,6,7}));
 
     // issue #556
@@ -67,11 +65,8 @@ int main()
             view::single(s | view::drop(2));
         auto v3 = view::concat(v1, v2);
 
-        // TODO:
-        // auto owner1 = v3 | to<std::vector<std::vector<char>>>();
-        // auto owner2 = v3 | to<std::vector<std::string>>();
-        auto owner1 = v3 | view::transform(to<std::vector>()) | to<std::vector>();
-        auto owner2 = v3 | view::transform(to<std::string>()) | to<std::vector>();
+        auto owner1 = v3 | to<std::vector<std::vector<char>>>();
+        auto owner2 = v3 | to<std::vector<std::string>>();
 
         ::check_equal(owner1, std::vector<std::vector<char>>{{'b', 'c'}, {'c'}});
         ::check_equal(owner2, std::vector<std::string>{{"bc"}, {"c"}});

--- a/test/view/drop.cpp
+++ b/test/view/drop.cpp
@@ -87,13 +87,15 @@ int main()
 
     {
         // Regression test for https://github.com/ericniebler/range-v3/issues/413
-        auto skips = [](std::vector<int> xs) -> std::vector<std::vector<int>> {
+        auto skips = [](std::vector<int> xs) {
             return view::ints(0, (int)xs.size())
                 | view::transform([&](int n) {
                     return xs | view::chunk(n + 1)
                               | view::transform(view::drop(n))
                               | view::join;
-                });
+                })
+                | view::transform(to<std::vector>())
+                | to<std::vector>();
         };
         auto skipped = skips({1,2,3,4,5,6,7,8});
         CHECK(skipped.size() == 8u);

--- a/test/view/drop.cpp
+++ b/test/view/drop.cpp
@@ -94,8 +94,7 @@ int main()
                               | view::transform(view::drop(n))
                               | view::join;
                 })
-                | view::transform(to<std::vector>())
-                | to<std::vector>();
+                | to<std::vector<std::vector<int>>>();
         };
         auto skipped = skips({1,2,3,4,5,6,7,8});
         CHECK(skipped.size() == 8u);

--- a/test/view/intersperse.cpp
+++ b/test/view/intersperse.cpp
@@ -46,59 +46,59 @@ int main()
         auto r0 = view::intersperse(c_str("abcde"), ',');
         models<CommonRangeConcept>(r0);
         CHECK((r0.end() - r0.begin()) == 9);
-        CHECK(std::string(r0) == "a,b,c,d,e");
+        CHECK(to<std::string>(r0) == "a,b,c,d,e");
         CHECK(r0.size() == 9u);
 
         auto r1 = view::intersperse(c_str(""), ',');
         models<CommonRangeConcept>(r1);
-        CHECK(std::string(r1) == "");
+        CHECK(to<std::string>(r1) == "");
         CHECK(r1.size() == 0u);
 
         auto r2 = view::intersperse(c_str("a"), ',');
         models<CommonRangeConcept>(r2);
-        CHECK(std::string(r2) == "a");
+        CHECK(to<std::string>(r2) == "a");
         CHECK(r2.size() == 1u);
 
         auto r3 = view::intersperse(c_str("ab"), ',');
         models<CommonRangeConcept>(r3);
-        CHECK(std::string(r3) == "a,b");
+        CHECK(to<std::string>(r3) == "a,b");
         CHECK(r3.size() == 3u);
     }
 
     {
         auto r0 = view::intersperse(c_str("abcde"), ',') | view::reverse;
         models<CommonRangeConcept>(r0);
-        CHECK(std::string(r0) == "e,d,c,b,a");
+        CHECK(to<std::string>(r0) == "e,d,c,b,a");
 
         auto r1 = view::intersperse(c_str(""), ',') | view::reverse;
         models<CommonRangeConcept>(r1);
-        CHECK(std::string(r1) == "");
+        CHECK(to<std::string>(r1) == "");
 
         auto r2 = view::intersperse(c_str("a"), ',') | view::reverse;
         models<CommonRangeConcept>(r2);
-        CHECK(std::string(r2) == "a");
+        CHECK(to<std::string>(r2) == "a");
 
         auto r3 = view::intersperse(c_str("ab"), ',') | view::reverse;
         models<CommonRangeConcept>(r3);
-        CHECK(std::string(r3) == "b,a");
+        CHECK(to<std::string>(r3) == "b,a");
     }
 
     {
         auto r0 = view::intersperse(c_str_("abcde"), ',');
         models_not<CommonRangeConcept>(r0);
-        CHECK(std::string(r0) == "a,b,c,d,e");
+        CHECK(to<std::string>(r0) == "a,b,c,d,e");
 
         auto r1 = view::intersperse(c_str_(""), ',');
         models_not<CommonRangeConcept>(r1);
-        CHECK(std::string(r1) == "");
+        CHECK(to<std::string>(r1) == "");
 
         auto r2 = view::intersperse(c_str_("a"), ',');
         models_not<CommonRangeConcept>(r2);
-        CHECK(std::string(r2) == "a");
+        CHECK(to<std::string>(r2) == "a");
 
         auto r3 = view::intersperse(c_str_("ab"), ',');
         models_not<CommonRangeConcept>(r3);
-        CHECK(std::string(r3) == "a,b");
+        CHECK(to<std::string>(r3) == "a,b");
     }
 
     {

--- a/test/view/join.cpp
+++ b/test/view/join.cpp
@@ -73,7 +73,7 @@ RANGES_DIAGNOSTIC_IGNORE("-Wunused-member-function")
             { 1, 2, 3 },
             { 4, 5, 6 }
         };
-        const std::vector<int> flat_nums = ranges::view::join( nums );
+        const auto flat_nums = ranges::view::join( nums ) | ranges::to<std::vector>();
         ::check_equal(flat_nums, {1,2,3,4,5,6});
     }
 }
@@ -114,7 +114,7 @@ int main()
 
     // Just for fun:
     std::string str = "Now,is,the,time,for,all,good,men,to,come,to,the,aid,of,their,country";
-    std::string res = str | view::split(',') | view::join(' ');
+    auto res = str | view::split(',') | view::join(' ') | to<std::string>();
     CHECK(res == "Now is the time for all good men to come to the aid of their country");
     static_assert(range_cardinality<decltype(res)>::value == ranges::finite, "");
 

--- a/test/view/sliding.cpp
+++ b/test/view/sliding.cpp
@@ -88,10 +88,11 @@ namespace
     using size_compare =
         size_compare_<Rng, RandomAccessRange<Rng> || (BidirectionalRange<Rng> && CommonRange<Rng>)>;
 
-    template<typename Base>
-    void test_finite()
+    template<typename ToBase>
+    void test_finite(ToBase to_base)
     {
-        Base v = view::iota(0,N);
+        auto v = to_base(view::iota(0,N));
+        using Base = decltype(v);
         auto rng = v | view::sliding(K);
         using Adapted = decltype(rng);
         test_size(rng, meta::bool_<SizedRange<Base>>{});
@@ -147,10 +148,10 @@ void bug_975()
 
 int main()
 {
-    test_finite<std::forward_list<int>>();
-    test_finite<std::list<int>>();
-    test_finite<std::vector<int>>();
-    test_finite<decltype(view::iota(0,N))>();
+    test_finite(to<std::forward_list<int>>());
+    test_finite(to<std::list<int>>());
+    test_finite(to<std::vector<int>>());
+    test_finite(identity{});
 
     {
         // An infinite, cyclic range with cycle length == 1


### PR DESCRIPTION
Also, extend `ranges::to` to handle conversions from range-of-range to container-of-container.