### PR TITLE
New concepts syntax

### DIFF
--- a/include/concepts/concepts.hpp
+++ b/include/concepts/concepts.hpp
@@ -1098,13 +1098,16 @@ namespace concepts
         CPP_DIAGNOSTIC_POP
     } // namespace detail
 
-#if defined(__clang__) || defined(_MSC_VER)
+#if defined(__clang__)
     template<bool B>
     std::enable_if_t<B> requires_()
     {}
-#else
+#elif defined(__GNUC__)
     template<bool B>
     CPP_INLINE_VAR constexpr std::enable_if_t<B, int> requires_ = 0;
+#else
+    template<bool B, std::enable_if_t<B, int> = 0>
+    CPP_INLINE_VAR constexpr bool requires_ = true;
 #endif
 
     inline namespace defs

--- a/include/range/v3/view/drop_while.hpp
+++ b/include/range/v3/view/drop_while.hpp
@@ -104,12 +104,10 @@ namespace ranges
             }
         };
 
-        struct drop_while_fn : drop_while_base_fn
+        struct drop_while_bind_fn
         {
-            using drop_while_base_fn::operator();
-
             template<typename Pred>
-            constexpr auto operator()(Pred pred) const
+            constexpr auto operator()(Pred pred) const // TODO: underconstrained
             {
                 return make_view_closure(
                     bind_back(drop_while_base_fn{}, std::move(pred)));
@@ -117,11 +115,18 @@ namespace ranges
             template<typename Pred, typename Proj>
             constexpr auto CPP_fun(operator())(Pred && pred,
                                                Proj proj)(const //
-                                                          requires(!range<Pred>))
+                                                          requires(!range<Pred>)) // TODO: underconstrained
             {
                 return make_view_closure(bind_back(
                     drop_while_base_fn{}, static_cast<Pred &&>(pred), std::move(proj)));
             }
+        };
+
+        struct RANGES_EMPTY_BASES drop_while_fn
+           : drop_while_base_fn, drop_while_bind_fn
+        {
+            using drop_while_base_fn::operator();
+            using drop_while_bind_fn::operator();
         };
 
         /// \relates drop_while_fn

--- a/include/range/v3/view/join.hpp
+++ b/include/range/v3/view/join.hpp
@@ -528,10 +528,10 @@ namespace ranges
 
         struct join_base_fn : cpp20_join_fn
         {
-            /// implementation detail
+        private:
             template<typename Rng>
             using inner_value_t = range_value_t<range_reference_t<Rng>>;
-
+        public:
             using cpp20_join_fn::operator();
 
             template<typename Rng>
@@ -552,13 +552,11 @@ namespace ranges
             }
         };
 
-        struct join_fn : join_base_fn
+        struct join_bind_fn
         {
-            using join_base_fn::operator();
-
             template<typename T>
             constexpr auto CPP_fun(operator())(T && t)(const //
-                                                       requires(!joinable_range<T>))
+                                                       requires(!joinable_range<T>)) // TODO: underconstrained
             {
                 return make_view_closure(bind_back(join_base_fn{}, static_cast<T &&>(t)));
             }
@@ -570,9 +568,9 @@ namespace ranges
 
                 template<typename Rng>
                 auto operator()(Rng && rng) const
-                    -> invoke_result_t<join_fn, Rng, T (&)[N]>
+                    -> invoke_result_t<join_base_fn, Rng, T (&)[N]>
                 {
-                    return join_fn{}(static_cast<Rng &&>(rng), val_);
+                    return join_base_fn{}(static_cast<Rng &&>(rng), val_);
                 }
             };
 
@@ -587,11 +585,18 @@ namespace ranges
             {
                 return make_view_closure(
                     [&val](
-                        auto && rng) -> invoke_result_t<join_fn, decltype(rng), T(&)[N]> {
-                        return join_fn{}(static_cast<decltype(rng)>(rng), val);
+                        auto && rng) -> invoke_result_t<join_base_fn, decltype(rng), T(&)[N]> {
+                        return join_base_fn{}(static_cast<decltype(rng)>(rng), val);
                     });
             }
 #endif // RANGES_WORKAROUND_MSVC_OLD_LAMBDA
+        };
+
+        struct RANGES_EMPTY_BASES join_fn
+          : join_base_fn, join_bind_fn
+        {
+            using join_base_fn::operator();
+            using join_bind_fn::operator();
         };
 
         /// \relates join_fn

--- a/include/range/v3/view/remove.hpp
+++ b/include/range/v3/view/remove.hpp
@@ -74,23 +74,28 @@ namespace ranges
             }
         };
 
-        struct remove_fn : remove_base_fn
+        struct remove_bind_fn
         {
-            using remove_base_fn::operator();
-
             template<typename Value>
-            constexpr auto operator()(Value value) const
+            constexpr auto operator()(Value value) const // TODO: underconstrained
             {
                 return make_view_closure(bind_back(remove_base_fn{}, std::move(value)));
             }
             template<typename Value, typename Proj>
             constexpr auto CPP_fun(operator())(Value && value,
                                                Proj proj)(const //
-                                                          requires(!range<Value>))
+                                                          requires(!range<Value>)) // TODO: underconstrained
             {
                 return make_view_closure(bind_back(
                     remove_base_fn{}, static_cast<Value &&>(value), std::move(proj)));
             }
