### PR TITLE
Strip build path in generated docs

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -3,7 +3,7 @@ PROJECT_BRIEF           = "Range algorithms, views, and actions for the Standard
 PROJECT_LOGO            =
 PROJECT_NUMBER          =
 
-STRIP_FROM_PATH         = @Range-v3_SOURCE_DIR@/include
+STRIP_FROM_PATH         = @Range-v3_SOURCE_DIR@/include @Range-v3_SOURCE_DIR@/doc
 BUILTIN_STL_SUPPORT     = YES
 STRIP_FROM_INC_PATH     = @Range-v3_SOURCE_DIR@/include
 ALIASES                 =


### PR DESCRIPTION
The path to your build directory is exposed in a URL of the [Examples][1] page. The patch fixes this minor issue, and so the page will be named as `md_examples.html`. If you think to add a redirect from the previous URL, it is possible to create a symbolic link to the new file name.

For predictable and reproducible builds it is important to eliminate all environment details from package data. Particularly, this is about Debian package [librange-v3-doc][2].

 [1]: https://ericniebler.github.io/range-v3/md___users_eniebler__code_range-v3_doc_examples.html
 [2]: https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/diffoscope-results/range-v3.html