### PR TITLE
Fix group_by to exclude the first element from the checks

### DIFF
--- a/include/range/v3/view/group_by.hpp
+++ b/include/range/v3/view/group_by.hpp
@@ -71,8 +71,8 @@ namespace ranges
             {
                 iterator_t<CRng> first_;
                 semiregular_box_ref_or_val_t<Fun, IsConst> fun_;
-                mutable bool first_invokation_{true};
-                bool operator()(range_reference_t<CRng> r) const
+                bool first_invokation_{true};
+                bool operator()(range_reference_t<CRng> r)
                 {
                     if (first_invokation_) {
                         first_invokation_ = false;

--- a/test/view/group_by.cpp
+++ b/test/view/group_by.cpp
@@ -109,11 +109,11 @@ int main()
     }
 
     {
-        std::vector<int> v = { 0, 1, 2 };
-        auto rng = views::cycle(v) | views::take(6) | views::group_by(std::less<>{});
+        std::vector<int> v4 = { 0, 1, 2 };
+        auto rng = views::cycle(v4) | views::take(6) | views::group_by(std::less<>{});
         CHECK(distance(rng) == 2);
-        check_equal(*rng.begin(), {0, 1, 2});
-        check_equal(*next(rng.begin()), {0, 1, 2});
+        check_equal(*rng.begin(), v4);
+        check_equal(*next(rng.begin()), v4);
     }
 
     return test_result();

--- a/test/view/group_by.cpp
+++ b/test/view/group_by.cpp
@@ -96,5 +96,15 @@ int main()
         CHECK(distance(rng0) == 4);
     }
 
+    {
+        std::vector<int> v3 = {2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 0};
+        auto rng = v3 | views::group_by(std::less<>{});
+        CHECK(distance(rng) == 4);
+        check_equal(*rng.begin(), {2, 3, 4, 5});
+        check_equal(*next(rng.begin()), {0, 1, 2, 3, 4, 5, 6});
+        check_equal(*next(rng.begin(), 2), {0, 1, 2, 3});
+        check_equal(*next(rng.begin(), 3), {0});
+    }
+
     return test_result();
 }

--- a/test/view/group_by.cpp
+++ b/test/view/group_by.cpp
@@ -13,8 +13,10 @@
 #include <vector>
 #include <range/v3/core.hpp>
 #include <range/v3/view/counted.hpp>
+#include <range/v3/view/cycle.hpp>
 #include <range/v3/view/group_by.hpp>
 #include <range/v3/view/remove_if.hpp>
+#include <range/v3/view/take.hpp>
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
@@ -104,6 +106,14 @@ int main()
         check_equal(*next(rng.begin()), {0, 1, 2, 3, 4, 5, 6});
         check_equal(*next(rng.begin(), 2), {0, 1, 2, 3});
         check_equal(*next(rng.begin(), 3), {0});
+    }
+
+    {
+        std::vector<int> v = { 0, 1, 2 };
+        auto rng = views::cycle(v) | views::take(6) | views::group_by(std::less<>{});
+        CHECK(distance(rng) == 2);
+        check_equal(*rng.begin(), {0, 1, 2});
+        check_equal(*next(rng.begin()), {0, 1, 2});
     }
 
     return test_result();


### PR DESCRIPTION
As the description of the `views::group_by` suggests ([Range-v3: User Manual](https://ericniebler.github.io/range-v3/index.html):

> Given a source range and a binary predicate, return a range of ranges where each range contains contiguous elements from the source range such that the following condition holds: for each element in the range **apart from the first**, when that element and the first element are passed to the binary predicate, the result is true. In essence, views::group_by groups contiguous elements together with a binary predicate.

This '_apart from the first_' part is crucial and enables to `group_by` a range like `{ 0, 1, 2, 0, 1, 2}` with a `std::less` predicate and get `{ { 0, 1, 2}, {0, 1, 2} }`.

Without this fix, the resulting view infinitely returns empty ranges.