### PR TITLE
includes new C++20 range adaptors in namespace cpp20

### DIFF
--- a/include/range/v3/view/drop.hpp
+++ b/include/range/v3/view/drop.hpp
@@ -167,6 +167,17 @@ namespace ranges
         /// \ingroup group-views
         RANGES_INLINE_VARIABLE(view<drop_fn>, drop)
     } // namespace view
+
+    namespace cpp20
+    {
+        namespace view
+        {
+            using ranges::view::drop;
+        }
+        CPP_template(typename Rng)( //
+            requires View<Rng>)     //
+            using drop_view = ranges::drop_view<Rng>;
+    } // namespace cpp20
     /// @}
 } // namespace ranges
 

--- a/include/range/v3/view/drop_while.hpp
+++ b/include/range/v3/view/drop_while.hpp
@@ -124,6 +124,18 @@ namespace ranges
         /// \ingroup group-views
         RANGES_INLINE_VARIABLE(view<drop_while_fn>, drop_while)
     } // namespace view
+
+    namespace cpp20
+    {
+        namespace view
+        {
+            using ranges::view::drop_while;
+        }
+        CPP_template(typename Rng, typename Pred)( //
+            requires ViewableRange<Rng> && InputRange<Rng> &&
+                        IndirectUnaryPredicate<Pred, iterator_t<Rng>>)     //
+            using drop_while_view = ranges::drop_while_view<Rng, Pred>;
+    } // namespace cpp20
     /// @}
 } // namespace ranges
 

--- a/include/range/v3/view/map.hpp
+++ b/include/range/v3/view/map.hpp
@@ -124,6 +124,16 @@ namespace ranges
         /// \ingroup group-views
         RANGES_INLINE_VARIABLE(view<values_fn>, values)
     } // namespace view
+
+    namespace cpp20
+    {
+        namespace view
+        {
+            using ranges::view::keys;
+            using ranges::view::values;
+        }
+        // TODO(@cjdb): provide implementation for elements_view
+    } // namespace cpp20
     /// @}
 } // namespace ranges
 

--- a/include/range/v3/view/take_while.hpp
+++ b/include/range/v3/view/take_while.hpp
@@ -175,6 +175,18 @@ namespace ranges
         /// \ingroup group-views
         RANGES_INLINE_VARIABLE(view<take_while_fn>, take_while)
     } // namespace view
+
+    namespace cpp20
+    {
+        namespace view
+        {
+            using ranges::view::take_while;
+        }
+        CPP_template(typename Rng, typename Pred)( //
+            requires ViewableRange<Rng> && InputRange<Rng> &&
+                        Predicate<Pred &, iterator_t<Rng>> && CopyConstructible<Pred>)     //
+            using take_while_view = ranges::take_while_view<Rng, Pred>;
+    } // namespace cpp20
     /// @}
 } // namespace ranges
 


### PR DESCRIPTION
The following are added to namespace cpp20:

* `take_while_view`
* `drop_view`
* `drop_while_view`
* `keys`
* `values`

The following are not added:

* `elements_view` (doesn't appear to exist)
* `istream_view` (will file NB comment to have `basic_istream_view` renamed to `istream_view`)