### PR TITLE
Finish implementation of P1870R1

### DIFF
--- a/include/range/v3/range/concepts.hpp
+++ b/include/range/v3/range/concepts.hpp
@@ -76,20 +76,16 @@ namespace ranges
 
     // clang-format off
     template<typename T>
-    CPP_concept_bool range_impl_ =
-        CPP_requires ((T &&) t) //
+    CPP_concept_bool range =
+        CPP_requires ((T &) t) //
         (
-            ranges::begin(CPP_fwd(t)), // not necessarily equality-preserving
-            ranges::end(CPP_fwd(t))
+            ranges::begin(t), // not necessarily equality-preserving
+            ranges::end(t)
         );
 
     template<typename T>
-    CPP_concept_bool range =
-        range_impl_<T &>;
-
-    template<typename T>
-    CPP_concept_bool forwarding_range_ =
-        range<T> && range_impl_<T>;
+    CPP_concept_bool safe_range =
+        range<T> && detail::_safe_range<T>;
 
     template<typename T, typename V>
     CPP_concept_fragment(output_range_, (T, V),
@@ -174,7 +170,7 @@ namespace ranges
     CPP_concept_fragment(sized_range_, (T),
         detail::integer_like_<range_size_t<T>>
     );
-    #define CPP_noop
+
     template<typename T>
     CPP_concept_bool sized_range =
         range<T> &&
@@ -286,7 +282,7 @@ namespace ranges
     template<typename T>
     CPP_concept_bool viewable_range =
         range<T> &&
-        (forwarding_range_<T> || view_<detail::decay_t<T>>);
+        (safe_range<T> || view_<uncvref_t<T>>);
     // clang-format on
 
     ////////////////////////////////////////////////////////////////////////////////////////////
@@ -354,7 +350,7 @@ namespace ranges
         CPP_concept range = CPP_defer(ranges::range, T);
 
         template<typename T>
-        CPP_concept forwarding_range_ = CPP_defer(ranges::forwarding_range_, T);
+        CPP_concept safe_range = CPP_defer(ranges::safe_range, T);
 
         template<typename T, typename V>
         CPP_concept output_range = CPP_defer(ranges::output_range, T, V);

--- a/include/range/v3/range/operations.hpp
+++ b/include/range/v3/range/operations.hpp
@@ -39,7 +39,7 @@ namespace ranges
         constexpr auto operator()(Rng && rng, range_difference_t<Rng> n) const
             -> CPP_ret(range_reference_t<Rng>)( //
                 requires random_access_range<Rng> && sized_range<Rng> &&
-                    forwarding_range_<Rng>)
+                    safe_range<Rng>)
         {
             // Workaround https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67371 in GCC 5
             check_throw(rng, n);
@@ -70,7 +70,7 @@ namespace ranges
         template<typename Rng, typename Int>
         constexpr auto operator()(Rng && rng,
                                   Int n) const -> CPP_ret(range_reference_t<Rng>)( //
-            requires random_access_range<Rng> && integral<Int> && forwarding_range_<Rng>)
+            requires random_access_range<Rng> && integral<Int> && safe_range<Rng>)
         {
             using D = range_difference_t<Rng>;
             RANGES_EXPECT(0 <= static_cast<D>(n));
@@ -92,8 +92,7 @@ namespace ranges
         /// \return `*prev(end(rng))`
         template<typename Rng>
         constexpr auto operator()(Rng && rng) const -> CPP_ret(range_reference_t<Rng>)( //
-            requires common_range<Rng> && bidirectional_range<Rng> &&
-                forwarding_range_<Rng>)
+            requires common_range<Rng> && bidirectional_range<Rng> && safe_range<Rng>)
         {
             return *prev(end(rng));
         }
@@ -109,7 +108,7 @@ namespace ranges
         /// \return `*begin(rng)`
         template<typename Rng>
         constexpr auto operator()(Rng && rng) const -> CPP_ret(range_reference_t<Rng>)( //
-            requires forward_range<Rng> && forwarding_range_<Rng>)
+            requires forward_range<Rng> && safe_range<Rng>)
         {
             return *begin(rng);
         }

--- a/include/range/v3/view/all.hpp
+++ b/include/range/v3/view/all.hpp
@@ -55,7 +55,7 @@ namespace ranges
                 return ranges::views::ref(t);
             }
 
-            /// Not a view and not an lvalue? If it's a forwarding_range_, then
+            /// Not a view and not an lvalue? If it's a safe_range, then
             /// return a subrange holding the range's begin/end.
             template<typename T>
             static constexpr auto from_range_(T && t, std::false_type, std::false_type,
@@ -71,7 +71,7 @@ namespace ranges
                 return all_fn::from_range_(static_cast<T &&>(t),
                                            meta::bool_<view_<uncvref_t<T>>>{},
                                            std::is_lvalue_reference<T>{},
-                                           meta::bool_<forwarding_range_<T>>{});
+                                           meta::bool_<safe_range<T>>{});
             }
 
             template<typename T>

