### PR TITLE
Add a step parameter to iota_view

### DIFF
--- a/include/range/v3/view/iota.hpp
+++ b/include/range/v3/view/iota.hpp
@@ -414,12 +414,6 @@ namespace ranges
                 return from_ == that.to_;
             }
             CPP_member
-            auto equal(sentinel const & that) const -> CPP_ret(bool)( //
-                requires detail::iota_stridable_<From, To>)
-            {
-                return detail::iota_distance_(from_, that.to_) >= detail::iota_abs_(step_.value());
-            }
-            CPP_member
             auto equal(cursor const & that) const -> CPP_ret(bool)( //
             requires equality_comparable<From>)
             {

--- a/include/range/v3/view/iota.hpp
+++ b/include/range/v3/view/iota.hpp
@@ -421,20 +421,13 @@ namespace ranges
             }
             CPP_member
             auto equal(cursor const & that) const -> CPP_ret(bool)( //
-            requires (equality_comparable<From> &&!detail::iota_stridable_<From, To>))
+            requires equality_comparable<From>)
             {
                 return that.from_ == from_;
             }
             CPP_member
-            auto equal(cursor const & that) const -> CPP_ret(bool)( //
-            requires detail::iota_stridable_<From, To>)
-            {
-                return from_ == that.from_;
-            }
-            CPP_member
             auto prev() -> CPP_ret(void)( //
-                requires(detail::decrementable_<From> &&
-                         (!detail::iota_stridable_<From, To>)))
+            requires(detail::decrementable_<From> && !detail::iota_stridable_<From, To>))
             {
                 --from_;
             }

--- a/test/view/iota.cpp
+++ b/test/view/iota.cpp
@@ -214,6 +214,15 @@ int main()
         CHECK((i - cstr2.begin()) == 4);
     }
 
+
+    {
+       // test step
+       ::check_equal(views::iota(0, 10, 2), {0, 2, 4, 6, 8});
+       ::check_equal(views::iota(5, 0, -1), {5, 4, 3, 2, 1});
+       ::check_equal(size(views::iota(1, 9, 3)), 3U);
+       ::check_equal(size(views::iota(9, 1, -3)), 3U);
+    }
+
     {  // test views::indices/closed_indices
         ::check_equal(views::indices | views::take(10), std::initializer_list<std::size_t>{0,1,2,3,4,5,6,7,8,9});
 

--- a/test/view/iota.cpp
+++ b/test/view/iota.cpp
@@ -224,7 +224,7 @@ int main()
        ::check_equal(views::iota(5, 0, -1) | views::reverse, {1, 2, 3, 4, 5});
        ::check_equal(size(views::iota(9, 1, -3)), 3U);
        ::check_equal(views::iota(1, 9, 3), {1, 4, 7});
-       ::check_equal(views::iota(1, 9, 3) | views::reverse, {6, 3});
+       ::check_equal(views::iota(1, 9, 3) | views::reverse, {7, 4, 1});
 
 
     }

--- a/test/view/iota.cpp
+++ b/test/view/iota.cpp
@@ -18,6 +18,7 @@
 #include <range/v3/view/iota.hpp>
 #include <range/v3/view/take.hpp>
 #include <range/v3/view/drop_exactly.hpp>
+#include <range/v3/view/reverse.hpp>
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
@@ -220,7 +221,12 @@ int main()
        ::check_equal(views::iota(0, 10, 2), {0, 2, 4, 6, 8});
        ::check_equal(views::iota(5, 0, -1), {5, 4, 3, 2, 1});
        ::check_equal(size(views::iota(1, 9, 3)), 3U);
+       ::check_equal(views::iota(5, 0, -1) | views::reverse, {1, 2, 3, 4, 5});
        ::check_equal(size(views::iota(9, 1, -3)), 3U);
+       ::check_equal(views::iota(1, 9, 3), {1, 4, 7});
+       ::check_equal(views::iota(1, 9, 3) | views::reverse, {6, 3});
+
+
     }
 
     {  // test views::indices/closed_indices


### PR DESCRIPTION
During LEWGI discussions about P1894R0, I suggested adding
a step parameter to iota_view so that it behaves as Python's range
function.

This patches implement that feature and fixes #723.

Iota views constructed from totally ordered advancable values can
take an extra step parameter which can be positive or negative.