### PR TITLE
Add source_location to unit tests.

### DIFF
--- a/test/simple_test.hpp
+++ b/test/simple_test.hpp
@@ -159,9 +159,11 @@ inline int test_result()
     return ::test_impl::test_failures() ? EXIT_FAILURE : EXIT_SUCCESS;
 }
 
-#define CHECK(...)                                                           \
-    (void)(::test_impl::S{__FILE__, __LINE__, #__VA_ARGS__} ->* __VA_ARGS__) \
+#define CHECK_LINE(file, line, ...)                                          \
+    (void)(::test_impl::S{file, line, #__VA_ARGS__} ->* __VA_ARGS__)         \
     /**/
+
+#define CHECK(...) CHECK_LINE(__FILE__, __LINE__, __VA_ARGS__)
 
 template<class>
 struct undef;


### PR DESCRIPTION
It's difficult to test things in ranges - when a check fails, it doesn't actually point back to the test, just points to the testing internals. This PR propagates the source information so that the test output looks like:

```
> ERROR: CHECK failed "(T &&) actual == (U &&) expected"
>       ../test/view/group_by.cpp(94)
>       EXPECTED: 8
>       ACTUAL: 7
```

instead of:

```
> ERROR: CHECK failed "(T &&) actual == (U &&) expected"
>       ../test/view/../test_utils.hpp(43)
>       EXPECTED: 8
>       ACTUAL: 7
```

It'd be nicer to actually have the error contain line 94 of group_by.cpp instead of something not particularly valuable for the tester - but at least this way I can find the right line. 