### PR TITLE
Use forwarding_range_ to make the range operations (front, back, etc) safer

### DIFF
--- a/include/range/v3/range/operations.hpp
+++ b/include/range/v3/range/operations.hpp
@@ -36,7 +36,8 @@ namespace ranges
         template<typename Rng>
         constexpr auto operator()(Rng && rng, range_difference_t<Rng> n) const
             -> CPP_ret(range_reference_t<Rng>)( //
-                requires random_access_range<Rng> && sized_range<Rng>)
+                requires random_access_range<Rng> && sized_range<Rng> &&
+                    forwarding_range_<Rng>)
         {
             // Workaround https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67371 in GCC 5
             check_throw(rng, n);
@@ -67,7 +68,8 @@ namespace ranges
         template<typename Rng, typename Int>
         constexpr auto operator()(Rng && rng, Int n) const
             -> CPP_ret(range_reference_t<Rng>)( //
-                requires random_access_range<Rng> && integral<Int>)
+                requires random_access_range<Rng> && integral<Int> &&
+                    forwarding_range_<Rng>)
         {
             using D = range_difference_t<Rng>;
             RANGES_EXPECT(0 <= static_cast<D>(n));
@@ -89,7 +91,8 @@ namespace ranges
         /// \return `*prev(end(rng))`
         template<typename Rng>
         constexpr auto operator()(Rng && rng) const -> CPP_ret(range_reference_t<Rng>)( //
-            requires common_range<Rng> && bidirectional_range<Rng>)
+            requires common_range<Rng> && bidirectional_range<Rng> &&
+                forwarding_range_<Rng>)
         {
             return *prev(end(rng));
         }
@@ -105,7 +108,7 @@ namespace ranges
         /// \return `*begin(rng)`
         template<typename Rng>
         constexpr auto operator()(Rng && rng) const -> CPP_ret(range_reference_t<Rng>)( //
-            requires forward_range<Rng>)
+            requires forward_range<Rng> && forwarding_range_<Rng>)
         {
             return *begin(rng);
         }


### PR DESCRIPTION
fixes #284