### PR TITLE
Fix warning about shadowing in adjacent_filter

### DIFF
--- a/cmake/ranges_flags.cmake
+++ b/cmake/ranges_flags.cmake
@@ -131,7 +131,6 @@ if (RANGES_DEBUG_BUILD AND RANGES_RELEASE_BUILD)
 endif()
 
 if (RANGES_DEBUG_BUILD)
-  ranges_append_flag(RANGES_HAS_O0 -O0)
   ranges_append_flag(RANGES_HAS_NO_INLINE -fno-inline)
   ranges_append_flag(RANGES_HAS_STACK_PROTECTOR_ALL -fstack-protector-all)
   ranges_append_flag(RANGES_HAS_G3 -g3)

--- a/include/range/v3/view/adjacent_filter.hpp
+++ b/include/range/v3/view/adjacent_filter.hpp
@@ -84,8 +84,8 @@ namespace ranges
                 auto const last = ranges::end(rng_->base());
                 auto & pred = rng_->adjacent_filter_view::box::get();
                 RANGES_EXPECT(it != last);
-                for(auto prev = it; ++it != last; prev = it)
-                    if(invoke(pred, *prev, *it))
+                for(auto tmp = it; ++it != last; tmp = it)
+                    if(invoke(pred, *tmp, *it))
                         break;
             }
             CPP_member
@@ -98,10 +98,10 @@ namespace ranges
                 --it;
                 while(it != first)
                 {
-                    auto prev = it;
-                    if(invoke(pred, *--prev, *it))
+                    auto tmp = it;
+                    if(invoke(pred, *--tmp, *it))
                         break;
-                    it = prev;
+                    it = tmp;
                 }
             }
             void distance_to() = delete;


### PR DESCRIPTION
Removing 2 warnings with gcc 6.2.0
`include/range/v3/view/adjacent_filter.hpp:97:26: error: declaration of 'prev' shadows a member of 'ranges::adjacent_filter_view<Rng, Pred>::adaptor<Const>' [-Werror=shadow]`
