### PR TITLE
Include iterate_range.hpp from all.hpp

### DIFF
--- a/include/range/v3/all.hpp
+++ b/include/range/v3/all.hpp
@@ -19,6 +19,7 @@
 #include <range/v3/core.hpp>
 #include <range/v3/functional.hpp>
 #include <range/v3/iterator.hpp>
+#include <range/v3/iterator_range.hpp>
 #include <range/v3/numeric.hpp>
 #include <range/v3/range.hpp>
 #include <range/v3/utility.hpp>


### PR DESCRIPTION
Some applications (e.g. Telegram Desktop) include all.hpp and use
iterator_range -- this worked up until v0.5.0, but in 0.9.x and master,
results in an error about make_iterator_range being undefined.

Signed-off-by: Bernhard Rosenkraenzer <bero@lindev.ch>