### PR TITLE
Parenthesize non-primary expressions in requires-clauses

### DIFF
--- a/include/range/v3/iterator/concepts.hpp
+++ b/include/range/v3/iterator/concepts.hpp
@@ -122,7 +122,7 @@ namespace ranges
     (
         template(typename I)
         concept readable,
-            requires (uncvref_t<I> const i) (
+            requires (uncvref_t<I> const& i) (
                 // { *i } -> same_as<iter_reference_t<I>>;
                 // { iter_move(i) } -> same_as<iter_rvalue_reference_t<I>>;
                 concepts::requires_<same_as<decltype(*i), iter_reference_t<I>>>,

--- a/include/range/v3/iterator/concepts.hpp
+++ b/include/range/v3/iterator/concepts.hpp
@@ -122,7 +122,7 @@ namespace ranges
     (
         template(typename I)
         concept readable,
-            requires (uncvref_t<I> const& i) (
+            requires (uncvref_t<I> const &i) (
                 // { *i } -> same_as<iter_reference_t<I>>;
                 // { iter_move(i) } -> same_as<iter_rvalue_reference_t<I>>;
                 concepts::requires_<same_as<decltype(*i), iter_reference_t<I>>>,

--- a/include/range/v3/view/tail.hpp
+++ b/include/range/v3/view/tail.hpp
@@ -81,7 +81,7 @@ namespace ranges
         }
         // Strange cast to bool in the requires clause is to work around gcc bug.
         CPP_member
-        constexpr auto CPP_fun(size)()(requires bool(sized_range<Rng>))
+        constexpr auto CPP_fun(size)()(requires (bool(sized_range<Rng>)))
         {
             using size_type = range_size_t<Rng>;
             return range_cardinality<Rng>::value >= 0
@@ -89,7 +89,7 @@ namespace ranges
                        : detail::prev_or_zero_(ranges::size(rng_));
         }
         CPP_member
-        constexpr auto CPP_fun(size)()(const requires bool(sized_range<Rng const>))
+        constexpr auto CPP_fun(size)()(const requires (bool(sized_range<Rng const>)))
         {
             using size_type = range_size_t<Rng>;
             return range_cardinality<Rng>::value >= 0


### PR DESCRIPTION
... in `view/tail.hpp`.

Fixes #1326.