### PR TITLE
Support cmake version less than 3.11 when installing targets (#1411)

### DIFF
--- a/cmake/range-v3-config.cmake
+++ b/cmake/range-v3-config.cmake
@@ -1,7 +1,17 @@
 include("${CMAKE_CURRENT_LIST_DIR}/range-v3-targets.cmake")
+
 add_library(range-v3::meta INTERFACE IMPORTED)
 add_library(range-v3::concepts INTERFACE IMPORTED)
 add_library(range-v3::range-v3 INTERFACE IMPORTED)
+
+# workaround for target_link_libraries on lower cmake versions (< 3.11)
+# see https://cmake.org/cmake/help/latest/release/3.11.html#commands
+if(CMAKE_VERSION VERSION_LESS 3.11)
+set_target_properties(range-v3::meta PROPERTIES INTERFACE_LINK_LIBRARIES "range-v3-meta")
+set_target_properties(range-v3::concepts PROPERTIES INTERFACE_LINK_LIBRARIES "range-v3-concepts")
+set_target_properties(range-v3::range-v3 PROPERTIES INTERFACE_LINK_LIBRARIES "range-v3")
+else()
 target_link_libraries(range-v3::meta INTERFACE range-v3-meta)
 target_link_libraries(range-v3::concepts INTERFACE range-v3-concepts)
 target_link_libraries(range-v3::range-v3 INTERFACE range-v3)
+endif()


### PR DESCRIPTION
> I didn't consider the minimum required version when making the change. The [patch notes for 3.11](https://cmake.org/cmake/help/latest/release/3.11.html#commands) says that `target_link_libraries()` was added then. @marehr, could you open a PR, please?

See #1411