### PR TITLE
Range std compat

### DIFF
--- a/include/range/v3/iterator/concepts.hpp
+++ b/include/range/v3/iterator/concepts.hpp
@@ -36,6 +36,18 @@
 
 #include <range/v3/detail/disable_warnings.hpp>
 
+#if __has_include(<version>)
+#  include <version>
+#  if __cpp_lib_ranges >= 201911
+#    define RANGE_V3_STD_COMPAT 1
+     namespace std {
+         template <typename S, typename I>
+         extern const bool disable_sized_sentinel_for;
+     }
+#  endif
+#endif
+
+
 namespace ranges
 {
     /// \addtogroup group-iterator-concepts
@@ -268,6 +280,9 @@ namespace ranges
             defer::sentinel_for<S, I>) &&
         #else
         (!disable_sized_sentinel<std::remove_cv_t<S>, std::remove_cv_t<I>>) &&
+        #ifdef RANGE_V3_STD_COMPAT
+        (!::std::disable_sized_sentinel_for<std::remove_cv_t<S>, std::remove_cv_t<I>>) &&
+        #endif
         defer::sentinel_for<S, I> &&
         #endif
         CPP_fragment(ranges::sized_sentinel_for_, S, I);
@@ -819,6 +834,14 @@ namespace ranges
         disable_sized_sentinel<std::reverse_iterator<S>, std::reverse_iterator<I>> =
             !static_cast<bool>(sized_sentinel_for<I, S>);
 } // namespace ranges
+
+#ifdef RANGE_V3_STD_COMPAT
+namespace std {
+    template <typename S, typename I>
+        requires ::ranges::disable_sized_sentinel<S, I>
+    constexpr bool disable_sized_sentinel_for<S, I> = true;
+}
+#endif
 
 #endif // defined(__GLIBCXX__) || (defined(_LIBCPP_VERSION) && _LIBCPP_VERSION <= 3900)
 

--- a/include/range/v3/iterator/concepts.hpp
+++ b/include/range/v3/iterator/concepts.hpp
@@ -36,18 +36,6 @@
 
 #include <range/v3/detail/disable_warnings.hpp>
 
-#if __has_include(<version>)
-#  include <version>
-#  if __cpp_lib_ranges >= 201911
-#    define RANGE_V3_STD_COMPAT 1
-     namespace std {
-         template <typename S, typename I>
-         extern const bool disable_sized_sentinel_for;
-     }
-#  endif
-#endif
-
-
 namespace ranges
 {
     /// \addtogroup group-iterator-concepts
@@ -834,14 +822,6 @@ namespace ranges
         disable_sized_sentinel<std::reverse_iterator<S>, std::reverse_iterator<I>> =
             !static_cast<bool>(sized_sentinel_for<I, S>);
 } // namespace ranges
-
-#ifdef RANGE_V3_STD_COMPAT
-namespace std {
-    template <typename S, typename I>
-        requires ::ranges::disable_sized_sentinel<S, I>
-    constexpr bool disable_sized_sentinel_for<S, I> = true;
-}
-#endif
 
 #endif // defined(__GLIBCXX__) || (defined(_LIBCPP_VERSION) && _LIBCPP_VERSION <= 3900)
 

--- a/include/range/v3/range/access.hpp
+++ b/include/range/v3/range/access.hpp
@@ -54,7 +54,11 @@ namespace ranges
     namespace detail
     {
         template<typename T>
-        RANGES_INLINE_VAR constexpr bool _safe_range = enable_safe_range<uncvref_t<T>>;
+        RANGES_INLINE_VAR constexpr bool _safe_range =
+#ifdef RANGE_V3_STD_COMPAT
+            ::std::ranges::enable_borrowed_range<uncvref_t<T>> ||
+#endif
+            enable_safe_range<uncvref_t<T>>;
 
         template<typename T>
         RANGES_INLINE_VAR constexpr bool _safe_range<T &> = true;

--- a/include/range/v3/range/concepts.hpp
+++ b/include/range/v3/range/concepts.hpp
@@ -42,6 +42,16 @@
 
 #include <range/v3/detail/disable_warnings.hpp>
 
+#ifdef RANGE_V3_STD_COMPAT
+namespace std::ranges {
+    template <typename T>
+    extern const bool enable_view;
+
+    template <typename T>
+    extern const bool disable_sized_range;
+}
+#endif
+
 namespace ranges
 {
     /// \addtogroup group-range
@@ -158,6 +168,9 @@ namespace ranges
     template<typename T>
     CPP_concept_bool sized_range =
         range<T> &&
+ #ifdef RANGE_V3_STD_COMPAT
+        !::std::ranges::disable_sized_range<uncvref_t<T>> &&
+ #endif
         !disable_sized_range<uncvref_t<T>> &&
         CPP_fragment(ranges::sized_range_, T);
     // clang-format on
@@ -197,7 +210,11 @@ namespace ranges
     CPP_concept_bool view_ =
         range<T> &&
         semiregular<T> &&
+ #ifdef RANGE_V3_STD_COMPAT
+        (enable_view<T> || ::std::ranges::enable_view<T>);
+ #else
         enable_view<T>;
+#endif
 
     template<typename T>
     CPP_concept_bool viewable_range =
@@ -331,6 +348,18 @@ namespace ranges
     } // namespace cpp20
     /// @}
 } // namespace ranges
