### PR TITLE
Apply [[no_unique_address]] to predicates

### DIFF
--- a/include/range/v3/functional/not_fn.hpp
+++ b/include/range/v3/functional/not_fn.hpp
@@ -32,7 +32,7 @@ namespace ranges
     {
     private:
         CPP_assert(same_as<FD, detail::decay_t<FD>> && move_constructible<FD>);
-        FD pred_;
+        RANGES_NO_UNIQUE_ADDRESS FD pred_;
 
     public:
         CPP_member

--- a/include/range/v3/view/drop_while.hpp
+++ b/include/range/v3/view/drop_while.hpp
@@ -43,7 +43,7 @@ namespace ranges
     {
     private:
         Rng rng_;
-        semiregular_box_t<Pred> pred_;
+        RANGES_NO_UNIQUE_ADDRESS semiregular_box_t<Pred> pred_;
         detail::non_propagating_cache<iterator_t<Rng>> begin_;
 
         iterator_t<Rng> get_begin_()

--- a/include/range/v3/view/take_while.hpp
+++ b/include/range/v3/view/take_while.hpp
@@ -43,7 +43,7 @@ namespace ranges
     {
     private:
         friend range_access;
-        semiregular_box_t<Pred> pred_;
+        RANGES_NO_UNIQUE_ADDRESS semiregular_box_t<Pred> pred_;
 
         template<bool IsConst>
         struct sentinel_adaptor : adaptor_base

--- a/include/range/v3/view/transform.hpp
+++ b/include/range/v3/view/transform.hpp
@@ -99,7 +99,7 @@ namespace ranges
     {
     private:
         friend range_access;
-        semiregular_box_t<Fun> fun_;
+        RANGES_NO_UNIQUE_ADDRESS semiregular_box_t<Fun> fun_;
         template<bool Const>
         using use_sentinel_t =
             meta::bool_<!common_range<meta::const_if_c<Const, Rng>> ||
@@ -204,7 +204,7 @@ namespace ranges
     {
     private:
         friend range_access;
-        semiregular_box_t<Fun> fun_;
+        RANGES_NO_UNIQUE_ADDRESS semiregular_box_t<Fun> fun_;
         Rng1 rng1_;
         Rng2 rng2_;
         using difference_type_ =


### PR DESCRIPTION
This PR applies `RANGES_NO_UNIQUE_ADDRESS` to functions/predicates in 

- transform, take_while, drop_while views
- `logical_negate`

The latter allows EBO out empty predicates in `filter_view`.