### PR TITLE
Don't muck with CMAKE_BUILD_TYPE

### DIFF
--- a/cmake/ranges_env.cmake
+++ b/cmake/ranges_env.cmake
@@ -75,7 +75,6 @@ elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
   endif()
 else()
   message(WARNING "[range-v3 warning]: unknown build type, defaults to release!")
-  set(CMAKE_BUILD_TYPE "Release")
   set(RANGES_RELEASE_BUILD TRUE)
 endif()
 


### PR DESCRIPTION
I use range-v3 and include it in a subdirectory of my build. I usually use `-DCMAKE_BUILD_TYPE=RelWithDebInfo`. The `range-v3` cmake script swoops in and says it doesn't recognize it, changes it to `CMAKE_BUILD_TYPE=Release` and changes my project config. I saw some parts of my project now being built with Release instead of RelWithDebInfo.

It's ok if range-v3 assumes that it's a release build if it doesn't recognize it, but it shouldn't modify the variable.