### PR TITLE
MSVC update:

### DIFF
--- a/include/concepts/swap.hpp
+++ b/include/concepts/swap.hpp
@@ -41,7 +41,7 @@
 #endif  // CPP_CXX_INLINE_VARIABLES
 
 #if defined(_MSC_VER) && !defined(__clang__)
-#define CPP_WORKAROUND_MSVC_620035 // Error when definition-context name binding finds only deleted function
+#define CPP_WORKAROUND_MSVC_895622 // Error when phase 1 name binding finds only deleted function
 #endif
 
 #if CPP_CXX_INLINE_VARIABLES < 201606L
@@ -157,7 +157,7 @@ namespace concepts
         template<typename T, std::size_t N>
         nope swap(T (&)[N], T (&)[N]) = delete;
 
-#ifdef CPP_WORKAROUND_MSVC_620035
+#ifdef CPP_WORKAROUND_MSVC_895622
         nope swap();
 #endif
 

--- a/include/range/v3/range/conversion.hpp
+++ b/include/range/v3/range/conversion.hpp
@@ -60,7 +60,7 @@ namespace ranges
         };
 
         // A simple, light-weight transform iterator that applies ranges::to
-        // to each element in the range. Used by ranges::to to convers a range
+        // to each element in the range. Used by ranges::to to convert a range
         // of ranges into a container of containers.
         template<typename Rng, typename Cont>
         struct to_container_iterator
@@ -203,7 +203,7 @@ namespace ranges
             concept ConvertibleToContainerContainerImpl,
                 Range<Cont> && (!View<Cont>) && MoveConstructible<Cont> &&
                 True<ranges::defer::Range<range_value_t<Cont>> &&
-                    (!ranges::defer::View<range_value_t<Cont>>)> &&
+                    !ranges::defer::View<range_value_t<Cont>>> &&
                 // Test that each element of the input range can be ranges::to<>
                 // to the output container.
                 Invocable<

--- a/include/std/detail/associated_types.hpp
+++ b/include/std/detail/associated_types.hpp
@@ -243,6 +243,11 @@ namespace ranges
 
         // For testing whether a particular instantiation of std::iterator_traits
         // is user-specified or not.
+#if defined(_MSVC_STL_UPDATE) && defined(__cpp_lib_concepts) && _MSVC_STL_UPDATE >= 201908L
+        template<typename I>
+        inline constexpr bool is_std_iterator_traits_specialized_v =
+            !std::_Is_from_primary<std::iterator_traits<I>>;
+#else
 #if defined(__GLIBCXX__)
         template<typename I>
         char (&is_std_iterator_traits_specialized_impl_(std::__iterator_traits<I> *))[2];
@@ -275,6 +280,7 @@ namespace ranges
         // This helps with `T volatile*` and `void *`.
         template<typename T>
         RANGES_INLINE_VAR constexpr bool is_std_iterator_traits_specialized_v<T *> = false;
+#endif
     }
     /// \endcond
 }


### PR DESCRIPTION
* React to future changes to MSVC's implementation of `iterator_traits` in `std/detail/associated_types.hpp`

* Use correct bug number for the `concepts::swap` workaround

Drive-by: Remove extraneous parens in the definition of concept `detail::ConvertibletoContainerContainerImpl`