+
+#ifdef RANGE_V3_STD_COMPAT
+namespace std::ranges {
+    template <typename T>
+        requires ::ranges::enable_view<T>
+    constexpr bool enable_view<T> = true;
+
+    template <typename T>
+        requires ::ranges::disable_sized_range<T>
+    constexpr bool disable_sized_range<T> = true;
+}
+#endif
 
 #include <range/v3/detail/reenable_warnings.hpp>
 

--- a/include/range/v3/range/concepts.hpp
+++ b/include/range/v3/range/concepts.hpp
@@ -42,16 +42,6 @@
 
 #include <range/v3/detail/disable_warnings.hpp>
 
-#ifdef RANGE_V3_STD_COMPAT
-namespace std::ranges {
-    template <typename T>
-    extern const bool enable_view;
-
-    template <typename T>
-    extern const bool disable_sized_range;
-}
-#endif
-
 namespace ranges
 {
     /// \addtogroup group-range

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -25,6 +25,29 @@
 #include <range/v3/utility/static_const.hpp>
 #include <range/v3/version.hpp>
 
+// if the standard library ships <ranges>, play nice with it
+#if __has_include(<version>)
+#  include <version>
+#  if __cpp_lib_ranges >= 201911
+#    define RANGE_V3_STD_COMPAT 1
+     namespace std {
+         template <typename S, typename I>
+         extern const bool disable_sized_sentinel_for;
+     }
+     namespace std::ranges {
+         template <typename T>
+         extern const bool enable_view;
+
+         template <typename T>
+         extern const bool enable_borrowed_range;
+
+         template <typename T>
+         extern const bool disable_sized_range;
+     }
+#  endif
+#endif
+
+
 /// \defgroup group-iterator Iterator
 /// Iterator functionality
 
@@ -820,6 +843,19 @@ namespace ranges
     }
 } // namespace ranges
 /// \endcond
+
+#ifdef RANGE_V3_STD_COMPAT
+namespace std {
+    template <typename S, typename I>
+        requires ::ranges::disable_sized_sentinel<S, I>
+    constexpr bool disable_sized_sentinel_for<S, I> = true;
+}
+namespace std::ranges {
+    template <typename T>
+        requires ::ranges::enable_safe_range<T>
+    constexpr bool enable_borrowed_range<T> = true;
+}
+#endif
 
 RANGES_DIAGNOSTIC_POP
 

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -28,7 +28,7 @@
 // if the standard library ships <ranges>, play nice with it
 #if __has_include(<version>)
 #  include <version>
-#  if __cpp_lib_ranges >= 201911
+#  if defined(__cpp_lib_ranges) && __cpp_lib_ranges >= 201911
 #    define RANGE_V3_STD_COMPAT 1
      namespace std {
          template <typename S, typename I>

--- a/test/view/transform.cpp
+++ b/test/view/transform.cpp
@@ -8,9 +8,6 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 //
 // Project home: https://github.com/ericniebler/range-v3
-#ifdef RANGE_V3_STD_COMPAT
-#include <ranges>
-#endif
 
 #include <string>
 #include <vector>
@@ -29,6 +26,9 @@
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 
+#ifdef RANGE_V3_STD_COMPAT
+#include <ranges>
+#endif
 
 struct is_odd
 {

--- a/test/view/transform.cpp
+++ b/test/view/transform.cpp
@@ -8,6 +8,9 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 //
 // Project home: https://github.com/ericniebler/range-v3
+#ifdef RANGE_V3_STD_COMPAT
+#include <ranges>
+#endif
 
 #include <string>
 #include <vector>
@@ -26,9 +29,6 @@
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 
-#ifdef RANGE_V3_STD_COMPAT
-#include <ranges>
-#endif
 
 struct is_odd
 {

--- a/test/view/transform.cpp
+++ b/test/view/transform.cpp
@@ -26,6 +26,10 @@
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 
+#ifdef RANGE_V3_STD_COMPAT
+#include <ranges>
+#endif
+
 struct is_odd
 {
     bool operator()(int i) const
@@ -221,6 +225,18 @@ int main()
 #endif // clang bug workaround
 #endif // use deduction guides
     }
+
+#ifdef RANGE_V3_STD_COMPAT
+    {
+        std::vector<int> vi = {1, 2, 3};
+        auto plus_one = [](int i){ return i + 1; };
+
+        auto result = vi | ranges::views::transform(plus_one)
+                         | std::views::transform(plus_one)
+                         | ranges::views::transform(plus_one);
+        ::check_equal(result, {4, 5, 6});
+    }
+#endif
 
     return test_result();
 }


### PR DESCRIPTION
This fixes #1470 by making the two view concepts cross-compatible. range-v3 will just use std's if available, and we set `std::ranges::enable_view<T>` to true for types which set `ranges::enable_view` to true. 

The downside of this approach is that it has to `#include <ranges>`. Also I don't know how to test this on CI since you need pretty recent gcc trunk to do this. 