### PR TITLE
Implementing D1870R1.

### DIFF
--- a/include/range/v3/range/access.hpp
+++ b/include/range/v3/range/access.hpp
@@ -31,9 +31,21 @@
 #include <range/v3/iterator/reverse_iterator.hpp>
 #include <range/v3/iterator/traits.hpp>
 #include <range/v3/utility/static_const.hpp>
+#include <concepts/type_traits.hpp>
 
 namespace ranges
 {
+    namespace _safe_
+    {
+        CPP_def
+        (
+            template(typename T)
+            concept Safe,
+                std::is_lvalue_reference<T>::value ||
+                enable_safe_range<concepts::detail::remove_cvref_t<T>>
+        );
+    }
+
     /// \cond
     namespace _begin_
     {
@@ -57,11 +69,10 @@ namespace ranges
         (
             template(typename T)
             concept HasMemberBegin,
-                requires (T &t)
+                requires (T &&t)
                 (
-                    _begin_::is_iterator(t.begin())
-                ) &&
-                std::is_lvalue_reference<T>::value
+                    _begin_::is_iterator(((T&&)t).begin())
+                )
         );
 
         CPP_def
@@ -112,12 +123,12 @@ namespace ranges
             constexpr auto CPP_fun(operator())(R && r)(
                 const                                   //
                 noexcept(noexcept(impl_v<R>((R &&) r))) //
-                requires(HasMemberBegin<R> || HasNonMemberBegin<R>))
+                requires(_safe_::Safe<R> && (HasMemberBegin<R> || HasNonMemberBegin<R>)))
 #else
             constexpr auto CPP_fun(operator())(R && r)(
                 const                                   //
                 noexcept(noexcept(impl<R>{}((R &&) r))) //
-                requires(HasMemberBegin<R> || HasNonMemberBegin<R>))
+                requires(_safe_::Safe<R> && (HasMemberBegin<R> || HasNonMemberBegin<R>)))
 #endif
             {
                 return impl<R>{}((R &&) r);
@@ -201,11 +212,10 @@ namespace ranges
         (
             template(typename T)
             concept HasMemberEnd,
-                requires (T &t)
+                requires (T &&t)
                 (
-                    _end_::is_sentinel<_begin_::_t<T>>(t.end())
-                ) &&
-                std::is_lvalue_reference<T>::value
+                    _end_::is_sentinel<_begin_::_t<T>>(((T&&)t).end())
+                )
         );
 
         CPP_def
@@ -227,9 +237,9 @@ namespace ranges
             {
                 // HasMemberEnd == true
                 template<typename R>
-                constexpr auto operator()(R && r) const noexcept(noexcept(r.end()))
+                constexpr auto operator()(R && r) const noexcept(noexcept(((R&&)r).end()))
                 {
-                    return r.end();
+                    return ((R&&)r).end();
                 }
             };
 
@@ -260,11 +270,11 @@ namespace ranges
 #ifdef RANGES_WORKAROUND_GCC_89953
             constexpr auto CPP_fun(operator())(R && r)(
                 const noexcept(noexcept(impl_v<R>((R &&) r))) //
-                requires(HasMemberEnd<R> || HasNonMemberEnd<R>))
+                requires(_safe_::Safe<R> && (HasMemberEnd<R> || HasNonMemberEnd<R>)))
 #else
             constexpr auto CPP_fun(operator())(R && r)(
                 const noexcept(noexcept(impl<R>{}((R &&) r))) //
-                requires(HasMemberEnd<R> || HasNonMemberEnd<R>))
+                requires(_safe_::Safe<R> && (HasMemberEnd<R> || HasNonMemberEnd<R>)))
 #endif
             {
                 return impl<R>{}((R &&) r);
@@ -397,11 +407,10 @@ namespace ranges
         (
             template(typename T)
             concept HasMemberRBegin,
-                requires (T &t)
+                requires (T &&t)
                 (
-                    _begin_::is_iterator(t.rbegin())
-                ) &&
-                std::is_lvalue_reference<T>::value
+                    _begin_::is_iterator(((T&&)t).rbegin())
+                )
         );
 
         CPP_def
