### PR TITLE
coerce the value written through ostream_iterator to the right type

### DIFF
--- a/include/range/v3/iterator/stream_iterators.hpp
+++ b/include/range/v3/iterator/stream_iterators.hpp
@@ -54,7 +54,7 @@ namespace ranges
             requires convertible_to<U, value_t<U> const &>)
         {
             RANGES_EXPECT(sout_);
-            *sout_ << value;
+            *sout_ << static_cast<value_t<U> const &>(static_cast<U &&>(value));
             if(delim_)
                 *sout_ << delim_;
             return *this;


### PR DESCRIPTION
fixes #1380