+        };
+
+        struct RANGES_EMPTY_BASES remove_fn
+          : remove_base_fn, remove_bind_fn
+        {
+            using remove_base_fn::operator();
+            using remove_bind_fn::operator();
         };
 
         /// \relates remove_fn

--- a/include/range/v3/view/remove_if.hpp
+++ b/include/range/v3/view/remove_if.hpp
@@ -167,23 +167,28 @@ namespace ranges
             }
         };
 
-        struct remove_if_fn : remove_if_base_fn
+        struct remove_if_bind_fn
         {
-            using remove_if_base_fn::operator();
-
             template<typename Pred>
-            constexpr auto operator()(Pred pred) const
+            constexpr auto operator()(Pred pred) const // TODO: underconstrained
             {
                 return make_view_closure(bind_back(remove_if_base_fn{}, std::move(pred)));
             }
             template<typename Pred, typename Proj>
             constexpr auto CPP_fun(operator())(Pred && pred,
                                                Proj proj)(const //
-                                                          requires(!range<Pred>))
+                                                          requires(!range<Pred>)) // TODO: underconstrained
             {
                 return make_view_closure(bind_back(
                     remove_if_base_fn{}, static_cast<Pred &&>(pred), std::move(proj)));
             }
+        };
+
+        struct RANGES_EMPTY_BASES remove_if_fn
+          : remove_if_base_fn, remove_if_bind_fn
+        {
+            using remove_if_base_fn::operator();
+            using remove_if_bind_fn::operator();
         };
 
         /// \relates remove_if_fn

--- a/include/range/v3/view/take_while.hpp
+++ b/include/range/v3/view/take_while.hpp
@@ -153,12 +153,10 @@ namespace ranges
             }
         };
 
-        struct take_while_fn : take_while_base_fn
+        struct take_while_bind_fn
         {
-            using take_while_base_fn::operator();
-
             template<typename Pred>
-            constexpr auto operator()(Pred pred) const
+            constexpr auto operator()(Pred pred) const // TODO: underconstrained
             {
                 return make_view_closure(
                     bind_back(take_while_base_fn{}, std::move(pred)));
@@ -166,11 +164,18 @@ namespace ranges
             template<typename Pred, typename Proj>
             constexpr auto CPP_fun(operator())(Pred && pred,
                                                Proj proj)(const //
-                                                          requires(!range<Pred>))
+                                                          requires(!range<Pred>)) // TODO: underconstrained
             {
                 return make_view_closure(bind_back(
                     take_while_base_fn{}, static_cast<Pred &&>(pred), std::move(proj)));
             }
+        };
+
+        struct RANGES_EMPTY_BASES take_while_fn
+          : take_while_base_fn, take_while_bind_fn
+        {
+            using take_while_base_fn::operator();
+            using take_while_bind_fn::operator();
         };
 
         /// \relates iter_take_while_fn

--- a/include/range/v3/view/trim.hpp
+++ b/include/range/v3/view/trim.hpp
@@ -120,23 +120,28 @@ namespace ranges
             }
         };
 
-        struct trim_fn : trim_base_fn
+        struct trim_bind_fn
         {
-            using trim_base_fn::operator();
-
             template<typename Pred>
-            constexpr auto operator()(Pred pred) const
+            constexpr auto operator()(Pred pred) const // TODO: underconstrained
             {
                 return make_view_closure(bind_back(trim_base_fn{}, std::move(pred)));
             }
             template<typename Pred, typename Proj>
             constexpr auto CPP_fun(operator())(Pred && pred,
                                                Proj proj)(const //
-                                                          requires(!range<Pred>))
+                                                          requires(!range<Pred>)) // TODO: underconstrained
             {
                 return make_view_closure(bind_back(
                     trim_base_fn{}, static_cast<Pred &&>(pred), std::move(proj)));
             }
+        };
+
+        struct RANGES_EMPTY_BASES trim_fn
+          : trim_base_fn, trim_bind_fn
+        {
+            using trim_base_fn::operator();
+            using trim_bind_fn::operator();
         };
 
         /// \relates trim_fn


### PR DESCRIPTION
One commit that works around what might be a bug in MSVC (I spent an hour scraping the Standard to find definitive wording for template-ids that refer to overload sets, before deciding to simply avoid them), and another commit that will ruin your day.

[[namespace.udecl]/14](http://eel.is/c++draft/namespace.udecl#14):

> When a *using-declarator* brings declarations from a base class into a derived class, member functions and member function templates in the derived class override and/or hide member functions and member function templates with the same name, parameter-type-list, cv-qualification, and *ref-qualifier* (if any) in a base class (rather than conflicting). Such hidden or overridden declarations are excluded from the set of declarations introduced by the *using-declarator*.

Note that there's no mention here of associated constraints. Consequently this:
```c++
template <class T>
concept C1 = std::same_as<T, int>;

template <class T>
concept C2 = std::same_as<T, float>;

struct Base {
    template <class T>
    void f(T) requires C1<T> {}
};

struct Derived : Base {
    using Base::f;

    template <class T>
    void f(T) requires C2<T> {}
};

int main() {
    Derived{}.f(3.14f);
    Derived{}.f(42);
}
```
is ill-formed: the `f` in `Derived` hides the `f` in `Base`. If we replace `Derived` and `Base` with `join_fn` and `cpp20_join_fn`, we'll see why MSVC was failing to compile `view.join`: the `operator()(T&&)` template in `join_fn` hides the `operator()(T&&)` in `cpp20_join_fn`.

There's more to fix, but I'm stopping for a but and thought I'd push what I have for now.