@@ -436,9 +445,9 @@ namespace ranges
             struct impl_
             {
                 template<typename R>
-                constexpr auto operator()(R && r) const noexcept(noexcept(r.rbegin()))
+                constexpr auto operator()(R && r) const noexcept(noexcept(((R&&)r).rbegin()))
                 {
-                    return r.rbegin();
+                    return ((R&&)r).rbegin();
                 }
             };
 
@@ -449,7 +458,7 @@ namespace ranges
             template<typename R>
             constexpr auto CPP_fun(operator())(R && r)(
                 const noexcept(noexcept(impl<R>{}((R &&) r))) //
-                requires(HasMemberRBegin<R> || HasNonMemberRBegin<R> || CanReverseEnd<R>))
+                requires(_safe_::Safe<R> && (HasMemberRBegin<R> || HasNonMemberRBegin<R> || CanReverseEnd<R>)))
             {
                 return impl<R>{}((R &&) r);
             }
@@ -531,11 +540,10 @@ namespace ranges
         (
             template(typename T)
             concept HasMemberREnd,
-                requires (T &t)
+                requires (T &&t)
                 (
-                    _end_::is_sentinel<_rbegin_::_t<T &>>(t.rend())
-                ) &&
-                std::is_lvalue_reference<T>::value
+                    _end_::is_sentinel<_rbegin_::_t<T &>>(((T&&)t).rend())
+                )
         );
 
         CPP_def
@@ -583,7 +591,7 @@ namespace ranges
             template<typename R>
             constexpr auto CPP_fun(operator())(R && r)(
                 const noexcept(noexcept(impl<R>{}((R &&) r))) //
-                requires(HasMemberREnd<R> || HasNonMemberREnd<R> || CanReverseBegin<R>))
+                requires(_safe_::Safe<R> && (HasMemberREnd<R> || HasNonMemberREnd<R> || CanReverseBegin<R>)))
             {
                 return impl<R>{}((R &&) r);
             }

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -393,6 +393,9 @@ namespace ranges
     template<typename S, typename I>
     RANGES_INLINE_VAR constexpr bool disable_sized_sentinel = false;
 
+    template<typename R>
+    RANGES_INLINE_VAR constexpr bool enable_safe_range = false;
+
     template<typename Cur>
     struct basic_mixin;
 

--- a/include/range/v3/view/iota.hpp
+++ b/include/range/v3/view/iota.hpp
@@ -161,38 +161,6 @@ namespace ranges
     } // namespace detail
     /// \endcond
 
-    /// \cond
-    namespace iota_view_detail
-    {
-        struct adl_hook
-        {};
-
-        // Extension: iota_view models forwarding-range, as suggested by
-        // https://github.com/ericniebler/stl2/issues/575
-        template<class From, class To>
-        constexpr auto begin(iota_view<From, To> r)
-        {
-            return r.begin();
-        }
-        template<class From, class To>
-        constexpr auto end(iota_view<From, To> r)
-        {
-            return r.end();
-        }
-
-        template<class From, class To>
-        constexpr auto begin(closed_iota_view<From, To> r)
-        {
-            return r.begin();
-        }
-        template<class From, class To>
-        constexpr auto end(closed_iota_view<From, To> r)
-        {
-            return r.end();
-        }
-    } // namespace iota_view_detail
-    /// \endcond
-
     /// \addtogroup group-views
     /// @{
 
@@ -200,7 +168,6 @@ namespace ranges
     template<typename From, typename To /* = From */>
     struct RANGES_EMPTY_BASES closed_iota_view
       : view_facade<closed_iota_view<From, To>, finite>
-      , private iota_view_detail::adl_hook
     {
     private:
         friend range_access;
@@ -322,6 +289,9 @@ namespace ranges
         }
     };
 
+    template<typename From, typename To>
+        RANGES_INLINE_VAR constexpr bool enable_safe_range<closed_iota_view<From, To>> = true;
+
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
     CPP_template(typename From, typename To)( //
         requires WeaklyIncrementable<From> && Semiregular<To> &&
@@ -339,7 +309,6 @@ namespace ranges
                         : std::is_integral<From>::value && std::is_integral<To>::value
                               ? finite
                               : unknown>
-      , private iota_view_detail::adl_hook
     {
     private:
         friend range_access;
@@ -455,6 +424,9 @@ namespace ranges
             check_bounds_(meta::bool_<StrictTotallyOrderedWith<From, To>>{});
         }
     };
