### PR TITLE
[FIX] cpp20::views::common with common input

### DIFF
--- a/include/range/v3/view/common.hpp
+++ b/include/range/v3/view/common.hpp
@@ -153,6 +153,13 @@ namespace ranges
         struct cpp20_common_fn
         {
             template<typename Rng>
+            auto operator()(Rng && rng) const -> CPP_ret(all_t<Rng>)( //
+                requires viewable_range<Rng> && common_range<Rng>)
+            {
+                return all(static_cast<Rng &&>(rng));
+            }
+
+            template<typename Rng>
             auto operator()(Rng && rng) const -> CPP_ret(common_view<all_t<Rng>>)( //
                 requires viewable_range<Rng> && (!common_range<Rng>))
             {


### PR DESCRIPTION
The cpp20 version of view::common is supposed to preserve the underlying range if that is already common, but currently it fails hard if the input is already common:
https://godbolt.org/z/H3LrVw

(the non-cpp20 version works and is unaffected by this PR).