### PR TITLE
assignable_from: use the definition from the C++20 standard

### DIFF
--- a/include/concepts/concepts.hpp
+++ b/include/concepts/concepts.hpp
@@ -1013,6 +1013,7 @@ namespace concepts
         template<typename T, typename U>
         CPP_concept_bool assignable_from =
             std::is_lvalue_reference<T>::value &&
+            common_reference_with<std::remove_reference_t<T> const &, std::remove_reference_t<U> const &> &&
             CPP_fragment(defs::assignable_from_, T, U);
 
         template<typename T>

--- a/include/concepts/concepts.hpp
+++ b/include/concepts/concepts.hpp
@@ -1013,7 +1013,7 @@ namespace concepts
         template<typename T, typename U>
         CPP_concept_bool assignable_from =
             std::is_lvalue_reference<T>::value &&
-            common_reference_with<std::remove_reference_t<T> const &, std::remove_reference_t<U> const &> &&
+            common_reference_with<detail::as_cref_t<T>, detail::as_cref_t<U>> &&
             CPP_fragment(defs::assignable_from_, T, U);
 
         template<typename T>

--- a/include/range/v3/utility/common_tuple.hpp
+++ b/include/range/v3/utility/common_tuple.hpp
@@ -182,7 +182,7 @@ namespace ranges
         auto operator=(std::tuple<Us...> & that) noexcept(
             meta::and_c<std::is_nothrow_assignable<Ts &, Us &>::value...>::value)
             -> CPP_ret(common_tuple &)( //
-                requires assignable_from<detail::args<Ts...> &, detail::rargs<Us...>>)
+                requires std::is_assignable<detail::args<Ts...> &, detail::rargs<Us...>>::value)
         {
             (void)tuple_transform(base(), that, element_assign_{});
             return *this;
@@ -191,8 +191,8 @@ namespace ranges
         auto operator=(std::tuple<Us...> const & that) noexcept(
             meta::and_c<std::is_nothrow_assignable<Ts &, Us const &>::value...>::value)
             -> CPP_ret(common_tuple &)( //
-                requires assignable_from<detail::args<Ts...> &,
-                                         detail::rargs<Us const...>>)
+                requires std::is_assignable<detail::args<Ts...> &,
+                                            detail::rargs<Us const...>>::value)
         {
             (void)tuple_transform(base(), that, element_assign_{});
             return *this;
@@ -201,7 +201,7 @@ namespace ranges
         auto operator=(std::tuple<Us...> && that) noexcept(
             meta::and_c<std::is_nothrow_assignable<Ts &, Us>::value...>::value)
             -> CPP_ret(common_tuple &)( //
-                requires assignable_from<detail::args<Ts...> &, detail::args<Us...>>)
+                requires std::is_assignable<detail::args<Ts...> &, detail::args<Us...>>::value)
         {
             (void)tuple_transform(base(), std::move(that), element_assign_{});
             return *this;
@@ -211,8 +211,8 @@ namespace ranges
         auto operator=(std::tuple<Us...> & that) const noexcept(
             meta::and_c<std::is_nothrow_assignable<Ts const &, Us &>::value...>::value)
             -> CPP_ret(common_tuple const &)( //
-                requires assignable_from<detail::args<Ts const...> &,
-                                         detail::rargs<Us...>>)
+                requires std::is_assignable<detail::args<Ts const...> &,
+                                            detail::rargs<Us...>>::value)
         {
             (void)tuple_transform(base(), that, element_assign_{});
             return *this;
@@ -222,8 +222,8 @@ namespace ranges
             noexcept(meta::and_c<
                      std::is_nothrow_assignable<Ts const &, Us const &>::value...>::value)
                 -> CPP_ret(common_tuple const &)( //
-                    requires assignable_from<detail::args<Ts const...> &,
-                                             detail::rargs<Us const...>>)
+                    requires std::is_assignable<detail::args<Ts const...> &,
+                                                detail::rargs<Us const...>>::value)
         {
             (void)tuple_transform(base(), that, element_assign_{});
             return *this;
@@ -232,8 +232,8 @@ namespace ranges
         auto operator=(std::tuple<Us...> && that) const noexcept(
             meta::and_c<std::is_nothrow_assignable<Ts const &, Us &&>::value...>::value)
             -> CPP_ret(common_tuple const &)( //
-                requires assignable_from<detail::args<Ts const...> &,
-                                         detail::args<Us...>>)
+                requires std::is_assignable<detail::args<Ts const...> &,
+                                            detail::args<Us...>>::value)
         {
             (void)tuple_transform(base(), std::move(that), element_assign_{});
             return *this;


### PR DESCRIPTION
https://eel.is/c++draft/concept.assignable

I noticed with this code that the current implementation of `concepts::assignable_from` is not the same as the one from the standard.

```c++
#include <concepts/concepts.hpp>

template <class LHS, class RHS>
concept assignable_from =
    // ::concepts::common_reference_with<std::remove_reference_t<LHS> const &, std::remove_reference_t<RHS> const&> &&
    ::concepts::assignable_from<LHS, RHS>;

int main() {
  using int_simd [[gnu::vector_size(sizeof(int) * 1)]] = int;
  using uint_simd [[gnu::vector_size(sizeof(unsigned) * 1)]] = unsigned;

//   int_simd a = uint_simd{};
  static_assert(::concepts::common_reference_with<std::remove_reference_t<int> const &, std::remove_reference_t<unsigned> const&>);
  static_assert(!::concepts::common_reference_with<std::remove_reference_t<int_simd> const &, std::remove_reference_t<uint_simd> const&>);
  static_assert(!assignable_from<int_simd &, uint_simd &>);
}
```
https://godbolt.org/z/ZbSt8z
(I know this is not a "normal" use case)