### PR TITLE
common reference/type of common_tuple now yields common_tuple, not std::tuple

### DIFF
--- a/include/range/v3/utility/common_tuple.hpp
+++ b/include/range/v3/utility/common_tuple.hpp
@@ -561,16 +561,6 @@ namespace ranges
                 meta::lazy::invoke<TupleLike, meta::lazy::_t<common_type<Ts, Us>>...>>
         {};
 
-        template<typename T, typename U>
-        using make_common_pair =
-            meta::if_<meta::or_<std::is_reference<T>, std::is_reference<U>>,
-                      common_pair<T, U>, std::pair<T, U>>;
-
-        template<typename... Ts>
-        using make_common_tuple =
-            meta::if_<meta::any_of<meta::list<Ts...>, meta::quote<std::is_reference>>,
-                      common_tuple<Ts...>, std::tuple<Ts...>>;
-
         template<typename, typename, typename, typename = void>
         struct common_ref_tuple_like
         {};
@@ -594,13 +584,13 @@ namespace concepts
     struct common_type<std::pair<F1, S1>, ranges::common_pair<F2, S2>>
       : ranges::detail::common_type_tuple_like<
             std::pair<F1, S1>, ranges::common_pair<F2, S2>,
-            meta::quote<ranges::detail::make_common_pair>>
+            meta::quote<ranges::common_pair>>
     {};
     template<typename F1, typename S1, typename F2, typename S2>
     struct common_type<ranges::common_pair<F1, S1>, std::pair<F2, S2>>
       : ranges::detail::common_type_tuple_like<
             ranges::common_pair<F1, S1>, std::pair<F2, S2>,
-            meta::quote<ranges::detail::make_common_pair>>
+            meta::quote<ranges::common_pair>>
     {};
     template<typename F1, typename S1, typename F2, typename S2>
     struct common_type<ranges::common_pair<F1, S1>, ranges::common_pair<F2, S2>>
@@ -613,13 +603,13 @@ namespace concepts
     struct common_type<ranges::common_tuple<Ts...>, std::tuple<Us...>>
       : ranges::detail::common_type_tuple_like<
             ranges::common_tuple<Ts...>, std::tuple<Us...>,
-            meta::quote<ranges::detail::make_common_tuple>>
+            meta::quote<ranges::common_tuple>>
     {};
     template<typename... Ts, typename... Us>
     struct common_type<std::tuple<Ts...>, ranges::common_tuple<Us...>>
       : ranges::detail::common_type_tuple_like<
             std::tuple<Ts...>, ranges::common_tuple<Us...>,
-            meta::quote<ranges::detail::make_common_tuple>>
+            meta::quote<ranges::common_tuple>>
     {};
     template<typename... Ts, typename... Us>
     struct common_type<ranges::common_tuple<Ts...>, ranges::common_tuple<Us...>>
@@ -635,7 +625,7 @@ namespace concepts
                                   Qual2>
       : ranges::detail::common_ref_tuple_like<
             ranges::common_pair<Qual1<F1>, Qual1<S1>>, std::pair<Qual2<F2>, Qual2<S2>>,
-            meta::quote<ranges::detail::make_common_pair>>
+            meta::quote<ranges::common_pair>>
     {};
     template<typename F1, typename S1, typename F2, typename S2,
              template<typename> class Qual1, template<typename> class Qual2>
@@ -643,7 +633,7 @@ namespace concepts
                                   Qual2>
       : ranges::detail::common_ref_tuple_like<
             std::pair<Qual1<F1>, Qual1<S1>>, ranges::common_pair<Qual2<F2>, Qual2<S2>>,
-            meta::quote<ranges::detail::make_common_pair>>
+            meta::quote<ranges::common_pair>>
     {};
     template<typename F1, typename S1, typename F2, typename S2,
              template<typename> class Qual1, template<typename> class Qual2>
@@ -660,7 +650,7 @@ namespace concepts
                                   Qual2>
       : ranges::detail::common_ref_tuple_like<
             ranges::common_tuple<Qual1<Ts>...>, std::tuple<Qual2<Us>...>,
-            meta::quote<ranges::detail::make_common_tuple>>
+            meta::quote<ranges::common_tuple>>
     {};
     template<typename... Ts, typename... Us, template<typename> class Qual1,
              template<typename> class Qual2>
@@ -668,7 +658,7 @@ namespace concepts
                                   Qual2>
       : ranges::detail::common_ref_tuple_like<
             std::tuple<Qual1<Ts>...>, ranges::common_tuple<Qual2<Us>...>,
-            meta::quote<ranges::detail::make_common_tuple>>
+            meta::quote<ranges::common_tuple>>
     {};
     template<typename... Ts, typename... Us, template<typename> class Qual1,
              template<typename> class Qual2>

--- a/test/utility/common_type.cpp
+++ b/test/utility/common_type.cpp
@@ -106,7 +106,7 @@ int main()
 #if !defined(__GNUC__) || __GNUC__ != 4 || __GNUC_MINOR__ > 8
     static_assert(std::is_same<
         common_reference_t<common_pair<int const &, int const &>, std::pair<int, int>>,
-        std::pair<int, int>
+        common_pair<int, int>
     >::value, "");
 
     static_assert(std::is_same<

--- a/test/view/cartesian_product.cpp
+++ b/test/view/cartesian_product.cpp
@@ -30,6 +30,7 @@
 #include <range/v3/view/take_exactly.hpp>
 #include <range/v3/view/transform.hpp>
 #include <range/v3/view/filter.hpp>
+#include <range/v3/view/enumerate.hpp>
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 
@@ -37,7 +38,8 @@ RANGES_DIAGNOSTIC_IGNORE_RANGE_LOOP_ANALYSIS
 
 using namespace ranges;
 
-struct printer {
+struct printer
+{
     std::ostream &os_;
     bool &first_;
 
@@ -50,7 +52,8 @@ struct printer {
     }
 };
 
-namespace std {
+namespace std
+{
     template<typename... Ts>
     std::ostream &operator<<(std::ostream &os, std::tuple<Ts...> const &t)
     {
@@ -278,6 +281,16 @@ void test_bug_1296()
 
     CHECK(ranges::size(v) == 1u);
     CHECK(*ranges::begin(v) == 42);
+}
+
+// https://github.com/ericniebler/range-v3/issues/1422
+void test_1422()
+{
+    int v1[] = {1,2,3};
+    auto e = v1 | ranges::views::enumerate;
+    auto cp = ranges::views::cartesian_product(e, e);
+    using CP = decltype(cp);
+    CPP_assert(ranges::input_range<CP>);
 }
 
 int main()


### PR DESCRIPTION
Ditto for `common_pair`. Fixes #1422