### PR TITLE
Make safe_iterator_t standard conformant

### DIFF
--- a/include/range/v3/range/dangling.hpp
+++ b/include/range/v3/range/dangling.hpp
@@ -20,6 +20,7 @@
 
 #include <range/v3/range_fwd.hpp>
 
+#include <range/v3/range/access.hpp>
 #include <range/v3/range/concepts.hpp>
 #include <range/v3/utility/static_const.hpp>
 
@@ -45,7 +46,7 @@ namespace ranges
     {
         CPP_template(class R, class U)( //
             requires range<R>)          //
-            using maybe_dangling_ = if_then_t<forwarding_range_<R>, U, dangling>;
+            using maybe_dangling_ = if_then_t<detail::_safe_range<R>, U, dangling>;
     }
     /// \endcond
 


### PR DESCRIPTION
Missed by #1370. A more complete PR would excise `forwarding_range_`.