--- a/include/range/v3/view/drop.hpp
+++ b/include/range/v3/view/drop.hpp
@@ -145,7 +145,7 @@ namespace ranges
             static auto impl_(Rng && rng, range_difference_t<Rng> n,
                               random_access_range_tag)
                 -> CPP_ret(subrange<iterator_t<Rng>, sentinel_t<Rng>>)( //
-                    requires forwarding_range_<Rng> && sized_range<Rng>)
+                    requires safe_range<Rng> && sized_range<Rng>)
             {
                 return {begin(rng) + ranges::min(n, distance(rng)), end(rng)};
             }

--- a/include/range/v3/view/drop_exactly.hpp
+++ b/include/range/v3/view/drop_exactly.hpp
@@ -139,7 +139,7 @@ namespace ranges
             static auto impl_(Rng && rng, range_difference_t<Rng> n,
                               random_access_range_tag)
                 -> CPP_ret(subrange<iterator_t<Rng>, sentinel_t<Rng>>)( //
-                    requires forwarding_range_<Rng>)
+                    requires safe_range<Rng>)
             {
                 return {begin(rng) + n, end(rng)};
             }

--- a/include/range/v3/view/slice.hpp
+++ b/include/range/v3/view/slice.hpp
@@ -203,7 +203,7 @@ namespace ranges
                               range_difference_t<Rng> count, random_access_range_tag,
                               common_range_tag = {})
                 -> CPP_ret(subrange<iterator_t<Rng>>)( //
-                    requires forwarding_range_<Rng>)
+                    requires safe_range<Rng>)
             {
                 auto it =
                     detail::pos_at_(rng, from, range_tag_of<Rng>{}, is_infinite<Rng>{});

--- a/include/range/v3/view/subrange.hpp
+++ b/include/range/v3/view/subrange.hpp
@@ -166,7 +166,7 @@ namespace ranges
         );
         template<typename R, typename I, typename S>
         CPP_concept_bool range_convertible_to_ =
-            forwarding_range_<R> &&
+            safe_range<R> &&
             CPP_fragment(detail::range_convertible_to_frag_, R, I, S);
 
         namespace defer
@@ -408,8 +408,8 @@ namespace ranges
         subrange(I, S, detail::iter_size_t<I>)
             ->subrange<I, S, subrange_kind::sized>;
 
-    CPP_template(typename R)(          //
-        requires forwarding_range_<R>) //
+    CPP_template(typename R)(   //
+        requires safe_range<R>) //
         subrange(R &&)
             ->subrange<iterator_t<R>, sentinel_t<R>,
                        (sized_range<R> ||
@@ -417,8 +417,8 @@ namespace ranges
                            ? subrange_kind::sized
                            : subrange_kind::unsized>;
 
-    CPP_template(typename R)(          //
-        requires forwarding_range_<R>) //
+    CPP_template(typename R)(   //
+        requires safe_range<R>) //
         subrange(R &&, detail::iter_size_t<iterator_t<R>>)
             ->subrange<iterator_t<R>, sentinel_t<R>, subrange_kind::sized>;
 #endif
@@ -444,14 +444,14 @@ namespace ranges
                      (sized_range<R> || sized_sentinel_for<sentinel_t<R>, iterator_t<R>>)
                          ? subrange_kind::sized
                          : subrange_kind::unsized>)( //
-            requires forwarding_range_<R>)
+            requires safe_range<R>)
         {
             return {(R &&) r};
         }
         template<typename R>
         constexpr auto operator()(R && r, detail::iter_size_t<iterator_t<R>> n) const
             -> CPP_ret(subrange<iterator_t<R>, sentinel_t<R>, subrange_kind::sized>)( //
-                requires forwarding_range_<R>)
+                requires safe_range<R>)
         {
             return {(R &&) r, n};
         }

--- a/include/range/v3/view/take_exactly.hpp
+++ b/include/range/v3/view/take_exactly.hpp
@@ -155,7 +155,7 @@ namespace ranges
             static constexpr auto impl_(Rng && rng, range_difference_t<Rng> n,
                                         random_access_range_tag)
                 -> CPP_ret(subrange<iterator_t<Rng>>)( //
-                    requires forwarding_range_<Rng>)
+                    requires safe_range<Rng>)
             {
                 return {begin(rng), next(begin(rng), n)};
             }


### PR DESCRIPTION
* fold `range_impl_` concept back into `range`
* Replace `forwarding_range_` concept with `safe_range`

Drive-by:
* Remove unused `#define CPP_noop`
* Use `view<uncvref_t<T>>` instead of `view<decay_t<T>>` in the definition of `viewable_range` since pointers cannot model `view`. (Per the editorialish change I submitted in https://github.com/cplusplus/draft/pull/3563).