### PR TITLE
Workaround deprecation warnings

### DIFF
--- a/test/range/conversion.cpp
+++ b/test/range/conversion.cpp
@@ -25,6 +25,8 @@
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 
+RANGES_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS
+
 template<typename T>
 struct vector_like : std::vector<T>
 {

--- a/test/view/conversion.cpp
+++ b/test/view/conversion.cpp
@@ -30,6 +30,8 @@
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 
+RANGES_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS
+
 int main()
 {
     using namespace ranges;

--- a/test/view/drop.cpp
+++ b/test/view/drop.cpp
@@ -23,6 +23,8 @@
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 
+RANGES_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS
+
 int main()
 {
     using namespace ranges;


### PR DESCRIPTION
...in tests triggered by #1238. Conversions to nested containers use `view_interface`'s now-deprecated conversion operator templates, triggering deprecation warnings. CI didn't catch this problem because the test cases all use standard containers, which are defined in system headers, for which clang and GCC don't emit warnings.