### PR TITLE
Try to reduce issue reports from MSVC users

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,15 +23,18 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 add_library(meta INTERFACE)
 target_include_directories(meta INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>)
 target_include_directories(meta SYSTEM INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
+target_compile_options(meta INTERFACE $<$<CXX_COMPILER_ID:MSVC>:/permissive->)
 
 add_library(concepts INTERFACE)
 target_include_directories(concepts INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>)
 target_include_directories(concepts SYSTEM INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
+target_compile_options(concepts INTERFACE $<$<CXX_COMPILER_ID:MSVC>:/permissive- /experimental:preprocessor /wd5105>)
 target_link_libraries(concepts INTERFACE meta)
 
 add_library(range-v3 INTERFACE)
 target_include_directories(range-v3 INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>)
 target_include_directories(range-v3 SYSTEM INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
+target_compile_options(range-v3 INTERFACE $<$<CXX_COMPILER_ID:MSVC>:/permissive->)
 target_link_libraries(range-v3 INTERFACE concepts meta)
 
 function(rv3_add_test TESTNAME EXENAME FIRSTSOURCE)

--- a/cmake/ranges_env.cmake
+++ b/cmake/ranges_env.cmake
@@ -50,16 +50,11 @@ else()
   message(WARNING "[range-v3 warning]: unknown system ${CMAKE_SYSTEM_NAME} !")
 endif()
 
-if (RANGES_CXX_COMPILER_CLANGCL OR RANGES_CXX_COMPILER_MSVC)
-  # Clang-CL will blow up in the standard library if compiling with less than
-  # C++14, and MSVC doesn't support less than C++14 at all.
-  if (RANGES_CXX_STD LESS 14)
-    set(RANGES_CXX_STD 14)
-  endif()
+if (RANGES_CXX_COMPILER_MSVC AND RANGES_CXX_STD LESS 17)
   # MSVC is currently supported only in 17+ mode
-  if (RANGES_CXX_COMPILER_MSVC AND RANGES_CXX_STD LESS 17)
-    set(RANGES_CXX_STD 17)
-  endif()
+  set(RANGES_CXX_STD 17)
+elseif(RANGES_CXX_STD LESS 14)
+  set(RANGES_CXX_STD 14)
 endif()
 
 # Build type

--- a/cmake/ranges_flags.cmake
+++ b/cmake/ranges_flags.cmake
@@ -25,8 +25,6 @@ message(STATUS "[range-v3]: C++ std=${RANGES_CXX_STD}")
 if (RANGES_CXX_COMPILER_CLANGCL OR RANGES_CXX_COMPILER_MSVC)
   ranges_append_flag(RANGES_HAS_CXXSTDCOLON "/std:c++${RANGES_CXX_STD}")
   set(RANGES_STD_FLAG "/std:c++${RANGES_CXX_STD}")
-  # Enable strict mode
-  ranges_append_flag(RANGES_HAS_PERMISSIVEMINUS "/permissive-")
   if (RANGES_CXX_COMPILER_CLANGCL)
     ranges_append_flag(RANGES_HAS_FNO_MS_COMPATIBIILITY "-fno-ms-compatibility")
     ranges_append_flag(RANGES_HAS_FNO_DELAYED_TEMPLATE_PARSING "-fno-delayed-template-parsing")
@@ -34,10 +32,6 @@ if (RANGES_CXX_COMPILER_CLANGCL OR RANGES_CXX_COMPILER_MSVC)
   # Enable "normal" warnings and make them errors:
   ranges_append_flag(RANGES_HAS_W3 /W3)
   ranges_append_flag(RANGES_HAS_WX /WX)
-  # range-v3 needs MSVC's experimental actually-conforming preprocessor...
-  ranges_append_flag(RANGES_HAS_EXPERIMENTAL_PREPROCESSOR /experimental:preprocessor)
-  # ...which warns about UB in macros in the UCRT headers =(
-  ranges_append_flag(RANGES_HAS_WD5105 /wd5105)
 else()
   ranges_append_flag(RANGES_HAS_CXXSTD "-std=c++${RANGES_CXX_STD}")
   set(RANGES_STD_FLAG "-std=c++${RANGES_CXX_STD}")

--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -215,6 +215,10 @@ namespace ranges
 
 #define RANGES_CXX_VER _MSVC_LANG
 
+#if _MSC_VER < 1920 || _MSVC_LANG < 201703L || !defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL != 0
+#error range-v3 requires Visual Studio 2019 with the /std:c++17 (or /std:c++latest) /permissive- and /experimental:preprocessor options.
+#endif
+
 #if _MSC_VER < 1923
 #define RANGES_WORKAROUND_MSVC_934330 // Deduction guide not correctly preferred to copy
                                       // deduction candidate [No workaround]

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -21,4 +21,3 @@ add_executable(example example.cpp)
 target_link_libraries(example ${CONAN_LIBS})
 
 set_property(TARGET example PROPERTY CXX_STANDARD 17)
-target_compile_options(example PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/experimental:preprocessor /wd5105>)


### PR DESCRIPTION
* export `/permissive- /experimental:preprocessor` as required flags in the cmake config

* Yell in `config.hpp` if we see old MSVC, C++14 mode, or the old preprocessor.