### PR TITLE
fix gcc10 `-Werror=type-limits`

### DIFF
--- a/include/range/v3/utility/memory.hpp
+++ b/include/range/v3/utility/memory.hpp
@@ -41,11 +41,8 @@ namespace ranges
     namespace detail
     {
         template<typename T>
-        std::pair<T *, std::ptrdiff_t> get_temporary_buffer_impl(
-            std::size_t count) noexcept
+        std::pair<T *, std::ptrdiff_t> get_temporary_buffer_impl(std::size_t n) noexcept
         {
-            RANGES_EXPECT(count >= 0);
-            std::size_t n = static_cast<std::size_t>(count);
             if(n > PTRDIFF_MAX / sizeof(T))
                 n = PTRDIFF_MAX / sizeof(T);
 


### PR DESCRIPTION
Fixes gcc10 error `-Werror=type-limits`:

```
In file included from /opt/gcc/gcc-git/include/c++/10.0.1/cassert:44,
                 from /range-v3/include/range/v3/detail/config.hpp:62,
                 from /range-v3/include/range/v3/range_fwd.hpp:24,
                 from /range-v3/include/range/v3/iterator/common_iterator.hpp:25,
                 from /range-v3/include/range/v3/core.hpp:17,
                 from /range-v3/test/algorithm/inplace_merge.cpp:23:
/range-v3/include/range/v3/utility/memory.hpp: In instantiation of ‘std::pair<_Tp*, long int> ranges::detail::get_temporary_buffer_impl(std::size_t) [with T = int; std::size_t = long unsigned int]’:
/range-v3/include/range/v3/utility/memory.hpp:74:56:   required from ‘std::pair<_Tp*, long int> ranges::detail::get_temporary_buffer(D) [with T = int; D = long int]’
/range-v3/include/range/v3/algorithm/inplace_merge.hpp:267:63:   required from ‘concepts::return_t<I, typename std::enable_if<((bidirectional_iterator<I> && sortable<I, C, P>) && concepts::detail::CPP_true(concepts::detail::Nil{})), void>::type> ranges::inplace_merge_fn::operator()(I, I, S, C, P) const [with I = BidirectionalIterator<int*>; S = BidirectionalIterator<int*>; C = ranges::less; P = ranges::identity; concepts::return_t<I, typename std::enable_if<((bidirectional_iterator<I> && sortable<I, C, P>) && concepts::detail::CPP_true(concepts::detail::Nil{})), void>::type> = BidirectionalIterator<int*>]’
/range-v3/test/algorithm/inplace_merge.cpp:47:41:   required from ‘void {anonymous}::test_one_iter(unsigned int, unsigned int) [with Iter = BidirectionalIterator<int*>; Sent = BidirectionalIterator<int*>]’
/range-v3/test/algorithm/inplace_merge.cpp:97:28:   required from ‘void {anonymous}::test_one(unsigned int, unsigned int) [with Iter = BidirectionalIterator<int*>]’
/range-v3/test/algorithm/inplace_merge.cpp:118:23:   required from ‘void {anonymous}::test() [with Iter = BidirectionalIterator<int*>]’
/range-v3/test/algorithm/inplace_merge.cpp:137:40:   required from here
/range-v3/include/range/v3/utility/memory.hpp:47:33: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
   47 |             RANGES_EXPECT(count >= 0);
      |                           ~~~~~~^~~~
/range-v3/include/range/v3/utility/memory.hpp:47:13: note: in expansion of macro ‘RANGES_EXPECT’
   47 |             RANGES_EXPECT(count >= 0);
      |             ^~~~~~~~~~~~~
```

The code change happened here:

https://github.com/ericniebler/range-v3/pull/1139/files#r374707274

Since `get_temporary_buffer_impl` takes a `std::size_t`, this check is
not needed any more.