### PR TITLE
Export CMake targets into range-v3:: namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,9 +162,11 @@ write_basic_package_version_file(
 set(CMAKE_SIZEOF_VOID_P ${OLD_CMAKE_SIZEOF_VOID_P})
 
 install(TARGETS concepts meta range-v3 EXPORT range-v3-targets DESTINATION lib)
-install(EXPORT range-v3-targets FILE range-v3-config.cmake DESTINATION lib/cmake/range-v3)
+install(EXPORT range-v3-targets NAMESPACE range-v3:: FILE range-v3-targets.cmake DESTINATION lib/cmake/range-v3)
+install(EXPORT range-v3-targets FILE range-v3-targets-compat.cmake DESTINATION lib/cmake/range-v3)
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/range-v3-config-version.cmake
+  cmake/range-v3-config.cmake
   DESTINATION lib/cmake/range-v3)
 install(DIRECTORY include/ DESTINATION include FILES_MATCHING PATTERN "*")
 

--- a/cmake/range-v3-config.cmake
+++ b/cmake/range-v3-config.cmake
@@ -1,0 +1,2 @@
+include("${CMAKE_CURRENT_LIST_DIR}/range-v3-targets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/range-v3-targets-compat.cmake")


### PR DESCRIPTION
The old targets without namespace are kept in an additional targets file
for compatibility reasons.

Addresses issue #1342.