+
+    template<typename From, typename To>
+        RANGES_INLINE_VAR constexpr bool enable_safe_range<iota_view<From, To>> = true;    
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
     CPP_template(typename From, typename To)( //

--- a/include/range/v3/view/ref.hpp
+++ b/include/range/v3/view/ref.hpp
@@ -32,44 +32,14 @@ namespace ranges
     template<typename Rng>
     struct ref_view;
 
-    /// \cond
-    namespace _ref_view_
-    {
-        struct adl_hook
-        {};
-
-        template<typename Rng>
-        constexpr iterator_t<Rng> begin(ref_view<Rng> && rng) noexcept(
-            noexcept(rng.begin()))
-        {
-            return rng.begin();
-        }
-        template<typename Rng>
-        constexpr iterator_t<Rng> begin(ref_view<Rng> const && rng) noexcept(
-            noexcept(rng.begin()))
-        {
-            return rng.begin();
-        }
-        template<typename Rng>
-        constexpr sentinel_t<Rng> end(ref_view<Rng> && rng) noexcept(noexcept(rng.end()))
-        {
-            return rng.end();
-        }
-        template<typename Rng>
-        constexpr sentinel_t<Rng> end(ref_view<Rng> const && rng) noexcept(
-            noexcept(rng.end()))
-        {
-            return rng.end();
-        }
-    } // namespace _ref_view_
-    /// \endcond
+    template<typename Rng>
+      RANGES_INLINE_VAR constexpr bool enable_safe_range<ref_view<Rng>> = true;
 
     /// \addtogroup group-views
     /// @{
     template<typename Rng>
     struct ref_view
       : view_interface<ref_view<Rng>, range_cardinality<Rng>::value>
-      , private _ref_view_::adl_hook
     {
     private:
         CPP_assert(Range<Rng>);

--- a/include/range/v3/view/subrange.hpp
+++ b/include/range/v3/view/subrange.hpp
@@ -163,37 +163,14 @@ namespace ranges
                  static_cast<subrange_kind>(detail::is_sized_sentinel_<S, I>())>
     struct subrange;
 
+    template<typename I, typename S, subrange_kind K>
+      RANGES_INLINE_VAR constexpr bool enable_safe_range<subrange<I, S, K>> = true;
+
     /// \cond
     namespace _subrange_
     {
         struct adl_hook
         {};
-
-        // A temporary subrange can be safely passed to ranges::begin and ranges::end.
-        template<typename I, typename S, subrange_kind K>
-        constexpr I begin(subrange<I, S, K> && r) noexcept(
-            std::is_nothrow_copy_constructible<I>::value)
-        {
-            return r.begin();
-        }
-        template<typename I, typename S, subrange_kind K>
-        constexpr I begin(subrange<I, S, K> const && r) noexcept(
-            std::is_nothrow_copy_constructible<I>::value)
-        {
-            return r.begin();
-        }
-        template<typename I, typename S, subrange_kind K>
-        constexpr S end(subrange<I, S, K> && r) noexcept(
-            std::is_nothrow_copy_constructible<S>::value)
-        {
-            return r.end();
-        }
-        template<typename I, typename S, subrange_kind K>
-        constexpr S end(subrange<I, S, K> const && r) noexcept(
-            std::is_nothrow_copy_constructible<S>::value)
-        {
-            return r.end();
-        }
 
         template<std::size_t N, typename I, typename S, subrange_kind K>
         constexpr auto get(subrange<I, S, K> const & r) -> CPP_ret(I)( //


### PR DESCRIPTION
This is an implementation of [D1871R1](http://wiki.edg.com/pub/Wg21belfast/LibraryEvolutionWorkingGroup/d1870r1.html) in range-v3. All tests pass.

This hasn't been run through clang-format, etc, and I didn't rename the forwarding range concept - the intent here was to demonstrate the viability of the patch.