### PR TITLE
Enable EBO for transform_view's iterator and take_while_view's sentinel

### DIFF
--- a/include/range/v3/utility/semiregular_box.hpp
+++ b/include/range/v3/utility/semiregular_box.hpp
@@ -14,6 +14,7 @@
 #ifndef RANGES_V3_UTILITY_SEMIREGULAR_BOX_HPP
 #define RANGES_V3_UTILITY_SEMIREGULAR_BOX_HPP
 
+#include <type_traits>
 #include <utility>
 
 #include <meta/meta.hpp>
@@ -295,10 +296,11 @@ namespace ranges
     using semiregular_box_t = meta::if_c<(bool)semiregular<T>, T, semiregular_box<T>>;
 
     template<typename T, bool IsConst = false>
-    using semiregular_box_ref_or_val_t =
-        meta::if_c<(bool)semiregular<T>, meta::if_c<IsConst, T, reference_wrapper<T>>,
-                   reference_wrapper<meta::if_c<IsConst, semiregular_box<T> const,
-                                                semiregular_box<T>>>>;
+    using semiregular_box_ref_or_val_t = meta::if_c<
+        (bool)semiregular<T>,
+        meta::if_c<IsConst || std::is_empty<T>::value, T, reference_wrapper<T>>,
+        reference_wrapper<
+            meta::if_c<IsConst, semiregular_box<T> const, semiregular_box<T>>>>;
     /// @}
 
     /// \cond
@@ -308,7 +310,7 @@ namespace ranges
 
     template<typename T, bool IsConst = false>
     using semiregular_ref_or_val_t RANGES_DEPRECATED(
-        "Please use semiregular_box_t instead.") =
+        "Please use semiregular_box_ref_or_val_t instead.") =
         semiregular_box_ref_or_val_t<T, IsConst>;
     /// \endcond
 

--- a/include/range/v3/view/take_while.hpp
+++ b/include/range/v3/view/take_while.hpp
@@ -51,7 +51,7 @@ namespace ranges
         private:
             friend struct sentinel_adaptor<!IsConst>;
             using CRng = meta::const_if_c<IsConst, Rng>;
-            semiregular_box_ref_or_val_t<Pred, IsConst> pred_;
+            RANGES_NO_UNIQUE_ADDRESS semiregular_box_ref_or_val_t<Pred, IsConst> pred_;
 
         public:
             sentinel_adaptor() = default;

--- a/include/range/v3/view/transform.hpp
+++ b/include/range/v3/view/transform.hpp
@@ -112,7 +112,7 @@ namespace ranges
             friend struct adaptor<!IsConst>;
             using CRng = meta::const_if_c<IsConst, Rng>;
             using fun_ref_ = semiregular_box_ref_or_val_t<Fun, IsConst>;
-            fun_ref_ fun_;
+            RANGES_NO_UNIQUE_ADDRESS fun_ref_ fun_;
 
         public:
             using value_type =


### PR DESCRIPTION
by making `semiregular_box_ref_or_val_t<T>` be just `T` if `T` is empty (and semiregular).
Drive by: fix typo in deprecation message.

Size changes in transform_view's iterator: 

|  views | before | after  |
|--------|:------:|:------:|
|<code>array &#124; transform</code>|16|8|
|<code>array &#124; transform &#124; transform</code>|24|8|
|<code>array &#124; transform &#124; transform &#124; transform</code>|32|8|

Size changes in take_while_view's sentinel:

|  views | before | after  |
|--------|:------:|:------:|
|<code>arr &#124; take_while</code>|16|8|

### Note
I think storing `semiregular_box_ref_or_val_t` (instead of a pointer) in transform_view's iterator is not conforming to C++20, since the difference is observable. Ditto for take_while_view's sentinel. I hope the Standard will allow such implementations eventually. Refs #1292.