### PR TITLE
Workaround fixed MSVC lambda bugs

### DIFF
--- a/include/range/v3/action/push_back.hpp
+++ b/include/range/v3/action/push_back.hpp
@@ -78,17 +78,33 @@ namespace ranges
             {
                 return bind_back(push_back, static_cast<T &&>(val));
             }
+#ifdef RANGES_WORKAROUND_MSVC_OLD_LAMBDA
             template<typename T, std::size_t N>
-            static auto bind(push_back_fn push_back, T (&val)[N])
+            struct lamduh
             {
-                return bind_back(
-                    [push_back](auto && rng, T(*val)[N])
-                        -> invoke_result_t<push_back_fn, decltype(rng), T(&)[N]> {
-                        return push_back(static_cast<decltype(rng)>(rng), *val);
-                    },
-                    &val);
-            }
+                T (&val_)[N];
 
+                template<typename Rng>
+                auto operator()(Rng && rng) const
+                    -> invoke_result_t<push_back_fn, Rng, T(&)[N]> {
+                    return push_back_fn{}(static_cast<Rng &&>(rng), val_);
+                }
+            };
+            template<typename T, std::size_t N>
+            static lamduh<T, N> bind(push_back_fn, T (&val)[N])
+            {
+                return {val};
+            }
+#else // ^^^ workaround / no workaround vvv
+            template<typename T, std::size_t N>
+            static auto bind(push_back_fn, T (&val)[N])
+            {
+                return [&val](auto && rng)
+                    -> invoke_result_t<push_back_fn, decltype(rng), T(&)[N]> {
+                    return push_back_fn{}(static_cast<decltype(rng)>(rng), val);
+                };
+            }
+#endif // RANGES_WORKAROUND_MSVC_OLD_LAMBDA
         public:
             template<typename Rng, typename T>
             auto operator()(Rng && rng, T && t) const -> CPP_ret(Rng)( //

--- a/include/range/v3/action/push_front.hpp
+++ b/include/range/v3/action/push_front.hpp
@@ -76,17 +76,33 @@ namespace ranges
             {
                 return bind_back(push_front, static_cast<T &&>(val));
             }
+#ifdef RANGES_WORKAROUND_MSVC_OLD_LAMBDA
             template<typename T, std::size_t N>
-            static auto bind(push_front_fn push_front, T (&val)[N])
+            struct lamduh
             {
-                return bind_back(
-                    [push_front](auto && rng, T(*val)[N])
-                        -> invoke_result_t<push_front_fn, decltype(rng), T(&)[N]> {
-                        return push_front(static_cast<decltype(rng)>(rng), *val);
-                    },
-                    &val);
-            }
+                T (&val_)[N];
 
+                template<typename Rng>
+                auto operator()(Rng && rng) const
+                    -> invoke_result_t<push_front_fn, Rng, T(&)[N]> {
+                    return push_front_fn{}(static_cast<Rng &&>(rng), val_);
+                }
+            };
+            template<typename T, std::size_t N>
+            static lamduh<T, N> bind(push_front_fn, T (&val)[N])
+            {
+                return {val};
+            }
+#else // ^^^ workaround / no workaround vvv
+            template<typename T, std::size_t N>
+            static auto bind(push_front_fn, T (&val)[N])
+            {
+                return [&val](auto && rng)
+                    -> invoke_result_t<push_front_fn, decltype(rng), T(&)[N]> {
+                    return push_front_fn{}(static_cast<decltype(rng)>(rng), val);
+                };
+            }
+#endif // RANGES_WORKAROUND_MSVC_OLD_LAMBDA
         public:
             template<typename Rng, typename T>
             auto operator()(Rng && rng, T && t) const -> CPP_ret(Rng)( //

--- a/include/range/v3/action/sort.hpp
+++ b/include/range/v3/action/sort.hpp
@@ -36,7 +36,7 @@ namespace ranges
         private:
             friend action_access;
             template<typename C, typename P = identity>
-            static auto CPP_fun(bind)(sort_fn sort, C pred, P proj = P{})( //
+            static auto CPP_fun(bind)(sort_fn sort, C pred, P proj = {})( //
                 requires(!range<C>))
             {
                 return bind_back(sort, std::move(pred), std::move(proj));
@@ -44,7 +44,7 @@ namespace ranges
 
         public:
             template<typename Rng, typename C = less, typename P = identity>
-            auto operator()(Rng && rng, C pred = C{}, P proj = P{}) const
+            auto operator()(Rng && rng, C pred = {}, P proj = {}) const
                 -> CPP_ret(Rng)( //
                     requires forward_range<Rng> && sortable<iterator_t<Rng>, C, P>)
             {

--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -259,6 +259,9 @@ namespace ranges
                                       // deleted function
 #define RANGES_WORKAROUND_MSVC_934264 // Explicitly-defaulted inherited default
                                       // constructor is not correctly implicitly constexpr
+#if _MSVC_LANG <= 201703L
+#define RANGES_WORKAROUND_MSVC_OLD_LAMBDA
+#endif
 
 #elif defined(__GNUC__) || defined(__clang__)
 #define RANGES_PRAGMA(X) _Pragma(#X)


### PR DESCRIPTION
... which are only fixed in c++latest or with /experimental:newLambdaProcessor

Drive-by:
* Optimize the metaprogramming in `<std/detail/associated_types.hpp>` for MSVC by using the `std` type traits directly (since they're mostly implemented in the compiler)
* Don't wrap lambdas in `bind_back` when we can use them directly.
* In `<action/sort.hpp>`, don't repeat typenames in predicate and projection default arguments.