### PR TITLE
MSVC: enable workarounds for VSO-895622 in VS 2019 v 16.6

### DIFF
--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -222,7 +222,7 @@ namespace ranges
 #error range-v3 requires Visual Studio 2019 with the /std:c++17 (or /std:c++latest) and /permissive- options.
 #endif
 
-#if _MSC_VER < 1926
+#if _MSC_VER < 1927
 #define RANGES_WORKAROUND_MSVC_895622 // Error when phase 1 name binding finds only
                                       // deleted function
 


### PR DESCRIPTION
Workarounds for this bug avoid triggering another bug in 16.6 that seems to be fixed in 16.7 Preview. I validated that everything worked in 16.6, so "another bug" must be triggered by changes since e9fde778be5354cec403afc59d0f026c9fb66cd5. :shrug: