### PR TITLE
MSVC bug workaround updates:

### DIFF
--- a/cmake/ranges_flags.cmake
+++ b/cmake/ranges_flags.cmake
@@ -26,7 +26,9 @@ if (RANGES_CXX_COMPILER_CLANGCL OR RANGES_CXX_COMPILER_MSVC)
   ranges_append_flag(RANGES_HAS_CXXSTDCOLON "/std:c++${RANGES_CXX_STD}")
   set(RANGES_STD_FLAG "/std:c++${RANGES_CXX_STD}")
   if (RANGES_CXX_COMPILER_CLANGCL)
-    ranges_append_flag(RANGES_HAS_FNO_MS_COMPATIBIILITY "-fno-ms-compatibility")
+    # The MSVC STL before VS 2019v16.6 with Clang 10 requires -fms-compatibility in C++17 mode, and
+    # doesn't support C++20 mode at all. Let's drop this flag until AppVeyor updates to VS2016v16.6.
+    # ranges_append_flag(RANGES_HAS_FNO_MS_COMPATIBIILITY "-fno-ms-compatibility")
     ranges_append_flag(RANGES_HAS_FNO_DELAYED_TEMPLATE_PARSING "-fno-delayed-template-parsing")
   endif()
   # Enable "normal" warnings and make them errors:

--- a/include/concepts/concepts.hpp
+++ b/include/concepts/concepts.hpp
@@ -44,8 +44,7 @@
 
 #if defined(_MSC_VER) && !defined(__clang__)
 #define CPP_WORKAROUND_MSVC_779763 // FATAL_UNREACHABLE calling constexpr function via template parameter
-#define CPP_WORKAROUND_MSVC_780775 // Incorrect substitution in function template return type
-#define CPP_WORKAROUND_MSVC_654601 // Failure to invoke *implicit* bool conversion in a constant expression
+#define CPP_WORKAROUND_MSVC_784772 // Failure to invoke *explicit* bool conversion in a constant expression
 #endif
 
 #if !defined(CPP_CXX_CONCEPTS)
@@ -169,7 +168,7 @@
     /**/
 #define CPP_assert_msg static_assert
 
-#ifdef CPP_WORKAROUND_MSVC_654601
+#ifdef CPP_WORKAROUND_MSVC_784772
 #define CPP_FORCE_TO_BOOL static_cast<bool>
 #else
 #define CPP_FORCE_TO_BOOL

--- a/include/concepts/swap.hpp
+++ b/include/concepts/swap.hpp
@@ -41,8 +41,10 @@
 #endif  // CPP_CXX_INLINE_VARIABLES
 
 #if defined(_MSC_VER) && !defined(__clang__)
+#if _MSC_VER < 1926
 #define CPP_WORKAROUND_MSVC_895622 // Error when phase 1 name binding finds only deleted function
-#endif
+#endif // _MSC_VER < 1926
+#endif // MSVC
 
 #if CPP_CXX_INLINE_VARIABLES < 201606L
 #define CPP_INLINE_VAR

--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -222,7 +222,16 @@ namespace ranges
 #error range-v3 requires Visual Studio 2019 with the /std:c++17 (or /std:c++latest) and /permissive- options.
 #endif
 
+#if _MSC_VER < 1926
+#define RANGES_WORKAROUND_MSVC_895622 // Error when phase 1 name binding finds only
+                                      // deleted function
+
+#if _MSC_VER < 1925
+#define RANGES_WORKAROUND_MSVC_779708 // ADL for operands of function type [No workaround]
+
 #if _MSC_VER < 1923
+#define RANGES_WORKAROUND_MSVC_573728 // rvalues of array types bind to lvalue references
+                                      // [no workaround]
 #define RANGES_WORKAROUND_MSVC_934330 // Deduction guide not correctly preferred to copy
                                       // deduction candidate [No workaround]
 
@@ -243,6 +252,8 @@ namespace ranges
 #endif                                // _MSC_VER < 1921
 #endif                                // _MSC_VER < 1922
 #endif                                // _MSC_VER < 1923
+#endif                                // _MSC_VER < 1925
+#endif                                // _MSC_VER < 1926
 
 #if 1 // Fixed in 1920, but more bugs hiding behind workaround
 #define RANGES_WORKAROUND_MSVC_701385 // Yet another alias expansion error
@@ -250,22 +261,17 @@ namespace ranges
 
 #define RANGES_WORKAROUND_MSVC_249830 // constexpr and arguments that aren't subject to
                                       // lvalue-to-rvalue conversion
-#define RANGES_WORKAROUND_MSVC_573728 // rvalues of array types bind to lvalue references
-                                      // [no workaround]
 #define RANGES_WORKAROUND_MSVC_677925 // Bogus C2676 "binary '++': '_Ty' does not define
                                       // this operator"
 #define RANGES_WORKAROUND_MSVC_683388 // decltype(*i) is incorrectly an rvalue reference
                                       // for pointer-to-array i
 #define RANGES_WORKAROUND_MSVC_688606 // SFINAE failing to account for access control
                                       // during specialization matching
-#define RANGES_WORKAROUND_MSVC_779708 // ADL for operands of function type [No workaround]
 #define RANGES_WORKAROUND_MSVC_786312 // Yet another mixed-pack-expansion failure
 #define RANGES_WORKAROUND_MSVC_792338 // Failure to match specialization enabled via call
                                       // to constexpr function
 #define RANGES_WORKAROUND_MSVC_835948 // Silent bad codegen destroying sized_generator [No
                                       // workaround]
-#define RANGES_WORKAROUND_MSVC_895622 // Error when phase 1 name binding finds only
-                                      // deleted function
 #define RANGES_WORKAROUND_MSVC_934264 // Explicitly-defaulted inherited default
                                       // constructor is not correctly implicitly constexpr
 #if _MSVC_LANG <= 201703L


### PR DESCRIPTION
* Don't build with the clang-cl flag `-fno-ms-compatibility` for now.
* VSO-573728 was fixed for 16.3
* VSO-654601 workaround is actually for VSO-784772 (What I thought was a regression was actually a distinct bug hidden behind the old workaround.)
* VSO-779708 was fixed for 16.5
* Workarounds for VSO-780775 were removed; there's no reason to keep the macro around.
* VSO-895622 was fixed for 16.6