### PR TITLE
Turn requires clauses automatically into Doxygen `\pre` blocks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -46,7 +46,7 @@
   ForEachMacros: ['RANGES_FOR',],
   IncludeBlocks: Regroup,
   IncludeCategories: [
-    { Regex:           '^<range/v3/detail/disable_warnings.hpp',
+    { Regex:           '^<range/v3/detail/prologue.hpp',
       Priority:        8},
     { Regex:           '^<range/v3/range_fwd.hpp',
       Priority:        6},

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 set(CMAKE_FOLDER "doc")
 
 configure_file(Doxyfile.in Doxyfile @ONLY)
+configure_file(preprocess.sh.in preprocess.sh @ONLY)
 add_custom_target(doc.check
     COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile
     COMMENT "Running Doxygen to validate the documentation"

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -65,6 +65,7 @@ EXAMPLE_PATH            = @Range-v3_SOURCE_DIR@/example \
                           @Range-v3_SOURCE_DIR@/test
 EXAMPLE_RECURSIVE       = YES
 IMAGE_PATH              = @Range-v3_BINARY_DIR@/image
+FILTER_PATTERNS         = *.hpp="\"@Range-v3_BINARY_DIR@/doc/preprocess.sh\""
 WARN_IF_UNDOCUMENTED    = NO
 
 SHOW_GROUPED_MEMB_INC   = YES
@@ -85,7 +86,6 @@ INLINE_SIMPLE_STRUCTS   = NO
 # Generated formats
 GENERATE_HTML           = YES
 GENERATE_LATEX          = NO
-
 
 GENERATE_TODOLIST       = YES
 GENERATE_TESTLIST       = YES

--- a/doc/ignore_errors.sh
+++ b/doc/ignore_errors.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+$* 2>/dev/null
+exit 0

--- a/doc/preprocess.sh.in
+++ b/doc/preprocess.sh.in
@@ -1,0 +1,3 @@
+#!/bin/bash
+@Range-v3_SOURCE_DIR@/doc/ignore_errors.sh @CMAKE_CXX_COMPILER@ -x c++ -std=c++2a -DRANGES_DOXYGEN_INVOKED=1 -DMETA_DOXYGEN_INVOKED=1 -DCPP_DOXYGEN_INVOKED=1 -I @Range-v3_SOURCE_DIR@/include -E -CC $1 | @Range-v3_SOURCE_DIR@/doc/unpreprocess.pl
+exit 0

--- a/doc/unpreprocess.pl
+++ b/doc/unpreprocess.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/perl
+
+use strict;
+
+my $file = "";
+my $first = 1;
+my $emit = 0;
+
+while(<>) {
+    if ($first) {
+        $_ =~ m/^#\s*\d+\s+"(.*)"/;
+        $file = $1;
+        $first = 0;
+    } elsif ($_ =~ m/^#\s*\d+\s+"(.*)"/) {
+        $emit = ($1 eq $file);
+    } elsif ($emit) {
+        print $_;
+    }
+}

--- a/include/concepts/concepts.hpp
+++ b/include/concepts/concepts.hpp
@@ -33,11 +33,11 @@
 #if defined(__clang__) && __cplusplus <= 201703L
 #define CPP_PP_IGNORE_CXX2A_COMPAT_BEGIN                                                \
     CPP_DIAGNOSTIC_PUSH                                                                 \
-    CPP_DIAGNOSTIC_IGNORE_CPP2A_COMPAT                                                  \
-    /**/
+    CPP_DIAGNOSTIC_IGNORE_CPP2A_COMPAT
+
 #define CPP_PP_IGNORE_CXX2A_COMPAT_END                                                  \
-    CPP_DIAGNOSTIC_POP                                                                  \
-    /**/
+    CPP_DIAGNOSTIC_POP
+
 #else
 #define CPP_PP_IGNORE_CXX2A_COMPAT_BEGIN
 #define CPP_PP_IGNORE_CXX2A_COMPAT_END
@@ -107,16 +107,15 @@
         40, 39, 38, 37, 36, 35, 34, 33, 32, 31,                                 \
         30, 29, 28, 27, 26, 25, 24, 23, 22, 21,                                 \
         20, 19, 18, 17, 16, 15, 14, 13, 12, 11,                                 \
-        10, 9, 8, 7, 6, 5, 4, 3, 2, 1,))                                        \
-    /**/
+        10, 9, 8, 7, 6, 5, 4, 3, 2, 1,))
+
 #define CPP_PP_COUNT_(                                                          \
     _01, _02, _03, _04, _05, _06, _07, _08, _09, _10,                           \
     _11, _12, _13, _14, _15, _16, _17, _18, _19, _20,                           \
     _21, _22, _23, _24, _25, _26, _27, _28, _29, _30,                           \
     _31, _32, _33, _34, _35, _36, _37, _38, _39, _40,                           \
     _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, N, ...)                   \
-    N                                                                           \
-    /**/
+    N
 
 #define CPP_PP_IIF(BIT) CPP_PP_CAT_(CPP_PP_IIF_, BIT)
 #define CPP_PP_IIF_0(TRUE, ...) __VA_ARGS__
@@ -134,8 +133,7 @@
 #define CPP_PP_LBRACE() {
 #define CPP_PP_RBRACE() }
 #define CPP_PP_COMMA_IIF(X)                                                     \
-    CPP_PP_IIF(X)(CPP_PP_EMPTY, CPP_PP_COMMA)()                                 \
-    /**/
+    CPP_PP_IIF(X)(CPP_PP_EMPTY, CPP_PP_COMMA)()
 
 #define CPP_PP_FOR_EACH(M, ...)                                                 \
     CPP_PP_FOR_EACH_N(CPP_PP_COUNT(__VA_ARGS__), M, __VA_ARGS__)
@@ -159,7 +157,7 @@
     M(_1), M(_2), M(_3), M(_4), M(_5), M(_6), M(_7), M(_8)
 
 #define CPP_PP_PROBE_EMPTY_PROBE_CPP_PP_PROBE_EMPTY                             \
-    CPP_PP_PROBE(~)                                                             \
+    CPP_PP_PROBE(~)
 
 #define CPP_PP_PROBE_EMPTY()
 #define CPP_PP_IS_NOT_EMPTY(...)                                                \
@@ -167,15 +165,14 @@
         CPP_PP_CHECK,                                                           \
         CPP_PP_CAT(                                                             \
             CPP_PP_PROBE_EMPTY_PROBE_,                                          \
-            CPP_PP_PROBE_EMPTY __VA_ARGS__ ()))                                 \
-    /**/
+            CPP_PP_PROBE_EMPTY __VA_ARGS__ ()))
 
 #if defined(_MSC_VER) && !defined(__clang__) && (__cplusplus <= 201703L)
 #define CPP_BOOL(...) ::meta::bool_<__VA_ARGS__>::value
 #define CPP_TRUE_FN                                                             \
     !::concepts::detail::instance_<                                             \
-        decltype(CPP_true_fn(::concepts::detail::xNil{}))>                      \
-    /**/
+        decltype(CPP_true_fn(::concepts::detail::xNil{}))>
+
 #define CPP_NOT(...) (!CPP_BOOL(__VA_ARGS__))
 #else
 #define CPP_BOOL(...) __VA_ARGS__
@@ -185,18 +182,18 @@
 
 #define CPP_assert(...)                                                         \
     static_assert(static_cast<bool>(__VA_ARGS__),                               \
-        "Concept assertion failed : " #__VA_ARGS__)                             \
-    /**/
+        "Concept assertion failed : " #__VA_ARGS__)
+
 #define CPP_assert_msg static_assert
 
 #if CPP_CXX_CONCEPTS || defined(CPP_DOXYGEN_INVOKED)
 #define CPP_concept META_CONCEPT
 #define CPP_and &&
-    /**/
+
 #else
 #define CPP_concept CPP_INLINE_VAR constexpr bool
 #define CPP_and CPP_and_sfinae
-    /**/
+
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -212,41 +209,51 @@
 #define CPP_member
 #define CPP_ctor(TYPE) TYPE CPP_CTOR_IMPL_1_
 
+#if defined(CPP_DOXYGEN_INVOKED) && CPP_DOXYGEN_INVOKED
+/// INTERNAL ONLY
+#define CPP_CTOR_IMPL_1_(...) (__VA_ARGS__) CPP_CTOR_IMPL_2_
+#define CPP_CTOR_IMPL_2_(...) __VA_ARGS__ `
+#else
 /// INTERNAL ONLY
 #define CPP_CTOR_IMPL_1_(...) (__VA_ARGS__) CPP_PP_EXPAND
+#endif
 
 /// INTERNAL ONLY
 #define CPP_TEMPLATE_AUX_(...)                                                  \
     > CPP_PP_CAT(                                                               \
         CPP_TEMPLATE_AUX_,                                                      \
-        CPP_TEMPLATE_AUX_WHICH_(__VA_ARGS__,))(__VA_ARGS__)                     \
-    /**/
+        CPP_TEMPLATE_AUX_WHICH_(__VA_ARGS__,))(__VA_ARGS__)
 
 /// INTERNAL ONLY
 #define CPP_TEMPLATE_AUX_WHICH_(FIRST, ...)                                     \
     CPP_PP_EVAL(                                                                \
         CPP_PP_CHECK,                                                           \
-        CPP_PP_CAT(CPP_TEMPLATE_PROBE_CONCEPT_, FIRST))                         \
-    /**/
+        CPP_PP_CAT(CPP_TEMPLATE_PROBE_CONCEPT_, FIRST))
 
 /// INTERNAL ONLY
 #define CPP_TEMPLATE_PROBE_CONCEPT_concept                                      \
-    CPP_PP_PROBE(~)                                                             \
-    /**/
+    CPP_PP_PROBE(~)
 
+#if defined(CPP_DOXYGEN_INVOKED) && CPP_DOXYGEN_INVOKED
+// A template with a requires clause. Turn the requires clause into
+// a Doxygen precondition block.
+/// INTERNAL ONLY
+#define CPP_TEMPLATE_AUX_0(...) __VA_ARGS__`
+#define requires requires `
+
+#else
 // A template with a requires clause
 /// INTERNAL ONLY
 #define CPP_TEMPLATE_AUX_0(...) __VA_ARGS__
+#endif
 
 // A concept definition
 /// INTERNAL ONLY
 #define CPP_TEMPLATE_AUX_1(DECL, ...)                                           \
-    CPP_concept CPP_CONCEPT_NAME_(DECL) = __VA_ARGS__                           \
-    /**/
+    CPP_concept CPP_CONCEPT_NAME_(DECL) = __VA_ARGS__
 
 #define CPP_concept_ref(NAME, ...)                                              \
-    CPP_PP_CAT(NAME, _concept_)<__VA_ARGS__>                                    \
-    /**/
+    CPP_PP_CAT(NAME, _concept_)<__VA_ARGS__>
 
 #else // ^^^^ with concepts / without concepts vvvv
 
@@ -256,8 +263,7 @@
 #define CPP_ctor CPP_ctor_sfinae
 #define CPP_concept_ref(NAME, ...)                                              \
     (1u == sizeof(CPP_PP_CAT(NAME, _concept_)(                                  \
-        (::concepts::detail::tag<__VA_ARGS__>*)nullptr)))                       \
-    /**/
+        (::concepts::detail::tag<__VA_ARGS__>*)nullptr)))
 
 /// INTERNAL ONLY
 #define CPP_TEMPLATE_AUX_ CPP_TEMPLATE_SFINAE_AUX_
@@ -266,27 +272,23 @@
 
 #define CPP_template_sfinae(...)                                                \
     CPP_PP_IGNORE_CXX2A_COMPAT_BEGIN                                            \
-    template<__VA_ARGS__ CPP_TEMPLATE_SFINAE_AUX_                               \
-    /**/
+    template<__VA_ARGS__ CPP_TEMPLATE_SFINAE_AUX_
 
 /// INTERNAL ONLY
 #define CPP_TEMPLATE_SFINAE_PROBE_CONCEPT_concept                               \
-    CPP_PP_PROBE(~)                                                             \
-    /**/
+    CPP_PP_PROBE(~)
 
 /// INTERNAL ONLY
 #define CPP_TEMPLATE_SFINAE_AUX_WHICH_(FIRST, ...)                              \
     CPP_PP_EVAL(                                                                \
         CPP_PP_CHECK,                                                           \
-        CPP_PP_CAT(CPP_TEMPLATE_SFINAE_PROBE_CONCEPT_, FIRST))                  \
-    /**/
+        CPP_PP_CAT(CPP_TEMPLATE_SFINAE_PROBE_CONCEPT_, FIRST))
 
 /// INTERNAL ONLY
 #define CPP_TEMPLATE_SFINAE_AUX_(...)                                           \
     CPP_PP_CAT(                                                                 \
         CPP_TEMPLATE_SFINAE_AUX_,                                               \
-        CPP_TEMPLATE_SFINAE_AUX_WHICH_(__VA_ARGS__,))(__VA_ARGS__)              \
-    /**/
+        CPP_TEMPLATE_SFINAE_AUX_WHICH_(__VA_ARGS__,))(__VA_ARGS__)
 
 // A template with a requires clause
 /// INTERNAL ONLY
@@ -296,8 +298,7 @@
         CPP_PP_CAT(CPP_TEMPLATE_SFINAE_AUX_3_, __VA_ARGS__) &&                  \
         CPP_BOOL(CPP_true),                                                     \
         int> = 0>                                                               \
-    CPP_PP_IGNORE_CXX2A_COMPAT_END                                              \
-    /**/
+    CPP_PP_IGNORE_CXX2A_COMPAT_END
 
 // A concept definition
 /// INTERNAL ONLY
@@ -308,37 +309,30 @@
         ::concepts::detail::tag<CPP_CONCEPT_PARAMS_(DECL)>*)                    \
         -> char(&)[1];                                                          \
     auto CPP_CONCEPT_NAME_(DECL)(...) -> char(&)[2]                             \
-    CPP_PP_IGNORE_CXX2A_COMPAT_END                                              \
-    /**/
+    CPP_PP_IGNORE_CXX2A_COMPAT_END
 
 /// INTERNAL ONLY
 #define CPP_CONCEPT_NAME_(DECL)                                                 \
     CPP_PP_EVAL(                                                                \
         CPP_PP_CAT,                                                             \
-        CPP_PP_EVAL(CPP_PP_FIRST, CPP_EAT_CONCEPT_(DECL)), _concept_)           \
-    /**/
+        CPP_PP_EVAL(CPP_PP_FIRST, CPP_EAT_CONCEPT_(DECL)), _concept_)
 
 /// INTERNAL ONLY
 #define CPP_CONCEPT_PARAMS_(DECL)                                               \
-    CPP_PP_EVAL(CPP_PP_SECOND, CPP_EAT_CONCEPT_(DECL))                          \
-    /**/
+    CPP_PP_EVAL(CPP_PP_SECOND, CPP_EAT_CONCEPT_(DECL))
 
 /// INTERNAL ONLY
 #define CPP_EAT_CONCEPT_(DECL)                                                  \
-    CPP_PP_CAT(CPP_EAT_CONCEPT_, DECL)                                          \
-    /**/
+    CPP_PP_CAT(CPP_EAT_CONCEPT_, DECL)
 
 /// INTERNAL ONLY
-#define CPP_EAT_CONCEPT_concept                                                 \
-    /**/
+#define CPP_EAT_CONCEPT_concept
 
 #define CPP_and_sfinae                                                          \
-    && CPP_BOOL(CPP_true), int> = 0, std::enable_if_t<                          \
-    /**/
+    && CPP_BOOL(CPP_true), int> = 0, std::enable_if_t<
 
 #define CPP_template_def_sfinae(...)                                            \
-    template<__VA_ARGS__ CPP_TEMPLATE_DEF_SFINAE_AUX_                           \
-    /**/
+    template<__VA_ARGS__ CPP_TEMPLATE_DEF_SFINAE_AUX_
 
 /// INTERNAL ONLY
 #define CPP_TEMPLATE_DEF_SFINAE_AUX_(...) ,                                     \
@@ -346,42 +340,35 @@
     std::enable_if_t<                                                           \
         CPP_PP_CAT(CPP_TEMPLATE_SFINAE_AUX_3_, __VA_ARGS__) &&                  \
         CPP_BOOL(CPP_true),                                                     \
-        int>>                                                                   \
-    /**/
+        int>>
 
 #define CPP_and_sfinae_def                                                      \
-    && CPP_BOOL(CPP_true), int>, std::enable_if_t<                              \
-    /**/
+    && CPP_BOOL(CPP_true), int>, std::enable_if_t<
 
 /// INTERNAL ONLY
 #define CPP_TEMPLATE_SFINAE_AUX_3_requires
 
 #define CPP_member_sfinae                                                       \
-    CPP_broken_friend_member                                                    \
-    /**/
+    CPP_broken_friend_member
 
 #define CPP_ctor_sfinae(TYPE)                                                   \
     CPP_PP_IGNORE_CXX2A_COMPAT_BEGIN                                            \
-    TYPE CPP_CTOR_SFINAE_IMPL_1_                                                \
-    /**/
+    TYPE CPP_CTOR_SFINAE_IMPL_1_
 
 /// INTERNAL ONLY
 #define CPP_CTOR_SFINAE_IMPL_1_(...)                                            \
     (__VA_ARGS__                                                                \
         CPP_PP_COMMA_IIF(                                                       \
             CPP_PP_NOT(CPP_PP_IS_NOT_EMPTY(__VA_ARGS__)))                       \
-    CPP_CTOR_SFINAE_REQUIRES                                                    \
-    /**/
+    CPP_CTOR_SFINAE_REQUIRES
 
 /// INTERNAL ONLY
 #define CPP_CTOR_SFINAE_PROBE_NOEXCEPT_noexcept                                 \
-    CPP_PP_PROBE(~)                                                             \
-    /**/
+    CPP_PP_PROBE(~)
 
 /// INTERNAL ONLY
 #define CPP_CTOR_SFINAE_MAKE_PROBE(FIRST,...)                                   \
-    CPP_PP_CAT(CPP_CTOR_SFINAE_PROBE_NOEXCEPT_, FIRST)                          \
-    /**/
+    CPP_PP_CAT(CPP_CTOR_SFINAE_PROBE_NOEXCEPT_, FIRST)
 
 /// INTERNAL ONLY
 #define CPP_CTOR_SFINAE_REQUIRES(...)                                           \
@@ -389,8 +376,7 @@
         CPP_CTOR_SFINAE_REQUIRES_,                                              \
         CPP_PP_EVAL(                                                            \
             CPP_PP_CHECK,                                                       \
-            CPP_CTOR_SFINAE_MAKE_PROBE(__VA_ARGS__,)))(__VA_ARGS__)             \
-    /**/
+            CPP_CTOR_SFINAE_MAKE_PROBE(__VA_ARGS__,)))(__VA_ARGS__)
 
 // No noexcept-clause:
 /// INTERNAL ONLY
@@ -399,8 +385,7 @@
         CPP_PP_CAT(CPP_TEMPLATE_SFINAE_AUX_3_, __VA_ARGS__) && CPP_TRUE_FN,     \
         ::concepts::detail::Nil                                                 \
     > = {})                                                                     \
-    CPP_PP_IGNORE_CXX2A_COMPAT_END                                              \
-    /**/
+    CPP_PP_IGNORE_CXX2A_COMPAT_END
 
 // Yes noexcept-clause:
 /// INTERNAL ONLY
@@ -411,8 +396,7 @@
             CPP_PP_CAT(CPP_CTOR_SFINAE_EAT_NOEXCEPT_, __VA_ARGS__)) && CPP_TRUE_FN,\
         ::concepts::detail::Nil                                                 \
     > = {})                                                                     \
-    CPP_PP_EXPAND(CPP_PP_CAT(CPP_CTOR_SFINAE_SHOW_NOEXCEPT_, __VA_ARGS__)))     \
-    /**/
+    CPP_PP_EXPAND(CPP_PP_CAT(CPP_CTOR_SFINAE_SHOW_NOEXCEPT_, __VA_ARGS__)))
 
 /// INTERNAL ONLY
 #define CPP_CTOR_SFINAE_EAT_NOEXCEPT_noexcept(...)
@@ -421,82 +405,71 @@
 #define CPP_CTOR_SFINAE_SHOW_NOEXCEPT_noexcept(...)                             \
     noexcept(__VA_ARGS__)                                                       \
     CPP_PP_IGNORE_CXX2A_COMPAT_END                                              \
-    CPP_PP_EAT CPP_PP_LPAREN                                                    \
-    /**/
+    CPP_PP_EAT CPP_PP_LPAREN
 
 #ifdef CPP_DOXYGEN_INVOKED
 #define CPP_broken_friend_ret(...)                                              \
-    __VA_ARGS__ CPP_PP_EXPAND                                                   \
-    /**/
+    __VA_ARGS__ CPP_PP_EXPAND
+
 #else // ^^^ CPP_DOXYGEN_INVOKED / not CPP_DOXYGEN_INVOKED vvv
 #define CPP_broken_friend_ret(...)                                              \
     ::concepts::return_t<                                                       \
         __VA_ARGS__,                                                            \
-        std::enable_if_t<CPP_BROKEN_FRIEND_RETURN_TYPE_AUX_                     \
-    /**/
+        std::enable_if_t<CPP_BROKEN_FRIEND_RETURN_TYPE_AUX_
 
 /// INTERNAL ONLY
 #define CPP_BROKEN_FRIEND_RETURN_TYPE_AUX_(...)                                 \
     CPP_BROKEN_FRIEND_RETURN_TYPE_AUX_3_(CPP_PP_CAT(                            \
-        CPP_TEMPLATE_AUX_2_, __VA_ARGS__))                                      \
-    /**/
+        CPP_TEMPLATE_AUX_2_, __VA_ARGS__))
 
 /// INTERNAL ONLY
 #define CPP_TEMPLATE_AUX_2_requires
 
 /// INTERNAL ONLY
 #define CPP_BROKEN_FRIEND_RETURN_TYPE_AUX_3_(...)                               \
-    __VA_ARGS__ && CPP_TRUE_FN>>                                                   \
-    /**/
+    __VA_ARGS__ && CPP_TRUE_FN>>
 
 #ifdef CPP_WORKAROUND_MSVC_779763
 #define CPP_broken_friend_member                                                \
     template<::concepts::detail::CPP_true_t const &CPP_true_fn =                \
-        ::concepts::detail::CPP_true_fn_>                                       \
-    /**/
+        ::concepts::detail::CPP_true_fn_>
+
 #else // ^^^ workaround / no workaround vvv
 #define CPP_broken_friend_member                                                \
     template<bool (&CPP_true_fn)(::concepts::detail::xNil) =                    \
-        ::concepts::detail::CPP_true_fn>                                        \
-    /**/
+        ::concepts::detail::CPP_true_fn>
+
 #endif // CPP_WORKAROUND_MSVC_779763
 #endif
 
 #if CPP_CXX_CONCEPTS
 #define CPP_requires(NAME, REQS)                                                \
 CPP_concept CPP_PP_CAT(NAME, _requires_) =                                      \
-    CPP_PP_CAT(CPP_REQUIRES_, REQS)                                             \
-    /**/
+    CPP_PP_CAT(CPP_REQUIRES_, REQS)
 
 #define CPP_requires_ref(NAME, ...)                                             \
-    CPP_PP_CAT(NAME, _requires_)<__VA_ARGS__>                                   \
-    /**/
+    CPP_PP_CAT(NAME, _requires_)<__VA_ARGS__>
 
 /// INTERNAL ONLY
 #define CPP_REQUIRES_requires(...)                                              \
-    requires(__VA_ARGS__) CPP_REQUIRES_AUX_                                     \
-    /**/
+    requires(__VA_ARGS__) CPP_REQUIRES_AUX_
 
 /// INTERNAL ONLY
 #define CPP_REQUIRES_AUX_(...)                                                  \
-    { __VA_ARGS__; }                                                            \
-    /**/
+    { __VA_ARGS__; }
 
 #else
 #define CPP_requires(NAME, REQS)                                                \
     auto CPP_PP_CAT(NAME, _requires_test_)                                      \
-    CPP_REQUIRES_AUX_(NAME, CPP_REQUIRES_ ## REQS)                              \
-    /**/
+    CPP_REQUIRES_AUX_(NAME, CPP_REQUIRES_ ## REQS)
 
 #define CPP_requires_ref(NAME, ...)                                             \
     (1u == sizeof(CPP_PP_CAT(NAME, _requires_)(                                 \
-        (::concepts::detail::tag<__VA_ARGS__>*)nullptr)))                       \
-    /**/
+        (::concepts::detail::tag<__VA_ARGS__>*)nullptr)))
 
 /// INTERNAL ONLY
 #define CPP_REQUIRES_requires(...)                                              \
-    (__VA_ARGS__) -> decltype CPP_REQUIRES_RETURN_                              \
-    /**/
+    (__VA_ARGS__) -> decltype CPP_REQUIRES_RETURN_
 
 /// INTERNAL ONLY
 #define CPP_REQUIRES_RETURN_(...) (__VA_ARGS__, void()) {}
@@ -509,28 +482,45 @@ CPP_concept CPP_PP_CAT(NAME, _requires_) =                                      
         ::concepts::detail::tag<As...> *,                                       \
         decltype(&CPP_PP_CAT(NAME, _requires_test_)<As...>) = nullptr)          \
         -> char(&)[1];                                                          \
-    auto CPP_PP_CAT(NAME, _requires_)(...) -> char(&)[2]                        \
-    /**/
+    auto CPP_PP_CAT(NAME, _requires_)(...) -> char(&)[2]
+
 #endif
 
 #if CPP_CXX_CONCEPTS
+
+#if defined(CPP_DOXYGEN_INVOKED) && CPP_DOXYGEN_INVOKED
 #define CPP_ret(...)                                                            \
-    __VA_ARGS__ CPP_PP_EXPAND                                                   \
-    /**/
+    __VA_ARGS__ CPP_RET_AUX_
+#define CPP_RET_AUX_(...) __VA_ARGS__ `
+#else
+#define CPP_ret(...)                                                            \
+    __VA_ARGS__ CPP_PP_EXPAND
+#endif
+
 #else
 #define CPP_ret                                                                 \
-    CPP_broken_friend_ret                                                       \
-    /**/
+    CPP_broken_friend_ret
+
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // CPP_fun
 #if CPP_CXX_CONCEPTS
+
+#if defined(CPP_DOXYGEN_INVOKED) && CPP_DOXYGEN_INVOKED
 /// INTERNAL ONLY
 #define CPP_FUN_IMPL_1_(...)                                                    \
     (__VA_ARGS__)                                                               \
-    CPP_PP_EXPAND                                                               \
-    /**/
+    CPP_FUN_IMPL_2_
+#define CPP_FUN_IMPL_2_(...)                                                    \
+    __VA_ARGS__ `
+#else
+/// INTERNAL ONLY
+#define CPP_FUN_IMPL_1_(...)                                                    \
+    (__VA_ARGS__)                                                               \
+    CPP_PP_EXPAND
+#endif
+
 #define CPP_fun(X) X CPP_FUN_IMPL_1_
 #else
 /// INTERNAL ONLY
@@ -538,23 +528,20 @@ CPP_concept CPP_PP_CAT(NAME, _requires_) =                                      
     (__VA_ARGS__                                                                \
         CPP_PP_COMMA_IIF(                                                       \
             CPP_PP_NOT(CPP_PP_IS_NOT_EMPTY(__VA_ARGS__)))                       \
-    CPP_FUN_IMPL_REQUIRES                                                       \
-    /**/
+    CPP_FUN_IMPL_REQUIRES
 
 /// INTERNAL ONLY
 #define CPP_FUN_IMPL_REQUIRES(...)                                              \
     CPP_PP_EVAL2_(                                                              \
         CPP_FUN_IMPL_SELECT_CONST_,                                             \
         (__VA_ARGS__,)                                                          \
-    )(__VA_ARGS__)                                                              \
-    /**/
+    )(__VA_ARGS__)
 
 /// INTERNAL ONLY
 #define CPP_FUN_IMPL_SELECT_CONST_(MAYBE_CONST, ...)                            \
     CPP_PP_CAT(CPP_FUN_IMPL_SELECT_CONST_,                                      \
         CPP_PP_EVAL(CPP_PP_CHECK, CPP_PP_CAT(                                   \
-            CPP_PP_PROBE_CONST_PROBE_, MAYBE_CONST)))                           \
-    /**/
+            CPP_PP_PROBE_CONST_PROBE_, MAYBE_CONST)))
 
 /// INTERNAL ONLY
 #define CPP_PP_PROBE_CONST_PROBE_const CPP_PP_PROBE(~)
@@ -564,15 +551,13 @@ CPP_concept CPP_PP_CAT(NAME, _requires_) =                                      
     CPP_PP_EVAL(                                                                \
         CPP_FUN_IMPL_SELECT_CONST_NOEXCEPT_,                                    \
         CPP_PP_CAT(CPP_FUN_IMPL_EAT_CONST_, __VA_ARGS__),)(                     \
-        CPP_PP_CAT(CPP_FUN_IMPL_EAT_CONST_, __VA_ARGS__))                       \
-    /**/
+        CPP_PP_CAT(CPP_FUN_IMPL_EAT_CONST_, __VA_ARGS__))
 
 /// INTERNAL ONLY
 #define CPP_FUN_IMPL_SELECT_CONST_NOEXCEPT_(MAYBE_NOEXCEPT, ...)                \
     CPP_PP_CAT(CPP_FUN_IMPL_SELECT_CONST_NOEXCEPT_,                             \
         CPP_PP_EVAL2(CPP_PP_CHECK, CPP_PP_CAT(                                  \
-            CPP_PP_PROBE_NOEXCEPT_PROBE_, MAYBE_NOEXCEPT)))                     \
-    /**/
+            CPP_PP_PROBE_NOEXCEPT_PROBE_, MAYBE_NOEXCEPT)))
 
 /// INTERNAL ONLY
 #define CPP_PP_PROBE_NOEXCEPT_PROBE_noexcept CPP_PP_PROBE(~)
@@ -586,8 +571,7 @@ CPP_concept CPP_PP_CAT(NAME, _requires_) =                                      
             __VA_ARGS__) && CPP_TRUE_FN,                                           \
         ::concepts::detail::Nil                                                 \
     > = {}) const                                                               \
-    CPP_PP_IGNORE_CXX2A_COMPAT_END                                              \
-    /**/
+    CPP_PP_IGNORE_CXX2A_COMPAT_END
 
 /// INTERNAL ONLY
 #define CPP_FUN_IMPL_SELECT_CONST_NOEXCEPT_1(...)                               \
@@ -598,8 +582,7 @@ CPP_concept CPP_PP_CAT(NAME, _requires_) =                                      
             CPP_PP_CAT(CPP_FUN_IMPL_EAT_NOEXCEPT_, __VA_ARGS__)) && CPP_TRUE_FN,   \
         ::concepts::detail::Nil                                                 \
     > = {}) const                                                               \
-    CPP_PP_EXPAND(CPP_PP_CAT(CPP_FUN_IMPL_SHOW_NOEXCEPT_, __VA_ARGS__)))        \
-    /**/
+    CPP_PP_EXPAND(CPP_PP_CAT(CPP_FUN_IMPL_SHOW_NOEXCEPT_, __VA_ARGS__)))
 
 /// INTERNAL ONLY
 #define CPP_FUN_IMPL_EAT_NOEXCEPT_noexcept(...)
@@ -607,23 +590,20 @@ CPP_concept CPP_PP_CAT(NAME, _requires_) =                                      
 /// INTERNAL ONLY
 #define CPP_FUN_IMPL_SHOW_NOEXCEPT_noexcept(...)                                \
     noexcept(__VA_ARGS__) CPP_PP_IGNORE_CXX2A_COMPAT_END                        \
-    CPP_PP_EAT CPP_PP_LPAREN                                                    \
-    /**/
+    CPP_PP_EAT CPP_PP_LPAREN
 
 /// INTERNAL ONLY
 #define CPP_FUN_IMPL_SELECT_CONST_0(...)                                        \
     CPP_PP_EVAL_(                                                               \
         CPP_FUN_IMPL_SELECT_NONCONST_NOEXCEPT_,                                 \
         (__VA_ARGS__,)                                                          \
-    )(__VA_ARGS__)                                                              \
-    /**/
+    )(__VA_ARGS__)
 
 /// INTERNAL ONLY
 #define CPP_FUN_IMPL_SELECT_NONCONST_NOEXCEPT_(MAYBE_NOEXCEPT, ...)             \
     CPP_PP_CAT(CPP_FUN_IMPL_SELECT_NONCONST_NOEXCEPT_,                          \
           CPP_PP_EVAL2(CPP_PP_CHECK, CPP_PP_CAT(                                \
-            CPP_PP_PROBE_NOEXCEPT_PROBE_, MAYBE_NOEXCEPT)))                     \
-    /**/
+            CPP_PP_PROBE_NOEXCEPT_PROBE_, MAYBE_NOEXCEPT)))
 
 /// INTERNAL ONLY
 #define CPP_FUN_IMPL_SELECT_NONCONST_NOEXCEPT_0(...)                            \
@@ -631,8 +611,7 @@ CPP_concept CPP_PP_CAT(NAME, _requires_) =                                      
         CPP_PP_CAT(CPP_FUN_IMPL_EAT_REQUIRES_, __VA_ARGS__) && CPP_TRUE_FN,        \
         ::concepts::detail::Nil                                                 \
     > = {})                                                                     \
-    CPP_PP_IGNORE_CXX2A_COMPAT_END                                              \
-    /**/
+    CPP_PP_IGNORE_CXX2A_COMPAT_END
 
 /// INTERNAL ONLY
 #define CPP_FUN_IMPL_SELECT_NONCONST_NOEXCEPT_1(...)                            \
@@ -644,8 +623,7 @@ CPP_concept CPP_PP_CAT(NAME, _requires_) =                                      
         ) && CPP_TRUE_FN,                                                          \
         ::concepts::detail::Nil                                                 \
     > = {})                                                                     \
-    CPP_PP_EXPAND(CPP_PP_CAT(CPP_FUN_IMPL_SHOW_NOEXCEPT_, __VA_ARGS__)))        \
-    /**/
+    CPP_PP_EXPAND(CPP_PP_CAT(CPP_FUN_IMPL_SHOW_NOEXCEPT_, __VA_ARGS__)))
 
 /// INTERNAL ONLY
 #define CPP_FUN_IMPL_EAT_CONST_const
@@ -684,15 +662,13 @@ CPP_concept CPP_PP_CAT(NAME, _requires_) =                                      
     CPP_PP_EVAL2_(                                                              \
         CPP_AUTO_FUN_SELECT_RETURNS_,                                           \
         (__VA_ARGS__,)                                                          \
-    )(__VA_ARGS__)                                                              \
-    /**/
+    )(__VA_ARGS__)
 
 /// INTERNAL ONLY
 #define CPP_AUTO_FUN_SELECT_RETURNS_(MAYBE_CONST, ...)                          \
     CPP_PP_CAT(CPP_AUTO_FUN_RETURNS_CONST_,                                     \
         CPP_PP_EVAL(CPP_PP_CHECK, CPP_PP_CAT(                                   \
-            CPP_PP_PROBE_CONST_MUTABLE_PROBE_, MAYBE_CONST)))                   \
-    /**/
+            CPP_PP_PROBE_CONST_MUTABLE_PROBE_, MAYBE_CONST)))
 
 /// INTERNAL ONLY
 #define CPP_PP_PROBE_CONST_MUTABLE_PROBE_const CPP_PP_PROBE_N(~, 1)
@@ -709,14 +685,12 @@ CPP_concept CPP_PP_CAT(NAME, _requires_) =                                      
 
 /// INTERNAL ONLY
 #define CPP_AUTO_FUN_RETURNS_CONST_1(...)                                       \
-    __VA_ARGS__ CPP_AUTO_FUN_RETURNS_CONST_0                                    \
-    /**/
+    __VA_ARGS__ CPP_AUTO_FUN_RETURNS_CONST_0
 
 /// INTERNAL ONLY
 #define CPP_AUTO_FUN_RETURNS_CONST_0(...)                                       \
     CPP_PP_EVAL(CPP_AUTO_FUN_DECLTYPE_NOEXCEPT_,                                \
-        CPP_PP_CAT(CPP_AUTO_FUN_RETURNS_, __VA_ARGS__))                         \
-    /**/
+        CPP_PP_CAT(CPP_AUTO_FUN_RETURNS_, __VA_ARGS__))
 
 /// INTERNAL ONLY
 #define CPP_AUTO_FUN_RETURNS_return
@@ -725,15 +699,15 @@ CPP_concept CPP_PP_CAT(NAME, _requires_) =                                      
 /// INTERNAL ONLY
 #define CPP_AUTO_FUN_DECLTYPE_NOEXCEPT_(...)                                    \
     noexcept(noexcept(__VA_ARGS__)) -> decltype(__VA_ARGS__)                    \
-    { return (__VA_ARGS__); }                                                   \
-    /**/
+    { return (__VA_ARGS__); }
+
 #else
 /// INTERNAL ONLY
 #define CPP_AUTO_FUN_DECLTYPE_NOEXCEPT_(...)                                    \
     noexcept(noexcept(decltype(__VA_ARGS__)(__VA_ARGS__))) ->                   \
     decltype(__VA_ARGS__)                                                       \
-    { return (__VA_ARGS__); }                                                   \
-    /**/
+    { return (__VA_ARGS__); }
+
 #endif
 
 namespace concepts

--- a/include/range/v3/action/action.hpp
+++ b/include/range/v3/action/action.hpp
@@ -72,9 +72,10 @@ namespace ranges
         {
             // clang-format off
             // Piping requires things are passed by value.
-            template(typename Rng, typename ActionFn)(                    //
-                requires (!std::is_lvalue_reference<Rng>::value) AND      //
-                range<Rng> AND invocable_action_closure<ActionFn, Rng &>) //
+            template(typename Rng, typename ActionFn)(
+                /// \pre
+                requires (!std::is_lvalue_reference<Rng>::value) AND
+                range<Rng> AND invocable_action_closure<ActionFn, Rng &>)
             friend constexpr auto
             operator|(Rng && rng, action_closure<ActionFn> act)
             {
@@ -96,6 +97,7 @@ namespace ranges
             template<typename ActionFn, typename Pipeable>
             friend constexpr auto operator|(action_closure<ActionFn> act, Pipeable pipe)
                 -> CPP_broken_friend_ret(action_closure<composed<Pipeable, ActionFn>>)(
+                    /// \pre
                     requires (is_pipeable_v<Pipeable>))
             {
                 return make_action_closure(compose(static_cast<Pipeable &&>(pipe),
@@ -104,7 +106,8 @@ namespace ranges
 
             template<typename Rng, typename ActionFn>
             friend constexpr auto operator|=(Rng & rng, action_closure<ActionFn> act) //
-                -> CPP_broken_friend_ret(Rng &)(                                      //
+                -> CPP_broken_friend_ret(Rng &)(
+                    /// \pre
                     requires range<Rng> && invocable<ActionFn, Rng &>)
             {
                 static_cast<ActionFn &&>(act)(rng);
@@ -204,8 +207,9 @@ namespace ranges
             {}
 
             // Calling directly requires things are passed by reference.
-            template(typename Rng, typename... Rest)( //
-                requires range<Rng> AND invocable<Action const &, Rng &, Rest...>) //
+            template(typename Rng, typename... Rest)(
+                /// \pre
+                requires range<Rng> AND invocable<Action const &, Rng &, Rest...>)
             invoke_result_t<Action const &, Rng &, Rest...> //
             operator()(Rng & rng, Rest &&... rest) const
             {
@@ -215,6 +219,7 @@ namespace ranges
             // Currying overload.
             // clang-format off
             template(typename... Rest, typename A = Action)(
+                /// \pre
                 requires (sizeof...(Rest) != 0))
             auto CPP_auto_fun(operator())(Rest &&... rest)(const)
             (

--- a/include/range/v3/action/adjacent_remove_if.hpp
+++ b/include/range/v3/action/adjacent_remove_if.hpp
@@ -36,7 +36,8 @@ namespace ranges
     {
         struct adjacent_remove_if_fn
         {
-            template(typename Pred, typename Proj = identity)( //
+            template(typename Pred, typename Proj = identity)(
+                /// \pre
                 requires (!range<Pred>))
             constexpr auto operator()(Pred pred, Proj proj = {}) const
             {
@@ -44,11 +45,12 @@ namespace ranges
                     bind_back(adjacent_remove_if_fn{}, std::move(pred), std::move(proj)));
             }
 
-            template(typename Rng, typename Pred, typename Proj = identity)( //
+            template(typename Rng, typename Pred, typename Proj = identity)(
+                /// \pre
                 requires forward_range<Rng> AND
                     erasable_range<Rng, iterator_t<Rng>, sentinel_t<Rng>> AND
                     indirect_relation<Pred, projected<iterator_t<Rng>, Proj>> AND
-                    permutable<iterator_t<Rng>>) //
+                    permutable<iterator_t<Rng>>)
             Rng operator()(Rng && rng, Pred pred, Proj proj = {}) const
             {
                 auto i = adjacent_remove_if(rng, std::move(pred), std::move(proj));

--- a/include/range/v3/action/concepts.hpp
+++ b/include/range/v3/action/concepts.hpp
@@ -111,30 +111,34 @@ namespace ranges
     /// \cond
     namespace detail
     {
-        template(typename T)( //
-            requires container<T>) //
+        template(typename T)(
+            /// \pre
+            requires container<T>)
         std::true_type is_lvalue_container_like(T &) noexcept
         {
             return {};
         }
 
-        template(typename T)( //
-            requires container<T>) //
+        template(typename T)(
+            /// \pre
+            requires container<T>)
         meta::not_<std::is_rvalue_reference<T>> //
         is_lvalue_container_like(reference_wrapper<T>) noexcept
         {
             return {};
         }
 
-        template(typename T)( //
-            requires container<T>) //
+        template(typename T)(
+            /// \pre
+            requires container<T>)
         std::true_type is_lvalue_container_like(std::reference_wrapper<T>) noexcept
         {
             return {};
         }
 
-        template(typename T)( //
-            requires container<T>) //
+        template(typename T)(
+            /// \pre
+            requires container<T>)
         std::true_type is_lvalue_container_like(ref_view<T>) noexcept
         {
             return {};

--- a/include/range/v3/action/drop.hpp
+++ b/include/range/v3/action/drop.hpp
@@ -34,7 +34,8 @@ namespace ranges
     {
         struct drop_fn
         {
-            template(typename Int)( //
+            template(typename Int)(
+                /// \pre
                 requires detail::integer_like_<Int>)
             constexpr auto operator()(Int n) const
             {
@@ -42,9 +43,10 @@ namespace ranges
                 return make_action_closure(bind_back(drop_fn{}, n));
             }
 
-            template(typename Rng)( //
-                requires forward_range<Rng> AND //
-                    erasable_range<Rng &, iterator_t<Rng>, iterator_t<Rng>>) //
+            template(typename Rng)(
+                /// \pre
+                requires forward_range<Rng> AND
+                    erasable_range<Rng &, iterator_t<Rng>, iterator_t<Rng>>)
             Rng operator()(Rng && rng, range_difference_t<Rng> n) const
             {
                 RANGES_EXPECT(n >= 0);

--- a/include/range/v3/action/drop_while.hpp
+++ b/include/range/v3/action/drop_while.hpp
@@ -34,17 +34,19 @@ namespace ranges
     {
         struct drop_while_fn
         {
-            template(typename Fun)( //
+            template(typename Fun)(
+                /// \pre
                 requires (!range<Fun>))
             constexpr auto operator()(Fun fun) const
             {
                 return make_action_closure(bind_back(drop_while_fn{}, std::move(fun)));
             }
 
-            template(typename Rng, typename Fun)( //
+            template(typename Rng, typename Fun)(
+                /// \pre
                 requires forward_range<Rng> AND
                     indirect_unary_predicate<Fun, iterator_t<Rng>> AND
-                        erasable_range<Rng &, iterator_t<Rng>, iterator_t<Rng>>) //
+                        erasable_range<Rng &, iterator_t<Rng>, iterator_t<Rng>>)
             Rng operator()(Rng && rng, Fun fun) const
             {
                 ranges::actions::erase(

--- a/include/range/v3/action/erase.hpp
+++ b/include/range/v3/action/erase.hpp
@@ -28,9 +28,10 @@ namespace ranges
     /// \cond
     namespace adl_erase_detail
     {
-        template(typename Cont, typename I, typename S)( //
-            requires lvalue_container_like<Cont> AND forward_iterator<I> AND //
-                sentinel_for<S, I>) //
+        template(typename Cont, typename I, typename S)(
+            /// \pre
+            requires lvalue_container_like<Cont> AND forward_iterator<I> AND
+                sentinel_for<S, I>)
         auto erase(Cont && cont, I first, S last)                            //
             -> decltype(unwrap_reference(cont).erase(first, last))
         {
@@ -39,8 +40,9 @@ namespace ranges
 
         struct erase_fn
         {
-            template(typename Rng, typename I, typename S)( //
-                requires range<Rng> AND forward_iterator<I> AND sentinel_for<S, I>) //
+            template(typename Rng, typename I, typename S)(
+                /// \pre
+                requires range<Rng> AND forward_iterator<I> AND sentinel_for<S, I>)
             auto operator()(Rng && rng, I first, S last) const
                 -> decltype(erase((Rng &&) rng, first, last))
             {

--- a/include/range/v3/action/insert.hpp
+++ b/include/range/v3/action/insert.hpp
@@ -36,7 +36,8 @@ namespace ranges
         using insert_result_t = decltype(
             unwrap_reference(std::declval<Cont>()).insert(std::declval<Args>()...));
 
-        template(typename Cont, typename T)( //
+        template(typename Cont, typename T)(
+            /// \pre
             requires lvalue_container_like<Cont> AND
             (!range<T> && constructible_from<range_value_t<Cont>, T>)) //
         insert_result_t<Cont &, T> insert(Cont && cont, T && t)
@@ -44,7 +45,8 @@ namespace ranges
             return unwrap_reference(cont).insert(static_cast<T &&>(t));
         }
 
-        template(typename Cont, typename I, typename S)( //
+        template(typename Cont, typename I, typename S)(
+            /// \pre
             requires lvalue_container_like<Cont> AND sentinel_for<S, I> AND (!range<S>))
         insert_result_t<Cont &, detail::cpp17_iterator_t<I, S>,
                                 detail::cpp17_iterator_t<I, S>>
@@ -54,8 +56,9 @@ namespace ranges
                                                  detail::cpp17_iterator_t<I, S>{j});
         }
 
-        template(typename Cont, typename Rng)( //
-            requires lvalue_container_like<Cont> AND range<Rng>) //
+        template(typename Cont, typename Rng)(
+            /// \pre
+            requires lvalue_container_like<Cont> AND range<Rng>)
         insert_result_t<Cont &, detail::range_cpp17_iterator_t<Rng>,
                                 detail::range_cpp17_iterator_t<Rng>>
         insert(Cont && cont, Rng && rng)
@@ -65,17 +68,19 @@ namespace ranges
                 detail::range_cpp17_iterator_t<Rng>{ranges::end(rng)});
         }
 
-        template(typename Cont, typename I, typename T)( //
-            requires lvalue_container_like<Cont> AND input_iterator<I> AND //
+        template(typename Cont, typename I, typename T)(
+            /// \pre
+            requires lvalue_container_like<Cont> AND input_iterator<I> AND
             (!range<T> && constructible_from<range_value_t<Cont>, T>)) //
         insert_result_t<Cont &, I, T> insert(Cont && cont, I p, T && t)
         {
             return unwrap_reference(cont).insert(p, static_cast<T &&>(t));
         }
 
-        template(typename Cont, typename I, typename N, typename T)( //
-            requires lvalue_container_like<Cont> AND input_iterator<I> AND //
-                integral<N> AND constructible_from<range_value_t<Cont>, T>) //
+        template(typename Cont, typename I, typename N, typename T)(
+            /// \pre
+            requires lvalue_container_like<Cont> AND input_iterator<I> AND
+                integral<N> AND constructible_from<range_value_t<Cont>, T>)
         insert_result_t<Cont &, I, N, T> insert(Cont && cont, I p, N n, T && t)
         {
             return unwrap_reference(cont).insert(p, n, static_cast<T &&>(t));
@@ -87,9 +92,10 @@ namespace ranges
             using ranges::detail::cpp17_iterator_t;
             using ranges::detail::range_cpp17_iterator_t;
 
-            template(typename Cont, typename P)( //
+            template(typename Cont, typename P)(
+                /// \pre
                 requires container<Cont> AND input_iterator<P> AND
-                        random_access_reservable<Cont>) //
+                        random_access_reservable<Cont>)
             iterator_t<Cont> insert_reserve_helper(
                 Cont & cont, P const p, range_size_t<Cont> const delta)
             {
@@ -110,7 +116,8 @@ namespace ranges
                 return ranges::begin(cont) + index;
             }
 
-            template(typename Cont, typename P, typename I, typename S)( //
+            template(typename Cont, typename P, typename I, typename S)(
+                /// \pre
                 requires sentinel_for<S, I> AND (!range<S>)) //
             auto insert_impl(Cont && cont, P p, I i, S j, std::false_type)
                 -> decltype(unwrap_reference(cont).insert(
@@ -120,7 +127,8 @@ namespace ranges
                 return unwrap_reference(cont).insert(p, C{i}, C{j});
             }
 
-            template(typename Cont, typename P, typename I, typename S)( //
+            template(typename Cont, typename P, typename I, typename S)(
+                /// \pre
                 requires sized_sentinel_for<S, I> AND random_access_reservable<Cont> AND
                     (!range<S>)) //
             auto insert_impl(Cont && cont_, P p, I i, S j, std::true_type)
@@ -135,8 +143,9 @@ namespace ranges
                 return cont.insert(pos, C{std::move(i)}, C{std::move(j)});
             }
 
-            template(typename Cont, typename I, typename Rng)( //
-                requires range<Rng>) //
+            template(typename Cont, typename I, typename Rng)(
+                /// \pre
+                requires range<Rng>)
             auto insert_impl(Cont && cont, I p, Rng && rng, std::false_type)
                 -> decltype(unwrap_reference(cont).insert(
                     p, range_cpp17_iterator_t<Rng>{ranges::begin(rng)},
@@ -147,8 +156,9 @@ namespace ranges
                     p, C{ranges::begin(rng)}, C{ranges::end(rng)});
             }
 
-            template(typename Cont, typename I, typename Rng)( //
-                requires random_access_reservable<Cont> AND sized_range<Rng>) //
+            template(typename Cont, typename I, typename Rng)(
+                /// \pre
+                requires random_access_reservable<Cont> AND sized_range<Rng>)
             auto insert_impl(Cont && cont_, I p, Rng && rng, std::true_type)
                 -> decltype(unwrap_reference(cont_).insert(
                     begin(unwrap_reference(cont_)),
@@ -164,7 +174,8 @@ namespace ranges
         } // namespace detail
         /// \endcond
 
-        template(typename Cont, typename P, typename I, typename S)( //
+        template(typename Cont, typename P, typename I, typename S)(
+            /// \pre
             requires lvalue_container_like<Cont> AND input_iterator<P> AND
                 sentinel_for<S, I> AND
             (!range<S>)) //
@@ -185,8 +196,9 @@ namespace ranges
                                                    sized_sentinel_for<S, I>>{});
         }
 
-        template(typename Cont, typename I, typename Rng)( //
-            requires lvalue_container_like<Cont> AND input_iterator<I> AND range<Rng>) //
+        template(typename Cont, typename I, typename Rng)(
+            /// \pre
+            requires lvalue_container_like<Cont> AND input_iterator<I> AND range<Rng>)
         auto insert(Cont && cont, I p, Rng && rng)
             -> decltype(detail::insert_impl(
                 static_cast<Cont &&>(cont), std::move(p), static_cast<Rng &&>(rng),
@@ -205,16 +217,18 @@ namespace ranges
             using insert_result_t =
                 decltype(insert(std::declval<Rng>(), std::declval<Args>()...));
 
-            template(typename Rng, typename T)( //
-                requires range<Rng> AND //
-                (!range<T>)&&constructible_from<range_value_t<Rng>, T>) //
+            template(typename Rng, typename T)(
+                /// \pre
+                requires range<Rng> AND
+                (!range<T>)&&constructible_from<range_value_t<Rng>, T>)
             insert_result_t<Rng, T> operator()(Rng && rng, T && t) const
             {
                 return insert(static_cast<Rng &&>(rng), static_cast<T &&>(t));
             }
 
-            template(typename Rng, typename Rng2)( //
-                requires range<Rng> AND range<Rng2>) //
+            template(typename Rng, typename Rng2)(
+                /// \pre
+                requires range<Rng> AND range<Rng2>)
             insert_result_t<Rng, Rng2> operator()(Rng && rng, Rng2 && rng2) const
             {
                 static_assert(!is_infinite<Rng>::value,
@@ -222,32 +236,36 @@ namespace ranges
                 return insert(static_cast<Rng &&>(rng), static_cast<Rng2 &&>(rng2));
             }
 
-            template(typename Rng, typename T)( //
-                requires range<Rng>) //
+            template(typename Rng, typename T)(
+                /// \pre
+                requires range<Rng>)
             insert_result_t<Rng, std::initializer_list<T> &> //
             operator()(Rng && rng, std::initializer_list<T> rng2) const
             {
                 return insert(static_cast<Rng &&>(rng), rng2);
             }
 
-            template(typename Rng, typename I, typename S)( //
+            template(typename Rng, typename I, typename S)(
+                /// \pre
                 requires range<Rng> AND sentinel_for<S, I> AND (!range<S>)) //
             insert_result_t<Rng, I, S> operator()(Rng && rng, I i, S j) const
             {
                 return insert(static_cast<Rng &&>(rng), std::move(i), std::move(j));
             }
 
-            template(typename Rng, typename I, typename T)( //
-                requires range<Rng> AND input_iterator<I> AND //
-                (!range<T>)&&constructible_from<range_value_t<Rng>, T>) //
+            template(typename Rng, typename I, typename T)(
+                /// \pre
+                requires range<Rng> AND input_iterator<I> AND
+                (!range<T>)&&constructible_from<range_value_t<Rng>, T>)
             insert_result_t<Rng, I, T> operator()(Rng && rng, I p, T && t) const
             {
                 return insert(
                     static_cast<Rng &&>(rng), std::move(p), static_cast<T &&>(t));
             }
 
-            template(typename Rng, typename I, typename Rng2)( //
-                requires range<Rng> AND input_iterator<I> AND range<Rng2>) //
+            template(typename Rng, typename I, typename Rng2)(
+                /// \pre
+                requires range<Rng> AND input_iterator<I> AND range<Rng2>)
             insert_result_t<Rng, I, Rng2> operator()(Rng && rng, I p, Rng2 && rng2) const
             {
                 static_assert(!is_infinite<Rng>::value,
@@ -256,25 +274,28 @@ namespace ranges
                     static_cast<Rng &&>(rng), std::move(p), static_cast<Rng2 &&>(rng2));
             }
 
-            template(typename Rng, typename I, typename T)( //
-                requires range<Rng> AND input_iterator<I>) //
+            template(typename Rng, typename I, typename T)(
+                /// \pre
+                requires range<Rng> AND input_iterator<I>)
             insert_result_t<Rng, I, std::initializer_list<T> &> //
             operator()(Rng && rng, I p, std::initializer_list<T> rng2) const
             {
                 return insert(static_cast<Rng &&>(rng), std::move(p), rng2);
             }
 
-            template(typename Rng, typename I, typename N, typename T)( //
-                requires range<Rng> AND input_iterator<I> AND integral<N> AND //
-                (!range<T>)&&constructible_from<range_value_t<Rng>, T>) //
+            template(typename Rng, typename I, typename N, typename T)(
+                /// \pre
+                requires range<Rng> AND input_iterator<I> AND integral<N> AND
+                (!range<T>)&&constructible_from<range_value_t<Rng>, T>)
             insert_result_t<Rng, I, N, T> operator()(Rng && rng, I p, N n, T && t) const
             {
                 return insert(
                     static_cast<Rng &&>(rng), std::move(p), n, static_cast<T &&>(t));
             }
 
-            template(typename Rng, typename P, typename I, typename S)( //
-                requires range<Rng> AND input_iterator<P> AND sentinel_for<S, I> AND //
+            template(typename Rng, typename P, typename I, typename S)(
+                /// \pre
+                requires range<Rng> AND input_iterator<P> AND sentinel_for<S, I> AND
                 (!range<S>)) //
             insert_result_t<Rng, P, I, S> operator()(Rng && rng, P p, I i, S j) const
             {

--- a/include/range/v3/action/insert.hpp
+++ b/include/range/v3/action/insert.hpp
@@ -220,7 +220,7 @@ namespace ranges
             template(typename Rng, typename T)(
                 /// \pre
                 requires range<Rng> AND
-                (!range<T>)&&constructible_from<range_value_t<Rng>, T>)
+                    (!range<T>) AND constructible_from<range_value_t<Rng>, T>)
             insert_result_t<Rng, T> operator()(Rng && rng, T && t) const
             {
                 return insert(static_cast<Rng &&>(rng), static_cast<T &&>(t));
@@ -256,7 +256,7 @@ namespace ranges
             template(typename Rng, typename I, typename T)(
                 /// \pre
                 requires range<Rng> AND input_iterator<I> AND
-                (!range<T>)&&constructible_from<range_value_t<Rng>, T>)
+                    (!range<T>) AND constructible_from<range_value_t<Rng>, T>)
             insert_result_t<Rng, I, T> operator()(Rng && rng, I p, T && t) const
             {
                 return insert(
@@ -286,7 +286,7 @@ namespace ranges
             template(typename Rng, typename I, typename N, typename T)(
                 /// \pre
                 requires range<Rng> AND input_iterator<I> AND integral<N> AND
-                (!range<T>)&&constructible_from<range_value_t<Rng>, T>)
+                    (!range<T>) AND constructible_from<range_value_t<Rng>, T>)
             insert_result_t<Rng, I, N, T> operator()(Rng && rng, I p, N n, T && t) const
             {
                 return insert(

--- a/include/range/v3/action/join.hpp
+++ b/include/range/v3/action/join.hpp
@@ -43,9 +43,10 @@ namespace ranges
 
         struct join_fn
         {
-            template(typename Rng)( //
+            template(typename Rng)(
+                /// \pre
                 requires input_range<Rng> AND input_range<range_value_t<Rng>> AND
-                    semiregular<join_action_value_t_<Rng>>) //
+                    semiregular<join_action_value_t_<Rng>>)
             join_action_value_t_<Rng> operator()(Rng && rng) const
             {
                 join_action_value_t_<Rng> ret;

--- a/include/range/v3/action/push_back.hpp
+++ b/include/range/v3/action/push_back.hpp
@@ -36,6 +36,7 @@ namespace ranges
     /// \cond
     namespace adl_push_back_detail
     {
+        /// \endcond
         template<typename Cont, typename T>
         using push_back_t = decltype(static_cast<void>(
             unwrap_reference(std::declval<Cont &>()).push_back(std::declval<T>())));
@@ -48,7 +49,7 @@ namespace ranges
         template(typename Cont, typename T)(
             /// \pre
             requires lvalue_container_like<Cont> AND
-            (!range<T>)&&constructible_from<range_value_t<Cont>, T>)
+                (!range<T>) AND constructible_from<range_value_t<Cont>, T>)
         push_back_t<Cont, T> push_back(Cont && cont, T && t)
         {
             unwrap_reference(cont).push_back(static_cast<T &&>(t));
@@ -130,6 +131,7 @@ namespace ranges
             }
             /// \endcond
         };
+        /// \cond
     } // namespace adl_push_back_detail
     /// \endcond
 

--- a/include/range/v3/action/push_back.hpp
+++ b/include/range/v3/action/push_back.hpp
@@ -45,16 +45,18 @@ namespace ranges
             ranges::insert(std::declval<Cont &>(), std::declval<sentinel_t<Cont>>(),
                            std::declval<Rng>())));
 
-        template(typename Cont, typename T)( //
+        template(typename Cont, typename T)(
+            /// \pre
             requires lvalue_container_like<Cont> AND
-            (!range<T>)&&constructible_from<range_value_t<Cont>, T>) //
+            (!range<T>)&&constructible_from<range_value_t<Cont>, T>)
         push_back_t<Cont, T> push_back(Cont && cont, T && t)
         {
             unwrap_reference(cont).push_back(static_cast<T &&>(t));
         }
 
-        template(typename Cont, typename Rng)( //
-            requires lvalue_container_like<Cont> AND range<Rng>) //
+        template(typename Cont, typename Rng)(
+            /// \pre
+            requires lvalue_container_like<Cont> AND range<Rng>)
         insert_t<Cont, Rng> push_back(Cont && cont, Rng && rng)
         {
             ranges::insert(cont, end(cont), static_cast<Rng &&>(rng));
@@ -83,7 +85,8 @@ namespace ranges
                     bind_back(push_back_fn{}, static_cast<T &&>(val)));
             }
 
-            template(typename T)( //
+            template(typename T)(
+                /// \pre
                 requires range<T &>)
             constexpr auto operator()(T & t) const
             {
@@ -97,8 +100,9 @@ namespace ranges
                 return make_action_closure(bind_back(push_back_fn{}, val));
             }
 
-            template(typename Rng, typename T)( //
-                requires input_range<Rng> AND can_push_back_<Rng, T> AND //
+            template(typename Rng, typename T)(
+                /// \pre
+                requires input_range<Rng> AND can_push_back_<Rng, T> AND
                 (range<T> || constructible_from<range_value_t<Rng>, T>)) //
             Rng operator()(Rng && rng, T && t) const //
             {
@@ -106,10 +110,11 @@ namespace ranges
                 return static_cast<Rng &&>(rng);
             }
 
-            template(typename Rng, typename T)( //
-                requires input_range<Rng> AND                          //
-                        can_push_back_<Rng, std::initializer_list<T>> AND  //
-                            constructible_from<range_value_t<Rng>, T const &>) //
+            template(typename Rng, typename T)(
+                /// \pre
+                requires input_range<Rng> AND
+                        can_push_back_<Rng, std::initializer_list<T>> AND
+                            constructible_from<range_value_t<Rng>, T const &>)
             Rng operator()(Rng && rng, std::initializer_list<T> t) const //
             {
                 push_back(rng, t);

--- a/include/range/v3/action/push_front.hpp
+++ b/include/range/v3/action/push_front.hpp
@@ -36,6 +36,7 @@ namespace ranges
     /// \cond
     namespace adl_push_front_detail
     {
+        /// \endcond
         template<typename Cont, typename T>
         using push_front_t = decltype(static_cast<void>(
             unwrap_reference(std::declval<Cont &>()).push_front(std::declval<T>())));
@@ -48,7 +49,7 @@ namespace ranges
         template(typename Cont, typename T)(
             /// \pre
             requires lvalue_container_like<Cont> AND
-            (!range<T>)&&constructible_from<range_value_t<Cont>, T>)
+                (!range<T>) AND constructible_from<range_value_t<Cont>, T>)
         push_front_t<Cont, T> push_front(Cont && cont, T && t)
         {
             unwrap_reference(cont).push_front(static_cast<T &&>(t));
@@ -62,6 +63,7 @@ namespace ranges
             ranges::insert(cont, begin(cont), static_cast<Rng &&>(rng));
         }
 
+        /// \cond
         // clang-format off
         template<typename Rng, typename T>
         CPP_requires(can_push_front_frag_,
@@ -73,6 +75,7 @@ namespace ranges
         CPP_concept can_push_front_ =
             CPP_requires_ref(adl_push_front_detail::can_push_front_frag_, Rng, T);
         // clang-format on
+        /// \endcond
 
         struct push_front_fn
         {
@@ -101,7 +104,7 @@ namespace ranges
             template(typename Rng, typename T)(
                 /// \pre
                 requires input_range<Rng> AND can_push_front_<Rng, T> AND
-                (range<T> || constructible_from<range_value_t<Rng>, T>)) //
+                    (range<T> || constructible_from<range_value_t<Rng>, T>)) //
             Rng operator()(Rng && rng, T && t) const //
             {
                 push_front(rng, static_cast<T &&>(t));
@@ -111,8 +114,8 @@ namespace ranges
             template(typename Rng, typename T)(
                 /// \pre
                 requires input_range<Rng> AND
-                        can_push_front_<Rng, std::initializer_list<T>> AND
-                            constructible_from<range_value_t<Rng>, T const &>)
+                    can_push_front_<Rng, std::initializer_list<T>> AND
+                    constructible_from<range_value_t<Rng>, T const &>)
             Rng operator()(Rng && rng, std::initializer_list<T> t) const //
             {
                 push_front(rng, t);
@@ -128,6 +131,7 @@ namespace ranges
             }
             /// \endcond
         };
+    /// \cond
     } // namespace adl_push_front_detail
     /// \endcond
 

--- a/include/range/v3/action/push_front.hpp
+++ b/include/range/v3/action/push_front.hpp
@@ -45,16 +45,18 @@ namespace ranges
             ranges::insert(std::declval<Cont &>(), std::declval<iterator_t<Cont>>(),
                            std::declval<Rng>())));
 
-        template(typename Cont, typename T)( //
+        template(typename Cont, typename T)(
+            /// \pre
             requires lvalue_container_like<Cont> AND
-            (!range<T>)&&constructible_from<range_value_t<Cont>, T>) //
+            (!range<T>)&&constructible_from<range_value_t<Cont>, T>)
         push_front_t<Cont, T> push_front(Cont && cont, T && t)
         {
             unwrap_reference(cont).push_front(static_cast<T &&>(t));
         }
 
-        template(typename Cont, typename Rng)( //
-            requires lvalue_container_like<Cont> AND range<Rng>) //
+        template(typename Cont, typename Rng)(
+            /// \pre
+            requires lvalue_container_like<Cont> AND range<Rng>)
         insert_t<Cont, Rng> push_front(Cont && cont, Rng && rng)
         {
             ranges::insert(cont, begin(cont), static_cast<Rng &&>(rng));
@@ -87,7 +89,8 @@ namespace ranges
                 return make_action_closure(bind_back(push_front_fn{}, val));
             }
 
-            template(typename T)( //
+            template(typename T)(
+                /// \pre
                 requires range<T &>)
             constexpr auto operator()(T & t) const
             {
@@ -95,8 +98,9 @@ namespace ranges
                     bind_back(push_front_fn{}, detail::reference_wrapper_<T>(t)));
             }
 
-            template(typename Rng, typename T)( //
-                requires input_range<Rng> AND can_push_front_<Rng, T> AND //
+            template(typename Rng, typename T)(
+                /// \pre
+                requires input_range<Rng> AND can_push_front_<Rng, T> AND
                 (range<T> || constructible_from<range_value_t<Rng>, T>)) //
             Rng operator()(Rng && rng, T && t) const //
             {
@@ -104,10 +108,11 @@ namespace ranges
                 return static_cast<Rng &&>(rng);
             }
 
-            template(typename Rng, typename T)( //
-                requires input_range<Rng> AND                          //
+            template(typename Rng, typename T)(
+                /// \pre
+                requires input_range<Rng> AND
                         can_push_front_<Rng, std::initializer_list<T>> AND
-                            constructible_from<range_value_t<Rng>, T const &>) //
+                            constructible_from<range_value_t<Rng>, T const &>)
             Rng operator()(Rng && rng, std::initializer_list<T> t) const //
             {
                 push_front(rng, t);

--- a/include/range/v3/action/remove.hpp
+++ b/include/range/v3/action/remove.hpp
@@ -35,7 +35,8 @@ namespace ranges
     {
         struct remove_fn
         {
-            template(typename V, typename P)( //
+            template(typename V, typename P)(
+                /// \pre
                 requires (!range<V>))
             constexpr auto operator()(V && value, P proj) const
             {
@@ -50,11 +51,12 @@ namespace ranges
                     bind_back(remove_fn{}, static_cast<V &&>(value), identity{}));
             }
 
-            template(typename Rng, typename V, typename P = identity)( //
+            template(typename Rng, typename V, typename P = identity)(
+                /// \pre
                 requires forward_range<Rng> AND permutable<iterator_t<Rng>> AND
                         erasable_range<Rng, iterator_t<Rng>, sentinel_t<Rng>> AND
                             indirect_relation<equal_to, projected<iterator_t<Rng>, P>,
-                                              V const *>) //
+                                              V const *>)
             Rng operator()(Rng && rng, V const & value, P proj = {}) const
             {
                 auto it = ranges::remove(rng, value, std::move(proj));

--- a/include/range/v3/action/remove_if.hpp
+++ b/include/range/v3/action/remove_if.hpp
@@ -38,7 +38,8 @@ namespace ranges
     {
         struct remove_if_fn
         {
-            template(typename C, typename P = identity)( //
+            template(typename C, typename P = identity)(
+                /// \pre
                 requires (!range<C>))
             constexpr auto operator()(C pred, P proj = P{}) const
             {
@@ -46,11 +47,12 @@ namespace ranges
                     bind_back(remove_if_fn{}, std::move(pred), std::move(proj)));
             }
 
-            template(typename Rng, typename C, typename P = identity)( //
+            template(typename Rng, typename C, typename P = identity)(
+                /// \pre
                 requires forward_range<Rng> AND
                     erasable_range<Rng &, iterator_t<Rng>, iterator_t<Rng>> AND
                         permutable<iterator_t<Rng>> AND
-                            indirect_unary_predicate<C, projected<iterator_t<Rng>, P>>) //
+                            indirect_unary_predicate<C, projected<iterator_t<Rng>, P>>)
             Rng operator()(Rng && rng, C pred, P proj = P{}) const
             {
                 auto it = ranges::remove_if(rng, std::move(pred), std::move(proj));

--- a/include/range/v3/action/reverse.hpp
+++ b/include/range/v3/action/reverse.hpp
@@ -34,8 +34,9 @@ namespace ranges
         /// Reversed the source range in-place.
         struct reverse_fn
         {
-            template(typename Rng)( //
-                requires bidirectional_range<Rng> AND permutable<iterator_t<Rng>>) //
+            template(typename Rng)(
+                /// \pre
+                requires bidirectional_range<Rng> AND permutable<iterator_t<Rng>>)
             Rng operator()(Rng && rng) const
             {
                 ranges::reverse(rng);

--- a/include/range/v3/action/shuffle.hpp
+++ b/include/range/v3/action/shuffle.hpp
@@ -35,7 +35,8 @@ namespace ranges
     {
         struct shuffle_fn
         {
-            template(typename Gen)( //
+            template(typename Gen)(
+                /// \pre
                 requires uniform_random_bit_generator<Gen>)
             constexpr auto operator()(Gen & gen) const
             {
@@ -43,7 +44,8 @@ namespace ranges
                     bind_back(shuffle_fn{}, detail::reference_wrapper_<Gen>(gen)));
             }
 
-            template(typename Gen)( //
+            template(typename Gen)(
+                /// \pre
                 requires uniform_random_bit_generator<Gen>)
             constexpr auto operator()(Gen && gen) const
             {
@@ -51,7 +53,8 @@ namespace ranges
                     bind_back(shuffle_fn{}, static_cast<Gen &&>(gen)));
             }
 
-            template(typename Rng, typename Gen)( //
+            template(typename Rng, typename Gen)(
+                /// \pre
                 requires random_access_range<Rng> AND permutable<iterator_t<Rng>> AND
                     uniform_random_bit_generator<std::remove_reference_t<Gen>> AND
                     convertible_to<invoke_result_t<Gen &>, range_difference_t<Rng>>)

--- a/include/range/v3/action/slice.hpp
+++ b/include/range/v3/action/slice.hpp
@@ -43,40 +43,46 @@ namespace ranges
 
         public:
             // Overloads for the pipe syntax: rng | actions::slice(from, to)
-            template(typename D)( //
+            template(typename D)(
+                /// \pre
                 requires integral<D>)
             constexpr auto operator()(D from, D to) const
             {
                 return make_action_closure(bind_back(slice_fn{}, from, to));
             }
-            template(typename D)( //
+            template(typename D)(
+                /// \pre
                 requires integral<D>)
             constexpr auto operator()(D from, detail::from_end_<D> to) const
             {
                 return make_action_closure(bind_back(slice_fn{}, from, to));
             }
-            template(typename D)( //
+            template(typename D)(
+                /// \pre
                 requires integral<D>)
             constexpr auto operator()(detail::from_end_<D> from, detail::from_end_<D> to)
                 const
             {
                 return make_action_closure(bind_back(slice_fn{}, from, to));
             }
-            template(typename D)( //
+            template(typename D)(
+                /// \pre
                 requires integral<D>)
             constexpr auto operator()(D from, end_fn const & to) const
             {
                 return make_action_closure(bind_back(slice_fn{}, from, to));
             }
-            template(typename D)( //
+            template(typename D)(
+                /// \pre
                 requires integral<D>)
             constexpr auto operator()(detail::from_end_<D> from, end_fn const & to) const
             {
                 return make_action_closure(bind_back(slice_fn{}, from, to));
             }
 
-            template(typename Rng, typename I = iterator_t<Rng>)( //
-                requires forward_range<Rng> AND erasable_range<Rng &, I, I>) //
+            template(typename Rng, typename I = iterator_t<Rng>)(
+                /// \pre
+                requires forward_range<Rng> AND erasable_range<Rng &, I, I>)
             Rng operator()(Rng && rng, diff_t<Rng> from, diff_t<Rng> to) const
             {
                 RANGES_EXPECT(0 <= from && 0 <= to && from <= to);
@@ -86,8 +92,9 @@ namespace ranges
                 return static_cast<Rng &&>(rng);
             }
 
-            template(typename Rng, typename I = iterator_t<Rng>)( //
-                requires bidirectional_range<Rng> AND erasable_range<Rng &, I, I>) //
+            template(typename Rng, typename I = iterator_t<Rng>)(
+                /// \pre
+                requires bidirectional_range<Rng> AND erasable_range<Rng &, I, I>)
             Rng operator()(Rng && rng,
                            diff_t<Rng> from,
                            detail::from_end_<diff_t<Rng>> to) const
@@ -103,8 +110,9 @@ namespace ranges
                 return static_cast<Rng &&>(rng);
             }
 
-            template(typename Rng, typename I = iterator_t<Rng>)( //
-                requires bidirectional_range<Rng> AND erasable_range<Rng &, I, I>) //
+            template(typename Rng, typename I = iterator_t<Rng>)(
+                /// \pre
+                requires bidirectional_range<Rng> AND erasable_range<Rng &, I, I>)
             Rng operator()(Rng && rng,
                            detail::from_end_<diff_t<Rng>> from,
                            detail::from_end_<diff_t<Rng>> to) const
@@ -119,8 +127,9 @@ namespace ranges
                 return static_cast<Rng &&>(rng);
             }
 
-            template(typename Rng, typename I = iterator_t<Rng>)( //
-                requires forward_range<Rng> AND erasable_range<Rng &, I, I>) //
+            template(typename Rng, typename I = iterator_t<Rng>)(
+                /// \pre
+                requires forward_range<Rng> AND erasable_range<Rng &, I, I>)
             Rng operator()(Rng && rng, diff_t<Rng> from, end_fn const &) const
             {
                 RANGES_EXPECT(0 <= from);
@@ -129,8 +138,9 @@ namespace ranges
                 return static_cast<Rng &&>(rng);
             }
 
-            template(typename Rng, typename I = iterator_t<Rng>)( //
-                requires bidirectional_range<Rng> AND erasable_range<Rng &, I, I>) //
+            template(typename Rng, typename I = iterator_t<Rng>)(
+                /// \pre
+                requires bidirectional_range<Rng> AND erasable_range<Rng &, I, I>)
             Rng operator()(Rng && rng,
                            detail::from_end_<diff_t<Rng>> from,
                            end_fn const &) const

--- a/include/range/v3/action/sort.hpp
+++ b/include/range/v3/action/sort.hpp
@@ -35,7 +35,8 @@ namespace ranges
     {
         struct sort_fn
         {
-            template(typename C, typename P = identity)( //
+            template(typename C, typename P = identity)(
+                /// \pre
                 requires (!range<C>))
             constexpr auto operator()(C pred, P proj = {}) const
             {
@@ -43,8 +44,9 @@ namespace ranges
                     bind_back(sort_fn{}, std::move(pred), std::move(proj)));
             }
 
-            template(typename Rng, typename C = less, typename P = identity)( //
-                requires forward_range<Rng> AND sortable<iterator_t<Rng>, C, P>) //
+            template(typename Rng, typename C = less, typename P = identity)(
+                /// \pre
+                requires forward_range<Rng> AND sortable<iterator_t<Rng>, C, P>)
             Rng operator()(Rng && rng, C pred = {}, P proj = {}) const
             {
                 ranges::sort(rng, std::move(pred), std::move(proj));

--- a/include/range/v3/action/split.hpp
+++ b/include/range/v3/action/split.hpp
@@ -44,7 +44,8 @@ namespace ranges
                 meta::if_c<(bool)ranges::container<Rng>, //
                            uncvref_t<Rng>, std::vector<range_value_t<Rng>>>;
 
-            template(typename T)( //
+            template(typename T)(
+                /// \pre
                 requires range<T &>)
             constexpr auto operator()(T & t) const
             {
@@ -60,9 +61,10 @@ namespace ranges
 
             // BUGBUG something is not right with the actions. It should be possible
             // to move a container into a split and have elements moved into the result.
-            template(typename Rng)( //
+            template(typename Rng)(
+                /// \pre
                 requires input_range<Rng> AND indirectly_comparable<
-                        iterator_t<Rng>, range_value_t<Rng> const *, ranges::equal_to>) //
+                        iterator_t<Rng>, range_value_t<Rng> const *, ranges::equal_to>)
             std::vector<split_value_t<Rng>> //
             operator()(Rng && rng, range_value_t<Rng> val) const
             {
@@ -70,9 +72,10 @@ namespace ranges
                        to<std::vector<split_value_t<Rng>>>();
             }
 
-            template(typename Rng, typename Pattern)( //
+            template(typename Rng, typename Pattern)(
+                /// \pre
                 requires input_range<Rng> AND viewable_range<Pattern> AND
-                    forward_range<Pattern> AND //
+                    forward_range<Pattern> AND
                     indirectly_comparable<
                         iterator_t<Rng>,
                         iterator_t<Pattern>,

--- a/include/range/v3/action/split_when.hpp
+++ b/include/range/v3/action/split_when.hpp
@@ -54,24 +54,26 @@ namespace ranges
 
             // BUGBUG something is not right with the actions. It should be possible
             // to move a container into a split and have elements moved into the result.
-            template(typename Rng, typename Fun)( //
-                requires forward_range<Rng> AND                            //
-                        invocable<Fun &, iterator_t<Rng>, sentinel_t<Rng>> AND //
+            template(typename Rng, typename Fun)(
+                /// \pre
+                requires forward_range<Rng> AND
+                        invocable<Fun &, iterator_t<Rng>, sentinel_t<Rng>> AND
                             invocable<Fun &, iterator_t<Rng>, iterator_t<Rng>> AND
                                 copy_constructible<Fun> AND
                                     convertible_to<invoke_result_t<Fun &, iterator_t<Rng>,
                                                                    sentinel_t<Rng>>,
-                                                   std::pair<bool, iterator_t<Rng>>>) //
+                                                   std::pair<bool, iterator_t<Rng>>>)
             std::vector<split_value_t<Rng>> operator()(Rng && rng, Fun fun) const
             {
                 return views::split_when(rng, std::move(fun)) |
                        to<std::vector<split_value_t<Rng>>>();
             }
 
-            template(typename Rng, typename Fun)( //
-                requires forward_range<Rng> AND                        //
-                        predicate<Fun const &, range_reference_t<Rng>> AND //
-                            copy_constructible<Fun>) //
+            template(typename Rng, typename Fun)(
+                /// \pre
+                requires forward_range<Rng> AND
+                        predicate<Fun const &, range_reference_t<Rng>> AND
+                            copy_constructible<Fun>)
             std::vector<split_value_t<Rng>> operator()(Rng && rng, Fun fun) const
             {
                 return views::split_when(rng, std::move(fun)) |

--- a/include/range/v3/action/stable_sort.hpp
+++ b/include/range/v3/action/stable_sort.hpp
@@ -35,7 +35,8 @@ namespace ranges
     {
         struct stable_sort_fn
         {
-            template(typename C, typename P = identity)( //
+            template(typename C, typename P = identity)(
+                /// \pre
                 requires (!range<C>))
             constexpr auto operator()(C pred, P proj = P{}) const
             {
@@ -43,8 +44,9 @@ namespace ranges
                     bind_back(stable_sort_fn{}, std::move(pred), std::move(proj)));
             }
 
-            template(typename Rng, typename C = less, typename P = identity)( //
-                requires forward_range<Rng> AND sortable<iterator_t<Rng>, C, P>) //
+            template(typename Rng, typename C = less, typename P = identity)(
+                /// \pre
+                requires forward_range<Rng> AND sortable<iterator_t<Rng>, C, P>)
             Rng operator()(Rng && rng, C pred = C{}, P proj = P{}) const
             {
                 ranges::stable_sort(rng, std::move(pred), std::move(proj));

--- a/include/range/v3/action/stride.hpp
+++ b/include/range/v3/action/stride.hpp
@@ -34,17 +34,19 @@ namespace ranges
     {
         struct stride_fn
         {
-            template(typename D)( //
+            template(typename D)(
+                /// \pre
                 requires detail::integer_like_<D>)
             constexpr auto operator()(D step) const
             {
                 return make_action_closure(bind_back(stride_fn{}, step));
             }
 
-            template(typename Rng, typename D = range_difference_t<Rng>)( //
-                requires forward_range<Rng> AND //
-                    erasable_range<Rng &, iterator_t<Rng>, sentinel_t<Rng>> AND //
-                    permutable<iterator_t<Rng>>) //
+            template(typename Rng, typename D = range_difference_t<Rng>)(
+                /// \pre
+                requires forward_range<Rng> AND
+                    erasable_range<Rng &, iterator_t<Rng>, sentinel_t<Rng>> AND
+                    permutable<iterator_t<Rng>>)
             Rng operator()(Rng && rng, range_difference_t<Rng> const step) const
             {
                 using I = iterator_t<Rng>;

--- a/include/range/v3/action/take.hpp
+++ b/include/range/v3/action/take.hpp
@@ -34,16 +34,18 @@ namespace ranges
     {
         struct take_fn
         {
-            template(typename Int)( //
+            template(typename Int)(
+                /// \pre
                 requires detail::integer_like_<Int>)
             constexpr auto operator()(Int n) const
             {
                 return make_action_closure(bind_back(take_fn{}, n));
             }
 
-            template(typename Rng)( //
-                requires forward_range<Rng> AND //
-                    erasable_range<Rng &, iterator_t<Rng>, sentinel_t<Rng>>) //
+            template(typename Rng)(
+                /// \pre
+                requires forward_range<Rng> AND
+                    erasable_range<Rng &, iterator_t<Rng>, sentinel_t<Rng>>)
             Rng operator()(Rng && rng, range_difference_t<Rng> n) const
             {
                 RANGES_EXPECT(n >= 0);

--- a/include/range/v3/action/take_while.hpp
+++ b/include/range/v3/action/take_while.hpp
@@ -34,17 +34,19 @@ namespace ranges
     {
         struct take_while_fn
         {
-            template(typename Fun)( //
+            template(typename Fun)(
+                /// \pre
                 requires (!range<Fun>))
             constexpr auto operator()(Fun fun) const
             {
                 return make_action_closure(bind_back(take_while_fn{}, std::move(fun)));
             }
 
-            template(typename Rng, typename Fun)( //
+            template(typename Rng, typename Fun)(
+                /// \pre
                 requires forward_range<Rng> AND
                     erasable_range<Rng &, iterator_t<Rng>, sentinel_t<Rng>> AND
-                    indirect_unary_predicate<Fun, iterator_t<Rng>>) //
+                    indirect_unary_predicate<Fun, iterator_t<Rng>>)
             Rng operator()(Rng && rng, Fun fun) const
             {
                 ranges::actions::erase(

--- a/include/range/v3/action/transform.hpp
+++ b/include/range/v3/action/transform.hpp
@@ -34,7 +34,8 @@ namespace ranges
     {
         struct transform_fn
         {
-            template(typename F, typename P = identity)( //
+            template(typename F, typename P = identity)(
+                /// \pre
                 requires (!range<F>))
             constexpr auto operator()(F fun, P proj = P{}) const
             {
@@ -42,11 +43,12 @@ namespace ranges
                     bind_back(transform_fn{}, std::move(fun), std::move(proj)));
             }
 
-            template(typename Rng, typename F, typename P = identity)( //
+            template(typename Rng, typename F, typename P = identity)(
+                /// \pre
                 requires input_range<Rng> AND copy_constructible<F> AND
                     indirectly_writable<
                         iterator_t<Rng>,
-                        indirect_result_t<F &, projected<iterator_t<Rng>, P>>>) //
+                        indirect_result_t<F &, projected<iterator_t<Rng>, P>>>)
             Rng operator()(Rng && rng, F fun, P proj = P{}) const
             {
                 ranges::transform(rng, begin(rng), std::move(fun), std::move(proj));

--- a/include/range/v3/action/unique.hpp
+++ b/include/range/v3/action/unique.hpp
@@ -36,7 +36,8 @@ namespace ranges
     {
         struct unique_fn
         {
-            template(typename C, typename P = identity)( //
+            template(typename C, typename P = identity)(
+                /// \pre
                 requires (!range<C>))
             constexpr auto operator()(C pred, P proj = P{}) const
             {
@@ -44,10 +45,11 @@ namespace ranges
                     bind_back(unique_fn{}, std::move(pred), std::move(proj)));
             }
 
-            template(typename Rng, typename C = equal_to, typename P = identity)( //
-                requires forward_range<Rng> AND //
-                    erasable_range<Rng &, iterator_t<Rng>, sentinel_t<Rng>> AND //
-                    sortable<iterator_t<Rng>, C, P>) //
+            template(typename Rng, typename C = equal_to, typename P = identity)(
+                /// \pre
+                requires forward_range<Rng> AND
+                    erasable_range<Rng &, iterator_t<Rng>, sentinel_t<Rng>> AND
+                    sortable<iterator_t<Rng>, C, P>)
             Rng operator()(Rng && rng, C pred = C{}, P proj = P{}) const
             {
                 auto it = ranges::unique(rng, std::move(pred), std::move(proj));

--- a/include/range/v3/action/unstable_remove_if.hpp
+++ b/include/range/v3/action/unstable_remove_if.hpp
@@ -38,7 +38,8 @@ namespace ranges
     {
         struct unstable_remove_if_fn
         {
-            template(typename C, typename P = identity)( //
+            template(typename C, typename P = identity)(
+                /// \pre
                 requires (!range<C>))
             constexpr auto operator()(C pred, P proj = P{}) const
             {
@@ -46,11 +47,12 @@ namespace ranges
                     bind_back(unstable_remove_if_fn{}, std::move(pred), std::move(proj)));
             }
 
-            template(typename Rng, typename C, typename P = identity)( //
+            template(typename Rng, typename C, typename P = identity)(
+                /// \pre
                 requires bidirectional_range<Rng> AND common_range<Rng> AND
                     permutable<iterator_t<Rng>> AND
                     indirect_unary_predicate<C, projected<iterator_t<Rng>, P>> AND
-                    erasable_range<Rng, iterator_t<Rng>, iterator_t<Rng>>) //
+                    erasable_range<Rng, iterator_t<Rng>, iterator_t<Rng>>)
             Rng operator()(Rng && rng, C pred, P proj = P{}) const
             {
                 auto it = ranges::unstable_remove_if(ranges::begin(rng),

--- a/include/range/v3/algorithm/adjacent_find.hpp
+++ b/include/range/v3/algorithm/adjacent_find.hpp
@@ -38,9 +38,10 @@ namespace ranges
         ///
         /// \pre `Rng` is a model of the `range` concept
         /// \pre `C` is a model of the `BinaryPredicate` concept
-        template(typename I, typename S, typename C = equal_to, typename P = identity)( //
-            requires forward_iterator<I> AND sentinel_for<S, I> AND //
-            indirect_relation<C, projected<I, P>>) //
+        template(typename I, typename S, typename C = equal_to, typename P = identity)(
+            /// \pre
+            requires forward_iterator<I> AND sentinel_for<S, I> AND
+            indirect_relation<C, projected<I, P>>)
         I RANGES_FUNC(adjacent_find)(I first, S last, C pred = C{}, P proj = P{})
         {
             if(first == last)
@@ -53,9 +54,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C = equal_to, typename P = identity)( //
-            requires forward_range<Rng> AND //
-            indirect_relation<C, projected<iterator_t<Rng>, P>>) //
+        template(typename Rng, typename C = equal_to, typename P = identity)(
+            /// \pre
+            requires forward_range<Rng> AND
+            indirect_relation<C, projected<iterator_t<Rng>, P>>)
         borrowed_iterator_t<Rng> //
         RANGES_FUNC(adjacent_find)(Rng && rng, C pred = C{}, P proj = P{}) //
         {

--- a/include/range/v3/algorithm/adjacent_remove_if.hpp
+++ b/include/range/v3/algorithm/adjacent_remove_if.hpp
@@ -44,9 +44,10 @@ namespace ranges
         ///
         /// \pre `Rng` is a model of the `forward_range` concept.
         /// \pre `Pred` is a model of the `BinaryPredicate` concept.
-        template(typename I, typename S, typename Pred, typename Proj = identity)( //
+        template(typename I, typename S, typename Pred, typename Proj = identity)(
+            /// \pre
             requires permutable<I> AND sentinel_for<S, I> AND
-                indirect_relation<Pred, projected<I, Proj>>) //
+                indirect_relation<Pred, projected<I, Proj>>)
         I RANGES_FUNC(adjacent_remove_if)(I first, S last, Pred pred = {}, Proj proj = {})
         {
             first = adjacent_find(std::move(first), last, std::ref(pred), std::ref(proj));
@@ -69,10 +70,11 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename Pred, typename Proj = identity)( //
-            requires forward_range<Rng> AND //
-            indirect_relation<Pred, projected<iterator_t<Rng>, Proj>> AND //
-            permutable<iterator_t<Rng>>) //
+        template(typename Rng, typename Pred, typename Proj = identity)(
+            /// \pre
+            requires forward_range<Rng> AND
+            indirect_relation<Pred, projected<iterator_t<Rng>, Proj>> AND
+            permutable<iterator_t<Rng>>)
         borrowed_iterator_t<Rng>
         RANGES_FUNC(adjacent_remove_if)(Rng && rng, Pred pred, Proj proj = {}) //
         {

--- a/include/range/v3/algorithm/all_of.hpp
+++ b/include/range/v3/algorithm/all_of.hpp
@@ -35,9 +35,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(all_of)
 
         /// \brief function template \c all_of
-        template(typename I, typename S, typename F, typename P = identity)( //
-            requires input_iterator<I> AND sentinel_for<S, I> AND //
-            indirect_unary_predicate<F, projected<I, P>>) //
+        template(typename I, typename S, typename F, typename P = identity)(
+            /// \pre
+            requires input_iterator<I> AND sentinel_for<S, I> AND
+            indirect_unary_predicate<F, projected<I, P>>)
         bool RANGES_FUNC(all_of)(I first, S last, F pred, P proj = P{}) //
         {
             for(; first != last; ++first)
@@ -47,9 +48,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename F, typename P = identity)( //
-            requires input_range<Rng> AND //
-            indirect_unary_predicate<F, projected<iterator_t<Rng>, P>>) //
+        template(typename Rng, typename F, typename P = identity)(
+            /// \pre
+            requires input_range<Rng> AND
+            indirect_unary_predicate<F, projected<iterator_t<Rng>, P>>)
         bool RANGES_FUNC(all_of)(Rng && rng, F pred, P proj = P{}) //
         {
             return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));

--- a/include/range/v3/algorithm/any_of.hpp
+++ b/include/range/v3/algorithm/any_of.hpp
@@ -36,9 +36,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(any_of)
 
         /// \brief function template \c any_of
-        template(typename I, typename S, typename F, typename P = identity)( //
-            requires input_iterator<I> AND sentinel_for<S, I> AND //
-            indirect_unary_predicate<F, projected<I, P>>) //
+        template(typename I, typename S, typename F, typename P = identity)(
+            /// \pre
+            requires input_iterator<I> AND sentinel_for<S, I> AND
+            indirect_unary_predicate<F, projected<I, P>>)
         bool RANGES_FUNC(any_of)(I first, S last, F pred, P proj = P{}) //
         {
             for(; first != last; ++first)
@@ -48,9 +49,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename F, typename P = identity)( //
-            requires input_range<Rng> AND //
-            indirect_unary_predicate<F, projected<iterator_t<Rng>, P>>) //
+        template(typename Rng, typename F, typename P = identity)(
+            /// \pre
+            requires input_range<Rng> AND
+            indirect_unary_predicate<F, projected<iterator_t<Rng>, P>>)
         bool RANGES_FUNC(any_of)(Rng && rng, F pred, P proj = P{}) //
         {
             return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));

--- a/include/range/v3/algorithm/aux_/equal_range_n.hpp
+++ b/include/range/v3/algorithm/aux_/equal_range_n.hpp
@@ -37,9 +37,10 @@ namespace ranges
     {
         struct equal_range_n_fn
         {
-            template(typename I, typename V, typename R = less, typename P = identity)( //
+            template(typename I, typename V, typename R = less, typename P = identity)(
+                /// \pre
                 requires forward_iterator<I> AND
-                    indirect_strict_weak_order<R, V const *, projected<I, P>>) //
+                    indirect_strict_weak_order<R, V const *, projected<I, P>>)
             subrange<I> operator()(I first,
                                    iter_difference_t<I> dist,
                                    V const & val,

--- a/include/range/v3/algorithm/aux_/lower_bound_n.hpp
+++ b/include/range/v3/algorithm/aux_/lower_bound_n.hpp
@@ -57,9 +57,10 @@ namespace ranges
     {
         struct lower_bound_n_fn
         {
-            template(typename I, typename V, typename C = less, typename P = identity)( //
+            template(typename I, typename V, typename C = less, typename P = identity)(
+                /// \pre
                 requires forward_iterator<I> AND
-                    indirect_strict_weak_order<C, V const *, projected<I, P>>) //
+                    indirect_strict_weak_order<C, V const *, projected<I, P>>)
             I operator()(I first,
                          iter_difference_t<I> d,
                          V const & val,

--- a/include/range/v3/algorithm/aux_/merge_n.hpp
+++ b/include/range/v3/algorithm/aux_/merge_n.hpp
@@ -56,8 +56,9 @@ namespace ranges
         struct merge_n_fn
         {
             template(typename I0, typename I1, typename O, typename C = less,
-                     typename P0 = identity, typename P1 = identity)( //
-                requires mergeable<I0, I1, O, C, P0, P1>) //
+                     typename P0 = identity, typename P1 = identity)(
+                /// \pre
+                requires mergeable<I0, I1, O, C, P0, P1>)
             merge_n_result<I0, I1, O> operator()(I0 begin0,
                                                  iter_difference_t<I0> n0,
                                                  I1 begin1,

--- a/include/range/v3/algorithm/aux_/merge_n_with_buffer.hpp
+++ b/include/range/v3/algorithm/aux_/merge_n_with_buffer.hpp
@@ -48,10 +48,11 @@ namespace ranges
     {
         struct merge_n_with_buffer_fn
         {
-            template(typename I, typename B, typename C = less, typename P = identity)( //
+            template(typename I, typename B, typename C = less, typename P = identity)(
+                /// \pre
                 requires same_as<iter_common_reference_t<I>,
                                      iter_common_reference_t<B>> AND
-                        indirectly_copyable<I, B> AND mergeable<B, I, I, C, P, P>) //
+                        indirectly_copyable<I, B> AND mergeable<B, I, I, C, P, P>)
             I operator()(I begin0,
                          iter_difference_t<I> n0,
                          I begin1,

--- a/include/range/v3/algorithm/aux_/partition_point_n.hpp
+++ b/include/range/v3/algorithm/aux_/partition_point_n.hpp
@@ -29,9 +29,10 @@ namespace ranges
     {
         struct partition_point_n_fn
         {
-            template(typename I, typename C, typename P = identity)( //
+            template(typename I, typename C, typename P = identity)(
+                /// \pre
                 requires forward_iterator<I> AND
-                        indirect_unary_predicate<C, projected<I, P>>) //
+                        indirect_unary_predicate<C, projected<I, P>>)
             I operator()(I first,
                          iter_difference_t<I> d,
                          C pred,

--- a/include/range/v3/algorithm/aux_/sort_n_with_buffer.hpp
+++ b/include/range/v3/algorithm/aux_/sort_n_with_buffer.hpp
@@ -48,10 +48,11 @@ namespace ranges
     {
         struct sort_n_with_buffer_fn
         {
-            template(typename I, typename B, typename C = less, typename P = identity)( //
+            template(typename I, typename B, typename C = less, typename P = identity)(
+                /// \pre
                 requires same_as<iter_common_reference_t<I>,
                                  iter_common_reference_t<B>> AND
-                    indirectly_copyable<I, B> AND mergeable<B, I, I, C, P, P>) //
+                    indirectly_copyable<I, B> AND mergeable<B, I, I, C, P, P>)
             I operator()(I first, iter_difference_t<I> n, B buff, C r = C{}, P p = P{})
                 const
             {

--- a/include/range/v3/algorithm/aux_/upper_bound_n.hpp
+++ b/include/range/v3/algorithm/aux_/upper_bound_n.hpp
@@ -62,9 +62,10 @@ namespace ranges
             /// range-based version of the `upper_bound` std algorithm
             ///
             /// \pre `Rng` is a model of the `range` concept
-            template(typename I, typename V, typename C = less, typename P = identity)( //
+            template(typename I, typename V, typename C = less, typename P = identity)(
+                /// \pre
                 requires forward_iterator<I> AND
-                    indirect_strict_weak_order<C, V const *, projected<I, P>>) //
+                    indirect_strict_weak_order<C, V const *, projected<I, P>>)
             I operator()(I first,
                          iter_difference_t<I> d,
                          V const & val,

--- a/include/range/v3/algorithm/binary_search.hpp
+++ b/include/range/v3/algorithm/binary_search.hpp
@@ -45,9 +45,10 @@ namespace ranges
                  typename S,
                  typename V,
                  typename C = less,
-                 typename P = identity)( //
+                 typename P = identity)(
+            /// \pre
             requires forward_iterator<I> AND sentinel_for<S, I> AND
-                indirect_strict_weak_order<C, V const *, projected<I, P>>) //
+                indirect_strict_weak_order<C, V const *, projected<I, P>>)
         bool RANGES_FUNC(binary_search)(
             I first, S last, V const & val, C pred = C{}, P proj = P{})
         {
@@ -57,7 +58,8 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename V, typename C = less, typename P = identity)( //
+        template(typename Rng, typename V, typename C = less, typename P = identity)(
+            /// \pre
             requires forward_range<Rng> AND
                 indirect_strict_weak_order<C, V const *, projected<iterator_t<Rng>, P>>)
         bool RANGES_FUNC(binary_search)(

--- a/include/range/v3/algorithm/contains.hpp
+++ b/include/range/v3/algorithm/contains.hpp
@@ -34,18 +34,20 @@ namespace ranges
     RANGES_FUNC_BEGIN(contains)
 
         /// \brief function template \c contains
-        template(typename I, typename S, typename T, typename P = identity)( //
-            requires input_iterator<I> AND sentinel_for<S, I> AND //
-            indirect_relation<equal_to, projected<I, P>, const T *>) //
+        template(typename I, typename S, typename T, typename P = identity)(
+            /// \pre
+            requires input_iterator<I> AND sentinel_for<S, I> AND
+            indirect_relation<equal_to, projected<I, P>, const T *>)
         constexpr bool RANGES_FUNC(contains)(I first, S last, const T & val, P proj = {})
         {
             return find(std::move(first), last, val, std::move(proj)) != last;
         }
 
         /// \overload
-        template(typename Rng, typename T, typename P = identity)( //
-            requires input_range<Rng> AND //
-            indirect_relation<equal_to, projected<iterator_t<Rng>, P>, const T *>) //
+        template(typename Rng, typename T, typename P = identity)(
+            /// \pre
+            requires input_range<Rng> AND
+            indirect_relation<equal_to, projected<iterator_t<Rng>, P>, const T *>)
         constexpr bool RANGES_FUNC(contains)(Rng && rng, const T & val, P proj = {})
         {
             return (*this)(begin(rng), end(rng), val, std::move(proj));

--- a/include/range/v3/algorithm/copy.hpp
+++ b/include/range/v3/algorithm/copy.hpp
@@ -41,9 +41,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(copy)
 
         /// \brief function template \c copy
-        template(typename I, typename S, typename O)( //
-            requires input_iterator<I> AND sentinel_for<S, I> AND //
-            weakly_incrementable<O> AND indirectly_copyable<I, O>) //
+        template(typename I, typename S, typename O)(
+            /// \pre
+            requires input_iterator<I> AND sentinel_for<S, I> AND
+            weakly_incrementable<O> AND indirectly_copyable<I, O>)
         constexpr copy_result<I, O> RANGES_FUNC(copy)(I first, S last, O out) //
         {
             for(; first != last; ++first, ++out)
@@ -52,9 +53,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename O)( //
-            requires input_range<Rng> AND weakly_incrementable<O> AND //
-            indirectly_copyable<iterator_t<Rng>, O>) //
+        template(typename Rng, typename O)(
+            /// \pre
+            requires input_range<Rng> AND weakly_incrementable<O> AND
+            indirectly_copyable<iterator_t<Rng>, O>)
         constexpr copy_result<borrowed_iterator_t<Rng>, O> //
         RANGES_FUNC(copy)(Rng && rng, O out)  //
         {

--- a/include/range/v3/algorithm/copy_backward.hpp
+++ b/include/range/v3/algorithm/copy_backward.hpp
@@ -39,9 +39,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(copy_backward)
 
         /// \brief function template \c copy_backward
-        template(typename I, typename S, typename O)( //
-            requires bidirectional_iterator<I> AND sentinel_for<S, I> AND //
-            bidirectional_iterator<O> AND indirectly_copyable<I, O>) //
+        template(typename I, typename S, typename O)(
+            /// \pre
+            requires bidirectional_iterator<I> AND sentinel_for<S, I> AND
+            bidirectional_iterator<O> AND indirectly_copyable<I, O>)
         copy_backward_result<I, O> RANGES_FUNC(copy_backward)(I first, S end_, O out)
         {
             I i = ranges::next(first, end_), last = i;
@@ -51,9 +52,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename O)( //
-            requires bidirectional_range<Rng> AND bidirectional_iterator<O> AND //
-            indirectly_copyable<iterator_t<Rng>, O>) //
+        template(typename Rng, typename O)(
+            /// \pre
+            requires bidirectional_range<Rng> AND bidirectional_iterator<O> AND
+            indirectly_copyable<iterator_t<Rng>, O>)
         copy_backward_result<borrowed_iterator_t<Rng>, O> //
         RANGES_FUNC(copy_backward)(Rng && rng, O out)
         {

--- a/include/range/v3/algorithm/copy_if.hpp
+++ b/include/range/v3/algorithm/copy_if.hpp
@@ -42,10 +42,11 @@ namespace ranges
 
         /// \brief function template \c copy_if
         template(typename I, typename S, typename O, typename F, typename P = identity)(
-            requires input_iterator<I> AND sentinel_for<S, I> AND //
-                weakly_incrementable<O> AND //
-                indirect_unary_predicate<F, projected<I, P>> AND //
-                indirectly_copyable<I, O>) //
+            /// \pre
+            requires input_iterator<I> AND sentinel_for<S, I> AND
+                weakly_incrementable<O> AND
+                indirect_unary_predicate<F, projected<I, P>> AND
+                indirectly_copyable<I, O>)
         copy_if_result<I, O> //
         RANGES_FUNC(copy_if)(I first, S last, O out, F pred, P proj = P{}) //
         {
@@ -62,10 +63,11 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename O, typename F, typename P = identity)( //
-            requires input_range<Rng> AND weakly_incrementable<O> AND //
-            indirect_unary_predicate<F, projected<iterator_t<Rng>, P>> AND //
-            indirectly_copyable<iterator_t<Rng>, O>) //
+        template(typename Rng, typename O, typename F, typename P = identity)(
+            /// \pre
+            requires input_range<Rng> AND weakly_incrementable<O> AND
+            indirect_unary_predicate<F, projected<iterator_t<Rng>, P>> AND
+            indirectly_copyable<iterator_t<Rng>, O>)
         copy_if_result<borrowed_iterator_t<Rng>, O> //
         RANGES_FUNC(copy_if)(Rng && rng, O out, F pred, P proj = P{})
         {

--- a/include/range/v3/algorithm/copy_n.hpp
+++ b/include/range/v3/algorithm/copy_n.hpp
@@ -41,9 +41,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(copy_n)
 
         /// \brief function template \c copy_n
-        template(typename I, typename O, typename P = identity)( //
-            requires input_iterator<I> AND weakly_incrementable<O> AND //
-            indirectly_copyable<I, O>) //
+        template(typename I, typename O, typename P = identity)(
+            /// \pre
+            requires input_iterator<I> AND weakly_incrementable<O> AND
+            indirectly_copyable<I, O>)
         copy_n_result<I, O> RANGES_FUNC(copy_n)(I first, iter_difference_t<I> n, O out)
         {
             RANGES_EXPECT(0 <= n);

--- a/include/range/v3/algorithm/count.hpp
+++ b/include/range/v3/algorithm/count.hpp
@@ -35,9 +35,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(count)
 
         /// \brief function template \c count
-        template(typename I, typename S, typename V, typename P = identity)( //
-            requires input_iterator<I> AND sentinel_for<S, I> AND //
-            indirect_relation<equal_to, projected<I, P>, V const *>) //
+        template(typename I, typename S, typename V, typename P = identity)(
+            /// \pre
+            requires input_iterator<I> AND sentinel_for<S, I> AND
+            indirect_relation<equal_to, projected<I, P>, V const *>)
         iter_difference_t<I> //
         RANGES_FUNC(count)(I first, S last, V const & val, P proj = P{})
         {
@@ -49,9 +50,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename V, typename P = identity)( //
-            requires input_range<Rng> AND //
-            indirect_relation<equal_to, projected<iterator_t<Rng>, P>, V const *>) //
+        template(typename Rng, typename V, typename P = identity)(
+            /// \pre
+            requires input_range<Rng> AND
+            indirect_relation<equal_to, projected<iterator_t<Rng>, P>, V const *>)
         iter_difference_t<iterator_t<Rng>> //
         RANGES_FUNC(count)(Rng && rng, V const & val, P proj = P{})
         {

--- a/include/range/v3/algorithm/count_if.hpp
+++ b/include/range/v3/algorithm/count_if.hpp
@@ -35,9 +35,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(count_if)
 
         /// \brief function template \c count_if
-        template(typename I, typename S, typename R, typename P = identity)( //
-            requires input_iterator<I> AND sentinel_for<S, I> AND //
-            indirect_unary_predicate<R, projected<I, P>>) //
+        template(typename I, typename S, typename R, typename P = identity)(
+            /// \pre
+            requires input_iterator<I> AND sentinel_for<S, I> AND
+            indirect_unary_predicate<R, projected<I, P>>)
         iter_difference_t<I> RANGES_FUNC(count_if)(I first, S last, R pred, P proj = P{})
         {
             iter_difference_t<I> n = 0;
@@ -48,9 +49,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename R, typename P = identity)( //
-            requires input_range<Rng> AND //
-            indirect_unary_predicate<R, projected<iterator_t<Rng>, P>>) //
+        template(typename Rng, typename R, typename P = identity)(
+            /// \pre
+            requires input_range<Rng> AND
+            indirect_unary_predicate<R, projected<iterator_t<Rng>, P>>)
         iter_difference_t<iterator_t<Rng>> //
         RANGES_FUNC(count_if)(Rng && rng, R pred, P proj = P{})
         {

--- a/include/range/v3/algorithm/ends_with.hpp
+++ b/include/range/v3/algorithm/ends_with.hpp
@@ -41,12 +41,13 @@ namespace ranges
                  typename S1,
                  typename C = equal_to,
                  typename P0 = identity,
-                 typename P1 = identity)( //
+                 typename P1 = identity)(
+            /// \pre
             requires ((forward_iterator<I0> && sentinel_for<S0, I0>) ||
                       (input_iterator<I0> && sized_sentinel_for<S0, I0>)) AND
                 ((forward_iterator<I1> && sentinel_for<S1, I1>) ||
                  (input_iterator<I1> && sized_sentinel_for<S1, I1>)) AND
-                indirectly_comparable<I0, I1, C, P0, P1>) //
+                indirectly_comparable<I0, I1, C, P0, P1>)
         constexpr bool RANGES_FUNC(ends_with)(I0 begin0,
                                               S0 end0,
                                               I1 begin1,
@@ -72,10 +73,11 @@ namespace ranges
                  typename Rng1,
                  typename C = equal_to,
                  typename P0 = identity,
-                 typename P1 = identity)( //
+                 typename P1 = identity)(
+            /// \pre
             requires (forward_range<Rng0> || (input_range<Rng0> && sized_range<Rng0>)) AND
                 (forward_range<Rng1> || (input_range<Rng1> && sized_range<Rng1>)) AND
-                indirectly_comparable<iterator_t<Rng0>, iterator_t<Rng1>, C, P0, P1>) //
+                indirectly_comparable<iterator_t<Rng0>, iterator_t<Rng1>, C, P0, P1>)
         constexpr bool RANGES_FUNC(ends_with)(
             Rng0 && rng0, Rng1 && rng1, C pred = C{}, P0 proj0 = P0{}, P1 proj1 = P1{}) //
         {

--- a/include/range/v3/algorithm/equal.hpp
+++ b/include/range/v3/algorithm/equal.hpp
@@ -59,7 +59,8 @@ namespace ranges
                      typename I1,
                      typename C = equal_to,
                      typename P0 = identity,
-                     typename P1 = identity)( //
+                     typename P1 = identity)(
+            /// \pre
             requires input_iterator<I0> AND sentinel_for<S0, I0> AND
                 input_iterator<I1> AND indirectly_comparable<I0, I1, C, P0, P1>)
         RANGES_DEPRECATED(
@@ -85,10 +86,11 @@ namespace ranges
                  typename S1,
                  typename C = equal_to,
                  typename P0 = identity,
-                 typename P1 = identity)( //
+                 typename P1 = identity)(
+            /// \pre
             requires input_iterator<I0> AND sentinel_for<S0, I0> AND
                 input_iterator<I1> AND sentinel_for<S1, I1> AND
-                indirectly_comparable<I0, I1, C, P0, P1>) //
+                indirectly_comparable<I0, I1, C, P0, P1>)
         constexpr bool RANGES_FUNC(equal)(I0 begin0,
                                           S0 end0,
                                           I1 begin1,
@@ -115,7 +117,8 @@ namespace ranges
                      typename I1Ref,
                      typename C = equal_to,
                      typename P0 = identity,
-                     typename P1 = identity)( //
+                     typename P1 = identity)(
+            /// \pre
             requires input_range<Rng0> AND input_iterator<uncvref_t<I1Ref>> AND
                 indirectly_comparable<iterator_t<Rng0>, uncvref_t<I1Ref>, C, P0, P1>)
         RANGES_DEPRECATED(
@@ -143,9 +146,10 @@ namespace ranges
                      typename Rng1,
                      typename C = equal_to,
                      typename P0 = identity,
-                     typename P1 = identity)( //
+                     typename P1 = identity)(
+            /// \pre
             requires input_range<Rng0> AND input_range<Rng1> AND
-                indirectly_comparable<iterator_t<Rng0>, iterator_t<Rng1>, C, P0, P1>) //
+                indirectly_comparable<iterator_t<Rng0>, iterator_t<Rng1>, C, P0, P1>)
         constexpr bool RANGES_FUNC(equal)(
             Rng0 && rng0, Rng1 && rng1, C pred = C{}, P0 proj0 = P0{}, P1 proj1 = P1{}) //
         {

--- a/include/range/v3/algorithm/equal_range.hpp
+++ b/include/range/v3/algorithm/equal_range.hpp
@@ -42,9 +42,10 @@ namespace ranges
                  typename S,
                  typename V,
                  typename C = less,
-                 typename P = identity)( //
+                 typename P = identity)(
+            /// \pre
             requires forward_iterator<I> AND sentinel_for<S, I> AND
-                indirect_strict_weak_order<C, V const *, projected<I, P>>) //
+                indirect_strict_weak_order<C, V const *, projected<I, P>>)
         subrange<I> RANGES_FUNC(equal_range)(
             I first, S last, V const & val, C pred = C{}, P proj = P{})
         {
@@ -100,7 +101,8 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename V, typename C = less, typename P = identity)( //
+        template(typename Rng, typename V, typename C = less, typename P = identity)(
+            /// \pre
             requires forward_range<Rng> AND
                 indirect_strict_weak_order<C, V const *, projected<iterator_t<Rng>, P>>)
         safe_subrange_t<Rng> //

--- a/include/range/v3/algorithm/fill.hpp
+++ b/include/range/v3/algorithm/fill.hpp
@@ -31,8 +31,9 @@ namespace ranges
     RANGES_FUNC_BEGIN(fill)
 
         /// \brief function template \c fill
-        template(typename O, typename S, typename V)( //
-            requires output_iterator<O, V const &> AND sentinel_for<S, O>) //
+        template(typename O, typename S, typename V)(
+            /// \pre
+            requires output_iterator<O, V const &> AND sentinel_for<S, O>)
         O RANGES_FUNC(fill)(O first, S last, V const & val) //
         {
             for(; first != last; ++first)
@@ -41,8 +42,9 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename V)( //
-            requires output_range<Rng, V const &>) //
+        template(typename Rng, typename V)(
+            /// \pre
+            requires output_range<Rng, V const &>)
         borrowed_iterator_t<Rng> RANGES_FUNC(fill)(Rng && rng, V const & val)
         {
             return (*this)(begin(rng), end(rng), val);

--- a/include/range/v3/algorithm/fill_n.hpp
+++ b/include/range/v3/algorithm/fill_n.hpp
@@ -33,8 +33,9 @@ namespace ranges
     RANGES_FUNC_BEGIN(fill_n)
 
         /// \brief function template \c equal
-        template(typename O, typename V)( //
-            requires output_iterator<O, V const &>) //
+        template(typename O, typename V)(
+            /// \pre
+            requires output_iterator<O, V const &>)
         O RANGES_FUNC(fill_n)(O first, iter_difference_t<O> n, V const & val)
         {
             RANGES_EXPECT(n >= 0);

--- a/include/range/v3/algorithm/find.hpp
+++ b/include/range/v3/algorithm/find.hpp
@@ -43,9 +43,10 @@ namespace ranges
         /// \pre `S` is a model of the `sentinel_for<I>` concept
         /// \pre `P` is a model of the `invocable<iter_common_reference_t<I>>` concept
         /// \pre The ResultType of `P` is equality_comparable with V
-        template(typename I, typename S, typename V, typename P = identity)( //
-            requires input_iterator<I> AND sentinel_for<S, I> AND //
-            indirect_relation<equal_to, projected<I, P>, V const *>) //
+        template(typename I, typename S, typename V, typename P = identity)(
+            /// \pre
+            requires input_iterator<I> AND sentinel_for<S, I> AND
+            indirect_relation<equal_to, projected<I, P>, V const *>)
         constexpr I RANGES_FUNC(find)(I first, S last, V const & val, P proj = P{})
         {
             for(; first != last; ++first)
@@ -55,9 +56,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename V, typename P = identity)( //
-            requires input_range<Rng> AND //
-            indirect_relation<equal_to, projected<iterator_t<Rng>, P>, V const *>) //
+        template(typename Rng, typename V, typename P = identity)(
+            /// \pre
+            requires input_range<Rng> AND
+            indirect_relation<equal_to, projected<iterator_t<Rng>, P>, V const *>)
         constexpr borrowed_iterator_t<Rng> //
         RANGES_FUNC(find)(Rng && rng, V const & val, P proj = P{})
         {

--- a/include/range/v3/algorithm/find_end.hpp
+++ b/include/range/v3/algorithm/find_end.hpp
@@ -38,22 +38,25 @@ namespace ranges
     /// \cond
     namespace detail
     {
-        template(typename I, typename S)( //
-            requires input_iterator<I> AND sentinel_for<S, I>) //
+        template(typename I, typename S)(
+            /// \pre
+            requires input_iterator<I> AND sentinel_for<S, I>)
         I next_to_if(I i, S s, std::true_type)
         {
             return ranges::next(i, s);
         }
 
-        template(typename I, typename S)( //
-            requires input_iterator<I> AND sentinel_for<S, I>) //
+        template(typename I, typename S)(
+            /// \pre
+            requires input_iterator<I> AND sentinel_for<S, I>)
         S next_to_if(I, S s, std::false_type)
         {
             return s;
         }
 
-        template(bool B, typename I, typename S)( //
-            requires input_iterator<I> AND sentinel_for<S, I>) //
+        template(bool B, typename I, typename S)(
+            /// \pre
+            requires input_iterator<I> AND sentinel_for<S, I>)
         meta::if_c<B, I, S> next_to_if(I i, S s)
         {
             return detail::next_to_if(std::move(i), std::move(s), meta::bool_<B>{});
@@ -186,10 +189,11 @@ namespace ranges
                  typename I2,
                  typename S2,
                  typename R = equal_to,
-                 typename P = identity)( //
+                 typename P = identity)(
+            /// \pre
             requires forward_iterator<I1> AND sentinel_for<S1, I1> AND
                 forward_iterator<I2> AND sentinel_for<S2, I2> AND
-                indirect_relation<R, projected<I1, P>, I2>) //
+                indirect_relation<R, projected<I1, P>, I2>)
         subrange<I1> RANGES_FUNC(find_end)(
             I1 begin1, S1 end1, I2 begin2, S2 end2, R pred = R{}, P proj = P{}) //
         {
@@ -209,9 +213,10 @@ namespace ranges
         template(typename Rng1,
                  typename Rng2,
                  typename R = equal_to,
-                 typename P = identity)( //
+                 typename P = identity)(
+            /// \pre
             requires forward_range<Rng1> AND forward_range<Rng2> AND
-                indirect_relation<R, projected<iterator_t<Rng1>, P>, iterator_t<Rng2>>) //
+                indirect_relation<R, projected<iterator_t<Rng1>, P>, iterator_t<Rng2>>)
         safe_subrange_t<Rng1> RANGES_FUNC(find_end)(
             Rng1 && rng1, Rng2 && rng2, R pred = R{}, P proj = P{}) //
         {

--- a/include/range/v3/algorithm/find_first_of.hpp
+++ b/include/range/v3/algorithm/find_first_of.hpp
@@ -48,10 +48,11 @@ namespace ranges
                  typename S1,
                  typename R = equal_to,
                  typename P0 = identity,
-                 typename P1 = identity)( //
+                 typename P1 = identity)(
+            /// \pre
             requires input_iterator<I0> AND sentinel_for<S0, I0> AND
                 forward_iterator<I1> AND sentinel_for<S1, I1> AND
-                indirect_relation<R, projected<I0, P0>, projected<I1, P1>>) //
+                indirect_relation<R, projected<I0, P0>, projected<I1, P1>>)
         constexpr I0 RANGES_FUNC(find_first_of)(I0 begin0,
                                                 S0 end0,
                                                 I1 begin1,
@@ -72,11 +73,12 @@ namespace ranges
                      typename Rng1,
                      typename R = equal_to,
                      typename P0 = identity,
-                     typename P1 = identity)( //
+                     typename P1 = identity)(
+            /// \pre
             requires input_range<Rng0> AND forward_range<Rng1> AND
                 indirect_relation<R,
                                   projected<iterator_t<Rng0>, P0>,
-                                  projected<iterator_t<Rng1>, P1>>) //
+                                  projected<iterator_t<Rng1>, P1>>)
         constexpr borrowed_iterator_t<Rng0> RANGES_FUNC(find_first_of)(
             Rng0 && rng0, Rng1 && rng1, R pred = R{}, P0 proj0 = P0{}, P1 proj1 = P1{}) //
         {

--- a/include/range/v3/algorithm/find_if.hpp
+++ b/include/range/v3/algorithm/find_if.hpp
@@ -45,9 +45,10 @@ namespace ranges
         ///      value type of I.
         /// \pre `F` models `predicate<X>`, where `X` is the result type
         ///      of `invocable<P, V>`
-        template(typename I, typename S, typename F, typename P = identity)( //
-            requires input_iterator<I> AND sentinel_for<S, I> AND //
-            indirect_unary_predicate<F, projected<I, P>>) //
+        template(typename I, typename S, typename F, typename P = identity)(
+            /// \pre
+            requires input_iterator<I> AND sentinel_for<S, I> AND
+            indirect_unary_predicate<F, projected<I, P>>)
         I RANGES_FUNC(find_if)(I first, S last, F pred, P proj = P{})
         {
             for(; first != last; ++first)
@@ -57,9 +58,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename F, typename P = identity)( //
-            requires input_range<Rng> AND //
-            indirect_unary_predicate<F, projected<iterator_t<Rng>, P>>) //
+        template(typename Rng, typename F, typename P = identity)(
+            /// \pre
+            requires input_range<Rng> AND
+            indirect_unary_predicate<F, projected<iterator_t<Rng>, P>>)
         borrowed_iterator_t<Rng> RANGES_FUNC(find_if)(Rng && rng, F pred, P proj = P{})
         {
             return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));

--- a/include/range/v3/algorithm/find_if_not.hpp
+++ b/include/range/v3/algorithm/find_if_not.hpp
@@ -45,9 +45,10 @@ namespace ranges
         ///      value type of I.
         /// \pre `F` models `predicate<X>`, where `X` is the result type
         ///      of `invocable<P, V>`
-        template(typename I, typename S, typename F, typename P = identity)( //
-            requires input_iterator<I> AND sentinel_for<S, I> AND //
-            indirect_unary_predicate<F, projected<I, P>>) //
+        template(typename I, typename S, typename F, typename P = identity)(
+            /// \pre
+            requires input_iterator<I> AND sentinel_for<S, I> AND
+            indirect_unary_predicate<F, projected<I, P>>)
         I RANGES_FUNC(find_if_not)(I first, S last, F pred, P proj = P{})
         {
             for(; first != last; ++first)
@@ -57,9 +58,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename F, typename P = identity)( //
-            requires input_range<Rng> AND //
-            indirect_unary_predicate<F, projected<iterator_t<Rng>, P>>) //
+        template(typename Rng, typename F, typename P = identity)(
+            /// \pre
+            requires input_range<Rng> AND
+            indirect_unary_predicate<F, projected<iterator_t<Rng>, P>>)
         borrowed_iterator_t<Rng> //
         RANGES_FUNC(find_if_not)(Rng && rng, F pred, P proj = P{})
         {

--- a/include/range/v3/algorithm/for_each.hpp
+++ b/include/range/v3/algorithm/for_each.hpp
@@ -40,9 +40,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(for_each)
 
         /// \brief function template \c for_each
-        template(typename I, typename S, typename F, typename P = identity)( //
-            requires input_iterator<I> AND sentinel_for<S, I> AND //
-            indirectly_unary_invocable<F, projected<I, P>>) //
+        template(typename I, typename S, typename F, typename P = identity)(
+            /// \pre
+            requires input_iterator<I> AND sentinel_for<S, I> AND
+            indirectly_unary_invocable<F, projected<I, P>>)
         for_each_result<I, F> RANGES_FUNC(for_each)(I first, S last, F fun, P proj = P{})
         {
             for(; first != last; ++first)
@@ -53,9 +54,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename F, typename P = identity)( //
-            requires input_range<Rng> AND //
-            indirectly_unary_invocable<F, projected<iterator_t<Rng>, P>>) //
+        template(typename Rng, typename F, typename P = identity)(
+            /// \pre
+            requires input_range<Rng> AND
+            indirectly_unary_invocable<F, projected<iterator_t<Rng>, P>>)
         for_each_result<borrowed_iterator_t<Rng>, F> //
         RANGES_FUNC(for_each)(Rng && rng, F fun, P proj = P{})
         {

--- a/include/range/v3/algorithm/for_each_n.hpp
+++ b/include/range/v3/algorithm/for_each_n.hpp
@@ -37,9 +37,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(for_each_n)
 
         /// \brief function template \c for_each_n
-        template(typename I, typename F, typename P = identity)( //
+        template(typename I, typename F, typename P = identity)(
+            /// \pre
             requires input_iterator<I> AND
-                indirectly_unary_invocable<F, projected<I, P>>) //
+                indirectly_unary_invocable<F, projected<I, P>>)
         I RANGES_FUNC(for_each_n)(I first, iter_difference_t<I> n, F fun, P proj = P{})
         {
             RANGES_EXPECT(0 <= n);
@@ -51,9 +52,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename F, typename P = identity)( //
+        template(typename Rng, typename F, typename P = identity)(
+            /// \pre
             requires input_range<Rng> AND
-                indirectly_unary_invocable<F, projected<iterator_t<Rng>, P>>) //
+                indirectly_unary_invocable<F, projected<iterator_t<Rng>, P>>)
         borrowed_iterator_t<Rng> RANGES_FUNC(for_each_n)(
             Rng && rng, range_difference_t<Rng> n, F fun, P proj = P{})
         {

--- a/include/range/v3/algorithm/generate.hpp
+++ b/include/range/v3/algorithm/generate.hpp
@@ -39,9 +39,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(generate)
 
         /// \brief function template \c generate_n
-        template(typename O, typename S, typename F)( //
-            requires invocable<F &> AND output_iterator<O, invoke_result_t<F &>> AND //
-            sentinel_for<S, O>) //
+        template(typename O, typename S, typename F)(
+            /// \pre
+            requires invocable<F &> AND output_iterator<O, invoke_result_t<F &>> AND
+            sentinel_for<S, O>)
         generate_result<O, F> RANGES_FUNC(generate)(O first, S last, F fun) //
         {
             for(; first != last; ++first)
@@ -50,8 +51,9 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename F)( //
-            requires invocable<F &> AND output_range<Rng, invoke_result_t<F &>>) //
+        template(typename Rng, typename F)(
+            /// \pre
+            requires invocable<F &> AND output_range<Rng, invoke_result_t<F &>>)
         generate_result<borrowed_iterator_t<Rng>, F> //
         RANGES_FUNC(generate)(Rng && rng, F fun)
         {

--- a/include/range/v3/algorithm/generate_n.hpp
+++ b/include/range/v3/algorithm/generate_n.hpp
@@ -39,8 +39,9 @@ namespace ranges
     RANGES_FUNC_BEGIN(generate_n)
 
         /// \brief function template \c generate_n
-        template(typename O, typename F)( //
-            requires invocable<F &> AND output_iterator<O, invoke_result_t<F &>>) //
+        template(typename O, typename F)(
+            /// \pre
+            requires invocable<F &> AND output_iterator<O, invoke_result_t<F &>>)
         generate_n_result<O, F> //
         RANGES_FUNC(generate_n)(O first, iter_difference_t<O> n, F fun)
         {

--- a/include/range/v3/algorithm/heap_algorithm.hpp
+++ b/include/range/v3/algorithm/heap_algorithm.hpp
@@ -48,9 +48,10 @@ namespace ranges
     {
         struct is_heap_until_n_fn
         {
-            template(typename I, typename C = less, typename P = identity)( //
+            template(typename I, typename C = less, typename P = identity)(
+                /// \pre
                 requires random_access_iterator<I> AND
-                    indirect_strict_weak_order<C, projected<I, P>>) //
+                    indirect_strict_weak_order<C, projected<I, P>>)
             I operator()(I const begin_, iter_difference_t<I> const n_, C pred = C{},
                             P proj = P{}) const
             {
@@ -78,9 +79,10 @@ namespace ranges
 
         struct is_heap_n_fn
         {
-            template(typename I, typename C = less, typename P = identity)( //
+            template(typename I, typename C = less, typename P = identity)(
+                /// \pre
                 requires random_access_iterator<I> AND
-                    indirect_strict_weak_order<C, projected<I, P>>) //
+                    indirect_strict_weak_order<C, projected<I, P>>)
             bool operator()(I first, iter_difference_t<I> n, C pred = C{},
                             P proj = P{}) const
             {
@@ -98,9 +100,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(is_heap_until)
 
         /// \brief function template \c is_heap_until
-        template(typename I, typename S, typename C = less, typename P = identity)( //
-            requires random_access_iterator<I> AND sentinel_for<S, I> AND //
-            indirect_strict_weak_order<C, projected<I, P>>) //
+        template(typename I, typename S, typename C = less, typename P = identity)(
+            /// \pre
+            requires random_access_iterator<I> AND sentinel_for<S, I> AND
+            indirect_strict_weak_order<C, projected<I, P>>)
         I RANGES_FUNC(is_heap_until)(I first, S last, C pred = C{}, P proj = P{})
         {
             return detail::is_heap_until_n(std::move(first),
@@ -110,9 +113,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C = less, typename P = identity)( //
-            requires random_access_range<Rng> AND //
-            indirect_strict_weak_order<C, projected<iterator_t<Rng>, P>>) //
+        template(typename Rng, typename C = less, typename P = identity)(
+            /// \pre
+            requires random_access_range<Rng> AND
+            indirect_strict_weak_order<C, projected<iterator_t<Rng>, P>>)
         borrowed_iterator_t<Rng> //
         RANGES_FUNC(is_heap_until)(Rng && rng, C pred = C{}, P proj = P{})
         {
@@ -130,9 +134,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(is_heap)
 
         /// \brief function template \c is_heap
-        template(typename I, typename S, typename C = less, typename P = identity)( //
-            requires random_access_iterator<I> AND sentinel_for<S, I> AND //
-            indirect_strict_weak_order<C, projected<I, P>>) //
+        template(typename I, typename S, typename C = less, typename P = identity)(
+            /// \pre
+            requires random_access_iterator<I> AND sentinel_for<S, I> AND
+            indirect_strict_weak_order<C, projected<I, P>>)
         bool RANGES_FUNC(is_heap)(I first, S last, C pred = C{}, P proj = P{}) //
         {
             return detail::is_heap_n(std::move(first),
@@ -142,9 +147,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C = less, typename P = identity)( //
-            requires random_access_range<Rng> AND //
-            indirect_strict_weak_order<C, projected<iterator_t<Rng>, P>>) //
+        template(typename Rng, typename C = less, typename P = identity)(
+            /// \pre
+            requires random_access_range<Rng> AND
+            indirect_strict_weak_order<C, projected<iterator_t<Rng>, P>>)
         bool RANGES_FUNC(is_heap)(Rng && rng, C pred = C{}, P proj = P{}) //
         {
             return detail::is_heap_n(
@@ -259,9 +265,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(push_heap)
 
         /// \brief function template \c push_heap
-        template(typename I, typename S, typename C = less, typename P = identity)( //
-            requires random_access_iterator<I> AND sentinel_for<S, I> AND //
-            sortable<I, C, P>) //
+        template(typename I, typename S, typename C = less, typename P = identity)(
+            /// \pre
+            requires random_access_iterator<I> AND sentinel_for<S, I> AND
+            sortable<I, C, P>)
         I RANGES_FUNC(push_heap)(I first, S last, C pred = C{}, P proj = P{})
         {
             auto n = distance(first, last);
@@ -270,8 +277,9 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C = less, typename P = identity)( //
-            requires random_access_range<Rng> AND sortable<iterator_t<Rng>, C, P>) //
+        template(typename Rng, typename C = less, typename P = identity)(
+            /// \pre
+            requires random_access_range<Rng> AND sortable<iterator_t<Rng>, C, P>)
         borrowed_iterator_t<Rng> //
         RANGES_FUNC(push_heap)(Rng && rng, C pred = C{}, P proj = P{}) //
         {
@@ -294,8 +302,9 @@ namespace ranges
     {
         struct pop_heap_n_fn
         {
-            template(typename I, typename C = less, typename P = identity)( //
-                requires random_access_iterator<I> AND sortable<I, C, P>) //
+            template(typename I, typename C = less, typename P = identity)(
+                /// \pre
+                requires random_access_iterator<I> AND sortable<I, C, P>)
             void operator()(I first, iter_difference_t<I> len, C pred = C{},
                             P proj = P{}) const
             {
@@ -317,9 +326,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(pop_heap)
 
         /// \brief function template \c pop_heap
-        template(typename I, typename S, typename C = less, typename P = identity)( //
-            requires random_access_iterator<I> AND sentinel_for<S, I> AND //
-            sortable<I, C, P>) //
+        template(typename I, typename S, typename C = less, typename P = identity)(
+            /// \pre
+            requires random_access_iterator<I> AND sentinel_for<S, I> AND
+            sortable<I, C, P>)
         I RANGES_FUNC(pop_heap)(I first, S last, C pred = C{}, P proj = P{})
         {
             auto n = distance(first, last);
@@ -328,8 +338,9 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C = less, typename P = identity)( //
-            requires random_access_range<Rng> AND sortable<iterator_t<Rng>, C, P>) //
+        template(typename Rng, typename C = less, typename P = identity)(
+            /// \pre
+            requires random_access_range<Rng> AND sortable<iterator_t<Rng>, C, P>)
         borrowed_iterator_t<Rng> //
         RANGES_FUNC(pop_heap)(Rng && rng, C pred = C{}, P proj = P{})
         {
@@ -349,9 +360,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(make_heap)
 
         /// \brief function template \c make_heap
-        template(typename I, typename S, typename C = less, typename P = identity)( //
-            requires random_access_iterator<I> AND sentinel_for<S, I> AND //
-            sortable<I, C, P>) //
+        template(typename I, typename S, typename C = less, typename P = identity)(
+            /// \pre
+            requires random_access_iterator<I> AND sentinel_for<S, I> AND
+            sortable<I, C, P>)
         I RANGES_FUNC(make_heap)(I first, S last, C pred = C{}, P proj = P{})
         {
             iter_difference_t<I> const n = distance(first, last);
@@ -364,8 +376,9 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C = less, typename P = identity)( //
-            requires random_access_range<Rng> AND sortable<iterator_t<Rng>, C, P>) //
+        template(typename Rng, typename C = less, typename P = identity)(
+            /// \pre
+            requires random_access_range<Rng> AND sortable<iterator_t<Rng>, C, P>)
         borrowed_iterator_t<Rng> //
         RANGES_FUNC(make_heap)(Rng && rng, C pred = C{}, P proj = P{})
         {
@@ -388,9 +401,10 @@ namespace ranges
 
     RANGES_FUNC_BEGIN(sort_heap)
 
-        template(typename I, typename S, typename C = less, typename P = identity)( //
-            requires random_access_iterator<I> AND sentinel_for<S, I> AND //
-            sortable<I, C, P>) //
+        template(typename I, typename S, typename C = less, typename P = identity)(
+            /// \pre
+            requires random_access_iterator<I> AND sentinel_for<S, I> AND
+            sortable<I, C, P>)
         I RANGES_FUNC(sort_heap)(I first, S last, C pred = C{}, P proj = P{})
         {
             iter_difference_t<I> const n = distance(first, last);
@@ -399,8 +413,9 @@ namespace ranges
             return first + n;
         }
 
-        template(typename Rng, typename C = less, typename P = identity)( //
-            requires random_access_range<Rng &> AND sortable<iterator_t<Rng>, C, P>) //
+        template(typename Rng, typename C = less, typename P = identity)(
+            /// \pre
+            requires random_access_range<Rng &> AND sortable<iterator_t<Rng>, C, P>)
         borrowed_iterator_t<Rng> //
         RANGES_FUNC(sort_heap)(Rng && rng, C pred = C{}, P proj = P{})
         {

--- a/include/range/v3/algorithm/inplace_merge.hpp
+++ b/include/range/v3/algorithm/inplace_merge.hpp
@@ -96,8 +96,9 @@ namespace ranges
             }
 
         public:
-            template(typename I, typename C = less, typename P = identity)( //
-                requires bidirectional_iterator<I> AND sortable<I, C, P>) //
+            template(typename I, typename C = less, typename P = identity)(
+                /// \pre
+                requires bidirectional_iterator<I> AND sortable<I, C, P>)
             void operator()(I first, I middle, I last, iter_difference_t<I> len1,
                             iter_difference_t<I> len2, iter_value_t<I> * buf,
                             std::ptrdiff_t buf_size, C pred = C{}, P proj = P{}) const
@@ -220,8 +221,9 @@ namespace ranges
 
         struct inplace_merge_no_buffer_fn
         {
-            template(typename I, typename C = less, typename P = identity)( //
-                requires bidirectional_iterator<I> AND sortable<I, C, P>) //
+            template(typename I, typename C = less, typename P = identity)(
+                /// \pre
+                requires bidirectional_iterator<I> AND sortable<I, C, P>)
             void operator()(I first, I middle, I last, iter_difference_t<I> len1,
                             iter_difference_t<I> len2, C pred = C{}, P proj = P{}) const
             {
@@ -248,8 +250,9 @@ namespace ranges
         // TODO reimplement to only need forward iterators
 
         /// \brief function template \c inplace_merge
-        template(typename I, typename S, typename C = less, typename P = identity)( //
-            requires bidirectional_iterator<I> AND sortable<I, C, P>) //
+        template(typename I, typename S, typename C = less, typename P = identity)(
+            /// \pre
+            requires bidirectional_iterator<I> AND sortable<I, C, P>)
         I RANGES_FUNC(inplace_merge)(
             I first, I middle, S last, C pred = C{}, P proj = P{})
         {
@@ -277,8 +280,9 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C = less, typename P = identity)( //
-            requires bidirectional_range<Rng> AND sortable<iterator_t<Rng>, C, P>) //
+        template(typename Rng, typename C = less, typename P = identity)(
+            /// \pre
+            requires bidirectional_range<Rng> AND sortable<iterator_t<Rng>, C, P>)
         borrowed_iterator_t<Rng> RANGES_FUNC(inplace_merge)(
             Rng && rng, iterator_t<Rng> middle, C pred = C{}, P proj = P{})
         {

--- a/include/range/v3/algorithm/is_partitioned.hpp
+++ b/include/range/v3/algorithm/is_partitioned.hpp
@@ -43,9 +43,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(is_partitioned)
 
         /// \brief function template \c is_partitioned
-        template(typename I, typename S, typename C, typename P = identity)( //
-            requires input_iterator<I> AND sentinel_for<S, I> AND //
-            indirect_unary_predicate<C, projected<I, P>>) //
+        template(typename I, typename S, typename C, typename P = identity)(
+            /// \pre
+            requires input_iterator<I> AND sentinel_for<S, I> AND
+            indirect_unary_predicate<C, projected<I, P>>)
         bool RANGES_FUNC(is_partitioned)(I first, S last, C pred, P proj = P{}) //
         {
             for(; first != last; ++first)
@@ -58,9 +59,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C, typename P = identity)( //
-            requires input_range<Rng> AND //
-            indirect_unary_predicate<C, projected<iterator_t<Rng>, P>>) //
+        template(typename Rng, typename C, typename P = identity)(
+            /// \pre
+            requires input_range<Rng> AND
+            indirect_unary_predicate<C, projected<iterator_t<Rng>, P>>)
         bool RANGES_FUNC(is_partitioned)(Rng && rng, C pred, P proj = P{}) //
         {
             return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));

--- a/include/range/v3/algorithm/is_sorted.hpp
+++ b/include/range/v3/algorithm/is_sorted.hpp
@@ -45,9 +45,10 @@ namespace ranges
         /// \pre `R` and `projected<I, P>` model the `indirect_strict_weak_order<R,
         /// projected<I, P>>` concept
         ///
-        template(typename I, typename S, typename R = less, typename P = identity)( //
-            requires forward_iterator<I> AND sentinel_for<S, I> AND //
-            indirect_strict_weak_order<R, projected<I, P>>) //
+        template(typename I, typename S, typename R = less, typename P = identity)(
+            /// \pre
+            requires forward_iterator<I> AND sentinel_for<S, I> AND
+            indirect_strict_weak_order<R, projected<I, P>>)
         bool RANGES_FUNC(is_sorted)(I first, S last, R rel = R{}, P proj = P{})
         {
             return is_sorted_until(
@@ -55,9 +56,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename R = less, typename P = identity)( //
-            requires forward_range<Rng> AND //
-            indirect_strict_weak_order<R, projected<iterator_t<Rng>, P>>) //
+        template(typename Rng, typename R = less, typename P = identity)(
+            /// \pre
+            requires forward_range<Rng> AND
+            indirect_strict_weak_order<R, projected<iterator_t<Rng>, P>>)
         bool RANGES_FUNC(is_sorted)(Rng && rng, R rel = R{}, P proj = P{}) //
         {
             return (*this)(begin(rng), end(rng), std::move(rel), std::move(proj));

--- a/include/range/v3/algorithm/is_sorted_until.hpp
+++ b/include/range/v3/algorithm/is_sorted_until.hpp
@@ -47,9 +47,10 @@ namespace ranges
         /// \pre `R` and `projected<I, P>` model the `indirect_strict_weak_order<R,
         /// projected<I, P>>` concept
         ///
-        template(typename I, typename S, typename R = less, typename P = identity)( //
-            requires forward_iterator<I> AND sentinel_for<S, I> AND //
-            indirect_strict_weak_order<R, projected<I, P>>) //
+        template(typename I, typename S, typename R = less, typename P = identity)(
+            /// \pre
+            requires forward_iterator<I> AND sentinel_for<S, I> AND
+            indirect_strict_weak_order<R, projected<I, P>>)
         I RANGES_FUNC(is_sorted_until)(I first, S last, R pred = R{}, P proj = P{})
         {
             auto i = first;
@@ -66,9 +67,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename R = less, typename P = identity)( //
-            requires forward_range<Rng> AND //
-            indirect_strict_weak_order<R, projected<iterator_t<Rng>, P>>) //
+        template(typename Rng, typename R = less, typename P = identity)(
+            /// \pre
+            requires forward_range<Rng> AND
+            indirect_strict_weak_order<R, projected<iterator_t<Rng>, P>>)
         borrowed_iterator_t<Rng> //
         RANGES_FUNC(is_sorted_until)(Rng && rng, R pred = R{}, P proj = P{})
         {

--- a/include/range/v3/algorithm/lexicographical_compare.hpp
+++ b/include/range/v3/algorithm/lexicographical_compare.hpp
@@ -40,10 +40,11 @@ namespace ranges
                  typename S1,
                  typename C = less,
                  typename P0 = identity,
-                 typename P1 = identity)( //
+                 typename P1 = identity)(
+            /// \pre
             requires input_iterator<I0> AND sentinel_for<S0, I0> AND
                 input_iterator<I1> AND sentinel_for<S1, I1> AND
-                indirect_strict_weak_order<C, projected<I0, P0>, projected<I1, P1>>) //
+                indirect_strict_weak_order<C, projected<I0, P0>, projected<I1, P1>>)
         bool RANGES_FUNC(lexicographical_compare)(I0 begin0,
                                                   S0 end0,
                                                   I1 begin1,
@@ -68,11 +69,12 @@ namespace ranges
                  typename Rng1,
                  typename C = less,
                  typename P0 = identity,
-                 typename P1 = identity)( //
+                 typename P1 = identity)(
+            /// \pre
             requires input_range<Rng0> AND input_range<Rng1> AND
                 indirect_strict_weak_order<C,
                                            projected<iterator_t<Rng0>, P0>,
-                                           projected<iterator_t<Rng1>, P1>>) //
+                                           projected<iterator_t<Rng1>, P1>>)
         bool RANGES_FUNC(lexicographical_compare)(
             Rng0 && rng0, Rng1 && rng1, C pred = C{}, P0 proj0 = P0{}, P1 proj1 = P1{}) //
         {

--- a/include/range/v3/algorithm/lower_bound.hpp
+++ b/include/range/v3/algorithm/lower_bound.hpp
@@ -41,9 +41,10 @@ namespace ranges
                  typename S,
                  typename V,
                  typename C = less,
-                 typename P = identity)( //
+                 typename P = identity)(
+            /// \pre
             requires forward_iterator<I> AND sentinel_for<S, I> AND
-                indirect_strict_weak_order<C, V const *, projected<I, P>>) //
+                indirect_strict_weak_order<C, V const *, projected<I, P>>)
         I RANGES_FUNC(lower_bound)(
             I first, S last, V const & val, C pred = C{}, P proj = P{})
         {
@@ -54,7 +55,8 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename V, typename C = less, typename P = identity)( //
+        template(typename Rng, typename V, typename C = less, typename P = identity)(
+            /// \pre
             requires forward_range<Rng> AND
                 indirect_strict_weak_order<C, V const *, projected<iterator_t<Rng>, P>>)
         borrowed_iterator_t<Rng> //

--- a/include/range/v3/algorithm/max.hpp
+++ b/include/range/v3/algorithm/max.hpp
@@ -37,8 +37,9 @@ namespace ranges
     RANGES_FUNC_BEGIN(max)
 
         /// \brief function template \c max
-        template(typename T, typename C = less, typename P = identity)( //
-            requires indirect_strict_weak_order<C, projected<T const *, P>>) //
+        template(typename T, typename C = less, typename P = identity)(
+            /// \pre
+            requires indirect_strict_weak_order<C, projected<T const *, P>>)
         constexpr T const & RANGES_FUNC(max)(
             T const & a, T const & b, C pred = C{}, P proj = P{}) //
         {
@@ -46,10 +47,11 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C = less, typename P = identity)( //
-            requires input_range<Rng> AND //
-            indirect_strict_weak_order<C, projected<iterator_t<Rng>, P>> AND //
-            indirectly_copyable_storable<iterator_t<Rng>, range_value_t<Rng> *>) //
+        template(typename Rng, typename C = less, typename P = identity)(
+            /// \pre
+            requires input_range<Rng> AND
+            indirect_strict_weak_order<C, projected<iterator_t<Rng>, P>> AND
+            indirectly_copyable_storable<iterator_t<Rng>, range_value_t<Rng> *>)
         constexpr range_value_t<Rng> //
         RANGES_FUNC(max)(Rng && rng, C pred = C{}, P proj = P{}) //
         {
@@ -67,9 +69,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename T, typename C = less, typename P = identity)( //
+        template(typename T, typename C = less, typename P = identity)(
+            /// \pre
             requires copyable<T> AND
-                indirect_strict_weak_order<C, projected<T const *, P>>) //
+                indirect_strict_weak_order<C, projected<T const *, P>>)
         constexpr T RANGES_FUNC(max)(
             std::initializer_list<T> const && rng, C pred = C{}, P proj = P{}) //
         {

--- a/include/range/v3/algorithm/max_element.hpp
+++ b/include/range/v3/algorithm/max_element.hpp
@@ -36,9 +36,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(max_element)
 
         /// \brief function template \c max_element
-        template(typename I, typename S, typename C = less, typename P = identity)( //
-            requires forward_iterator<I> AND sentinel_for<S, I> AND //
-            indirect_strict_weak_order<C, projected<I, P>>) //
+        template(typename I, typename S, typename C = less, typename P = identity)(
+            /// \pre
+            requires forward_iterator<I> AND sentinel_for<S, I> AND
+            indirect_strict_weak_order<C, projected<I, P>>)
         I RANGES_FUNC(max_element)(I first, S last, C pred = C{}, P proj = P{})
         {
             if(first != last)
@@ -49,9 +50,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C = less, typename P = identity)( //
-            requires forward_range<Rng> AND //
-            indirect_strict_weak_order<C, projected<iterator_t<Rng>, P>>) //
+        template(typename Rng, typename C = less, typename P = identity)(
+            /// \pre
+            requires forward_range<Rng> AND
+            indirect_strict_weak_order<C, projected<iterator_t<Rng>, P>>)
         borrowed_iterator_t<Rng> //
         RANGES_FUNC(max_element)(Rng && rng, C pred = C{}, P proj = P{})
         {

--- a/include/range/v3/algorithm/merge.hpp
+++ b/include/range/v3/algorithm/merge.hpp
@@ -64,9 +64,10 @@ namespace ranges
                  typename O,
                  typename C = less,
                  typename P0 = identity,
-                 typename P1 = identity)( //
+                 typename P1 = identity)(
+            /// \pre
             requires sentinel_for<S0, I0> AND sentinel_for<S1, I1> AND
-                mergeable<I0, I1, O, C, P0, P1>) //
+                mergeable<I0, I1, O, C, P0, P1>)
         merge_result<I0, I1, O> RANGES_FUNC(merge)(I0 begin0,
                                                    S0 end0,
                                                    I1 begin1,
@@ -100,9 +101,10 @@ namespace ranges
                  typename O,
                  typename C = less,
                  typename P0 = identity,
-                 typename P1 = identity)( //
+                 typename P1 = identity)(
+            /// \pre
             requires range<Rng0> AND range<Rng1> AND
-                mergeable<iterator_t<Rng0>, iterator_t<Rng1>, O, C, P0, P1>) //
+                mergeable<iterator_t<Rng0>, iterator_t<Rng1>, O, C, P0, P1>)
         merge_result<borrowed_iterator_t<Rng0>, borrowed_iterator_t<Rng1>, O>
         RANGES_FUNC(merge)(Rng0 && rng0,
                            Rng1 && rng1,

--- a/include/range/v3/algorithm/min.hpp
+++ b/include/range/v3/algorithm/min.hpp
@@ -37,8 +37,9 @@ namespace ranges
     RANGES_FUNC_BEGIN(min)
 
         /// \brief function template \c min
-        template(typename T, typename C = less, typename P = identity)( //
-            requires indirect_strict_weak_order<C, projected<T const *, P>>) //
+        template(typename T, typename C = less, typename P = identity)(
+            /// \pre
+            requires indirect_strict_weak_order<C, projected<T const *, P>>)
         constexpr T const & RANGES_FUNC(min)(
             T const & a, T const & b, C pred = C{}, P proj = P{}) //
         {
@@ -46,10 +47,11 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C = less, typename P = identity)( //
-            requires input_range<Rng> AND //
-            indirect_strict_weak_order<C, projected<iterator_t<Rng>, P>> AND //
-            indirectly_copyable_storable<iterator_t<Rng>, range_value_t<Rng> *>) //
+        template(typename Rng, typename C = less, typename P = identity)(
+            /// \pre
+            requires input_range<Rng> AND
+            indirect_strict_weak_order<C, projected<iterator_t<Rng>, P>> AND
+            indirectly_copyable_storable<iterator_t<Rng>, range_value_t<Rng> *>)
         constexpr range_value_t<Rng> //
         RANGES_FUNC(min)(Rng && rng, C pred = C{}, P proj = P{}) //
         {
@@ -67,9 +69,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename T, typename C = less, typename P = identity)( //
+        template(typename T, typename C = less, typename P = identity)(
+            /// \pre
             requires copyable<T> AND
-                indirect_strict_weak_order<C, projected<T const *, P>>) //
+                indirect_strict_weak_order<C, projected<T const *, P>>)
         constexpr T RANGES_FUNC(min)(
             std::initializer_list<T> const && rng, C pred = C{}, P proj = P{}) //
         {

--- a/include/range/v3/algorithm/min_element.hpp
+++ b/include/range/v3/algorithm/min_element.hpp
@@ -36,9 +36,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(min_element)
 
         /// \brief function template \c min_element
-        template(typename I, typename S, typename C = less, typename P = identity)( //
-            requires forward_iterator<I> AND sentinel_for<S, I> AND //
-            indirect_strict_weak_order<C, projected<I, P>>) //
+        template(typename I, typename S, typename C = less, typename P = identity)(
+            /// \pre
+            requires forward_iterator<I> AND sentinel_for<S, I> AND
+            indirect_strict_weak_order<C, projected<I, P>>)
         I RANGES_FUNC(min_element)(I first, S last, C pred = C{}, P proj = P{})
         {
             if(first != last)
@@ -49,9 +50,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C = less, typename P = identity)( //
-            requires forward_range<Rng> AND //
-            indirect_strict_weak_order<C, projected<iterator_t<Rng>, P>>) //
+        template(typename Rng, typename C = less, typename P = identity)(
+            /// \pre
+            requires forward_range<Rng> AND
+            indirect_strict_weak_order<C, projected<iterator_t<Rng>, P>>)
         borrowed_iterator_t<Rng> //
         RANGES_FUNC(min_element)(Rng && rng, C pred = C{}, P proj = P{}) //
         {

--- a/include/range/v3/algorithm/minmax.hpp
+++ b/include/range/v3/algorithm/minmax.hpp
@@ -41,8 +41,9 @@ namespace ranges
     RANGES_FUNC_BEGIN(minmax)
 
         /// \brief function template \c minmax
-        template(typename T, typename C = less, typename P = identity)( //
-            requires indirect_strict_weak_order<C, projected<T const *, P>>) //
+        template(typename T, typename C = less, typename P = identity)(
+            /// \pre
+            requires indirect_strict_weak_order<C, projected<T const *, P>>)
         constexpr minmax_result<T const &> RANGES_FUNC(minmax)(
             T const & a, T const & b, C pred = C{}, P proj = P{}) //
         {
@@ -51,10 +52,11 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C = less, typename P = identity)( //
-            requires input_range<Rng> AND //
-            indirect_strict_weak_order<C, projected<iterator_t<Rng>, P>> AND //
-            indirectly_copyable_storable<iterator_t<Rng>, range_value_t<Rng> *>) //
+        template(typename Rng, typename C = less, typename P = identity)(
+            /// \pre
+            requires input_range<Rng> AND
+            indirect_strict_weak_order<C, projected<iterator_t<Rng>, P>> AND
+            indirectly_copyable_storable<iterator_t<Rng>, range_value_t<Rng> *>)
         constexpr minmax_result<range_value_t<Rng>> //
         RANGES_FUNC(minmax)(Rng && rng, C pred = C{}, P proj = P{}) //
         {
@@ -106,9 +108,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename T, typename C = less, typename P = identity)( //
+        template(typename T, typename C = less, typename P = identity)(
+            /// \pre
             requires copyable<T> AND
-                indirect_strict_weak_order<C, projected<T const *, P>>) //
+                indirect_strict_weak_order<C, projected<T const *, P>>)
         constexpr minmax_result<T> RANGES_FUNC(minmax)(
             std::initializer_list<T> const && rng, C pred = C{}, P proj = P{}) //
         {

--- a/include/range/v3/algorithm/minmax_element.hpp
+++ b/include/range/v3/algorithm/minmax_element.hpp
@@ -42,9 +42,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(minmax_element)
 
         /// \brief function template \c minmax_element
-        template(typename I, typename S, typename C = less, typename P = identity)( //
-            requires forward_iterator<I> AND sentinel_for<S, I> AND //
-            indirect_strict_weak_order<C, projected<I, P>>) //
+        template(typename I, typename S, typename C = less, typename P = identity)(
+            /// \pre
+            requires forward_iterator<I> AND sentinel_for<S, I> AND
+            indirect_strict_weak_order<C, projected<I, P>>)
         minmax_element_result<I> //
         RANGES_FUNC(minmax_element)(I first, S last, C pred = C{}, P proj = P{}) //
         {
@@ -88,9 +89,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C = less, typename P = identity)( //
-            requires forward_range<Rng> AND //
-            indirect_strict_weak_order<C, projected<iterator_t<Rng>, P>>) //
+        template(typename Rng, typename C = less, typename P = identity)(
+            /// \pre
+            requires forward_range<Rng> AND
+            indirect_strict_weak_order<C, projected<iterator_t<Rng>, P>>)
         minmax_element_result<borrowed_iterator_t<Rng>> //
         RANGES_FUNC(minmax_element)(Rng && rng, C pred = C{}, P proj = P{}) //
         {

--- a/include/range/v3/algorithm/mismatch.hpp
+++ b/include/range/v3/algorithm/mismatch.hpp
@@ -48,9 +48,10 @@ namespace ranges
                      typename I2,
                      typename C = equal_to,
                      typename P1 = identity,
-                     typename P2 = identity)( //
-            requires input_iterator<I1> AND sentinel_for<S1, I1> AND //
-                input_iterator<I2> AND //
+                     typename P2 = identity)(
+            /// \pre
+            requires input_iterator<I1> AND sentinel_for<S1, I1> AND
+                input_iterator<I2> AND
                 indirect_relation<C, projected<I1, P1>, projected<I2, P2>>)
         RANGES_DEPRECATED(
             "Use the variant of ranges::mismatch that takes an upper bound for "
@@ -75,10 +76,11 @@ namespace ranges
                      typename S2,
                      typename C = equal_to,
                      typename P1 = identity,
-                     typename P2 = identity)( //
+                     typename P2 = identity)(
+            /// \pre
             requires input_iterator<I1> AND sentinel_for<S1, I1> AND
                 input_iterator<I2> AND sentinel_for<S2, I2> AND
-                indirect_relation<C, projected<I1, P1>, projected<I2, P2>>) //
+                indirect_relation<C, projected<I1, P1>, projected<I2, P2>>)
         mismatch_result<I1, I2> RANGES_FUNC(mismatch)(I1 begin1,
                                                       S1 end1,
                                                       I2 begin2,
@@ -129,11 +131,12 @@ namespace ranges
                      typename Rng2,
                      typename C = equal_to,
                      typename P1 = identity,
-                     typename P2 = identity)( //
+                     typename P2 = identity)(
+            /// \pre
             requires input_range<Rng1> AND input_range<Rng2> AND
                 indirect_relation<C,
                                   projected<iterator_t<Rng1>, P1>,
-                                  projected<iterator_t<Rng2>, P2>>) //
+                                  projected<iterator_t<Rng2>, P2>>)
         mismatch_result<borrowed_iterator_t<Rng1>, borrowed_iterator_t<Rng2>> //
         RANGES_FUNC(mismatch)(Rng1 && rng1,
                               Rng2 && rng2,

--- a/include/range/v3/algorithm/move.hpp
+++ b/include/range/v3/algorithm/move.hpp
@@ -40,9 +40,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(move)
 
         /// \brief function template \c move
-        template(typename I, typename S, typename O)( //
-            requires input_iterator<I> AND sentinel_for<S, I> AND //
-            weakly_incrementable<O> AND indirectly_movable<I, O>) //
+        template(typename I, typename S, typename O)(
+            /// \pre
+            requires input_iterator<I> AND sentinel_for<S, I> AND
+            weakly_incrementable<O> AND indirectly_movable<I, O>)
         move_result<I, O> RANGES_FUNC(move)(I first, S last, O out) //
         {
             for(; first != last; ++first, ++out)
@@ -51,9 +52,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename O)( //
-            requires input_range<Rng> AND weakly_incrementable<O> AND //
-            indirectly_movable<iterator_t<Rng>, O>) //
+        template(typename Rng, typename O)(
+            /// \pre
+            requires input_range<Rng> AND weakly_incrementable<O> AND
+            indirectly_movable<iterator_t<Rng>, O>)
         move_result<borrowed_iterator_t<Rng>, O> //
         RANGES_FUNC(move)(Rng && rng, O out)            //
         {

--- a/include/range/v3/algorithm/move_backward.hpp
+++ b/include/range/v3/algorithm/move_backward.hpp
@@ -39,9 +39,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(move_backward)
 
         /// \brief function template \c move_backward
-        template(typename I, typename S, typename O)( //
-            requires bidirectional_iterator<I> AND sentinel_for<S, I> AND //
-            bidirectional_iterator<O> AND indirectly_movable<I, O>) //
+        template(typename I, typename S, typename O)(
+            /// \pre
+            requires bidirectional_iterator<I> AND sentinel_for<S, I> AND
+            bidirectional_iterator<O> AND indirectly_movable<I, O>)
         move_backward_result<I, O> RANGES_FUNC(move_backward)(I first, S end_, O out) //
         {
             I i = ranges::next(first, end_), last = i;
@@ -51,9 +52,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename O)( //
-            requires bidirectional_range<Rng> AND bidirectional_iterator<O> AND //
-            indirectly_movable<iterator_t<Rng>, O>) //
+        template(typename Rng, typename O)(
+            /// \pre
+            requires bidirectional_range<Rng> AND bidirectional_iterator<O> AND
+            indirectly_movable<iterator_t<Rng>, O>)
         move_backward_result<borrowed_iterator_t<Rng>, O> //
         RANGES_FUNC(move_backward)(Rng && rng, O out)            //
         {

--- a/include/range/v3/algorithm/none_of.hpp
+++ b/include/range/v3/algorithm/none_of.hpp
@@ -36,9 +36,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(none_of)
 
         /// \brief function template \c none_of
-        template(typename I, typename S, typename F, typename P = identity)( //
-            requires input_iterator<I> AND sentinel_for<S, I> AND //
-            indirect_unary_predicate<F, projected<I, P>>) //
+        template(typename I, typename S, typename F, typename P = identity)(
+            /// \pre
+            requires input_iterator<I> AND sentinel_for<S, I> AND
+            indirect_unary_predicate<F, projected<I, P>>)
         bool RANGES_FUNC(none_of)(I first, S last, F pred, P proj = P{}) //
         {
             for(; first != last; ++first)
@@ -48,9 +49,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename F, typename P = identity)( //
-            requires input_range<Rng> AND //
-            indirect_unary_predicate<F, projected<iterator_t<Rng>, P>>) //
+        template(typename Rng, typename F, typename P = identity)(
+            /// \pre
+            requires input_range<Rng> AND
+            indirect_unary_predicate<F, projected<iterator_t<Rng>, P>>)
         bool RANGES_FUNC(none_of)(Rng && rng, F pred, P proj = P{}) //
         {
             return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));

--- a/include/range/v3/algorithm/nth_element.hpp
+++ b/include/range/v3/algorithm/nth_element.hpp
@@ -50,8 +50,9 @@ namespace ranges
     {
         // stable, 2-3 compares, 0-2 swaps
 
-        template(typename I, typename C, typename P)( //
-            requires forward_iterator<I> AND indirect_relation<C, projected<I, P>>) //
+        template(typename I, typename C, typename P)(
+            /// \pre
+            requires forward_iterator<I> AND indirect_relation<C, projected<I, P>>)
         unsigned sort3(I x, I y, I z, C & pred, P & proj)
         {
             unsigned r = 0;
@@ -85,7 +86,8 @@ namespace ranges
             return r;
         } // x <= y && y <= z
 
-        template(typename I, typename C, typename P)( //
+        template(typename I, typename C, typename P)(
+            /// \pre
             requires bidirectional_iterator<I> AND indirect_relation<C, projected<I, P>>)
         void selection_sort(I first, I last, C & pred, P & proj)
         {
@@ -105,8 +107,9 @@ namespace ranges
     RANGES_FUNC_BEGIN(nth_element)
 
         /// \brief function template \c nth_element
-        template(typename I, typename S, typename C = less, typename P = identity)( //
-            requires random_access_iterator<I> AND sortable<I, C, P>) //
+        template(typename I, typename S, typename C = less, typename P = identity)(
+            /// \pre
+            requires random_access_iterator<I> AND sortable<I, C, P>)
         I RANGES_FUNC(nth_element)(
             I first, I nth, S end_, C pred = C{}, P proj = P{}) //
         {
@@ -308,8 +311,9 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C = less, typename P = identity)( //
-            requires random_access_range<Rng> AND sortable<iterator_t<Rng>, C, P>) //
+        template(typename Rng, typename C = less, typename P = identity)(
+            /// \pre
+            requires random_access_range<Rng> AND sortable<iterator_t<Rng>, C, P>)
         borrowed_iterator_t<Rng> RANGES_FUNC(nth_element)(
             Rng && rng, iterator_t<Rng> nth, C pred = C{}, P proj = P{}) //
         {

--- a/include/range/v3/algorithm/partial_sort.hpp
+++ b/include/range/v3/algorithm/partial_sort.hpp
@@ -38,9 +38,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(partial_sort)
 
         /// \brief function template \c partial_sort
-        template(typename I, typename S, typename C = less, typename P = identity)( //
+        template(typename I, typename S, typename C = less, typename P = identity)(
+            /// \pre
             requires sortable<I, C, P> AND random_access_iterator<I> AND
-                sentinel_for<S, I>) //
+                sentinel_for<S, I>)
         I RANGES_FUNC(partial_sort)(
             I first, I middle, S last, C pred = C{}, P proj = P{}) //
         {
@@ -61,8 +62,9 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C = less, typename P = identity)( //
-            requires sortable<iterator_t<Rng>, C, P> AND random_access_range<Rng>) //
+        template(typename Rng, typename C = less, typename P = identity)(
+            /// \pre
+            requires sortable<iterator_t<Rng>, C, P> AND random_access_range<Rng>)
         borrowed_iterator_t<Rng> RANGES_FUNC(partial_sort)(
             Rng && rng, iterator_t<Rng> middle, C pred = C{}, P proj = P{}) //
         {

--- a/include/range/v3/algorithm/partial_sort_copy.hpp
+++ b/include/range/v3/algorithm/partial_sort_copy.hpp
@@ -44,11 +44,12 @@ namespace ranges
                  typename SO,
                  typename C = less,
                  typename PI = identity,
-                 typename PO = identity)( //
+                 typename PO = identity)(
+            /// \pre
             requires input_iterator<I> AND sentinel_for<SI, I> AND
                 random_access_iterator<O> AND sentinel_for<SO, O> AND
                 indirectly_copyable<I, O> AND sortable<O, C, PO> AND
-                indirect_strict_weak_order<C, projected<I, PI>, projected<O, PO>>) //
+                indirect_strict_weak_order<C, projected<I, PI>, projected<O, PO>>)
         O RANGES_FUNC(partial_sort_copy)(I first,
                                          SI last,
                                          O out_begin,
@@ -87,13 +88,14 @@ namespace ranges
                  typename OutRng,
                  typename C = less,
                  typename PI = identity,
-                 typename PO = identity)( //
+                 typename PO = identity)(
+            /// \pre
             requires input_range<InRng> AND random_access_range<OutRng> AND
                 indirectly_copyable<iterator_t<InRng>, iterator_t<OutRng>> AND
                 sortable<iterator_t<OutRng>, C, PO> AND
                 indirect_strict_weak_order<C,
                                            projected<iterator_t<InRng>, PI>,
-                                           projected<iterator_t<OutRng>, PO>>) //
+                                           projected<iterator_t<OutRng>, PO>>)
         borrowed_iterator_t<OutRng> RANGES_FUNC(partial_sort_copy)(InRng && in_rng,
                                                                    OutRng && out_rng,
                                                                    C pred = C{},

--- a/include/range/v3/algorithm/partition.hpp
+++ b/include/range/v3/algorithm/partition.hpp
@@ -98,9 +98,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(partition)
 
         /// \brief function template \c partition
-        template(typename I, typename S, typename C, typename P = identity)( //
-            requires permutable<I> AND sentinel_for<S, I> AND //
-            indirect_unary_predicate<C, projected<I, P>>) //
+        template(typename I, typename S, typename C, typename P = identity)(
+            /// \pre
+            requires permutable<I> AND sentinel_for<S, I> AND
+            indirect_unary_predicate<C, projected<I, P>>)
         I RANGES_FUNC(partition)(I first, S last, C pred, P proj = P{})
         {
             return detail::partition_impl(std::move(first),
@@ -111,9 +112,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C, typename P = identity)( //
-            requires forward_range<Rng> AND permutable<iterator_t<Rng>> AND //
-            indirect_unary_predicate<C, projected<iterator_t<Rng>, P>>) //
+        template(typename Rng, typename C, typename P = identity)(
+            /// \pre
+            requires forward_range<Rng> AND permutable<iterator_t<Rng>> AND
+            indirect_unary_predicate<C, projected<iterator_t<Rng>, P>>)
         borrowed_iterator_t<Rng> RANGES_FUNC(partition)(Rng && rng, C pred, P proj = P{})
         {
             return detail::partition_impl(begin(rng),

--- a/include/range/v3/algorithm/partition_copy.hpp
+++ b/include/range/v3/algorithm/partition_copy.hpp
@@ -48,11 +48,12 @@ namespace ranges
                  typename O0,
                  typename O1,
                  typename C,
-                 typename P = identity)( //
+                 typename P = identity)(
+            /// \pre
             requires input_iterator<I> AND sentinel_for<S, I> AND
                 weakly_incrementable<O0> AND weakly_incrementable<O1> AND
                 indirectly_copyable<I, O0> AND indirectly_copyable<I, O1> AND
-                indirect_unary_predicate<C, projected<I, P>>) //
+                indirect_unary_predicate<C, projected<I, P>>)
         partition_copy_result<I, O0, O1> RANGES_FUNC(partition_copy)(
             I first, S last, O0 o0, O1 o1, C pred, P proj = P{})
         {
@@ -78,11 +79,12 @@ namespace ranges
                  typename O0,
                  typename O1,
                  typename C,
-                 typename P = identity)( //
+                 typename P = identity)(
+            /// \pre
             requires input_range<Rng> AND weakly_incrementable<O0> AND
                 weakly_incrementable<O1> AND indirectly_copyable<iterator_t<Rng>, O0> AND
                 indirectly_copyable<iterator_t<Rng>, O1> AND
-                indirect_unary_predicate<C, projected<iterator_t<Rng>, P>>) //
+                indirect_unary_predicate<C, projected<iterator_t<Rng>, P>>)
         partition_copy_result<borrowed_iterator_t<Rng>, O0, O1> //
         RANGES_FUNC(partition_copy)(Rng && rng, O0 o0, O1 o1, C pred, P proj = P{})
         {

--- a/include/range/v3/algorithm/partition_point.hpp
+++ b/include/range/v3/algorithm/partition_point.hpp
@@ -48,9 +48,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(partition_point)
 
         /// \brief function template \c partition_point
-        template(typename I, typename S, typename C, typename P = identity)( //
-            requires forward_iterator<I> AND sentinel_for<S, I> AND //
-            indirect_unary_predicate<C, projected<I, P>>) //
+        template(typename I, typename S, typename C, typename P = identity)(
+            /// \pre
+            requires forward_iterator<I> AND sentinel_for<S, I> AND
+            indirect_unary_predicate<C, projected<I, P>>)
         I RANGES_FUNC(partition_point)(I first, S last, C pred, P proj = P{})
         {
             if(RANGES_CONSTEXPR_IF(sized_sentinel_for<S, I>))
@@ -79,9 +80,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C, typename P = identity)( //
-            requires forward_range<Rng> AND //
-            indirect_unary_predicate<C, projected<iterator_t<Rng>, P>>) //
+        template(typename Rng, typename C, typename P = identity)(
+            /// \pre
+            requires forward_range<Rng> AND
+            indirect_unary_predicate<C, projected<iterator_t<Rng>, P>>)
         borrowed_iterator_t<Rng> //
         RANGES_FUNC(partition_point)(Rng && rng, C pred, P proj = P{}) //
         {

--- a/include/range/v3/algorithm/permutation.hpp
+++ b/include/range/v3/algorithm/permutation.hpp
@@ -104,7 +104,8 @@ namespace ranges
                  typename I2,
                  typename C = equal_to,
                  typename P1 = identity,
-                 typename P2 = identity)( //
+                 typename P2 = identity)(
+            /// \pre
             requires forward_iterator<I1> AND sentinel_for<S1, I1> AND
                 forward_iterator<I2> AND indirectly_comparable<I1, I2, C, P1, P2>)
         RANGES_DEPRECATED(
@@ -164,10 +165,11 @@ namespace ranges
                  typename S2,
                  typename C = equal_to,
                  typename P1 = identity,
-                 typename P2 = identity)( //
+                 typename P2 = identity)(
+            /// \pre
             requires forward_iterator<I1> AND sentinel_for<S1, I1> AND
                 forward_iterator<I2> AND sentinel_for<S2, I2> AND
-                indirectly_comparable<I1, I2, C, P1, P2>) //
+                indirectly_comparable<I1, I2, C, P1, P2>)
         bool RANGES_FUNC(is_permutation)(I1 begin1,
                                          S1 end1,
                                          I2 begin2,
@@ -204,7 +206,8 @@ namespace ranges
                      typename I2Ref,
                      typename C = equal_to,
                      typename P1 = identity,
-                     typename P2 = identity)( //
+                     typename P2 = identity)(
+            /// \pre
             requires forward_range<Rng1> AND forward_iterator<uncvref_t<I2Ref>> AND
                 indirectly_comparable<iterator_t<Rng1>, uncvref_t<I2Ref>, C, P1, P2>)
         RANGES_DEPRECATED(
@@ -232,9 +235,10 @@ namespace ranges
                      typename Rng2,
                      typename C = equal_to,
                      typename P1 = identity,
-                     typename P2 = identity)( //
+                     typename P2 = identity)(
+            /// \pre
             requires forward_range<Rng1> AND forward_range<Rng2> AND
-                indirectly_comparable<iterator_t<Rng1>, iterator_t<Rng2>, C, P1, P2>) //
+                indirectly_comparable<iterator_t<Rng1>, iterator_t<Rng2>, C, P1, P2>)
         bool RANGES_FUNC(is_permutation)(
             Rng1 && rng1, Rng2 && rng2, C pred = C{}, P1 proj1 = P1{}, P2 proj2 = P2{}) //
         {
@@ -264,9 +268,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(next_permutation)
 
         /// \brief function template \c next_permutation
-        template(typename I, typename S, typename C = less, typename P = identity)( //
-            requires bidirectional_iterator<I> AND sentinel_for<S, I> AND //
-                sortable<I, C, P>) //
+        template(typename I, typename S, typename C = less, typename P = identity)(
+            /// \pre
+            requires bidirectional_iterator<I> AND sentinel_for<S, I> AND
+                sortable<I, C, P>)
         bool RANGES_FUNC(next_permutation)(I first, S end_, C pred = C{}, P proj = P{}) //
         {
             if(first == end_)
@@ -295,8 +300,9 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C = less, typename P = identity)( //
-            requires bidirectional_range<Rng> AND sortable<iterator_t<Rng>, C, P>) //
+        template(typename Rng, typename C = less, typename P = identity)(
+            /// \pre
+            requires bidirectional_range<Rng> AND sortable<iterator_t<Rng>, C, P>)
         bool RANGES_FUNC(next_permutation)(Rng && rng, C pred = C{}, P proj = P{}) //
         {
             return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));
@@ -307,9 +313,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(prev_permutation)
 
         /// \brief function template \c prev_permutation
-        template(typename I, typename S, typename C = less, typename P = identity)( //
-            requires bidirectional_iterator<I> AND sentinel_for<S, I> AND //
-                sortable<I, C, P>) //
+        template(typename I, typename S, typename C = less, typename P = identity)(
+            /// \pre
+            requires bidirectional_iterator<I> AND sentinel_for<S, I> AND
+                sortable<I, C, P>)
         bool RANGES_FUNC(prev_permutation)(I first, S end_, C pred = C{}, P proj = P{}) //
         {
             if(first == end_)
@@ -338,8 +345,9 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C = less, typename P = identity)( //
-            requires bidirectional_range<Rng> AND sortable<iterator_t<Rng>, C, P>) //
+        template(typename Rng, typename C = less, typename P = identity)(
+            /// \pre
+            requires bidirectional_range<Rng> AND sortable<iterator_t<Rng>, C, P>)
         bool RANGES_FUNC(prev_permutation)(Rng && rng, C pred = C{}, P proj = P{}) //
         {
             return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));

--- a/include/range/v3/algorithm/remove.hpp
+++ b/include/range/v3/algorithm/remove.hpp
@@ -38,9 +38,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(remove)
 
         /// \brief function template \c remove
-        template(typename I, typename S, typename T, typename P = identity)( //
-            requires permutable<I> AND sentinel_for<S, I> AND //
-            indirect_relation<equal_to, projected<I, P>, T const *>) //
+        template(typename I, typename S, typename T, typename P = identity)(
+            /// \pre
+            requires permutable<I> AND sentinel_for<S, I> AND
+            indirect_relation<equal_to, projected<I, P>, T const *>)
         I RANGES_FUNC(remove)(I first, S last, T const & val, P proj = P{})
         {
             first = find(std::move(first), last, val, std::ref(proj));
@@ -59,9 +60,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename T, typename P = identity)( //
-            requires forward_range<Rng> AND permutable<iterator_t<Rng>> AND //
-            indirect_relation<equal_to, projected<iterator_t<Rng>, P>, T const *>) //
+        template(typename Rng, typename T, typename P = identity)(
+            /// \pre
+            requires forward_range<Rng> AND permutable<iterator_t<Rng>> AND
+            indirect_relation<equal_to, projected<iterator_t<Rng>, P>, T const *>)
         borrowed_iterator_t<Rng> //
         RANGES_FUNC(remove)(Rng && rng, T const & val, P proj = P{})
         {

--- a/include/range/v3/algorithm/remove_copy.hpp
+++ b/include/range/v3/algorithm/remove_copy.hpp
@@ -41,10 +41,11 @@ namespace ranges
 
         /// \brief function template \c remove_copy
         template(typename I, typename S, typename O, typename T, typename P = identity)(
+            /// \pre
             requires input_iterator<I> AND sentinel_for<S, I> AND
                 weakly_incrementable<O> AND
                 indirect_relation<equal_to, projected<I, P>, T const *> AND
-                indirectly_copyable<I, O>) //
+                indirectly_copyable<I, O>)
         remove_copy_result<I, O> RANGES_FUNC(remove_copy)(
             I first, S last, O out, T const & val, P proj = P{}) //
         {
@@ -61,10 +62,11 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename O, typename T, typename P = identity)( //
-            requires input_range<Rng> AND weakly_incrementable<O> AND //
-            indirect_relation<equal_to, projected<iterator_t<Rng>, P>, T const *> AND //
-            indirectly_copyable<iterator_t<Rng>, O>) //
+        template(typename Rng, typename O, typename T, typename P = identity)(
+            /// \pre
+            requires input_range<Rng> AND weakly_incrementable<O> AND
+            indirect_relation<equal_to, projected<iterator_t<Rng>, P>, T const *> AND
+            indirectly_copyable<iterator_t<Rng>, O>)
         remove_copy_result<borrowed_iterator_t<Rng>, O> //
         RANGES_FUNC(remove_copy)(Rng && rng, O out, T const & val, P proj = P{}) //
         {

--- a/include/range/v3/algorithm/remove_copy_if.hpp
+++ b/include/range/v3/algorithm/remove_copy_if.hpp
@@ -41,9 +41,10 @@ namespace ranges
 
         /// \brief function template \c remove_copy_if
         template(typename I, typename S, typename O, typename C, typename P = identity)(
-            requires input_iterator<I> AND sentinel_for<S, I> AND //
+            /// \pre
+            requires input_iterator<I> AND sentinel_for<S, I> AND
             weakly_incrementable<O> AND indirect_unary_predicate<C, projected<I, P>> AND
-            indirectly_copyable<I, O>) //
+            indirectly_copyable<I, O>)
         remove_copy_if_result<I, O> //
         RANGES_FUNC(remove_copy_if)(I first, S last, O out, C pred, P proj = P{}) //
         {
@@ -60,10 +61,11 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename O, typename C, typename P = identity)( //
-            requires input_range<Rng> AND weakly_incrementable<O> AND //
-            indirect_unary_predicate<C, projected<iterator_t<Rng>, P>> AND //
-            indirectly_copyable<iterator_t<Rng>, O>) //
+        template(typename Rng, typename O, typename C, typename P = identity)(
+            /// \pre
+            requires input_range<Rng> AND weakly_incrementable<O> AND
+            indirect_unary_predicate<C, projected<iterator_t<Rng>, P>> AND
+            indirectly_copyable<iterator_t<Rng>, O>)
         remove_copy_if_result<borrowed_iterator_t<Rng>, O> //
         RANGES_FUNC(remove_copy_if)(Rng && rng, O out, C pred, P proj = P{}) //
         {

--- a/include/range/v3/algorithm/remove_if.hpp
+++ b/include/range/v3/algorithm/remove_if.hpp
@@ -38,9 +38,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(remove_if)
 
         /// \brief function template \c remove_if
-        template(typename I, typename S, typename C, typename P = identity)( //
-            requires permutable<I> AND sentinel_for<S, I> AND //
-            indirect_unary_predicate<C, projected<I, P>>) //
+        template(typename I, typename S, typename C, typename P = identity)(
+            /// \pre
+            requires permutable<I> AND sentinel_for<S, I> AND
+            indirect_unary_predicate<C, projected<I, P>>)
         I RANGES_FUNC(remove_if)(I first, S last, C pred, P proj = P{})
         {
             first = find_if(std::move(first), last, std::ref(pred), std::ref(proj));
@@ -59,9 +60,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C, typename P = identity)( //
-            requires forward_range<Rng> AND permutable<iterator_t<Rng>> AND //
-            indirect_unary_predicate<C, projected<iterator_t<Rng>, P>>) //
+        template(typename Rng, typename C, typename P = identity)(
+            /// \pre
+            requires forward_range<Rng> AND permutable<iterator_t<Rng>> AND
+            indirect_unary_predicate<C, projected<iterator_t<Rng>, P>>)
         borrowed_iterator_t<Rng> RANGES_FUNC(remove_if)(Rng && rng, C pred, P proj = P{})
         {
             return (*this)(begin(rng), end(rng), std::move(pred), std::move(proj));

--- a/include/range/v3/algorithm/replace.hpp
+++ b/include/range/v3/algorithm/replace.hpp
@@ -37,9 +37,10 @@ namespace ranges
 
         /// \brief function template \c replace
         template(typename I, typename S, typename T1, typename T2, typename P = identity)(
+            /// \pre
             requires input_iterator<I> AND sentinel_for<S, I> AND
                 indirectly_writable<I, T2 const &> AND
-                indirect_relation<equal_to, projected<I, P>, T1 const *>) //
+                indirect_relation<equal_to, projected<I, P>, T1 const *>)
         I RANGES_FUNC(replace)(
             I first, S last, T1 const & old_value, T2 const & new_value, P proj = {}) //
         {
@@ -50,10 +51,11 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename T1, typename T2, typename P = identity)( //
+        template(typename Rng, typename T1, typename T2, typename P = identity)(
+            /// \pre
             requires input_range<Rng> AND
                 indirectly_writable<iterator_t<Rng>, T2 const &> AND
-                indirect_relation<equal_to, projected<iterator_t<Rng>, P>, T1 const *>) //
+                indirect_relation<equal_to, projected<iterator_t<Rng>, P>, T1 const *>)
         borrowed_iterator_t<Rng> RANGES_FUNC(replace)(
             Rng && rng, T1 const & old_value, T2 const & new_value, P proj = {}) //
         {

--- a/include/range/v3/algorithm/replace_copy.hpp
+++ b/include/range/v3/algorithm/replace_copy.hpp
@@ -45,10 +45,11 @@ namespace ranges
                  typename O,
                  typename T1,
                  typename T2,
-                 typename P = identity)( //
+                 typename P = identity)(
+            /// \pre
             requires input_iterator<I> AND sentinel_for<S, I> AND
                 output_iterator<O, T2 const &> AND indirectly_copyable<I, O> AND
-                indirect_relation<equal_to, projected<I, P>, T1 const *>) //
+                indirect_relation<equal_to, projected<I, P>, T1 const *>)
         replace_copy_result<I, O> RANGES_FUNC(replace_copy)(I first,
                                                             S last,
                                                             O out,
@@ -72,10 +73,11 @@ namespace ranges
                  typename O,
                  typename T1,
                  typename T2,
-                 typename P = identity)( //
+                 typename P = identity)(
+            /// \pre
             requires input_range<Rng> AND output_iterator<O, T2 const &> AND
                 indirectly_copyable<iterator_t<Rng>, O> AND
-                indirect_relation<equal_to, projected<iterator_t<Rng>, P>, T1 const *>) //
+                indirect_relation<equal_to, projected<iterator_t<Rng>, P>, T1 const *>)
         replace_copy_result<borrowed_iterator_t<Rng>, O> RANGES_FUNC(replace_copy)(
             Rng && rng, O out, T1 const & old_value, T2 const & new_value, P proj = {}) //
         {

--- a/include/range/v3/algorithm/replace_copy_if.hpp
+++ b/include/range/v3/algorithm/replace_copy_if.hpp
@@ -45,11 +45,12 @@ namespace ranges
                  typename O,
                  typename C,
                  typename T,
-                 typename P = identity)( //
+                 typename P = identity)(
+            /// \pre
             requires input_iterator<I> AND sentinel_for<S, I> AND
                 output_iterator<O, T const &> AND
                 indirect_unary_predicate<C, projected<I, P>> AND
-                indirectly_copyable<I, O>) //
+                indirectly_copyable<I, O>)
         replace_copy_if_result<I, O> RANGES_FUNC(replace_copy_if)(
             I first, S last, O out, C pred, T const & new_value, P proj = {}) //
         {
@@ -66,9 +67,10 @@ namespace ranges
 
         /// \overload
         template(typename Rng, typename O, typename C, typename T, typename P = identity)(
+            /// \pre
             requires input_range<Rng> AND output_iterator<O, T const &> AND
                 indirect_unary_predicate<C, projected<iterator_t<Rng>, P>> AND
-                indirectly_copyable<iterator_t<Rng>, O>) //
+                indirectly_copyable<iterator_t<Rng>, O>)
         replace_copy_if_result<borrowed_iterator_t<Rng>, O> RANGES_FUNC(replace_copy_if)(
             Rng && rng, O out, C pred, T const & new_value, P proj = {}) //
         {

--- a/include/range/v3/algorithm/replace_if.hpp
+++ b/include/range/v3/algorithm/replace_if.hpp
@@ -37,9 +37,10 @@ namespace ranges
 
         /// \brief function template \c replace_if
         template(typename I, typename S, typename C, typename T, typename P = identity)(
+            /// \pre
             requires input_iterator<I> AND sentinel_for<S, I> AND
                 indirect_unary_predicate<C, projected<I, P>> AND
-                indirectly_writable<I, T const &>) //
+                indirectly_writable<I, T const &>)
         I RANGES_FUNC(replace_if)(
             I first, S last, C pred, T const & new_value, P proj = P{}) //
         {
@@ -50,10 +51,11 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C, typename T, typename P = identity)( //
+        template(typename Rng, typename C, typename T, typename P = identity)(
+            /// \pre
             requires input_range<Rng> AND
                 indirect_unary_predicate<C, projected<iterator_t<Rng>, P>> AND
-                indirectly_writable<iterator_t<Rng>, T const &>) //
+                indirectly_writable<iterator_t<Rng>, T const &>)
         borrowed_iterator_t<Rng> RANGES_FUNC(replace_if)(
             Rng && rng, C pred, T const & new_value, P proj = P{}) //
         {

--- a/include/range/v3/algorithm/reverse.hpp
+++ b/include/range/v3/algorithm/reverse.hpp
@@ -60,7 +60,8 @@ namespace ranges
     RANGES_FUNC_BEGIN(reverse)
 
         /// \brief function template \c reverse
-        template(typename I, typename S)( //
+        template(typename I, typename S)(
+            /// \pre
             requires bidirectional_iterator<I> AND sentinel_for<S, I> AND permutable<I>)
         I RANGES_FUNC(reverse)(I first, S end_)
         {
@@ -70,8 +71,9 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename I = iterator_t<Rng>)( //
-            requires bidirectional_range<Rng> AND permutable<I>) //
+        template(typename Rng, typename I = iterator_t<Rng>)(
+            /// \pre
+            requires bidirectional_range<Rng> AND permutable<I>)
         borrowed_iterator_t<Rng> RANGES_FUNC(reverse)(Rng && rng) //
         {
             return (*this)(begin(rng), end(rng));

--- a/include/range/v3/algorithm/reverse_copy.hpp
+++ b/include/range/v3/algorithm/reverse_copy.hpp
@@ -39,9 +39,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(reverse_copy)
 
         /// \brief function template \c reverse_copy
-        template(typename I, typename S, typename O)( //
-            requires bidirectional_iterator<I> AND sentinel_for<S, I> AND //
-            weakly_incrementable<O> AND indirectly_copyable<I, O>) //
+        template(typename I, typename S, typename O)(
+            /// \pre
+            requires bidirectional_iterator<I> AND sentinel_for<S, I> AND
+            weakly_incrementable<O> AND indirectly_copyable<I, O>)
         reverse_copy_result<I, O> RANGES_FUNC(reverse_copy)(I first, S end_, O out) //
         {
             I last = ranges::next(first, end_), res = last;
@@ -51,9 +52,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename O)( //
-            requires bidirectional_range<Rng> AND weakly_incrementable<O> AND //
-            indirectly_copyable<iterator_t<Rng>, O>) //
+        template(typename Rng, typename O)(
+            /// \pre
+            requires bidirectional_range<Rng> AND weakly_incrementable<O> AND
+            indirectly_copyable<iterator_t<Rng>, O>)
         reverse_copy_result<borrowed_iterator_t<Rng>, O> //
         RANGES_FUNC(reverse_copy)(Rng && rng, O out)            //
         {

--- a/include/range/v3/algorithm/rotate.hpp
+++ b/include/range/v3/algorithm/rotate.hpp
@@ -196,8 +196,9 @@ namespace ranges
     RANGES_FUNC_BEGIN(rotate)
 
         /// \brief function template \c rotate
-        template(typename I, typename S)( //
-            requires permutable<I> AND sentinel_for<S, I>) //
+        template(typename I, typename S)(
+            /// \pre
+            requires permutable<I> AND sentinel_for<S, I>)
         subrange<I> RANGES_FUNC(rotate)(I first, I middle, S last) //
         {
             if(first == middle)
@@ -213,8 +214,9 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename I = iterator_t<Rng>)( //
-            requires range<Rng> AND permutable<I>) //
+        template(typename Rng, typename I = iterator_t<Rng>)(
+            /// \pre
+            requires range<Rng> AND permutable<I>)
         safe_subrange_t<Rng> RANGES_FUNC(rotate)(Rng && rng, I middle) //
         {
             return (*this)(begin(rng), std::move(middle), end(rng));

--- a/include/range/v3/algorithm/rotate_copy.hpp
+++ b/include/range/v3/algorithm/rotate_copy.hpp
@@ -40,9 +40,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(rotate_copy)
 
         /// \brief function template \c rotate_copy
-        template(typename I, typename S, typename O, typename P = identity)( //
-            requires forward_iterator<I> AND sentinel_for<S, I> AND //
-            weakly_incrementable<O> AND indirectly_copyable<I, O>) //
+        template(typename I, typename S, typename O, typename P = identity)(
+            /// \pre
+            requires forward_iterator<I> AND sentinel_for<S, I> AND
+            weakly_incrementable<O> AND indirectly_copyable<I, O>)
         rotate_copy_result<I, O> //
         RANGES_FUNC(rotate_copy)(I first, I middle, S last, O out) //
         {
@@ -52,9 +53,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename O, typename P = identity)( //
-            requires range<Rng> AND weakly_incrementable<O> AND //
-            indirectly_copyable<iterator_t<Rng>, O>) //
+        template(typename Rng, typename O, typename P = identity)(
+            /// \pre
+            requires range<Rng> AND weakly_incrementable<O> AND
+            indirectly_copyable<iterator_t<Rng>, O>)
         rotate_copy_result<borrowed_iterator_t<Rng>, O> //
         RANGES_FUNC(rotate_copy)(Rng && rng, iterator_t<Rng> middle, O out) //
         {

--- a/include/range/v3/algorithm/sample.hpp
+++ b/include/range/v3/algorithm/sample.hpp
@@ -79,7 +79,8 @@ namespace ranges
         template(typename I,
                  typename S,
                  typename O,
-                 typename Gen = detail::default_random_engine &)( //
+                 typename Gen = detail::default_random_engine &)(
+            /// \pre
             requires input_iterator<I> AND sentinel_for<S, I> AND
                 weakly_incrementable<O> AND indirectly_copyable<I, O> AND
                 uniform_random_bit_generator<std::remove_reference_t<Gen>> AND
@@ -137,7 +138,8 @@ namespace ranges
         template(typename I,
                  typename S,
                  typename ORng,
-                 typename Gen = detail::default_random_engine &)( //
+                 typename Gen = detail::default_random_engine &)(
+            /// \pre
             requires input_iterator<I> AND sentinel_for<S, I> AND
                 weakly_incrementable<iterator_t<ORng>> AND
                 indirectly_copyable<I, iterator_t<ORng>> AND
@@ -175,6 +177,7 @@ namespace ranges
         template(typename Rng,
                  typename O,
                  typename Gen = detail::default_random_engine &)(
+            /// \pre
             requires input_range<Rng> AND weakly_incrementable<O> AND
                 indirectly_copyable<iterator_t<Rng>, O> AND
                 uniform_random_bit_generator<std::remove_reference_t<Gen>> AND
@@ -204,7 +207,8 @@ namespace ranges
         /// \overload
         template(typename IRng,
                  typename ORng,
-                 typename Gen = detail::default_random_engine &)( //
+                 typename Gen = detail::default_random_engine &)(
+            /// \pre
             requires input_range<IRng> AND range<ORng> AND
                 indirectly_copyable<iterator_t<IRng>, iterator_t<ORng>> AND
                 uniform_random_bit_generator<std::remove_reference_t<Gen>> AND

--- a/include/range/v3/algorithm/sample.hpp
+++ b/include/range/v3/algorithm/sample.hpp
@@ -144,9 +144,9 @@ namespace ranges
                 weakly_incrementable<iterator_t<ORng>> AND
                 indirectly_copyable<I, iterator_t<ORng>> AND
                 uniform_random_bit_generator<std::remove_reference_t<Gen>> AND
-                (forward_range<ORng> ||
-                 sized_range<ORng>)&&(random_access_iterator<iterator_t<ORng>> ||
-                                      forward_iterator<I> || sized_sentinel_for<S, I>))
+                (forward_range<ORng> || sized_range<ORng>) AND
+                (random_access_iterator<iterator_t<ORng>> || forward_iterator<I> ||
+                    sized_sentinel_for<S, I>))
         sample_result<I, borrowed_iterator_t<ORng>> RANGES_FUNC(sample)(
             I first,
             S last,
@@ -213,7 +213,8 @@ namespace ranges
                 indirectly_copyable<iterator_t<IRng>, iterator_t<ORng>> AND
                 uniform_random_bit_generator<std::remove_reference_t<Gen>> AND
                 (random_access_iterator<iterator_t<ORng>> || forward_range<IRng> ||
-                 sized_range<IRng>)&&(forward_range<ORng> || sized_range<ORng>))
+                    sized_range<IRng>) AND
+                (forward_range<ORng> || sized_range<ORng>))
         sample_result<borrowed_iterator_t<IRng>, borrowed_iterator_t<ORng>> //
         RANGES_FUNC(sample)(IRng && rng,
                             ORng && out,

--- a/include/range/v3/algorithm/search.hpp
+++ b/include/range/v3/algorithm/search.hpp
@@ -152,10 +152,11 @@ namespace ranges
                  typename S2,
                  typename C = equal_to,
                  typename P1 = identity,
-                 typename P2 = identity)( //
+                 typename P2 = identity)(
+            /// \pre
             requires forward_iterator<I1> AND sentinel_for<S1, I1> AND
                 forward_iterator<I2> AND sentinel_for<S2, I2> AND
-                indirectly_comparable<I1, I2, C, P1, P2>) //
+                indirectly_comparable<I1, I2, C, P1, P2>)
         subrange<I1> RANGES_FUNC(search)(I1 begin1,
                                          S1 end1,
                                          I2 begin2,
@@ -192,9 +193,10 @@ namespace ranges
                  typename Rng2,
                  typename C = equal_to,
                  typename P1 = identity,
-                 typename P2 = identity)( //
+                 typename P2 = identity)(
+            /// \pre
             requires forward_range<Rng1> AND forward_range<Rng2> AND
-                indirectly_comparable<iterator_t<Rng1>, iterator_t<Rng2>, C, P1, P2>) //
+                indirectly_comparable<iterator_t<Rng1>, iterator_t<Rng2>, C, P1, P2>)
         safe_subrange_t<Rng1> RANGES_FUNC(search)(
             Rng1 && rng1, Rng2 && rng2, C pred = C{}, P1 proj1 = P1{}, P2 proj2 = P2{}) //
         {

--- a/include/range/v3/algorithm/search_n.hpp
+++ b/include/range/v3/algorithm/search_n.hpp
@@ -139,9 +139,10 @@ namespace ranges
                  typename S,
                  typename V,
                  typename C = equal_to,
-                 typename P = identity)( //
+                 typename P = identity)(
+            /// \pre
             requires forward_iterator<I> AND sentinel_for<S, I> AND
-                indirectly_comparable<I, V const *, C, P>) //
+                indirectly_comparable<I, V const *, C, P>)
         subrange<I> RANGES_FUNC(search_n)(I first,
                                           S last,
                                           iter_difference_t<I> cnt,
@@ -166,8 +167,9 @@ namespace ranges
 
         /// \overload
         template(typename Rng, typename V, typename C = equal_to, typename P = identity)(
+            /// \pre
             requires forward_range<Rng> AND
-                indirectly_comparable<iterator_t<Rng>, V const *, C, P>) //
+                indirectly_comparable<iterator_t<Rng>, V const *, C, P>)
         safe_subrange_t<Rng> RANGES_FUNC(search_n)(Rng && rng,
                                                    iter_difference_t<iterator_t<Rng>> cnt,
                                                    V const & val,

--- a/include/range/v3/algorithm/set_algorithm.hpp
+++ b/include/range/v3/algorithm/set_algorithm.hpp
@@ -53,10 +53,11 @@ namespace ranges
                  typename S2,
                  typename C = less,
                  typename P1 = identity,
-                 typename P2 = identity)( //
+                 typename P2 = identity)(
+            /// \pre
             requires input_iterator<I1> AND sentinel_for<S1, I1> AND
                 input_iterator<I2> AND sentinel_for<S2, I2> AND
-                indirect_strict_weak_order<C, projected<I1, P1>, projected<I2, P2>>) //
+                indirect_strict_weak_order<C, projected<I1, P1>, projected<I2, P2>>)
         bool RANGES_FUNC(includes)(I1 begin1,
                                    S1 end1,
                                    I2 begin2,
@@ -81,11 +82,12 @@ namespace ranges
                  typename Rng2,
                  typename C = less,
                  typename P1 = identity,
-                 typename P2 = identity)( //
+                 typename P2 = identity)(
+            /// \pre
             requires input_range<Rng1> AND input_range<Rng2> AND
                 indirect_strict_weak_order<C,
                                            projected<iterator_t<Rng1>, P1>,
-                                           projected<iterator_t<Rng2>, P2>>) //
+                                           projected<iterator_t<Rng2>, P2>>)
         bool RANGES_FUNC(includes)(
             Rng1 && rng1, Rng2 && rng2, C pred = C{}, P1 proj1 = P1{}, P2 proj2 = P2{}) //
         {
@@ -118,9 +120,10 @@ namespace ranges
                  typename O,
                  typename C = less,
                  typename P1 = identity,
-                 typename P2 = identity)( //
+                 typename P2 = identity)(
+            /// \pre
             requires sentinel_for<S1, I1> AND sentinel_for<S2, I2> AND
-                mergeable<I1, I2, O, C, P1, P2>) //
+                mergeable<I1, I2, O, C, P1, P2>)
         set_union_result<I1, I2, O> RANGES_FUNC(set_union)(I1 begin1,
                                                            S1 end1,
                                                            I2 begin2,
@@ -160,9 +163,10 @@ namespace ranges
                  typename O,
                  typename C = less,
                  typename P1 = identity,
-                 typename P2 = identity)( //
+                 typename P2 = identity)(
+            /// \pre
             requires range<Rng1> AND range<Rng2> AND
-                mergeable<iterator_t<Rng1>, iterator_t<Rng2>, O, C, P1, P2>) //
+                mergeable<iterator_t<Rng1>, iterator_t<Rng2>, O, C, P1, P2>)
         set_union_result<borrowed_iterator_t<Rng1>, borrowed_iterator_t<Rng2>, O> //
         RANGES_FUNC(set_union)(Rng1 && rng1,
                                Rng2 && rng2,
@@ -199,9 +203,10 @@ namespace ranges
                  typename O,
                  typename C = less,
                  typename P1 = identity,
-                 typename P2 = identity)( //
+                 typename P2 = identity)(
+            /// \pre
             requires sentinel_for<S1, I1> AND sentinel_for<S2, I2> AND
-                mergeable<I1, I2, O, C, P1, P2>) //
+                mergeable<I1, I2, O, C, P1, P2>)
         O RANGES_FUNC(set_intersection)(I1 begin1,
                                         S1 end1,
                                         I2 begin2,
@@ -235,9 +240,10 @@ namespace ranges
                  typename O,
                  typename C = less,
                  typename P1 = identity,
-                 typename P2 = identity)( //
+                 typename P2 = identity)(
+            /// \pre
             requires range<Rng1> AND range<Rng2> AND
-                mergeable<iterator_t<Rng1>, iterator_t<Rng2>, O, C, P1, P2>) //
+                mergeable<iterator_t<Rng1>, iterator_t<Rng2>, O, C, P1, P2>)
         O RANGES_FUNC(set_intersection)(Rng1 && rng1,
                                         Rng2 && rng2,
                                         O out,
@@ -275,9 +281,10 @@ namespace ranges
                  typename O,
                  typename C = less,
                  typename P1 = identity,
-                 typename P2 = identity)( //
+                 typename P2 = identity)(
+            /// \pre
             requires sentinel_for<S1, I1> AND sentinel_for<S2, I2> AND
-                mergeable<I1, I2, O, C, P1, P2>) //
+                mergeable<I1, I2, O, C, P1, P2>)
         set_difference_result<I1, O> RANGES_FUNC(set_difference)(I1 begin1,
                                                                  S1 end1,
                                                                  I2 begin2,
@@ -316,9 +323,10 @@ namespace ranges
                  typename O,
                  typename C = less,
                  typename P1 = identity,
-                 typename P2 = identity)( //
+                 typename P2 = identity)(
+            /// \pre
             requires range<Rng1> AND range<Rng2> AND
-                mergeable<iterator_t<Rng1>, iterator_t<Rng2>, O, C, P1, P2>) //
+                mergeable<iterator_t<Rng1>, iterator_t<Rng2>, O, C, P1, P2>)
         set_difference_result<borrowed_iterator_t<Rng1>, O> //
         RANGES_FUNC(set_difference)(Rng1 && rng1,
                                     Rng2 && rng2,
@@ -358,9 +366,10 @@ namespace ranges
                  typename O,
                  typename C = less,
                  typename P1 = identity,
-                 typename P2 = identity)( //
+                 typename P2 = identity)(
+            /// \pre
             requires sentinel_for<S1, I1> AND sentinel_for<S2, I2> AND
-                mergeable<I1, I2, O, C, P1, P2>) //
+                mergeable<I1, I2, O, C, P1, P2>)
         set_symmetric_difference_result<I1, I2, O> //
         RANGES_FUNC(set_symmetric_difference)(I1 begin1,
                                               S1 end1,
@@ -406,9 +415,10 @@ namespace ranges
                  typename O,
                  typename C = less,
                  typename P1 = identity,
-                 typename P2 = identity)( //
+                 typename P2 = identity)(
+            /// \pre
             requires range<Rng1> AND range<Rng2> AND
-                mergeable<iterator_t<Rng1>, iterator_t<Rng2>, O, C, P1, P2>) //
+                mergeable<iterator_t<Rng1>, iterator_t<Rng2>, O, C, P1, P2>)
         set_symmetric_difference_result<borrowed_iterator_t<Rng1>,
                                         borrowed_iterator_t<Rng2>,
                                         O>

--- a/include/range/v3/algorithm/shuffle.hpp
+++ b/include/range/v3/algorithm/shuffle.hpp
@@ -39,10 +39,11 @@ namespace ranges
 
         /// \brief function template \c shuffle
         template(typename I, typename S, typename Gen = detail::default_random_engine &)(
+            /// \pre
             requires random_access_iterator<I> AND sentinel_for<S, I> AND
                 permutable<I> AND
                 uniform_random_bit_generator<std::remove_reference_t<Gen>> AND
-                convertible_to<invoke_result_t<Gen &>, iter_difference_t<I>>) //
+                convertible_to<invoke_result_t<Gen &>, iter_difference_t<I>>)
         I RANGES_FUNC(shuffle)(I const first,
                                S const last,
                                Gen && gen = detail::get_random_engine()) //
@@ -65,11 +66,12 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename Gen = detail::default_random_engine &)( //
+        template(typename Rng, typename Gen = detail::default_random_engine &)(
+            /// \pre
             requires random_access_range<Rng> AND permutable<iterator_t<Rng>> AND
                 uniform_random_bit_generator<std::remove_reference_t<Gen>> AND
                 convertible_to<invoke_result_t<Gen &>,
-                               iter_difference_t<iterator_t<Rng>>>) //
+                               iter_difference_t<iterator_t<Rng>>>)
         borrowed_iterator_t<Rng> //
         RANGES_FUNC(shuffle)(Rng && rng, Gen && rand = detail::get_random_engine()) //
         {

--- a/include/range/v3/algorithm/sort.hpp
+++ b/include/range/v3/algorithm/sort.hpp
@@ -194,9 +194,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(sort)
 
         /// \brief function template \c sort
-        template(typename I, typename S, typename C = less, typename P = identity)( //
-            requires sortable<I, C, P> AND random_access_iterator<I> AND //
-            sentinel_for<S, I>) //
+        template(typename I, typename S, typename C = less, typename P = identity)(
+            /// \pre
+            requires sortable<I, C, P> AND random_access_iterator<I> AND
+                sentinel_for<S, I>)
         I RANGES_FUNC(sort)(I first, S end_, C pred = C{}, P proj = P{})
         {
             I last = ranges::next(first, std::move(end_));
@@ -210,8 +211,9 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C = less, typename P = identity)( //
-            requires sortable<iterator_t<Rng>, C, P> AND random_access_range<Rng>) //
+        template(typename Rng, typename C = less, typename P = identity)(
+            /// \pre
+            requires sortable<iterator_t<Rng>, C, P> AND random_access_range<Rng>)
         borrowed_iterator_t<Rng> //
         RANGES_FUNC(sort)(Rng && rng, C pred = C{}, P proj = P{}) //
         {

--- a/include/range/v3/algorithm/stable_partition.hpp
+++ b/include/range/v3/algorithm/stable_partition.hpp
@@ -293,9 +293,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(stable_partition)
 
         /// \brief function template \c stable_partition
-        template(typename I, typename S, typename C, typename P = identity)( //
-            requires bidirectional_iterator<I> AND sentinel_for<S, I> AND //
-            indirect_unary_predicate<C, projected<I, P>> AND permutable<I>) //
+        template(typename I, typename S, typename C, typename P = identity)(
+            /// \pre
+            requires bidirectional_iterator<I> AND sentinel_for<S, I> AND
+            indirect_unary_predicate<C, projected<I, P>> AND permutable<I>)
         I RANGES_FUNC(stable_partition)(I first, S last, C pred, P proj = P{})
         {
             return detail::stable_partition_impl(std::move(first),
@@ -307,10 +308,11 @@ namespace ranges
 
         // BUGBUG Can this be optimized if Rng has O1 size?
         /// \overload
-        template(typename Rng, typename C, typename P = identity)( //
-            requires bidirectional_range<Rng> AND //
-            indirect_unary_predicate<C, projected<iterator_t<Rng>, P>> AND //
-            permutable<iterator_t<Rng>>) //
+        template(typename Rng, typename C, typename P = identity)(
+            /// \pre
+            requires bidirectional_range<Rng> AND
+            indirect_unary_predicate<C, projected<iterator_t<Rng>, P>> AND
+            permutable<iterator_t<Rng>>)
         borrowed_iterator_t<Rng> //
         RANGES_FUNC(stable_partition)(Rng && rng, C pred, P proj = P{}) //
         {

--- a/include/range/v3/algorithm/stable_partition.hpp
+++ b/include/range/v3/algorithm/stable_partition.hpp
@@ -288,7 +288,7 @@ namespace ranges
             return detail::stable_partition_impl(first, last, pred, proj, len, p, bi);
         }
     } // namespace detail
-    /// endcond
+    /// \endcond
 
     RANGES_FUNC_BEGIN(stable_partition)
 

--- a/include/range/v3/algorithm/stable_sort.hpp
+++ b/include/range/v3/algorithm/stable_sort.hpp
@@ -193,9 +193,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(stable_sort)
 
         /// \brief function template \c stable_sort
-        template(typename I, typename S, typename C = less, typename P = identity)( //
-            requires sortable<I, C, P> AND random_access_iterator<I> AND //
-            sentinel_for<S, I>) //
+        template(typename I, typename S, typename C = less, typename P = identity)(
+            /// \pre
+            requires sortable<I, C, P> AND random_access_iterator<I> AND
+            sentinel_for<S, I>)
         I RANGES_FUNC(stable_sort)(I first, S end_, C pred = C{}, P proj = P{})
         {
             I last = ranges::next(first, end_);
@@ -214,8 +215,9 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C = less, typename P = identity)( //
-            requires sortable<iterator_t<Rng>, C, P> AND random_access_range<Rng>) //
+        template(typename Rng, typename C = less, typename P = identity)(
+            /// \pre
+            requires sortable<iterator_t<Rng>, C, P> AND random_access_range<Rng>)
         borrowed_iterator_t<Rng> //
         RANGES_FUNC(stable_sort)(Rng && rng, C pred = C{}, P proj = P{}) //
         {

--- a/include/range/v3/algorithm/starts_with.hpp
+++ b/include/range/v3/algorithm/starts_with.hpp
@@ -48,10 +48,11 @@ namespace ranges
                  typename S2,
                  typename Comp = equal_to,
                  typename Proj1 = identity,
-                 typename Proj2 = identity)( //
+                 typename Proj2 = identity)(
+            /// \pre
             requires input_iterator<I1> AND sentinel_for<S1, I1> AND
                 input_iterator<I2> AND sentinel_for<S2, I2> AND
-                indirectly_comparable<I1, I2, Comp, Proj1, Proj2>) //
+                indirectly_comparable<I1, I2, Comp, Proj1, Proj2>)
         constexpr bool RANGES_FUNC(starts_with)(I1 first1,
                                                 S1 last1,
                                                 I2 first2,
@@ -75,7 +76,8 @@ namespace ranges
                  typename R2,
                  typename Comp = equal_to,
                  typename Proj1 = identity,
-                 typename Proj2 = identity)( //
+                 typename Proj2 = identity)(
+            /// \pre
             requires input_range<R1> AND input_range<R2> AND
                 indirectly_comparable<iterator_t<R1>, iterator_t<R2>, Comp, Proj1, Proj2>)
         constexpr bool RANGES_FUNC(starts_with)(

--- a/include/range/v3/algorithm/swap_ranges.hpp
+++ b/include/range/v3/algorithm/swap_ranges.hpp
@@ -36,9 +36,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(swap_ranges)
 
         /// \brief function template \c swap_ranges
-        template(typename I1, typename S1, typename I2)( //
-            requires input_iterator<I1> AND sentinel_for<S1, I1> AND //
-            input_iterator<I2> AND indirectly_swappable<I1, I2>) //
+        template(typename I1, typename S1, typename I2)(
+            /// \pre
+            requires input_iterator<I1> AND sentinel_for<S1, I1> AND
+            input_iterator<I2> AND indirectly_swappable<I1, I2>)
         swap_ranges_result<I1, I2> //
         RANGES_FUNC(swap_ranges)(I1 begin1, S1 end1, I2 begin2) //
         {
@@ -48,10 +49,11 @@ namespace ranges
         }
 
         /// \overload
-        template(typename I1, typename S1, typename I2, typename S2)( //
+        template(typename I1, typename S1, typename I2, typename S2)(
+            /// \pre
             requires input_iterator<I1> AND sentinel_for<S1, I1> AND
                 input_iterator<I2> AND sentinel_for<S2, I2> AND
-                indirectly_swappable<I1, I2>) //
+                indirectly_swappable<I1, I2>)
         swap_ranges_result<I1, I2> RANGES_FUNC(swap_ranges)(I1 begin1,
                                                             S1 end1,
                                                             I2 begin2,
@@ -62,18 +64,20 @@ namespace ranges
             return {begin1, begin2};
         }
 
-        template(typename Rng1, typename I2_)( //
-            requires input_range<Rng1> AND input_iterator<uncvref_t<I2_>> AND //
-            indirectly_swappable<iterator_t<Rng1>, uncvref_t<I2_>>) //
+        template(typename Rng1, typename I2_)(
+            /// \pre
+            requires input_range<Rng1> AND input_iterator<uncvref_t<I2_>> AND
+            indirectly_swappable<iterator_t<Rng1>, uncvref_t<I2_>>)
         swap_ranges_result<iterator_t<Rng1>, uncvref_t<I2_>> //
         RANGES_FUNC(swap_ranges)(Rng1 && rng1, I2_ && begin2) //
         {
             return (*this)(begin(rng1), end(rng1), (I2_ &&) begin2);
         }
 
-        template(typename Rng1, typename Rng2)( //
+        template(typename Rng1, typename Rng2)(
+            /// \pre
             requires input_range<Rng1> AND input_range<Rng2> AND
-                indirectly_swappable<iterator_t<Rng1>, iterator_t<Rng2>>) //
+                indirectly_swappable<iterator_t<Rng1>, iterator_t<Rng2>>)
         swap_ranges_result<borrowed_iterator_t<Rng1>, borrowed_iterator_t<Rng2>> //
         RANGES_FUNC(swap_ranges)(Rng1 && rng1, Rng2 && rng2) //
         {

--- a/include/range/v3/algorithm/transform.hpp
+++ b/include/range/v3/algorithm/transform.hpp
@@ -48,9 +48,10 @@ namespace ranges
         // Single-range variant
         /// \brief function template \c transform
         template(typename I, typename S, typename O, typename F, typename P = identity)(
-            requires input_iterator<I> AND sentinel_for<S, I> AND //
-            weakly_incrementable<O> AND copy_constructible<F> AND //
-            indirectly_writable<O, indirect_result_t<F &, projected<I, P>>>) //
+            /// \pre
+            requires input_iterator<I> AND sentinel_for<S, I> AND
+            weakly_incrementable<O> AND copy_constructible<F> AND
+            indirectly_writable<O, indirect_result_t<F &, projected<I, P>>>)
         unary_transform_result<I, O> //
         RANGES_FUNC(transform)(I first, S last, O out, F fun, P proj = P{}) //
         {
@@ -60,9 +61,10 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename O, typename F, typename P = identity)( //
-            requires input_range<Rng> AND weakly_incrementable<O> AND //
-            copy_constructible<F> AND //
+        template(typename Rng, typename O, typename F, typename P = identity)(
+            /// \pre
+            requires input_range<Rng> AND weakly_incrementable<O> AND
+            copy_constructible<F> AND
             indirectly_writable<O, indirect_result_t<F &, projected<iterator_t<Rng>, P>>>)
         unary_transform_result<borrowed_iterator_t<Rng>, O> //
         RANGES_FUNC(transform)(Rng && rng, O out, F fun, P proj = P{}) //
@@ -80,13 +82,14 @@ namespace ranges
                  typename O,
                  typename F,
                  typename P0 = identity,
-                 typename P1 = identity)( //
+                 typename P1 = identity)(
+            /// \pre
             requires input_iterator<I0> AND sentinel_for<S0, I0> AND
                 input_iterator<I1> AND sentinel_for<S1, I1> AND
                 weakly_incrementable<O> AND copy_constructible<F> AND
                 indirectly_writable<
                     O,
-                    indirect_result_t<F &, projected<I0, P0>, projected<I1, P1>>>) //
+                    indirect_result_t<F &, projected<I0, P0>, projected<I1, P1>>>)
         binary_transform_result<I0, I1, O> //
         RANGES_FUNC(transform)(I0 begin0,
                                S0 end0,
@@ -108,14 +111,15 @@ namespace ranges
                  typename O,
                  typename F,
                  typename P0 = identity,
-                 typename P1 = identity)( //
+                 typename P1 = identity)(
+            /// \pre
             requires input_range<Rng0> AND input_range<Rng1> AND
                 weakly_incrementable<O> AND copy_constructible<F> AND
                 indirectly_writable<
                     O,
                     indirect_result_t<F &,
                                       projected<iterator_t<Rng0>, P0>,
-                                      projected<iterator_t<Rng1>, P1>>>) //
+                                      projected<iterator_t<Rng1>, P1>>>)
         binary_transform_result<borrowed_iterator_t<Rng0>,
                                 borrowed_iterator_t<Rng1>,
                                 O> //
@@ -140,10 +144,11 @@ namespace ranges
                      typename O,
                      typename F,
                      typename P0 = identity,
-                     typename P1 = identity)( //
+                     typename P1 = identity)(
+            /// \pre
             requires input_iterator<I0> AND sentinel_for<S0, I0> AND
                 input_iterator<I1> AND weakly_incrementable<O> AND
-                copy_constructible<F> AND //
+                copy_constructible<F> AND
                 indirectly_writable<
                     O,
                     indirect_result_t<F &, projected<I0, P0>, projected<I1, P1>>>)
@@ -175,7 +180,8 @@ namespace ranges
                  typename O,
                  typename F,
                  typename P0 = identity,
-                 typename P1 = identity)( //
+                 typename P1 = identity)(
+            /// \pre
             requires input_range<Rng0> AND input_iterator<uncvref_t<I1Ref>> AND
                 weakly_incrementable<O> AND copy_constructible<F> AND
                 indirectly_writable<

--- a/include/range/v3/algorithm/unique.hpp
+++ b/include/range/v3/algorithm/unique.hpp
@@ -47,8 +47,9 @@ namespace ranges
         /// \pre `S` is a model of the `sentinel_for` concept
         /// \pre `C` is a model of the `relation` concept
         ///
-        template(typename I, typename S, typename C = equal_to, typename P = identity)( //
-            requires sortable<I, C, P> AND sentinel_for<S, I>) //
+        template(typename I, typename S, typename C = equal_to, typename P = identity)(
+            /// \pre
+            requires sortable<I, C, P> AND sentinel_for<S, I>)
         I RANGES_FUNC(unique)(I first, S last, C pred = C{}, P proj = P{})
         {
             first = adjacent_find(std::move(first), last, std::ref(pred), std::ref(proj));
@@ -64,8 +65,9 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C = equal_to, typename P = identity)( //
-            requires sortable<iterator_t<Rng>, C, P> AND range<Rng>) //
+        template(typename Rng, typename C = equal_to, typename P = identity)(
+            /// \pre
+            requires sortable<iterator_t<Rng>, C, P> AND range<Rng>)
         borrowed_iterator_t<Rng> //
         RANGES_FUNC(unique)(Rng && rng, C pred = C{}, P proj = P{}) //
         {

--- a/include/range/v3/algorithm/unique_copy.hpp
+++ b/include/range/v3/algorithm/unique_copy.hpp
@@ -126,7 +126,8 @@ namespace ranges
                  typename S,
                  typename O,
                  typename C = equal_to,
-                 typename P = identity)( //
+                 typename P = identity)(
+            /// \pre
             requires input_iterator<I> AND sentinel_for<S, I> AND
                 indirect_relation<C, projected<I, P>> AND weakly_incrementable<O> AND
                 indirectly_copyable<I, O> AND
@@ -146,6 +147,7 @@ namespace ranges
 
         /// \overload
         template(typename Rng, typename O, typename C = equal_to, typename P = identity)(
+            /// \pre
             requires input_range<Rng> AND
                 indirect_relation<C, projected<iterator_t<Rng>, P>> AND
                 weakly_incrementable<O> AND indirectly_copyable<iterator_t<Rng>, O> AND

--- a/include/range/v3/algorithm/unstable_remove_if.hpp
+++ b/include/range/v3/algorithm/unstable_remove_if.hpp
@@ -44,9 +44,10 @@ namespace ranges
     RANGES_FUNC_BEGIN(unstable_remove_if)
 
         /// \brief function template \c unstable_remove_if
-        template(typename I, typename C, typename P = identity)( //
-            requires bidirectional_iterator<I> AND permutable<I> AND //
-            indirect_unary_predicate<C, projected<I, P>>) //
+        template(typename I, typename C, typename P = identity)(
+            /// \pre
+            requires bidirectional_iterator<I> AND permutable<I> AND
+            indirect_unary_predicate<C, projected<I, P>>)
         I RANGES_FUNC(unstable_remove_if)(I first, I last, C pred, P proj = {})
         {
             while(true)
@@ -67,10 +68,11 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename C, typename P = identity)( //
-            requires bidirectional_range<Rng> AND common_range<Rng> AND //
-            permutable<iterator_t<Rng>> AND //
-            indirect_unary_predicate<C, projected<iterator_t<Rng>, P>>) //
+        template(typename Rng, typename C, typename P = identity)(
+            /// \pre
+            requires bidirectional_range<Rng> AND common_range<Rng> AND
+            permutable<iterator_t<Rng>> AND
+            indirect_unary_predicate<C, projected<iterator_t<Rng>, P>>)
         borrowed_iterator_t<Rng> //
         RANGES_FUNC(unstable_remove_if)(Rng && rng, C pred, P proj = P{}) //
         {

--- a/include/range/v3/algorithm/upper_bound.hpp
+++ b/include/range/v3/algorithm/upper_bound.hpp
@@ -39,9 +39,10 @@ namespace ranges
                  typename S,
                  typename V,
                  typename C = less,
-                 typename P = identity)( //
+                 typename P = identity)(
+            /// \pre
             requires forward_iterator<I> AND sentinel_for<S, I> AND
-                indirect_strict_weak_order<C, V const *, projected<I, P>>) //
+                indirect_strict_weak_order<C, V const *, projected<I, P>>)
         I RANGES_FUNC(upper_bound)(
             I first, S last, V const & val, C pred = C{}, P proj = P{}) //
         {
@@ -52,7 +53,8 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Rng, typename V, typename C = less, typename P = identity)( //
+        template(typename Rng, typename V, typename C = less, typename P = identity)(
+            /// \pre
             requires forward_range<Rng> AND
                 indirect_strict_weak_order<C, V const *, projected<iterator_t<Rng>, P>>)
         borrowed_iterator_t<Rng> RANGES_FUNC(upper_bound)(

--- a/include/range/v3/detail/adl_get.hpp
+++ b/include/range/v3/detail/adl_get.hpp
@@ -70,14 +70,16 @@ namespace ranges
             // Clang 3.x have a problem with inheriting constructors
             // that causes the declarations in the preceeding PP block to get
             // instantiated too early.
-            template(typename B = TupleLike)( //
-                requires move_constructible<B>) //
+            template(typename B = TupleLike)(
+                /// \pre
+                requires move_constructible<B>)
                 constexpr forward_tuple_interface(TupleLike && base) noexcept(
                     std::is_nothrow_move_constructible<TupleLike>::value)
               : TupleLike(static_cast<TupleLike &&>(base))
             {}
-            template(typename B = TupleLike)( //
-                requires copy_constructible<B>) //
+            template(typename B = TupleLike)(
+                /// \pre
+                requires copy_constructible<B>)
                 constexpr forward_tuple_interface(TupleLike const & base) noexcept(
                     std::is_nothrow_copy_constructible<TupleLike>::value)
               : TupleLike(base)

--- a/include/range/v3/detail/prologue.hpp
+++ b/include/range/v3/detail/prologue.hpp
@@ -33,6 +33,5 @@ RANGES_DIAGNOSTIC_KEYWORD_MACRO
 #define template(...)                                                           \
     CPP_PP_IGNORE_CXX2A_COMPAT_BEGIN                                            \
     template<__VA_ARGS__ CPP_TEMPLATE_AUX_                                      \
-    /**/
 
 #define AND CPP_and

--- a/include/range/v3/detail/range_access.hpp
+++ b/include/range/v3/detail/range_access.hpp
@@ -338,7 +338,8 @@ namespace ranges
             sized_sentinel_for_cursor<T, T> && //
             CPP_requires_ref(detail::random_access_cursor_, T);
 
-        template(class T)( //
+        template(class T)(
+            /// \pre
             requires std::is_lvalue_reference<T>::value)
         void is_lvalue_reference(T&&);
 

--- a/include/range/v3/detail/variant.hpp
+++ b/include/range/v3/detail/variant.hpp
@@ -108,7 +108,8 @@ namespace ranges
     {
         struct indexed_element_fn;
 
-        template(typename I, typename S, typename O)( //
+        template(typename I, typename S, typename O)(
+            /// \pre
             requires (!sized_sentinel_for<S, I>)) //
         O uninitialized_copy(I first, S last, O out)
         {
@@ -117,8 +118,9 @@ namespace ranges
             return out;
         }
 
-        template(typename I, typename S, typename O)( //
-            requires sized_sentinel_for<S, I>) //
+        template(typename I, typename S, typename O)(
+            /// \pre
+            requires sized_sentinel_for<S, I>)
         O uninitialized_copy(I first, S last, O out)
         {
             return std::uninitialized_copy_n(first, (last - first), out);
@@ -145,14 +147,16 @@ namespace ranges
                     requires default_constructible<T>)
               : datum_{}
             {}
-            template(typename... Ts)(                                      //
+            template(typename... Ts)(
+                /// \pre
                 requires constructible_from<T, Ts...> AND (sizeof...(Ts) != 0)) //
             constexpr indexed_datum(Ts &&... ts) noexcept(
                     std::is_nothrow_constructible<T, Ts...>::value)
               : datum_(static_cast<Ts &&>(ts)...)
             {}
-            template(typename U)( //
-                requires (!same_as<T, U>) AND convertible_to<U, T>) //
+            template(typename U)(
+                /// \pre
+                requires (!same_as<T, U>) AND convertible_to<U, T>)
             constexpr indexed_datum(indexed_datum<U, Index> that) //
                 noexcept(std::is_nothrow_constructible<T, U>::value) //
               : datum_(std::move(that.datum_))
@@ -664,7 +668,8 @@ namespace ranges
           : detail::variant_data<Ts...>{}
           , index_((std::size_t)-1)
         {}
-        template(typename... Args)( //
+        template(typename... Args)(
+            /// \pre
             requires (sizeof...(Args) == sizeof...(Ts))) //
         static constexpr bool all_convertible_to(int) noexcept
         {
@@ -683,16 +688,18 @@ namespace ranges
                 requires default_constructible<datum_t<0>>)
           : variant{emplaced_index<0>}
         {}
-        template(std::size_t N, typename... Args)(        //
-            requires constructible_from<datum_t<N>, Args...>) //
+        template(std::size_t N, typename... Args)(
+            /// \pre
+            requires constructible_from<datum_t<N>, Args...>)
             constexpr variant(emplaced_index_t<N>, Args &&... args) noexcept(
                 std::is_nothrow_constructible<datum_t<N>, Args...>::value)
           : detail::variant_data<Ts...>{meta::size_t<N>{}, static_cast<Args &&>(args)...}
           , index_(N)
         {}
-        template(std::size_t N, typename T, typename... Args)( //
+        template(std::size_t N, typename T, typename... Args)(
+            /// \pre
             requires constructible_from<datum_t<N>, std::initializer_list<T> &,
-                                        Args...>) //
+                                        Args...>)
             constexpr variant(
                 emplaced_index_t<N>, std::initializer_list<T> il,
                 Args &&... args) noexcept(std::
@@ -704,8 +711,9 @@ namespace ranges
                                         static_cast<Args &&>(args)...}
           , index_(N)
         {}
-        template(std::size_t N)( //
-            requires constructible_from<datum_t<N>, meta::nil_>) //
+        template(std::size_t N)(
+            /// \pre
+            requires constructible_from<datum_t<N>, meta::nil_>)
         constexpr variant(emplaced_index_t<N>, meta::nil_)
             noexcept(std::is_nothrow_constructible<datum_t<N>, meta::nil_>::value)
           : detail::variant_data<Ts...>{meta::size_t<N>{}, meta::nil_{}}
@@ -720,8 +728,9 @@ namespace ranges
           : detail::variant_data<Ts...>{}
           , index_(detail::variant_move_copy_(that.index(), data_(), that.data_()))
         {}
-        template(typename... Args)( //
-            requires (!same_as<variant<Args...>, variant>) AND //
+        template(typename... Args)(
+            /// \pre
+            requires (!same_as<variant<Args...>, variant>) AND
             (all_convertible_to<Args...>(0))) //
         variant(variant<Args...> that)
           : detail::variant_data<Ts...>{}
@@ -742,7 +751,8 @@ namespace ranges
             this->assign_(that);
             return *this;
         }
-        template(typename... Args)( //
+        template(typename... Args)(
+            /// \pre
             requires (!same_as<variant<Args...>, variant>) AND
             (all_convertible_to<Args...>(0)))
         variant & operator=(variant<Args...> that)
@@ -756,8 +766,9 @@ namespace ranges
         {
             return sizeof...(Ts);
         }
-        template(std::size_t N, typename... Args)( //
-            requires constructible_from<datum_t<N>, Args...>) //
+        template(std::size_t N, typename... Args)(
+            /// \pre
+            requires constructible_from<datum_t<N>, Args...>)
         void emplace(Args &&... args)
         {
             this->clear_();
@@ -815,8 +826,9 @@ namespace ranges
         }
     };
 
-    template(typename... Ts, typename... Us)( //
-        requires and_v<equality_comparable_with<Ts, Us>...>) //
+    template(typename... Ts, typename... Us)(
+        /// \pre
+        requires and_v<equality_comparable_with<Ts, Us>...>)
     bool operator==(variant<Ts...> const & lhs, variant<Us...> const & rhs)
     {
         return (!lhs.valid() && !rhs.valid()) ||
@@ -826,8 +838,9 @@ namespace ranges
                                        detail::variant_core_access::data(rhs)));
     }
 
-    template(typename... Ts, typename... Us)( //
-        requires and_v<equality_comparable_with<Ts, Us>...>) //
+    template(typename... Ts, typename... Us)(
+        /// \pre
+        requires and_v<equality_comparable_with<Ts, Us>...>)
     bool operator!=(variant<Ts...> const & lhs, variant<Us...> const & rhs)
     {
         return !(lhs == rhs);
@@ -835,8 +848,9 @@ namespace ranges
 
     //////////////////////////////////////////////////////////////////////////////////////
     // emplace
-    template(std::size_t N, typename... Ts, typename... Args)( //
-        requires constructible_from<detail::variant_datum_t<N, Ts...>, Args...>) //
+    template(std::size_t N, typename... Ts, typename... Args)(
+        /// \pre
+        requires constructible_from<detail::variant_datum_t<N, Ts...>, Args...>)
     void emplace(variant<Ts...> & var, Args &&... args)
     {
         var.template emplace<N>(static_cast<Args &&>(args)...);

--- a/include/range/v3/experimental/utility/generator.hpp
+++ b/include/range/v3/experimental/utility/generator.hpp
@@ -210,7 +210,8 @@ namespace ranges
                 except_ = std::current_exception();
                 RANGES_EXPECT(except_);
             }
-            template(typename Arg)( //
+            template(typename Arg)(
+                /// \pre
                 requires convertible_to<Arg, Reference> AND
                         std::is_assignable<semiregular_box_t<Reference> &, Arg>::value) //
             RANGES_COROUTINES_NS::suspend_always yield_value(Arg && arg) noexcept(

--- a/include/range/v3/experimental/view/shared.hpp
+++ b/include/range/v3/experimental/view/shared.hpp
@@ -59,7 +59,9 @@ namespace ranges
             }
 
             CPP_member
-            auto CPP_fun(size)()(const requires sized_range<Rng>)
+            auto CPP_fun(size)()(const
+                /// \pre
+                requires sized_range<Rng>)
             {
                 return ranges::size(*rng_ptr_);
             }
@@ -71,9 +73,10 @@ namespace ranges
         struct RANGES_STRUCT_WITH_ADL_BARRIER(shared_closure_base)
         {
             // Piping requires viewable_ranges.
-            template(typename Rng, typename SharedFn)( //
-                requires range<Rng> AND (!viewable_range<Rng>) AND //
-                    constructible_from<detail::decay_t<Rng>, Rng>) //
+            template(typename Rng, typename SharedFn)(
+                /// \pre
+                requires range<Rng> AND (!viewable_range<Rng>) AND
+                    constructible_from<detail::decay_t<Rng>, Rng>)
             friend constexpr auto operator|(Rng && rng, shared_closure<SharedFn> vw)
             {
                 return static_cast<SharedFn &&>(vw)(static_cast<Rng &&>(rng));
@@ -82,6 +85,7 @@ namespace ranges
             template<typename SharedFn, typename Pipeable>
             friend constexpr auto operator|(shared_closure<SharedFn> sh, Pipeable pipe)
                 -> CPP_broken_friend_ret(shared_closure<composed<Pipeable, SharedFn>>)(
+                    /// \pre
                     requires (is_pipeable_v<Pipeable>))
             {
                 return shared_closure<composed<Pipeable, SharedFn>>{compose(
@@ -104,9 +108,10 @@ namespace ranges
         {
             struct shared_fn
             {
-                template(typename Rng)( //
-                    requires range<Rng> AND (!viewable_range<Rng>)AND //
-                        constructible_from<detail::decay_t<Rng>, Rng>) //
+                template(typename Rng)(
+                    /// \pre
+                    requires range<Rng> AND (!viewable_range<Rng>)AND
+                        constructible_from<detail::decay_t<Rng>, Rng>)
                 shared_view<detail::decay_t<Rng>> operator()(Rng && rng) const
                 {
                     return shared_view<detail::decay_t<Rng>>{static_cast<Rng &&>(rng)};

--- a/include/range/v3/functional/bind.hpp
+++ b/include/range/v3/functional/bind.hpp
@@ -97,14 +97,16 @@ namespace ranges
 
     struct protect_fn
     {
-        template(typename F)( //
+        template(typename F)(
+            /// \pre
             requires std::is_bind_expression<uncvref_t<F>>::value) //
         protector<uncvref_t<F>> operator()(F && f) const
         {
             return {static_cast<F &&>(f)};
         }
         /// \overload
-        template(typename F)( //
+        template(typename F)(
+            /// \pre
             requires (!std::is_bind_expression<uncvref_t<F>>::value)) //
         F operator()(F && f) const
         {

--- a/include/range/v3/functional/comparisons.hpp
+++ b/include/range/v3/functional/comparisons.hpp
@@ -26,8 +26,9 @@ namespace ranges
     /// @{
     struct equal_to
     {
-        template(typename T, typename U)( //
-            requires equality_comparable_with<T, U>) //
+        template(typename T, typename U)(
+            /// \pre
+            requires equality_comparable_with<T, U>)
         constexpr bool operator()(T && t, U && u) const
         {
             return (T &&) t == (U &&) u;
@@ -37,8 +38,9 @@ namespace ranges
 
     struct not_equal_to
     {
-        template(typename T, typename U)( //
-            requires equality_comparable_with<T, U>) //
+        template(typename T, typename U)(
+            /// \pre
+            requires equality_comparable_with<T, U>)
         constexpr bool operator()(T && t, U && u) const
         {
             return !equal_to{}((T &&) t, (U &&) u);
@@ -48,8 +50,9 @@ namespace ranges
 
     struct less
     {
-        template(typename T, typename U)( //
-            requires totally_ordered_with<T, U>) //
+        template(typename T, typename U)(
+            /// \pre
+            requires totally_ordered_with<T, U>)
         constexpr bool operator()(T && t, U && u) const
         {
             return (T &&) t < (U &&) u;
@@ -59,8 +62,9 @@ namespace ranges
 
     struct less_equal
     {
-        template(typename T, typename U)( //
-            requires totally_ordered_with<T, U>) //
+        template(typename T, typename U)(
+            /// \pre
+            requires totally_ordered_with<T, U>)
         constexpr bool operator()(T && t, U && u) const
         {
             return !less{}((U &&) u, (T &&) t);
@@ -70,8 +74,9 @@ namespace ranges
 
     struct greater_equal
     {
-        template(typename T, typename U)( //
-            requires totally_ordered_with<T, U>) //
+        template(typename T, typename U)(
+            /// \pre
+            requires totally_ordered_with<T, U>)
         constexpr bool operator()(T && t, U && u) const
         {
             return !less{}((T &&) t, (U &&) u);
@@ -81,8 +86,9 @@ namespace ranges
 
     struct greater
     {
-        template(typename T, typename U)( //
-            requires totally_ordered_with<T, U>) //
+        template(typename T, typename U)(
+            /// \pre
+            requires totally_ordered_with<T, U>)
         constexpr bool operator()(T && t, U && u) const
         {
             return less{}((U &&) u, (T &&) t);
@@ -97,7 +103,8 @@ namespace ranges
     __has_include(<compare>)
     struct compare_three_way
     {
-        template(typename T, typename U)( //
+        template(typename T, typename U)(
+            /// \pre
             requires three_way_comparable_with<T, U>)
         constexpr auto operator()(T && t, U && u) const
             -> decltype((T &&) t <=> (U &&) u)

--- a/include/range/v3/functional/invoke.hpp
+++ b/include/range/v3/functional/invoke.hpp
@@ -90,23 +90,26 @@ namespace ranges
     struct invoke_fn
     {
     private:
-        template(typename, typename T1)( //
-            requires detail::dereferenceable_<T1>) //
+        template(typename, typename T1)(
+            /// \pre
+            requires detail::dereferenceable_<T1>)
         static constexpr decltype(auto) coerce(T1 && t1, long)
             noexcept(noexcept(*static_cast<T1 &&>(t1)))
         {
             return *static_cast<T1 &&>(t1);
         }
 
-        template(typename T, typename T1)( //
-            requires derived_from<detail::decay_t<T1>, T>) //
+        template(typename T, typename T1)(
+            /// \pre
+            requires derived_from<detail::decay_t<T1>, T>)
         static constexpr T1 && coerce(T1 && t1, int) noexcept
         {
             return static_cast<T1 &&>(t1);
         }
 
-        template(typename, typename T1)( //
-            requires detail::is_reference_wrapper_v<detail::decay_t<T1>>) //
+        template(typename, typename T1)(
+            /// \pre
+            requires detail::is_reference_wrapper_v<detail::decay_t<T1>>)
         static constexpr decltype(auto) coerce(T1 && t1, int) noexcept
         {
             return static_cast<T1 &&>(t1).get();

--- a/include/range/v3/functional/not_fn.hpp
+++ b/include/range/v3/functional/not_fn.hpp
@@ -42,29 +42,33 @@ namespace ranges
             noexcept(std::is_nothrow_default_constructible<FD>::value) //
                 requires default_constructible<FD>)
         {}
-        template(typename T)( //
-            requires (!same_as<detail::decay_t<T>, logical_negate>) AND //
-                constructible_from<FD, T>) //
+        template(typename T)(
+            /// \pre
+            requires (!same_as<detail::decay_t<T>, logical_negate>) AND
+                constructible_from<FD, T>)
         constexpr explicit logical_negate(T && pred)
           : pred_(static_cast<T &&>(pred))
         {}
 
-        template(typename... Args)( //
-            requires predicate<FD &, Args...>) //
+        template(typename... Args)(
+            /// \pre
+            requires predicate<FD &, Args...>)
         constexpr bool operator()(Args &&... args) &
         {
             return !invoke(pred_, static_cast<Args &&>(args)...);
         }
         /// \overload
-        template(typename... Args)( //
-            requires predicate<FD const &, Args...>) //
+        template(typename... Args)(
+            /// \pre
+            requires predicate<FD const &, Args...>)
         constexpr bool operator()(Args &&... args) const &
         {
             return !invoke(pred_, static_cast<Args &&>(args)...);
         }
         /// \overload
-        template(typename... Args)( //
-            requires predicate<FD, Args...>) //
+        template(typename... Args)(
+            /// \pre
+            requires predicate<FD, Args...>)
         constexpr bool operator()(Args &&... args) &&
         {
             return !invoke(static_cast<FD &&>(pred_), static_cast<Args &&>(args)...);
@@ -73,9 +77,10 @@ namespace ranges
 
     struct not_fn_fn
     {
-        template(typename Pred)( //
-            requires move_constructible<detail::decay_t<Pred>> AND //
-                constructible_from<detail::decay_t<Pred>, Pred>) //
+        template(typename Pred)(
+            /// \pre
+            requires move_constructible<detail::decay_t<Pred>> AND
+                constructible_from<detail::decay_t<Pred>, Pred>)
         constexpr logical_negate<detail::decay_t<Pred>> operator()(Pred && pred) const
         {
             return logical_negate<detail::decay_t<Pred>>{(Pred &&) pred};

--- a/include/range/v3/functional/overload.hpp
+++ b/include/range/v3/functional/overload.hpp
@@ -108,12 +108,14 @@ namespace ranges
         {}
 
         template(typename... Args)(
+            /// \pre
             requires invocable<First, Args...>)
         constexpr _result_t<detail::_id, Args...> operator()(Args &&... args) &&
         {
             return invoke((First &&) first_, (Args &&) args...);
         }
         template(typename... Args)(
+            /// \pre
             requires (!invocable<First, Args...>) AND
                 invocable<overloaded<Rest...>, Args...>)
         constexpr _result_t<detail::_id, Args...> operator()(Args &&... args) &&
@@ -122,12 +124,14 @@ namespace ranges
         }
 
         template(typename... Args)(
+            /// \pre
             requires invocable<First &, Args...>)
         constexpr _result_t<detail::_ref, Args...> operator()(Args &&... args) &
         {
             return invoke(first_, (Args &&) args...);
         }
         template(typename... Args)(
+            /// \pre
             requires (!invocable<First &, Args...>) AND
                 invocable<overloaded<Rest...> &, Args...>)
         constexpr _result_t<detail::_ref, Args...> operator()(Args &&... args) &
@@ -136,12 +140,14 @@ namespace ranges
         }
 
         template(typename... Args)(
+            /// \pre
             requires invocable<First const &, Args...>)
         constexpr _result_t<detail::_cref, Args...> operator()(Args &&... args) const &
         {
             return invoke(first_, (Args &&) args...);
         }
         template(typename... Args)(
+            /// \pre
             requires (!invocable<First const &, Args...>) AND
                 invocable<overloaded<Rest...> const &, Args...>)
         constexpr _result_t<detail::_cref, Args...> operator()(Args &&... args) const &

--- a/include/range/v3/functional/pipeable.hpp
+++ b/include/range/v3/functional/pipeable.hpp
@@ -101,7 +101,7 @@ namespace ranges
             -> CPP_broken_friend_ret(Arg &)(
                 /// \pre
                 requires (is_pipeable_v<Pipe>) &&
-                (!is_pipeable_v<Arg>)&&invocable<Pipe, Arg &>)
+                    (!is_pipeable_v<Arg>) && invocable<Pipe, Arg &>)
         {
             static_cast<Pipe &&>(pipe)(arg);
             return arg;

--- a/include/range/v3/functional/pipeable.hpp
+++ b/include/range/v3/functional/pipeable.hpp
@@ -78,7 +78,8 @@ namespace ranges
         friend pipeable_access;
 
         // Evaluate the pipe with an argument
-        template(typename Arg, typename Pipe)( //
+        template(typename Arg, typename Pipe)(
+            /// \pre
             requires (!is_pipeable_v<Arg>) AND is_pipeable_v<Pipe> AND
             invocable<Pipe, Arg>) // clang-format off
         friend constexpr auto operator|(Arg &&arg, Pipe pipe) // clang-format off
@@ -87,7 +88,8 @@ namespace ranges
         }
 
         // Compose two pipes
-        template(typename Pipe0, typename Pipe1)( //
+        template(typename Pipe0, typename Pipe1)(
+            /// \pre
             requires is_pipeable_v<Pipe0> AND is_pipeable_v<Pipe1>) // clang-format off
         friend constexpr auto operator|(Pipe0 pipe0, Pipe1 pipe1) // clang-format on
         {
@@ -96,7 +98,8 @@ namespace ranges
 
         template<typename Arg, typename Pipe>
         friend auto operator|=(Arg & arg, Pipe pipe) //
-            -> CPP_broken_friend_ret(Arg &)(         //
+            -> CPP_broken_friend_ret(Arg &)(
+                /// \pre
                 requires (is_pipeable_v<Pipe>) &&
                 (!is_pipeable_v<Arg>)&&invocable<Pipe, Arg &>)
         {

--- a/include/range/v3/functional/reference_wrapper.hpp
+++ b/include/range/v3/functional/reference_wrapper.hpp
@@ -83,9 +83,10 @@ namespace ranges
         using reference = meta::if_<std::is_reference<T>, T, T &>;
 
         constexpr reference_wrapper() = default;
-        template(typename U)( //
-            requires (!same_as<uncvref_t<U>, reference_wrapper>) AND //
-                constructible_from<base_, U>) //
+        template(typename U)(
+            /// \pre
+            requires (!same_as<uncvref_t<U>, reference_wrapper>) AND
+                constructible_from<base_, U>)
         constexpr reference_wrapper(U && u) noexcept(
             std::is_nothrow_constructible<base_, U>::value)
           : detail::reference_wrapper_<T>{static_cast<U &&>(u)}
@@ -98,7 +99,8 @@ namespace ranges
         {
             return get();
         }
-        template(typename...)(                          //
+        template(typename...)(
+            /// \pre
             requires (!std::is_rvalue_reference<T>::value)) //
         operator std::reference_wrapper<type>() const noexcept
         {
@@ -115,7 +117,8 @@ namespace ranges
 
     struct ref_fn
     {
-        template(typename T)( //
+        template(typename T)(
+            /// \pre
             requires (!is_reference_wrapper_v<T>)) //
         reference_wrapper<T> operator()(T & t) const
         {

--- a/include/range/v3/iterator/basic_iterator.hpp
+++ b/include/range/v3/iterator/basic_iterator.hpp
@@ -187,8 +187,9 @@ namespace ranges
             // public:
             basic_proxy_reference_() = default;
             basic_proxy_reference_(basic_proxy_reference_ const &) = default;
-            template(typename OtherCur)( //
-                requires convertible_to<OtherCur *, Cur *>) //
+            template(typename OtherCur)(
+                /// \pre
+                requires convertible_to<OtherCur *, Cur *>)
             constexpr basic_proxy_reference_(
                 basic_proxy_reference<OtherCur> const & that) noexcept
               : cur_(that.cur_)
@@ -198,14 +199,16 @@ namespace ranges
             {}
             CPP_member
             constexpr auto operator=(basic_proxy_reference_ && that)
-                -> CPP_ret(basic_proxy_reference_ &)( //
+                -> CPP_ret(basic_proxy_reference_ &)(
+                    /// \pre
                     requires readable_cursor<Cur>)
             {
                 return *this = that;
             }
             CPP_member
             constexpr auto operator=(basic_proxy_reference_ const & that)
-                -> CPP_ret(basic_proxy_reference_ &)( //
+                -> CPP_ret(basic_proxy_reference_ &)(
+                    /// \pre
                     requires readable_cursor<Cur>)
             {
                 this->write_(that.read_());
@@ -213,62 +216,70 @@ namespace ranges
             }
             CPP_member
             constexpr auto operator=(basic_proxy_reference_ && that) const
-                -> CPP_ret(basic_proxy_reference_ const &)( //
+                -> CPP_ret(basic_proxy_reference_ const &)(
+                    /// \pre
                     requires readable_cursor<Cur>)
             {
                 return *this = that;
             }
             CPP_member
             constexpr auto operator=(basic_proxy_reference_ const & that) const
-                -> CPP_ret(basic_proxy_reference_ const &)( //
+                -> CPP_ret(basic_proxy_reference_ const &)(
+                    /// \pre
                     requires readable_cursor<Cur>)
             {
                 this->write_(that.read_());
                 return *this;
             }
-            template(typename OtherCur)( //
-                requires readable_cursor<OtherCur> AND //
-                    writable_cursor<Cur, cursor_reference_t<OtherCur>>) //
+            template(typename OtherCur)(
+                /// \pre
+                requires readable_cursor<OtherCur> AND
+                    writable_cursor<Cur, cursor_reference_t<OtherCur>>)
             constexpr basic_proxy_reference_ & //
             operator=(basic_proxy_reference<OtherCur> && that)
             {
                 return *this = that;
             }
-            template(typename OtherCur)( //
-                requires readable_cursor<OtherCur> AND //
-                    writable_cursor<Cur, cursor_reference_t<OtherCur>>) //
+            template(typename OtherCur)(
+                /// \pre
+                requires readable_cursor<OtherCur> AND
+                    writable_cursor<Cur, cursor_reference_t<OtherCur>>)
             constexpr basic_proxy_reference_ & //
             operator=(basic_proxy_reference<OtherCur> const & that)
             {
                 this->write_(that.read_());
                 return *this;
             }
-            template(typename OtherCur)( //
-                requires readable_cursor<OtherCur> AND //
-                    writable_cursor<Cur, cursor_reference_t<OtherCur>>) //
+            template(typename OtherCur)(
+                /// \pre
+                requires readable_cursor<OtherCur> AND
+                    writable_cursor<Cur, cursor_reference_t<OtherCur>>)
             constexpr basic_proxy_reference_ const & //
             operator=(basic_proxy_reference<OtherCur> && that) const
             {
                 return *this = that;
             }
-            template(typename OtherCur)( //
-                requires readable_cursor<OtherCur> AND //
-                    writable_cursor<Cur, cursor_reference_t<OtherCur>>) //
+            template(typename OtherCur)(
+                /// \pre
+                requires readable_cursor<OtherCur> AND
+                    writable_cursor<Cur, cursor_reference_t<OtherCur>>)
             constexpr basic_proxy_reference_ const & //
             operator=(basic_proxy_reference<OtherCur> const & that) const
             {
                 this->write_(that.read_());
                 return *this;
             }
-            template(typename T)( //
-                requires writable_cursor<Cur, T>) //
+            template(typename T)(
+                /// \pre
+                requires writable_cursor<Cur, T>)
             constexpr basic_proxy_reference_ & operator=(T && t) //
             {
                 this->write_((T &&) t);
                 return *this;
             }
-            template(typename T)( //
-                requires writable_cursor<Cur, T>) //
+            template(typename T)(
+                /// \pre
+                requires writable_cursor<Cur, T>)
             constexpr basic_proxy_reference_ const & operator=(T && t) const
             {
                 this->write_((T &&) t);
@@ -276,43 +287,49 @@ namespace ranges
             }
         };
 
-        template(typename Cur, bool IsReadable)( //
-            requires readable_cursor<Cur> AND equality_comparable<cursor_value_t<Cur>>) //
+        template(typename Cur, bool IsReadable)(
+            /// \pre
+            requires readable_cursor<Cur> AND equality_comparable<cursor_value_t<Cur>>)
         constexpr bool operator==(basic_proxy_reference_<Cur, IsReadable> const & x,
                                   cursor_value_t<Cur> const & y)
         {
             return x.read_() == y;
         }
-        template(typename Cur, bool IsReadable)( //
-            requires readable_cursor<Cur> AND equality_comparable<cursor_value_t<Cur>>) //
+        template(typename Cur, bool IsReadable)(
+            /// \pre
+            requires readable_cursor<Cur> AND equality_comparable<cursor_value_t<Cur>>)
         constexpr bool operator!=(basic_proxy_reference_<Cur, IsReadable> const & x,
                                   cursor_value_t<Cur> const & y)
         {
             return !(x == y);
         }
-        template(typename Cur, bool IsReadable)( //
-            requires readable_cursor<Cur> AND equality_comparable<cursor_value_t<Cur>>) //
+        template(typename Cur, bool IsReadable)(
+            /// \pre
+            requires readable_cursor<Cur> AND equality_comparable<cursor_value_t<Cur>>)
         constexpr bool operator==(cursor_value_t<Cur> const & x,
                                   basic_proxy_reference_<Cur, IsReadable> const & y)
         {
             return x == y.read_();
         }
-        template(typename Cur, bool IsReadable)( //
-            requires readable_cursor<Cur> AND equality_comparable<cursor_value_t<Cur>>) //
+        template(typename Cur, bool IsReadable)(
+            /// \pre
+            requires readable_cursor<Cur> AND equality_comparable<cursor_value_t<Cur>>)
         constexpr bool operator!=(cursor_value_t<Cur> const & x,
                                   basic_proxy_reference_<Cur, IsReadable> const & y)
         {
             return !(x == y);
         }
-        template(typename Cur, bool IsReadable)( //
-            requires readable_cursor<Cur> AND equality_comparable<cursor_value_t<Cur>>) //
+        template(typename Cur, bool IsReadable)(
+            /// \pre
+            requires readable_cursor<Cur> AND equality_comparable<cursor_value_t<Cur>>)
         constexpr bool operator==(basic_proxy_reference_<Cur, IsReadable> const & x,
                                   basic_proxy_reference_<Cur, IsReadable> const & y)
         {
             return x.read_() == y.read_();
         }
-        template(typename Cur, bool IsReadable)( //
-            requires readable_cursor<Cur> AND equality_comparable<cursor_value_t<Cur>>) //
+        template(typename Cur, bool IsReadable)(
+            /// \pre
+            requires readable_cursor<Cur> AND equality_comparable<cursor_value_t<Cur>>)
         constexpr bool operator!=(basic_proxy_reference_<Cur, IsReadable> const & x,
                                   basic_proxy_reference_<Cur, IsReadable> const & y)
         {
@@ -544,9 +561,10 @@ namespace ranges
     public:
         using typename assoc_types_::difference_type;
         constexpr basic_iterator() = default;
-        template(typename OtherCur)( //
-            requires (!same_as<OtherCur, Cur>) AND convertible_to<OtherCur, Cur> AND //
-            constructible_from<mixin_t, OtherCur>) //
+        template(typename OtherCur)(
+            /// \pre
+            requires (!same_as<OtherCur, Cur>) AND convertible_to<OtherCur, Cur> AND
+            constructible_from<mixin_t, OtherCur>)
         constexpr basic_iterator(basic_iterator<OtherCur> that)
           : base_t{std::move(that.pos())}
         {}
@@ -561,8 +579,9 @@ namespace ranges
           : base_t(cur)
         {}
 
-        template(typename OtherCur)( //
-            requires (!same_as<OtherCur, Cur>) AND convertible_to<OtherCur, Cur>) //
+        template(typename OtherCur)(
+            /// \pre
+            requires (!same_as<OtherCur, Cur>) AND convertible_to<OtherCur, Cur>)
         constexpr basic_iterator & operator=(basic_iterator<OtherCur> that)
         {
             pos() = std::move(that.pos());
@@ -572,7 +591,8 @@ namespace ranges
         CPP_member
         constexpr auto operator*() const
             noexcept(noexcept(range_access::read(std::declval<Cur const &>())))
-            -> CPP_ret(const_reference_t)( //
+            -> CPP_ret(const_reference_t)(
+                /// \pre
                 requires detail::readable_cursor<Cur> &&
                     (!detail::is_writable_cursor_v<Cur>))
         {
@@ -581,7 +601,8 @@ namespace ranges
         CPP_member
         constexpr auto operator*() //
             noexcept(noexcept(iter_reference_t{std::declval<Cur &>()})) //
-            -> CPP_ret(iter_reference_t)( //
+            -> CPP_ret(iter_reference_t)(
+                /// \pre
                 requires detail::has_cursor_next<Cur> &&
                     detail::is_writable_cursor_v<Cur>)
         {
@@ -590,7 +611,8 @@ namespace ranges
         CPP_member
         constexpr auto operator*() const
             noexcept(noexcept(const_reference_t{std::declval<Cur const &>()}))
-            -> CPP_ret(const_reference_t)( //
+            -> CPP_ret(const_reference_t)(
+                /// \pre
                 requires detail::has_cursor_next<Cur> &&
                     detail::is_writable_cursor_v<Cur const>)
         {
@@ -598,14 +620,16 @@ namespace ranges
         }
         CPP_member
         constexpr auto operator*() noexcept //
-            -> CPP_ret(basic_iterator &)( //
+            -> CPP_ret(basic_iterator &)(
+                /// \pre
                 requires (!detail::has_cursor_next<Cur>))
         {
             return *this;
         }
 
         // Use cursor's arrow() member, if any.
-        template(typename C = Cur)( //
+        template(typename C = Cur)(
+            /// \pre
             requires detail::has_cursor_arrow<C>)
         constexpr detail::cursor_arrow_t<C> operator-> () const
             noexcept(noexcept(range_access::arrow(std::declval<C const &>())))
@@ -614,7 +638,8 @@ namespace ranges
         }
         // Otherwise, if iter_reference_t is an lvalue reference to cv-qualified
         // iter_value_t, return the address of **this.
-        template(typename C = Cur)( //
+        template(typename C = Cur)(
+            /// \pre
             requires (!detail::has_cursor_arrow<C>) AND detail::readable_cursor<C> AND
                 std::is_lvalue_reference<const_reference_t>::value AND
                 same_as<typename detail::iterator_associated_types_base<C>::value_type,
@@ -627,7 +652,8 @@ namespace ranges
 
         CPP_member
         constexpr auto operator++() //
-            -> CPP_ret(basic_iterator &)( //
+            -> CPP_ret(basic_iterator &)(
+                /// \pre
                 requires detail::has_cursor_next<Cur>)
         {
             range_access::next(pos());
@@ -635,7 +661,8 @@ namespace ranges
         }
         CPP_member
         constexpr auto operator++() noexcept //
-            -> CPP_ret(basic_iterator &)( //
+            -> CPP_ret(basic_iterator &)(
+                /// \pre
                 requires (!detail::has_cursor_next<Cur>))
         {
             return *this;
@@ -650,9 +677,10 @@ namespace ranges
         }
         // Attempt to satisfy the C++17 iterator requirements by returning a
         // proxy from postfix increment:
-        template(typename A = assoc_types_, typename V = typename A::value_type)( //
-            requires constructible_from<V, typename A::reference> AND //
-                move_constructible<V>) //
+        template(typename A = assoc_types_, typename V = typename A::value_type)(
+            /// \pre
+            requires constructible_from<V, typename A::reference> AND
+                move_constructible<V>)
         constexpr auto post_increment_(std::true_type, int) //
             -> detail::postfix_increment_proxy<V>
         {
@@ -676,7 +704,8 @@ namespace ranges
 
         CPP_member
         constexpr auto operator--()
-            -> CPP_ret(basic_iterator &)( //
+            -> CPP_ret(basic_iterator &)(
+                /// \pre
                 requires detail::bidirectional_cursor<Cur>)
         {
             range_access::prev(pos());
@@ -684,7 +713,8 @@ namespace ranges
         }
         CPP_member
         constexpr auto operator--(int) //
-            -> CPP_ret(basic_iterator)( //
+            -> CPP_ret(basic_iterator)(
+                /// \pre
                 requires detail::bidirectional_cursor<Cur>)
         {
             basic_iterator tmp(*this);
@@ -693,7 +723,8 @@ namespace ranges
         }
         CPP_member
         constexpr auto operator+=(difference_type n) //
-            -> CPP_ret(basic_iterator &)( //
+            -> CPP_ret(basic_iterator &)(
+                /// \pre
                 requires detail::random_access_cursor<Cur>)
         {
             range_access::advance(pos(), n);
@@ -701,7 +732,8 @@ namespace ranges
         }
         CPP_member
         constexpr auto operator-=(difference_type n) //
-            -> CPP_ret(basic_iterator &)( //
+            -> CPP_ret(basic_iterator &)(
+                /// \pre
                 requires detail::random_access_cursor<Cur>)
         {
             range_access::advance(pos(), (difference_type)-n);
@@ -709,7 +741,8 @@ namespace ranges
         }
         CPP_member
         constexpr auto operator[](difference_type n) const //
-            -> CPP_ret(const_reference_t)( //
+            -> CPP_ret(const_reference_t)(
+                /// \pre
                 requires detail::random_access_cursor<Cur>)
         {
             return *(*this + n);
@@ -722,7 +755,8 @@ namespace ranges
         friend constexpr auto iter_move(basic_iterator const & it) noexcept(
             noexcept(range_access::move(std::declval<C const &>())))
             -> CPP_broken_friend_ret(
-                decltype(range_access::move(std::declval<C const &>())))( //
+                decltype(range_access::move(std::declval<C const &>())))(
+                /// \pre
                 requires same_as<C, Cur> && detail::input_cursor<Cur>)
         {
             return range_access::move(it.pos());
@@ -730,66 +764,75 @@ namespace ranges
 #endif
     };
 
-    template(typename Cur, typename Cur2)( //
-        requires detail::sentinel_for_cursor<Cur2, Cur>) //
+    template(typename Cur, typename Cur2)(
+        /// \pre
+        requires detail::sentinel_for_cursor<Cur2, Cur>)
     constexpr bool operator==(basic_iterator<Cur> const & left,
                               basic_iterator<Cur2> const & right)
     {
         return range_access::equal(range_access::pos(left), range_access::pos(right));
     }
-    template(typename Cur, typename Cur2)( //
-        requires detail::sentinel_for_cursor<Cur2, Cur>) //
+    template(typename Cur, typename Cur2)(
+        /// \pre
+        requires detail::sentinel_for_cursor<Cur2, Cur>)
     constexpr bool operator!=(basic_iterator<Cur> const & left,
                               basic_iterator<Cur2> const & right)
     {
         return !(left == right);
     }
-    template(typename Cur, typename S)( //
-        requires detail::sentinel_for_cursor<S, Cur>) //
+    template(typename Cur, typename S)(
+        /// \pre
+        requires detail::sentinel_for_cursor<S, Cur>)
     constexpr bool operator==(basic_iterator<Cur> const & left,
                               S const & right)
     {
         return range_access::equal(range_access::pos(left), right);
     }
-    template(typename Cur, typename S)( //
-        requires detail::sentinel_for_cursor<S, Cur>) //
+    template(typename Cur, typename S)(
+        /// \pre
+        requires detail::sentinel_for_cursor<S, Cur>)
     constexpr bool operator!=(basic_iterator<Cur> const & left,
                               S const & right)
     {
         return !(left == right);
     }
-    template(typename S, typename Cur)( //
-        requires detail::sentinel_for_cursor<S, Cur>) //
+    template(typename S, typename Cur)(
+        /// \pre
+        requires detail::sentinel_for_cursor<S, Cur>)
     constexpr bool operator==(S const & left,
                               basic_iterator<Cur> const & right)
     {
         return right == left;
     }
-    template(typename S, typename Cur)( //
-        requires detail::sentinel_for_cursor<S, Cur>) //
+    template(typename S, typename Cur)(
+        /// \pre
+        requires detail::sentinel_for_cursor<S, Cur>)
     constexpr bool operator!=(S const & left,
                               basic_iterator<Cur> const & right)
     {
         return right != left;
     }
 
-    template(typename Cur)( //
-        requires detail::random_access_cursor<Cur>) //
+    template(typename Cur)(
+        /// \pre
+        requires detail::random_access_cursor<Cur>)
     constexpr basic_iterator<Cur> //
     operator+(basic_iterator<Cur> left, typename basic_iterator<Cur>::difference_type n)
     {
         left += n;
         return left;
     }
-    template(typename Cur)( //
-        requires detail::random_access_cursor<Cur>) //
+    template(typename Cur)(
+        /// \pre
+        requires detail::random_access_cursor<Cur>)
     constexpr basic_iterator<Cur> //
     operator+(typename basic_iterator<Cur>::difference_type n, basic_iterator<Cur> right)
     {
         right += n;
         return right;
     }
-    template(typename Cur)( //
+    template(typename Cur)(
+        /// \pre
         requires detail::random_access_cursor<Cur>)
     constexpr basic_iterator<Cur> //
     operator-(basic_iterator<Cur> left, typename basic_iterator<Cur>::difference_type n)
@@ -797,7 +840,8 @@ namespace ranges
         left -= n;
         return left;
     }
-    template(typename Cur2, typename Cur)( //
+    template(typename Cur2, typename Cur)(
+        /// \pre
         requires detail::sized_sentinel_for_cursor<Cur2, Cur>)
     constexpr typename basic_iterator<Cur>::difference_type //
     operator-(basic_iterator<Cur2> const & left, basic_iterator<Cur> const & right)
@@ -805,44 +849,50 @@ namespace ranges
         return range_access::distance_to(range_access::pos(right),
                                          range_access::pos(left));
     }
-    template(typename S, typename Cur)( //
-        requires detail::sized_sentinel_for_cursor<S, Cur>) //
+    template(typename S, typename Cur)(
+        /// \pre
+        requires detail::sized_sentinel_for_cursor<S, Cur>)
     constexpr typename basic_iterator<Cur>::difference_type //
     operator-(S const & left, basic_iterator<Cur> const & right)
     {
         return range_access::distance_to(range_access::pos(right), left);
     }
-    template(typename Cur, typename S)( //
-        requires detail::sized_sentinel_for_cursor<S, Cur>) //
+    template(typename Cur, typename S)(
+        /// \pre
+        requires detail::sized_sentinel_for_cursor<S, Cur>)
     constexpr typename basic_iterator<Cur>::difference_type //
     operator-(basic_iterator<Cur> const & left, S const & right)
     {
         return -(right - left);
     }
     // Asymmetric comparisons
-    template(typename Left, typename Right)( //
-        requires detail::sized_sentinel_for_cursor<Right, Left>) //
+    template(typename Left, typename Right)(
+        /// \pre
+        requires detail::sized_sentinel_for_cursor<Right, Left>)
     constexpr bool operator<(basic_iterator<Left> const & left,
                              basic_iterator<Right> const & right)
     {
         return 0 < (right - left);
     }
-    template(typename Left, typename Right)( //
-        requires detail::sized_sentinel_for_cursor<Right, Left>) //
+    template(typename Left, typename Right)(
+        /// \pre
+        requires detail::sized_sentinel_for_cursor<Right, Left>)
     constexpr bool operator<=(basic_iterator<Left> const & left,
                               basic_iterator<Right> const & right)
     {
         return 0 <= (right - left);
     }
-    template(typename Left, typename Right)( //
-        requires detail::sized_sentinel_for_cursor<Right, Left>) //
+    template(typename Left, typename Right)(
+        /// \pre
+        requires detail::sized_sentinel_for_cursor<Right, Left>)
     constexpr bool operator>(basic_iterator<Left> const & left,
                              basic_iterator<Right> const & right)
     {
         return (right - left) < 0;
     }
-    template(typename Left, typename Right)( //
-        requires detail::sized_sentinel_for_cursor<Right, Left>) //
+    template(typename Left, typename Right)(
+        /// \pre
+        requires detail::sized_sentinel_for_cursor<Right, Left>)
     constexpr bool operator>=(basic_iterator<Left> const & left,
                               basic_iterator<Right> const & right)
     {
@@ -858,7 +908,8 @@ namespace ranges
         constexpr auto iter_move(basic_iterator<Cur> const & it) noexcept(
             noexcept(range_access::move(std::declval<Cur const &>())))
             -> CPP_broken_friend_ret(
-                decltype(range_access::move(std::declval<Cur const &>())))( //
+                decltype(range_access::move(std::declval<Cur const &>())))(
+                /// \pre
                 requires detail::input_cursor<Cur>)
         {
             return range_access::move(range_access::pos(it));

--- a/include/range/v3/iterator/common_iterator.hpp
+++ b/include/range/v3/iterator/common_iterator.hpp
@@ -109,15 +109,17 @@ namespace ranges
         {
             return j;
         }
-        template(typename J, typename R = iter_reference_t<J>)( //
+        template(typename J, typename R = iter_reference_t<J>)(
+            /// \pre
             requires std::is_reference<R>::value) //
         static meta::_t<std::add_pointer<R>> operator_arrow_(J const & j, long) noexcept
         {
             auto && r = *j;
             return std::addressof(r);
         }
-        template(typename J, typename V = iter_value_t<J>)( //
-            requires constructible_from<V, iter_reference_t<J>>) //
+        template(typename J, typename V = iter_value_t<J>)(
+            /// \pre
+            requires constructible_from<V, iter_reference_t<J>>)
         static arrow_proxy_ operator_arrow_(J const & j, ...) noexcept(noexcept(V(V(*j))))
         {
             return arrow_proxy_(*j);
@@ -133,15 +135,17 @@ namespace ranges
         common_iterator(S s)
           : data_(emplaced_index<1>, std::move(s))
         {}
-        template(typename I2, typename S2)( //
-            requires convertible_to<I2, I> AND convertible_to<S2, S>) //
+        template(typename I2, typename S2)(
+            /// \pre
+            requires convertible_to<I2, I> AND convertible_to<S2, S>)
         common_iterator(common_iterator<I2, S2> const & that)
           : data_(detail::variant_core_access::make_empty<I, S>())
         {
             detail::cidata(that).visit_i(emplace_fn{&data_});
         }
-        template(typename I2, typename S2)( //
-            requires convertible_to<I2, I> AND convertible_to<S2, S>) //
+        template(typename I2, typename S2)(
+            /// \pre
+            requires convertible_to<I2, I> AND convertible_to<S2, S>)
         common_iterator & operator=(common_iterator<I2, S2> const & that)
         {
             detail::cidata(that).visit_i(emplace_fn{&data_});
@@ -155,12 +159,14 @@ namespace ranges
         CPP_member
         auto operator*() const //
             noexcept(noexcept(iter_reference_t<I>(*std::declval<I const &>())))
-            -> CPP_ret(iter_reference_t<I>)( //
+            -> CPP_ret(iter_reference_t<I>)(
+                /// \pre
                 requires indirectly_readable<I const>)
         {
             return *ranges::get<0>(data_);
         }
-        template(typename J = I)( //
+        template(typename J = I)(
+            /// \pre
             requires indirectly_readable<J>)
         auto operator->() const //
             noexcept(
@@ -175,7 +181,8 @@ namespace ranges
             return *this;
         }
 #ifdef RANGES_WORKAROUND_MSVC_677925
-        template(typename I2 = I)( //
+        template(typename I2 = I)(
+            /// \pre
             requires (!forward_iterator<I2>)) //
         auto operator++(int) //
             -> decltype(std::declval<I2 &>()++)
@@ -185,7 +192,8 @@ namespace ranges
 #else  // ^^^ workaround ^^^ / vvv no workaround vvv
         CPP_member
         auto operator++(int) //
-            -> CPP_ret(decltype(std::declval<I &>()++))( //
+            -> CPP_ret(decltype(std::declval<I &>()++))(
+                /// \pre
                 requires (!forward_iterator<I>))
         {
             return ranges::get<0>(data_)++;
@@ -193,7 +201,8 @@ namespace ranges
 #endif // RANGES_WORKAROUND_MSVC_677925
         CPP_member
         auto operator++(int) //
-            -> CPP_ret(common_iterator)( //
+            -> CPP_ret(common_iterator)(
+                /// \pre
                 requires forward_iterator<I>)
         {
             return common_iterator(ranges::get<0>(data_)++);
@@ -203,7 +212,8 @@ namespace ranges
         template<typename I_ = I>
         friend constexpr auto iter_move(common_iterator const & i) //
             noexcept(detail::has_nothrow_iter_move_v<I>)
-            -> CPP_broken_friend_ret(iter_rvalue_reference_t<I>)( //
+            -> CPP_broken_friend_ret(iter_rvalue_reference_t<I>)(
+                /// \pre
                 requires input_iterator<I_>)
         {
             return ranges::iter_move(ranges::get<0>(detail::cidata(i)));
@@ -213,7 +223,8 @@ namespace ranges
             common_iterator const & x,
             common_iterator<I2, S2> const &
                 y) noexcept(is_nothrow_indirectly_swappable<I, I2>::value)
-            -> CPP_broken_friend_ret(void)( //
+            -> CPP_broken_friend_ret(void)(
+                /// \pre
                 requires indirectly_swappable<I2, I>)
         {
             return ranges::iter_swap(ranges::get<0>(detail::cidata(x)),
@@ -229,7 +240,8 @@ namespace ranges
         template<typename I, typename S>
         constexpr auto iter_move(common_iterator<I, S> const & i) noexcept(
             detail::has_nothrow_iter_move_v<I>)
-            -> CPP_broken_friend_ret(iter_rvalue_reference_t<I>)( //
+            -> CPP_broken_friend_ret(iter_rvalue_reference_t<I>)(
+                /// \pre
                 requires input_iterator<I>)
         {
             return ranges::iter_move(ranges::get<0>(detail::cidata(i)));
@@ -238,7 +250,8 @@ namespace ranges
         auto iter_swap(common_iterator<I1, S1> const & x,
                        common_iterator<I2, S2> const & y) //
             noexcept(is_nothrow_indirectly_swappable<I1, I2>::value)
-                -> CPP_broken_friend_ret(void)( //
+                -> CPP_broken_friend_ret(void)(
+                    /// \pre
                     requires indirectly_swappable<I1, I2>)
         {
             return ranges::iter_swap(ranges::get<0>(detail::cidata(x)),
@@ -248,8 +261,9 @@ namespace ranges
 #endif
     /// \endcond
 
-    template(typename I1, typename I2, typename S1, typename S2)( //
-        requires sentinel_for<S1, I2> AND sentinel_for<S2, I1> AND //
+    template(typename I1, typename I2, typename S1, typename S2)(
+        /// \pre
+        requires sentinel_for<S1, I2> AND sentinel_for<S2, I1> AND
         (!equality_comparable_with<I1, I2>)) //
     bool operator==(common_iterator<I1, S1> const & x, common_iterator<I2, S2> const & y)
     {
@@ -261,9 +275,10 @@ namespace ranges
                                                       ranges::get<1>(detail::cidata(y)));
     }
 
-    template(typename I1, typename I2, typename S1, typename S2)( //
-        requires sentinel_for<S1, I2> AND sentinel_for<S2, I1> AND //
-            equality_comparable_with<I1, I2>) //
+    template(typename I1, typename I2, typename S1, typename S2)(
+        /// \pre
+        requires sentinel_for<S1, I2> AND sentinel_for<S2, I1> AND
+            equality_comparable_with<I1, I2>)
     bool operator==(common_iterator<I1, S1> const & x, common_iterator<I2, S2> const & y)
     {
         return detail::cidata(x).index() == 1u
@@ -277,16 +292,18 @@ namespace ranges
                                 ranges::get<0>(detail::cidata(y)));
     }
 
-    template(typename I1, typename I2, typename S1, typename S2)( //
-        requires sentinel_for<S1, I2> AND sentinel_for<S2, I1>) //
+    template(typename I1, typename I2, typename S1, typename S2)(
+        /// \pre
+        requires sentinel_for<S1, I2> AND sentinel_for<S2, I1>)
     bool operator!=(common_iterator<I1, S1> const & x, common_iterator<I2, S2> const & y)
     {
         return !(x == y);
     }
 
-    template(typename I1, typename I2, typename S1, typename S2)( //
-        requires sized_sentinel_for<I1, I2> AND sized_sentinel_for<S1, I2> AND //
-            sized_sentinel_for<S2, I1>) //
+    template(typename I1, typename I2, typename S1, typename S2)(
+        /// \pre
+        requires sized_sentinel_for<I1, I2> AND sized_sentinel_for<S1, I2> AND
+            sized_sentinel_for<S2, I1>)
     iter_difference_t<I2> operator-(common_iterator<I1, S1> const & x,
                                     common_iterator<I2, S2> const & y)
     {
@@ -318,7 +335,8 @@ namespace ranges
         template<typename I>
         auto demote_common_iter_cat(long)
             -> with_iterator_category<std::input_iterator_tag>;
-        template(typename I)( //
+        template(typename I)(
+            /// \pre
             requires derived_from<typename std::iterator_traits<I>::iterator_category,
                                       std::forward_iterator_tag>)
         auto demote_common_iter_cat(int)
@@ -410,21 +428,24 @@ namespace ranges
             }
             CPP_member
             auto prev() //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires bidirectional_iterator<I>)
             {
                 --it_;
             }
             CPP_member
             auto advance(std::ptrdiff_t n) //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires random_access_iterator<I>)
             {
                 it_ += static_cast<iter_difference_t<I>>(n);
             }
             CPP_member
             auto distance_to(cpp17_iterator_cursor const & that) //
-                -> CPP_ret(std::ptrdiff_t)( //
+                -> CPP_ret(std::ptrdiff_t)(
+                    /// \pre
                     requires random_access_iterator<I>)
             {
                 auto d = that.it_ - it_;

--- a/include/range/v3/iterator/concepts.hpp
+++ b/include/range/v3/iterator/concepts.hpp
@@ -49,55 +49,66 @@ namespace ranges
                                         std::iterator_traits<I>, I>;
 
 #if defined(_GLIBCXX_DEBUG)
-        template(typename I, typename T, typename Seq)( //
-            requires same_as<I, __gnu_debug::_Safe_iterator<T *, Seq>>) //
+        template(typename I, typename T, typename Seq)(
+            /// \pre
+            requires same_as<I, __gnu_debug::_Safe_iterator<T *, Seq>>)
         auto iter_concept_(__gnu_debug::_Safe_iterator<T *, Seq>, priority_tag<3>)
             -> ranges::contiguous_iterator_tag
 #endif
 #if defined(__GLIBCXX__)
-        template(typename I, typename T, typename Seq)( //
-            requires same_as<I, __gnu_cxx::__normal_iterator<T *, Seq>>) //
+        template(typename I, typename T, typename Seq)(
+            /// \pre
+            requires same_as<I, __gnu_cxx::__normal_iterator<T *, Seq>>)
         auto iter_concept_(__gnu_cxx::__normal_iterator<T *, Seq>, priority_tag<3>)
             -> ranges::contiguous_iterator_tag;
 #endif
 #if defined(_LIBCPP_VERSION)
-        template(typename I, typename T)( //
-            requires same_as<I, std::__wrap_iter<T *>>) //
+        template(typename I, typename T)(
+            /// \pre
+            requires same_as<I, std::__wrap_iter<T *>>)
         auto iter_concept_(std::__wrap_iter<T *>, priority_tag<3>)
             -> ranges::contiguous_iterator_tag;
 #endif
 #if defined(_MSVC_STL_VERSION) || defined(_IS_WRS)
-        template(typename I)( //
-            requires same_as<I, class I::_Array_iterator>) //
+        template(typename I)(
+            /// \pre
+            requires same_as<I, class I::_Array_iterator>)
         auto iter_concept_(I, priority_tag<3>)
             -> ranges::contiguous_iterator_tag;
-        template(typename I)( //
-            requires same_as<I, class I::_Array_const_iterator>) //
+        template(typename I)(
+            /// \pre
+            requires same_as<I, class I::_Array_const_iterator>)
         auto iter_concept_(I, priority_tag<3>)
             -> ranges::contiguous_iterator_tag;
-        template(typename I)( //
-            requires same_as<I, class I::_Vector_iterator>) //
+        template(typename I)(
+            /// \pre
+            requires same_as<I, class I::_Vector_iterator>)
         auto iter_concept_(I, priority_tag<3>)
             -> ranges::contiguous_iterator_tag;
-        template(typename I)( //
-            requires same_as<I, class I::_Vector_const_iterator>) //
+        template(typename I)(
+            /// \pre
+            requires same_as<I, class I::_Vector_const_iterator>)
         auto iter_concept_(I, priority_tag<3>)
             -> ranges::contiguous_iterator_tag;
-        template(typename I)( //
-            requires same_as<I, class I::_String_iterator>) //
+        template(typename I)(
+            /// \pre
+            requires same_as<I, class I::_String_iterator>)
         auto iter_concept_(I, priority_tag<3>)
             -> ranges::contiguous_iterator_tag;
-        template(typename I)( //
-            requires same_as<I, class I::_String_const_iterator>) //
+        template(typename I)(
+            /// \pre
+            requires same_as<I, class I::_String_const_iterator>)
         auto iter_concept_(I, priority_tag<3>)
             -> ranges::contiguous_iterator_tag;
-        template(typename I)( //
-            requires same_as<I, class I::_String_view_iterator>) //
+        template(typename I)(
+            /// \pre
+            requires same_as<I, class I::_String_view_iterator>)
         auto iter_concept_(I, priority_tag<3>)
             -> ranges::contiguous_iterator_tag;
 #endif
-        template(typename I, typename T)( //
-            requires same_as<I, T *>) //
+        template(typename I, typename T)(
+            /// \pre
+            requires same_as<I, T *>)
         auto iter_concept_(T *, priority_tag<3>)
             -> ranges::contiguous_iterator_tag;
         template<typename I>
@@ -827,12 +838,14 @@ namespace ranges
 // necessary operation.
 namespace __gnu_debug
 {
-    template(typename I1, typename I2, typename Seq)( //
+    template(typename I1, typename I2, typename Seq)(
+        /// \pre
         requires (!::ranges::sized_sentinel_for<I1, I2>)) //
     void operator-(_Safe_iterator<I1, Seq> const &, _Safe_iterator<I2, Seq> const &) =
         delete;
 
-    template(typename I1, typename Seq)( //
+    template(typename I1, typename Seq)(
+        /// \pre
         requires (!::ranges::sized_sentinel_for<I1, I1>)) //
     void operator-(_Safe_iterator<I1, Seq> const &, _Safe_iterator<I1, Seq> const &) =
         delete;

--- a/include/range/v3/iterator/counted_iterator.hpp
+++ b/include/range/v3/iterator/counted_iterator.hpp
@@ -107,15 +107,17 @@ namespace ranges
             RANGES_EXPECT(n >= 0);
         }
 
-        template(typename I2)( //
-            requires convertible_to<I2, I>) //
+        template(typename I2)(
+            /// \pre
+            requires convertible_to<I2, I>)
         constexpr counted_iterator(counted_iterator<I2> const & i)
           : current_(_counted_iterator_::access::current(i))
           , cnt_(i.count())
         {}
 
-        template(typename I2)( //
-            requires convertible_to<I2, I>) //
+        template(typename I2)(
+            /// \pre
+            requires convertible_to<I2, I>)
         constexpr counted_iterator & operator=(counted_iterator<I2> const & i)
         {
             current_ = _counted_iterator_::access::current(i);
@@ -138,8 +140,9 @@ namespace ranges
             RANGES_EXPECT(cnt_ > 0);
             return *current_;
         }
-        template(typename I2 = I)( //
-            requires indirectly_readable<I2 const>) //
+        template(typename I2 = I)(
+            /// \pre
+            requires indirectly_readable<I2 const>)
         constexpr iter_reference_t<I2> operator*() const //
             noexcept(noexcept(iter_reference_t<I>(*current_)))
         {
@@ -156,13 +159,15 @@ namespace ranges
         }
 
 #ifdef RANGES_WORKAROUND_MSVC_677925
-        template(typename I2 = I)( //
+        template(typename I2 = I)(
+            /// \pre
             requires (!forward_iterator<I2>)) //
         constexpr auto operator++(int) -> decltype(std::declval<I2 &>()++)
 #else  // ^^^ workaround ^^^ / vvv no workaround vvv
         CPP_member
         constexpr auto operator++(int) //
-            -> CPP_ret(decltype(std::declval<I &>()++))( //
+            -> CPP_ret(decltype(std::declval<I &>()++))(
+                /// \pre
                 requires (!forward_iterator<I>))
 #endif // RANGES_WORKAROUND_MSVC_677925
         {
@@ -172,7 +177,8 @@ namespace ranges
 
         CPP_member
         constexpr auto operator++(int) //
-            -> CPP_ret(counted_iterator)( //
+            -> CPP_ret(counted_iterator)(
+                /// \pre
                 requires forward_iterator<I>)
         {
             auto tmp(*this);
@@ -182,7 +188,8 @@ namespace ranges
 
         CPP_member
         constexpr auto operator--() //
-            -> CPP_ret(counted_iterator &)( //
+            -> CPP_ret(counted_iterator &)(
+                /// \pre
                 requires bidirectional_iterator<I>)
         {
             --current_;
@@ -192,7 +199,8 @@ namespace ranges
 
         CPP_member
         constexpr auto operator--(int) //
-            -> CPP_ret(counted_iterator)( //
+            -> CPP_ret(counted_iterator)(
+                /// \pre
                 requires bidirectional_iterator<I>)
         {
             auto tmp(*this);
@@ -202,7 +210,8 @@ namespace ranges
 
         CPP_member
         constexpr auto operator+=(difference_type n) //
-            -> CPP_ret(counted_iterator &)( //
+            -> CPP_ret(counted_iterator &)(
+                /// \pre
                 requires random_access_iterator<I>)
         {
             RANGES_EXPECT(cnt_ >= n);
@@ -213,7 +222,8 @@ namespace ranges
 
         CPP_member
         constexpr auto operator+(difference_type n) const //
-            -> CPP_ret(counted_iterator)( //
+            -> CPP_ret(counted_iterator)(
+                /// \pre
                 requires random_access_iterator<I>)
         {
             auto tmp(*this);
@@ -223,7 +233,8 @@ namespace ranges
 
         CPP_member
         constexpr auto operator-=(difference_type n) //
-            -> CPP_ret(counted_iterator &)( //
+            -> CPP_ret(counted_iterator &)(
+                /// \pre
                 requires random_access_iterator<I>)
         {
             RANGES_EXPECT(cnt_ >= -n);
@@ -234,7 +245,8 @@ namespace ranges
 
         CPP_member
         constexpr auto operator-(difference_type n) const //
-            -> CPP_ret(counted_iterator)( //
+            -> CPP_ret(counted_iterator)(
+                /// \pre
                 requires random_access_iterator<I>)
         {
             auto tmp(*this);
@@ -244,7 +256,8 @@ namespace ranges
 
         CPP_member
         constexpr auto operator[](difference_type n) const //
-            -> CPP_ret(iter_reference_t<I>)( //
+            -> CPP_ret(iter_reference_t<I>)(
+                /// \pre
                 requires random_access_iterator<I>)
         {
             RANGES_EXPECT(cnt_ >= n);
@@ -254,8 +267,9 @@ namespace ranges
 #if !RANGES_BROKEN_CPO_LOOKUP
         CPP_broken_friend_member
         friend constexpr auto iter_move(counted_iterator const & i) //
-            noexcept(detail::has_nothrow_iter_move_v<I>) //
-            -> CPP_broken_friend_ret(iter_rvalue_reference_t<I>)( //
+            noexcept(detail::has_nothrow_iter_move_v<I>)
+            -> CPP_broken_friend_ret(iter_rvalue_reference_t<I>)(
+                /// \pre
                 requires input_iterator<I>)
         {
             return ranges::iter_move(i.current_);
@@ -264,7 +278,8 @@ namespace ranges
         friend constexpr auto iter_swap(counted_iterator const & x,
                                         counted_iterator<I2> const & y) //
             noexcept(is_nothrow_indirectly_swappable<I, I2>::value)
-            -> CPP_broken_friend_ret(void)( //
+            -> CPP_broken_friend_ret(void)(
+                /// \pre
                 requires indirectly_swappable<I2, I>)
         {
             return ranges::iter_swap(x.current_, _counted_iterator_::access::current(y));
@@ -279,7 +294,8 @@ namespace ranges
         template<typename I>
         constexpr auto iter_move(counted_iterator<I> const & i) noexcept(
             detail::has_nothrow_iter_move_v<I>)
-            -> CPP_broken_friend_ret(iter_rvalue_reference_t<I>)( //
+            -> CPP_broken_friend_ret(iter_rvalue_reference_t<I>)(
+                /// \pre
                 requires input_iterator<I>)
         {
             return ranges::iter_move(_counted_iterator_::access::current(i));
@@ -289,7 +305,8 @@ namespace ranges
             counted_iterator<I1> const & x,
             counted_iterator<I2> const &
                 y) noexcept(is_nothrow_indirectly_swappable<I1, I2>::value)
-            -> CPP_broken_friend_ret(void)( //
+            -> CPP_broken_friend_ret(void)(
+                /// \pre
                 requires indirectly_swappable<I2, I1>)
         {
             return ranges::iter_swap(_counted_iterator_::access::current(x),
@@ -299,8 +316,9 @@ namespace ranges
 #endif
     /// endcond
 
-    template(typename I1, typename I2)( //
-        requires common_with<I1, I2>) //
+    template(typename I1, typename I2)(
+        /// \pre
+        requires common_with<I1, I2>)
     constexpr bool operator==(counted_iterator<I1> const & x,
                               counted_iterator<I2> const & y)
     {
@@ -319,8 +337,9 @@ namespace ranges
         return x.count() == 0;
     }
 
-    template(typename I1, typename I2)( //
-        requires common_with<I1, I2>) //
+    template(typename I1, typename I2)(
+        /// \pre
+        requires common_with<I1, I2>)
     constexpr bool operator!=(counted_iterator<I1> const & x,
                               counted_iterator<I2> const & y)
     {
@@ -339,40 +358,45 @@ namespace ranges
         return !(x == y);
     }
 
-    template(typename I1, typename I2)( //
-        requires common_with<I1, I2>) //
+    template(typename I1, typename I2)(
+        /// \pre
+        requires common_with<I1, I2>)
     constexpr bool operator<(counted_iterator<I1> const & x,
                              counted_iterator<I2> const & y)
     {
         return y.count() < x.count();
     }
 
-    template(typename I1, typename I2)( //
-        requires common_with<I1, I2>) //
+    template(typename I1, typename I2)(
+        /// \pre
+        requires common_with<I1, I2>)
     constexpr bool operator<=(counted_iterator<I1> const & x,
                               counted_iterator<I2> const & y)
     {
         return !(y < x);
     }
 
-    template(typename I1, typename I2)( //
-        requires common_with<I1, I2>) //
+    template(typename I1, typename I2)(
+        /// \pre
+        requires common_with<I1, I2>)
     constexpr bool operator>(counted_iterator<I1> const & x,
                              counted_iterator<I2> const & y)
     {
         return y < x;
     }
 
-    template(typename I1, typename I2)( //
-        requires common_with<I1, I2>) //
+    template(typename I1, typename I2)(
+        /// \pre
+        requires common_with<I1, I2>)
     constexpr bool operator>=(counted_iterator<I1> const & x,
                               counted_iterator<I2> const & y)
     {
         return !(x < y);
     }
 
-    template(typename I1, typename I2)( //
-        requires common_with<I1, I2>) //
+    template(typename I1, typename I2)(
+        /// \pre
+        requires common_with<I1, I2>)
     constexpr iter_difference_t<I2> operator-(counted_iterator<I1> const & x,
                                               counted_iterator<I2> const & y)
     {
@@ -393,16 +417,18 @@ namespace ranges
         return y.count();
     }
 
-    template(typename I)( //
-        requires random_access_iterator<I>) //
+    template(typename I)(
+        /// \pre
+        requires random_access_iterator<I>)
     constexpr counted_iterator<I> operator+(iter_difference_t<I> n,
                                             counted_iterator<I> const & x)
     {
         return x + n;
     }
 
-    template(typename I)( //
-        requires input_or_output_iterator<I>) //
+    template(typename I)(
+        /// \pre
+        requires input_or_output_iterator<I>)
     constexpr counted_iterator<I> make_counted_iterator(I i, iter_difference_t<I> n)
     {
         return {std::move(i), n};
@@ -416,8 +442,9 @@ namespace ranges
             meta::nil_>
     {};
 
-    CPP_template_def(typename I)( //
-        requires input_or_output_iterator<I>) //
+    CPP_template_def(typename I)(
+        /// \pre
+        requires input_or_output_iterator<I>)
     constexpr void advance_fn::operator()(counted_iterator<I> & i,
                                           iter_difference_t<I> n) const
     {

--- a/include/range/v3/iterator/diffmax_t.hpp
+++ b/include/range/v3/iterator/diffmax_t.hpp
@@ -61,8 +61,9 @@ namespace ranges
         public:
             diffmax_t() = default;
 
-            template(typename T)( //
-                requires integral<T>) //
+            template(typename T)(
+                /// \pre
+                requires integral<T>)
             constexpr diffmax_t(T val) noexcept
               : neg_(0 > val)
               , val_(0 > val ? static_cast<std::uintmax_t>(-val)
@@ -219,63 +220,72 @@ namespace ranges
 
             template<typename T>
             friend constexpr auto operator+=(T & a, diffmax_t b) noexcept
-                -> CPP_broken_friend_ret(T &)( //
+                -> CPP_broken_friend_ret(T &)(
+                    /// \pre
                     requires integral<T>)
             {
                 return (a = static_cast<T>(diffmax_t{a} + b));
             }
             template<typename T>
             friend constexpr auto operator-=(T & a, diffmax_t b) noexcept
-                -> CPP_broken_friend_ret(T &)( //
+                -> CPP_broken_friend_ret(T &)(
+                    /// \pre
                     requires integral<T>)
             {
                 return (a = static_cast<T>(diffmax_t{a} - b));
             }
             template<typename T>
             friend constexpr auto operator*=(T & a, diffmax_t b) noexcept
-                -> CPP_broken_friend_ret(T &)( //
+                -> CPP_broken_friend_ret(T &)(
+                    /// \pre
                     requires integral<T>)
             {
                 return (a = static_cast<T>(diffmax_t{a} * b));
             }
             template<typename T>
             friend constexpr auto operator/=(T & a, diffmax_t b) noexcept
-                -> CPP_broken_friend_ret(T &)( //
+                -> CPP_broken_friend_ret(T &)(
+                    /// \pre
                     requires integral<T>)
             {
                 return (a = static_cast<T>(diffmax_t{a} / b));
             }
             template<typename T>
             friend constexpr auto operator%=(T & a, diffmax_t b) noexcept
-                -> CPP_broken_friend_ret(T &)( //
+                -> CPP_broken_friend_ret(T &)(
+                    /// \pre
                     requires integral<T>)
             {
                 return (a = static_cast<T>(diffmax_t{a} % b));
             }
             template<typename T>
             friend constexpr auto operator&=(T & a, diffmax_t b) noexcept
-                -> CPP_broken_friend_ret(T &)( //
+                -> CPP_broken_friend_ret(T &)(
+                    /// \pre
                     requires integral<T>)
             {
                 return (a = static_cast<T>(diffmax_t{a} & b));
             }
             template<typename T>
             friend constexpr auto operator|=(T & a, diffmax_t b) noexcept
-                -> CPP_broken_friend_ret(T &)( //
+                -> CPP_broken_friend_ret(T &)(
+                    /// \pre
                     requires integral<T>)
             {
                 return (a = static_cast<T>(diffmax_t{a} | b));
             }
             template<typename T>
             friend constexpr auto operator^=(T & a, diffmax_t b) noexcept
-                -> CPP_broken_friend_ret(T &)( //
+                -> CPP_broken_friend_ret(T &)(
+                    /// \pre
                     requires integral<T>)
             {
                 return (a = static_cast<T>(diffmax_t{a} ^ b));
             }
             template<typename T>
             friend constexpr auto operator<<=(T & a, diffmax_t b) noexcept
-                -> CPP_broken_friend_ret(T &)( //
+                -> CPP_broken_friend_ret(T &)(
+                    /// \pre
                     requires integral<T>)
             {
                 a = static_cast<T>(diffmax_t{a} << b);
@@ -283,7 +293,8 @@ namespace ranges
             }
             template<typename T>
             friend constexpr auto operator>>=(T & a, diffmax_t b) noexcept
-                -> CPP_broken_friend_ret(T &)( //
+                -> CPP_broken_friend_ret(T &)(
+                    /// \pre
                     requires integral<T>)
             {
                 a = static_cast<T>(diffmax_t{a} >> b);
@@ -313,8 +324,9 @@ namespace ranges
                 return tmp;
             }
 
-            template(typename T)( //
-                requires integral<T>) //
+            template(typename T)(
+                /// \pre
+                requires integral<T>)
                 constexpr explicit
                 operator T() const noexcept
             {
@@ -331,7 +343,8 @@ namespace ranges
 
             template<typename Ostream>
             friend auto operator<<(Ostream & sout, diffmax_t a)
-                -> CPP_broken_friend_ret(std::ostream &)( //
+                -> CPP_broken_friend_ret(std::ostream &)(
+                    /// \pre
                     requires derived_from<
                         Ostream, std::basic_ostream<typename Ostream::char_type,
                                                     typename Ostream::traits_type>>)

--- a/include/range/v3/iterator/move_iterators.hpp
+++ b/include/range/v3/iterator/move_iterators.hpp
@@ -46,13 +46,15 @@ namespace ranges
         explicit move_iterator(I i)
           : current_(i)
         {}
-        template(typename O)( //
-            requires convertible_to<O, I>) //
+        template(typename O)(
+            /// \pre
+            requires convertible_to<O, I>)
         move_iterator(move_iterator<O> const & i)
           : current_(i.base())
         {}
-        template(typename O)( //
-            requires convertible_to<O, I>) //
+        template(typename O)(
+            /// \pre
+            requires convertible_to<O, I>)
         move_iterator & operator=(move_iterator<O> const & i)
         {
             current_ = i.base();
@@ -76,21 +78,24 @@ namespace ranges
         }
         CPP_member
         auto operator++(int) //
-            -> CPP_ret(void)( //
+            -> CPP_ret(void)(
+                /// \pre
                 requires (!forward_iterator<I>))
         {
             ++current_;
         }
         CPP_member
         auto operator++(int) //
-            -> CPP_ret(move_iterator)( //
+            -> CPP_ret(move_iterator)(
+                /// \pre
                 requires forward_iterator<I>)
         {
             return move_iterator(current_++);
         }
         CPP_member
         auto operator--() //
-            -> CPP_ret(move_iterator &)( //
+            -> CPP_ret(move_iterator &)(
+                /// \pre
                 requires forward_iterator<I>)
         {
             --current_;
@@ -98,21 +103,24 @@ namespace ranges
         }
         CPP_member
         auto operator--(int) //
-            -> CPP_ret(move_iterator)( //
+            -> CPP_ret(move_iterator)(
+                /// \pre
                 requires bidirectional_iterator<I>)
         {
             return move_iterator(current_--);
         }
         CPP_member
         auto operator+(difference_type n) const //
-            -> CPP_ret(move_iterator)( //
+            -> CPP_ret(move_iterator)(
+                /// \pre
                 requires random_access_iterator<I>)
         {
             return move_iterator(current_ + n);
         }
         CPP_member
         auto operator+=(difference_type n)
-            -> CPP_ret(move_iterator &)( //
+            -> CPP_ret(move_iterator &)(
+                /// \pre
                 requires random_access_iterator<I>)
         {
             current_ += n;
@@ -120,14 +128,16 @@ namespace ranges
         }
         CPP_member
         auto operator-(difference_type n) const //
-            -> CPP_ret(move_iterator)( //
+            -> CPP_ret(move_iterator)(
+                /// \pre
                 requires random_access_iterator<I>)
         {
             return move_iterator(current_ - n);
         }
         CPP_member
         auto operator-=(difference_type n) //
-            -> CPP_ret(move_iterator &)( //
+            -> CPP_ret(move_iterator &)(
+                /// \pre
                 requires random_access_iterator<I>)
         {
             current_ -= n;
@@ -135,7 +145,8 @@ namespace ranges
         }
         CPP_member
         auto operator[](difference_type n) const //
-            -> CPP_ret(reference)( //
+            -> CPP_ret(reference)(
+                /// \pre
                 requires random_access_iterator<I>)
         {
             return iter_move(current_ + n);
@@ -143,42 +154,48 @@ namespace ranges
 
         template<typename I2>
         friend auto operator==(move_iterator const & x, move_iterator<I2> const & y)
-            -> CPP_broken_friend_ret(bool)( //
+            -> CPP_broken_friend_ret(bool)(
+                /// \pre
                 requires equality_comparable_with<I, I2>)
         {
             return x.base() == y.base();
         }
         template<typename I2>
         friend auto operator!=(move_iterator const & x, move_iterator<I2> const & y)
-            -> CPP_broken_friend_ret(bool)( //
+            -> CPP_broken_friend_ret(bool)(
+                /// \pre
                 requires equality_comparable_with<I, I2>)
         {
             return !(x == y);
         }
         template<typename I2>
         friend auto operator<(move_iterator const & x, move_iterator<I2> const & y)
-            -> CPP_broken_friend_ret(bool)( //
+            -> CPP_broken_friend_ret(bool)(
+                /// \pre
                 requires totally_ordered_with<I, I2>)
         {
             return x.base() < y.base();
         }
         template<typename I2>
         friend auto operator<=(move_iterator const & x, move_iterator<I2> const & y)
-            -> CPP_broken_friend_ret(bool)( //
+            -> CPP_broken_friend_ret(bool)(
+                /// \pre
                 requires totally_ordered_with<I, I2>)
         {
             return !(y < x);
         }
         template<typename I2>
         friend auto operator>(move_iterator const & x, move_iterator<I2> const & y)
-            -> CPP_broken_friend_ret(bool)( //
+            -> CPP_broken_friend_ret(bool)(
+                /// \pre
                 requires totally_ordered_with<I, I2>)
         {
             return y < x;
         }
         template<typename I2>
         friend auto operator>=(move_iterator const & x, move_iterator<I2> const & y)
-            -> CPP_broken_friend_ret(bool)( //
+            -> CPP_broken_friend_ret(bool)(
+                /// \pre
                 requires totally_ordered_with<I, I2>)
         {
             return !(x < y);
@@ -186,7 +203,8 @@ namespace ranges
 
         template<typename I2>
         friend auto operator-(move_iterator const & x, move_iterator<I2> const & y)
-            -> CPP_broken_friend_ret(iter_difference_t<I2>)( //
+            -> CPP_broken_friend_ret(iter_difference_t<I2>)(
+                /// \pre
                 requires sized_sentinel_for<I, I2>)
         {
             return x.base() - y.base();
@@ -194,7 +212,8 @@ namespace ranges
         CPP_broken_friend_member
         friend auto operator+(iter_difference_t<I> n,
                               move_iterator const & x)
-            -> CPP_broken_friend_ret(move_iterator)( //
+            -> CPP_broken_friend_ret(move_iterator)(
+                /// \pre
                 requires random_access_iterator<I>)
         {
             return x + n;
@@ -203,8 +222,9 @@ namespace ranges
 
     struct make_move_iterator_fn
     {
-        template(typename I)( //
-            requires input_iterator<I>) //
+        template(typename I)(
+            /// \pre
+            requires input_iterator<I>)
         constexpr move_iterator<I> operator()(I it) const
         {
             return move_iterator<I>{detail::move(it)};
@@ -226,13 +246,15 @@ namespace ranges
         constexpr explicit move_sentinel(S s)
           : sent_(detail::move(s))
         {}
-        template(typename OS)( //
-            requires convertible_to<OS, S>) //
+        template(typename OS)(
+            /// \pre
+            requires convertible_to<OS, S>)
         constexpr explicit move_sentinel(move_sentinel<OS> const & that)
           : sent_(that.base())
         {}
-        template(typename OS)( //
-            requires convertible_to<OS, S>) //
+        template(typename OS)(
+            /// \pre
+            requires convertible_to<OS, S>)
         move_sentinel & operator=(move_sentinel<OS> const & that)
         {
             sent_ = that.base();
@@ -245,28 +267,32 @@ namespace ranges
 
         template<typename I>
         friend auto operator==(move_iterator<I> const & i, move_sentinel const & s)
-            -> CPP_broken_friend_ret(bool)( //
+            -> CPP_broken_friend_ret(bool)(
+                /// \pre
                 requires sentinel_for<S, I>)
         {
             return i.base() == s.base();
         }
         template<typename I>
         friend auto operator==(move_sentinel const & s, move_iterator<I> const & i)
-            -> CPP_broken_friend_ret(bool)( //
+            -> CPP_broken_friend_ret(bool)(
+                /// \pre
                 requires sentinel_for<S, I>)
         {
             return s.base() == i.base();
         }
         template<typename I>
         friend auto operator!=(move_iterator<I> const & i, move_sentinel const & s)
-            -> CPP_broken_friend_ret(bool)( //
+            -> CPP_broken_friend_ret(bool)(
+                /// \pre
                 requires sentinel_for<S, I>)
         {
             return i.base() != s.base();
         }
         template<typename I>
         friend auto operator!=(move_sentinel const & s, move_iterator<I> const & i)
-            -> CPP_broken_friend_ret(bool)( //
+            -> CPP_broken_friend_ret(bool)(
+                /// \pre
                 requires sentinel_for<S, I>)
         {
             return s.base() != i.base();
@@ -275,14 +301,16 @@ namespace ranges
 
     struct make_move_sentinel_fn
     {
-        template(typename I)( //
-            requires input_iterator<I>) //
+        template(typename I)(
+            /// \pre
+            requires input_iterator<I>)
         constexpr move_iterator<I> operator()(I i) const
         {
             return move_iterator<I>{detail::move(i)};
         }
 
-        template(typename S)( //
+        template(typename S)(
+            /// \pre
             requires semiregular<S> AND (!input_iterator<S>)) //
         constexpr move_sentinel<S> operator()(S s) const
         {
@@ -346,55 +374,63 @@ namespace ranges
             {
                 ++it_;
             }
-            template(typename T)( //
-                requires indirectly_writable<I, aux::move_t<T>>) //
+            template(typename T)(
+                /// \pre
+                requires indirectly_writable<I, aux::move_t<T>>)
             void write(T && t) noexcept(noexcept(*it_ = std::move(t)))
             {
                 *it_ = std::move(t);
             }
-            template(typename T)( //
-                requires indirectly_writable<I, aux::move_t<T>>) //
+            template(typename T)(
+                /// \pre
+                requires indirectly_writable<I, aux::move_t<T>>)
             void write(T && t) const noexcept(noexcept(*it_ = std::move(t)))
             {
                 *it_ = std::move(t);
             }
             CPP_member
             auto read() const noexcept(noexcept(*std::declval<I const &>()))
-                -> CPP_ret(iter_reference_t<I>)( //
+                -> CPP_ret(iter_reference_t<I>)(
+                    /// \pre
                     requires indirectly_readable<I>)
             {
                 return *it_;
             }
             CPP_member
             auto equal(move_into_cursor const & that) const //
-                -> CPP_ret(bool)( //
+                -> CPP_ret(bool)(
+                    /// \pre
                     requires input_iterator<I>)
             {
                 return it_ == that.it_;
             }
             CPP_member
             auto prev() //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires bidirectional_iterator<I>)
             {
                 --it_;
             }
             CPP_member
             auto advance(iter_difference_t<I> n) //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires random_access_iterator<I>)
             {
                 it_ += n;
             }
             CPP_member
             auto distance_to(move_into_cursor const & that) const //
-                -> CPP_ret(iter_difference_t<I>)( //
+                -> CPP_ret(iter_difference_t<I>)(
+                    /// \pre
                     requires sized_sentinel_for<I, I>)
             {
                 return that.it_ - it_;
             }
-            template(typename II = I const)( //
-                requires same_as<I const, II> AND indirectly_readable<II>) //
+            template(typename II = I const)(
+                /// \pre
+                requires same_as<I const, II> AND indirectly_readable<II>)
             constexpr iter_rvalue_reference_t<II> move() const //
                 noexcept(has_nothrow_iter_move_v<II>)
             {

--- a/include/range/v3/iterator/operations.hpp
+++ b/include/range/v3/iterator/operations.hpp
@@ -38,8 +38,9 @@ namespace ranges
     struct advance_fn
     {
 #if RANGES_CXX_IF_CONSTEXPR >= RANGES_CXX_IF_CONSTEXPR_17
-        template(typename I)( //
-            requires input_or_output_iterator<I>) //
+        template(typename I)(
+            /// \pre
+            requires input_or_output_iterator<I>)
         constexpr void operator()(I & i, iter_difference_t<I> n) const
         // [[expects: n >= 0 || bidirectional_iterator<I>]]
         {
@@ -58,8 +59,9 @@ namespace ranges
             }
         }
 
-        template(typename I, typename S)( //
-            requires sentinel_for<S, I>) //
+        template(typename I, typename S)(
+            /// \pre
+            requires sentinel_for<S, I>)
         constexpr void operator()(I & i, S bound) const
         // [[expects axiom: reachable(i, bound)]]
         {
@@ -78,8 +80,9 @@ namespace ranges
                     ++i;
         }
 
-        template(typename I, typename S)( //
-            requires sentinel_for<S, I>) //
+        template(typename I, typename S)(
+            /// \pre
+            requires sentinel_for<S, I>)
         constexpr iter_difference_t<I> //
         operator()(I & i, iter_difference_t<I> n, S bound) const
         // [[expects axiom: 0 == n ||
@@ -169,23 +172,26 @@ namespace ranges
 
     public:
         // Advance a certain number of steps:
-        template(typename I)( //
-            requires input_or_output_iterator<I>) //
+        template(typename I)(
+            /// \pre
+            requires input_or_output_iterator<I>)
         constexpr void operator()(I & i, iter_difference_t<I> n) const
         {
             advance_fn::n_(i, n, iterator_tag_of<I>{});
         }
         // Advance to a certain position:
-        template(typename I, typename S)( //
-            requires sentinel_for<S, I>) //
+        template(typename I, typename S)(
+            /// \pre
+            requires sentinel_for<S, I>)
         constexpr void operator()(I & i, S s) const
         {
             advance_fn::to_(
                 i, static_cast<S &&>(s), meta::bool_<assignable_from<I &, S>>());
         }
         // Advance a certain number of times, with a bound:
-        template(typename I, typename S)( //
-            requires sentinel_for<S, I>) //
+        template(typename I, typename S)(
+            /// \pre
+            requires sentinel_for<S, I>)
         constexpr iter_difference_t<I> //
         operator()(I & it, iter_difference_t<I> n, S bound) const
         {
@@ -197,8 +203,9 @@ namespace ranges
         }
 #endif
 
-        template(typename I)( //
-            requires input_or_output_iterator<I>) //
+        template(typename I)(
+            /// \pre
+            requires input_or_output_iterator<I>)
         constexpr void operator()(counted_iterator<I> & i, iter_difference_t<I> n) const;
     };
 
@@ -299,28 +306,32 @@ namespace ranges
 
     struct next_fn
     {
-        template(typename I)( //
-            requires input_or_output_iterator<I>) //
+        template(typename I)(
+            /// \pre
+            requires input_or_output_iterator<I>)
         constexpr I operator()(I it) const
         {
             return ++it;
         }
-        template(typename I)( //
-            requires input_or_output_iterator<I>) //
+        template(typename I)(
+            /// \pre
+            requires input_or_output_iterator<I>)
         constexpr I operator()(I it, iter_difference_t<I> n) const
         {
             advance(it, n);
             return it;
         }
-        template(typename I, typename S)( //
-            requires sentinel_for<S, I>) //
+        template(typename I, typename S)(
+            /// \pre
+            requires sentinel_for<S, I>)
         constexpr I operator()(I it, S s) const
         {
             advance(it, static_cast<S &&>(s));
             return it;
         }
-        template(typename I, typename S)( //
-            requires sentinel_for<S, I>) //
+        template(typename I, typename S)(
+            /// \pre
+            requires sentinel_for<S, I>)
         constexpr I operator()(I it, iter_difference_t<I> n, S bound) const
         {
             advance(it, n, static_cast<S &&>(bound));
@@ -333,21 +344,24 @@ namespace ranges
 
     struct prev_fn
     {
-        template(typename I)( //
-            requires bidirectional_iterator<I>) //
+        template(typename I)(
+            /// \pre
+            requires bidirectional_iterator<I>)
         constexpr I operator()(I it) const
         {
             return --it;
         }
-        template(typename I)( //
-            requires bidirectional_iterator<I>) //
+        template(typename I)(
+            /// \pre
+            requires bidirectional_iterator<I>)
         constexpr I operator()(I it, iter_difference_t<I> n) const
         {
             advance(it, -n);
             return it;
         }
-        template(typename I)( //
-            requires bidirectional_iterator<I>) //
+        template(typename I)(
+            /// \pre
+            requires bidirectional_iterator<I>)
         constexpr I operator()(I it, iter_difference_t<I> n, I bound) const
         {
             advance(it, -n, static_cast<I &&>(bound));
@@ -361,7 +375,8 @@ namespace ranges
     struct iter_enumerate_fn
     {
     private:
-        template(typename I, typename S)( //
+        template(typename I, typename S)(
+            /// \pre
             requires (!sized_sentinel_for<I, I>)) //
         static constexpr std::pair<iter_difference_t<I>, I> //
         impl_i(I first, S last, sentinel_tag)
@@ -371,8 +386,9 @@ namespace ranges
                 ++d;
             return {d, first};
         }
-        template(typename I, typename S)( //
-            requires sized_sentinel_for<I, I>) //
+        template(typename I, typename S)(
+            /// \pre
+            requires sized_sentinel_for<I, I>)
         static constexpr std::pair<iter_difference_t<I>, I> //
         impl_i(I first, S end_, sentinel_tag)
         {
@@ -391,8 +407,9 @@ namespace ranges
         }
 
     public:
-        template(typename I, typename S)( //
-            requires sentinel_for<S, I>) //
+        template(typename I, typename S)(
+            /// \pre
+            requires sentinel_for<S, I>)
         constexpr std::pair<iter_difference_t<I>, I> operator()(I first, S last) const
         {
             return iter_enumerate_fn::impl_i(static_cast<I &&>(first),
@@ -422,8 +439,9 @@ namespace ranges
         }
 
     public:
-        template(typename I, typename S)( //
-            requires input_or_output_iterator<I> AND sentinel_for<S, I>) //
+        template(typename I, typename S)(
+            /// \pre
+            requires input_or_output_iterator<I> AND sentinel_for<S, I>)
         constexpr iter_difference_t<I> operator()(I first, S last) const
         {
             return iter_distance_fn::impl_i(static_cast<I &&>(first),
@@ -463,8 +481,9 @@ namespace ranges
         }
 
     public:
-        template(typename I, typename S)( //
-            requires input_iterator<I> AND sentinel_for<S, I>) //
+        template(typename I, typename S)(
+            /// \pre
+            requires input_iterator<I> AND sentinel_for<S, I>)
         constexpr int operator()(I first, S last, iter_difference_t<I> n) const
         {
             return iter_distance_compare_fn::impl_i(static_cast<I &&>(first),
@@ -480,8 +499,9 @@ namespace ranges
     // Like distance(b,e), but guaranteed to be O(1)
     struct iter_size_fn
     {
-        template(typename I, typename S)( //
-            requires sized_sentinel_for<S, I>) //
+        template(typename I, typename S)(
+            /// \pre
+            requires sized_sentinel_for<S, I>)
         constexpr meta::_t<std::make_unsigned<iter_difference_t<I>>> //
         operator()(I const & first, S last) const
         {
@@ -554,8 +574,9 @@ namespace ranges
     public:
         using iter_enumerate_fn::operator();
 
-        template(typename Rng)( //
-            requires range<Rng>) //
+        template(typename Rng)(
+            /// \pre
+            requires range<Rng>)
         std::pair<range_difference_t<Rng>, iterator_t<Rng>> operator()(Rng && rng) const
         {
             // Better not be trying to compute the distance of an infinite range:
@@ -585,8 +606,9 @@ namespace ranges
     public:
         using iter_distance_fn::operator();
 
-        template(typename Rng)( //
-            requires range<Rng>) //
+        template(typename Rng)(
+            /// \pre
+            requires range<Rng>)
         constexpr range_difference_t<Rng> operator()(Rng && rng) const
         {
             // Better not be trying to compute the distance of an infinite range:
@@ -625,8 +647,9 @@ namespace ranges
     public:
         using iter_distance_compare_fn::operator();
 
-        template(typename Rng)( //
-            requires range<Rng>) //
+        template(typename Rng)(
+            /// \pre
+            requires range<Rng>)
         int operator()(Rng && rng, range_difference_t<Rng> n) const
         {
             return distance_compare_fn::impl_r(rng, n, sized_range_tag_of<Rng>());

--- a/include/range/v3/iterator/reverse_iterator.hpp
+++ b/include/range/v3/iterator/reverse_iterator.hpp
@@ -79,8 +79,9 @@ namespace ranges
             {
                 return it_;
             }
-            template(typename J)( //
-                requires sentinel_for<J, I>) //
+            template(typename J)(
+                /// \pre
+                requires sentinel_for<J, I>)
             constexpr bool equal(reverse_cursor<J> const & that) const
             {
                 return it_ == that.it_;
@@ -95,13 +96,15 @@ namespace ranges
             }
             CPP_member
             constexpr auto advance(iter_difference_t<I> n) //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires random_access_iterator<I>)
             {
                 it_ -= n;
             }
-            template(typename J)( //
-                requires sized_sentinel_for<J, I>) //
+            template(typename J)(
+                /// \pre
+                requires sized_sentinel_for<J, I>)
             constexpr iter_difference_t<I> distance_to(reverse_cursor<J> const & that) //
                 const
             {
@@ -118,8 +121,9 @@ namespace ranges
 
         public:
             reverse_cursor() = default;
-            template(typename U)( //
-                requires convertible_to<U, I>) //
+            template(typename U)(
+                /// \pre
+                requires convertible_to<U, I>)
             constexpr reverse_cursor(reverse_cursor<U> const & u)
               : it_(u.base())
             {}
@@ -129,8 +133,9 @@ namespace ranges
 
     struct make_reverse_iterator_fn
     {
-        template(typename I)( //
-            requires bidirectional_iterator<I>) //
+        template(typename I)(
+            /// \pre
+            requires bidirectional_iterator<I>)
         constexpr reverse_iterator<I> operator()(I i) const
         {
             return reverse_iterator<I>(i);

--- a/include/range/v3/iterator/stream_iterators.hpp
+++ b/include/range/v3/iterator/stream_iterators.hpp
@@ -49,8 +49,9 @@ namespace ranges
           : sout_(&s)
           , delim_(d)
         {}
-        template(typename U)( //
-            requires convertible_to<U, value_t<U> const &>) //
+        template(typename U)(
+            /// \pre
+            requires convertible_to<U, value_t<U> const &>)
         ostream_iterator & operator=(U && value)
         {
             RANGES_EXPECT(sout_);
@@ -129,8 +130,9 @@ namespace ranges
 
     struct make_ostream_joiner_fn
     {
-        template(typename Delim, typename Char, typename Traits)( //
-            requires semiregular<detail::decay_t<Delim>>) //
+        template(typename Delim, typename Char, typename Traits)(
+            /// \pre
+            requires semiregular<detail::decay_t<Delim>>)
         ostream_joiner<detail::decay_t<Delim>, Char, Traits> //
         operator()(std::basic_ostream<Char, Traits> & s, Delim && d) const
         {

--- a/include/range/v3/iterator/unreachable_sentinel.hpp
+++ b/include/range/v3/iterator/unreachable_sentinel.hpp
@@ -27,28 +27,32 @@ namespace ranges
     {
         template<typename I>
         friend constexpr auto operator==(I const &, unreachable_sentinel_t) noexcept
-            -> CPP_broken_friend_ret(bool)( //
+            -> CPP_broken_friend_ret(bool)(
+                /// \pre
                 requires weakly_incrementable<I>)
         {
             return false;
         }
         template<typename I>
         friend constexpr auto operator==(unreachable_sentinel_t, I const &) noexcept
-            -> CPP_broken_friend_ret(bool)( //
+            -> CPP_broken_friend_ret(bool)(
+                /// \pre
                 requires weakly_incrementable<I>)
         {
             return false;
         }
         template<typename I>
         friend constexpr auto operator!=(I const &, unreachable_sentinel_t) noexcept
-            -> CPP_broken_friend_ret(bool)( //
+            -> CPP_broken_friend_ret(bool)(
+                /// \pre
                 requires weakly_incrementable<I>)
         {
             return true;
         }
         template<typename I>
         friend constexpr auto operator!=(unreachable_sentinel_t, I const &) noexcept
-            -> CPP_broken_friend_ret(bool)( //
+            -> CPP_broken_friend_ret(bool)(
+                /// \pre
                 requires weakly_incrementable<I>)
         {
             return true;

--- a/include/range/v3/iterator_range.hpp
+++ b/include/range/v3/iterator_range.hpp
@@ -154,28 +154,31 @@ namespace ranges
         constexpr iterator_range(I first, S last)
           : compressed_pair<I, S>{detail::move(first), detail::move(last)}
         {}
-        template(typename X, typename Y)( //
-            requires constructible_from<I, X> AND constructible_from<S, Y>) //
+        template(typename X, typename Y)(
+            /// \pre
+            requires constructible_from<I, X> AND constructible_from<S, Y>)
         constexpr iterator_range(iterator_range<X, Y> rng)
           : compressed_pair<I, S>{detail::move(rng.begin()), detail::move(rng.end())}
         {}
-        template(typename X, typename Y)( //
-            requires constructible_from<I, X> AND constructible_from<S, Y>) //
+        template(typename X, typename Y)(
+            /// \pre
+            requires constructible_from<I, X> AND constructible_from<S, Y>)
         constexpr explicit iterator_range(std::pair<X, Y> rng)
           : compressed_pair<I, S>{detail::move(rng.first), detail::move(rng.second)}
         {}
-        template(typename X, typename Y)( //
-            requires assignable_from<I &, X> AND assignable_from<S &, Y>) //
+        template(typename X, typename Y)(
+            /// \pre
+            requires assignable_from<I &, X> AND assignable_from<S &, Y>)
         iterator_range & operator=(iterator_range<X, Y> rng)
         {
             base().first() = std::move(rng.base()).first();
             base().second() = std::move(rng.base()).second();
             return *this;
         }
-        template(typename X, typename Y)(                      //
-            requires convertible_to<I, X> AND convertible_to<S, Y>) //
-            constexpr
-            operator std::pair<X, Y>() const
+        template(typename X, typename Y)(
+            /// \pre
+            requires convertible_to<I, X> AND convertible_to<S, Y>)
+        constexpr operator std::pair<X, Y>() const
         {
             return {base().first(), base().second()};
         }
@@ -220,28 +223,32 @@ namespace ranges
                           static_cast<size_type>(ranges::distance(rng_)) == size_);
 #endif
         }
-        template(typename X, typename Y)( //
+        template(typename X, typename Y)(
+            /// \pre
             requires constructible_from<I, X> AND constructible_from<S, Y>)
         RANGES_NDEBUG_CONSTEXPR sized_iterator_range(std::pair<X, Y> rng, size_type size)
           : sized_iterator_range{detail::move(rng).first, detail::move(rng).second, size}
         {}
-        template(typename X, typename Y)( //
-            requires constructible_from<I, X> AND constructible_from<S, Y>) //
+        template(typename X, typename Y)(
+            /// \pre
+            requires constructible_from<I, X> AND constructible_from<S, Y>)
         RANGES_NDEBUG_CONSTEXPR sized_iterator_range(iterator_range<X, Y> rng,
                                                      size_type size)
           : sized_iterator_range{detail::move(rng).first(),
                                  detail::move(rng).second,
                                  size}
         {}
-        template(typename X, typename Y)( //
-            requires constructible_from<I, X> AND constructible_from<S, Y>) //
+        template(typename X, typename Y)(
+            /// \pre
+            requires constructible_from<I, X> AND constructible_from<S, Y>)
         RANGES_NDEBUG_CONSTEXPR sized_iterator_range(sized_iterator_range<X, Y> rng)
           : sized_iterator_range{detail::move(rng).rng_.first(),
                                  detail::move(rng).rng_.second,
                                  rng.size_}
         {}
-        template(typename X, typename Y)( //
-            requires assignable_from<I &, X> AND assignable_from<S &, Y>) //
+        template(typename X, typename Y)(
+            /// \pre
+            requires assignable_from<I &, X> AND assignable_from<S &, Y>)
         sized_iterator_range & operator=(sized_iterator_range<X, Y> rng)
         {
             rng_ = detail::move(rng).rng_;
@@ -260,14 +267,16 @@ namespace ranges
         {
             return size_;
         }
-        template(typename X, typename Y)(                      //
-            requires convertible_to<I, X> AND convertible_to<S, Y>) //
+        template(typename X, typename Y)(
+            /// \pre
+            requires convertible_to<I, X> AND convertible_to<S, Y>)
         constexpr operator std::pair<X, Y>() const
         {
             return rng_;
         }
-        template(typename X, typename Y)(                      //
-            requires convertible_to<I, X> AND convertible_to<S, Y>) //
+        template(typename X, typename Y)(
+            /// \pre
+            requires convertible_to<I, X> AND convertible_to<S, Y>)
         constexpr operator iterator_range<X, Y>() const
         {
             return rng_;
@@ -278,7 +287,8 @@ namespace ranges
         }
         // clang-format off
         /// Tuple-like access for `sized_iterator_range`
-        template(std::size_t N)( //
+        template(std::size_t N)(
+            /// \pre
             requires (N < 2))        //
         friend constexpr auto CPP_auto_fun(get)(sized_iterator_range const &p)
         (
@@ -287,7 +297,8 @@ namespace ranges
         )
         // clang-format on
         /// \overload
-        template(std::size_t N)( //
+        template(std::size_t N)(
+            /// \pre
             requires (N == 2)) //
         friend constexpr size_type get(sized_iterator_range const & p) noexcept
         {
@@ -298,16 +309,18 @@ namespace ranges
     struct make_iterator_range_fn
     {
         /// \return `{first, last}`
-        template(typename I, typename S)( //
-            requires sentinel_for<S, I>) //
+        template(typename I, typename S)(
+            /// \pre
+            requires sentinel_for<S, I>)
         constexpr iterator_range<I, S> operator()(I first, S last) const
         {
             return {detail::move(first), detail::move(last)};
         }
 
         /// \return `{first, last, size}`
-        template(typename I, typename S)( //
-            requires sentinel_for<S, I>) //
+        template(typename I, typename S)(
+            /// \pre
+            requires sentinel_for<S, I>)
         constexpr sized_iterator_range<I, S> //
         operator()(I first, S last, detail::iter_size_t<I> sz) const
         {

--- a/include/range/v3/numeric/accumulate.hpp
+++ b/include/range/v3/numeric/accumulate.hpp
@@ -34,10 +34,11 @@ namespace ranges
     struct accumulate_fn
     {
         template(typename I, typename S, typename T, typename Op = plus,
-                 typename P = identity)( //
+                 typename P = identity)(
+            /// \pre
             requires sentinel_for<S, I> AND input_iterator<I> AND
                 indirectly_binary_invocable_<Op, T *, projected<I, P>> AND
-                assignable_from<T &, indirect_result_t<Op &, T *, projected<I, P>>>) //
+                assignable_from<T &, indirect_result_t<Op &, T *, projected<I, P>>>)
         T operator()(I first, S last, T init, Op op = Op{},
                         P proj = P{}) const
         {
@@ -46,11 +47,12 @@ namespace ranges
             return init;
         }
 
-        template(typename Rng, typename T, typename Op = plus, typename P = identity)( //
+        template(typename Rng, typename T, typename Op = plus, typename P = identity)(
+            /// \pre
             requires input_range<Rng> AND
                 indirectly_binary_invocable_<Op, T *, projected<iterator_t<Rng>, P>> AND
                 assignable_from<
-                    T &, indirect_result_t<Op &, T *, projected<iterator_t<Rng>, P>>>) //
+                    T &, indirect_result_t<Op &, T *, projected<iterator_t<Rng>, P>>>)
         T operator()(Rng && rng, T init, Op op = Op{}, P proj = P{}) const
         {
             return (*this)(

--- a/include/range/v3/numeric/adjacent_difference.hpp
+++ b/include/range/v3/numeric/adjacent_difference.hpp
@@ -70,9 +70,10 @@ namespace ranges
     struct adjacent_difference_fn
     {
         template(typename I, typename S, typename O, typename S2, typename BOp = minus,
-                 typename P = identity)( //
+                 typename P = identity)(
+            /// \pre
             requires sentinel_for<S, I> AND sentinel_for<S2, O> AND
-                differenceable<I, O, BOp, P>) //
+                differenceable<I, O, BOp, P>)
         adjacent_difference_result<I, O> operator()(I first,
                                                     S last,
                                                     O result,
@@ -102,8 +103,9 @@ namespace ranges
         }
 
         template(typename I, typename S, typename O, typename BOp = minus,
-                 typename P = identity)( //
-            requires sentinel_for<S, I> AND differenceable<I, O, BOp, P>) //
+                 typename P = identity)(
+            /// \pre
+            requires sentinel_for<S, I> AND differenceable<I, O, BOp, P>)
         adjacent_difference_result<I, O> //
         operator()(I first, S last, O result, BOp bop = BOp{}, P proj = P{}) const
         {
@@ -116,7 +118,8 @@ namespace ranges
         }
 
         template(typename Rng, typename ORef, typename BOp = minus, typename P = identity,
-                 typename I = iterator_t<Rng>, typename O = uncvref_t<ORef>)( //
+                 typename I = iterator_t<Rng>, typename O = uncvref_t<ORef>)(
+            /// \pre
             requires range<Rng> AND differenceable<I, O, BOp, P>)
         adjacent_difference_result<borrowed_iterator_t<Rng>, O> //
         operator()(Rng && rng, ORef && result, BOp bop = BOp{}, P proj = P{}) const
@@ -129,7 +132,8 @@ namespace ranges
         }
 
         template(typename Rng, typename ORng, typename BOp = minus, typename P = identity,
-                 typename I = iterator_t<Rng>, typename O = iterator_t<ORng>)( //
+                 typename I = iterator_t<Rng>, typename O = iterator_t<ORng>)(
+            /// \pre
             requires range<Rng> AND range<ORng> AND differenceable<I, O, BOp, P>)
         adjacent_difference_result<borrowed_iterator_t<Rng>, borrowed_iterator_t<ORng>>
         operator()(Rng && rng, ORng && result, BOp bop = BOp{}, P proj = P{}) const

--- a/include/range/v3/numeric/inner_product.hpp
+++ b/include/range/v3/numeric/inner_product.hpp
@@ -73,9 +73,10 @@ namespace ranges
     {
         template(typename I1, typename S1, typename I2, typename S2, typename T,
                  typename BOp1 = plus, typename BOp2 = multiplies, typename P1 = identity,
-                 typename P2 = identity)( //
+                 typename P2 = identity)(
+            /// \pre
             requires sentinel_for<S1, I1> AND sentinel_for<S2, I2> AND
-                inner_product_constraints<I1, I2, T, BOp1, BOp2, P1, P2>) //
+                inner_product_constraints<I1, I2, T, BOp1, BOp2, P1, P2>)
         T operator()(I1 begin1, S1 end1, I2 begin2, S2 end2, T init,
                      BOp1 bop1 = BOp1{}, BOp2 bop2 = BOp2{}, P1 proj1 = P1{},
                      P2 proj2 = P2{}) const
@@ -90,9 +91,10 @@ namespace ranges
 
         template(typename I1, typename S1, typename I2, typename T, typename BOp1 = plus,
                  typename BOp2 = multiplies, typename P1 = identity,
-                 typename P2 = identity)( //
+                 typename P2 = identity)(
+            /// \pre
             requires sentinel_for<S1, I1> AND
-                inner_product_constraints<I1, I2, T, BOp1, BOp2, P1, P2>) //
+                inner_product_constraints<I1, I2, T, BOp1, BOp2, P1, P2>)
         T operator()(I1 begin1, S1 end1, I2 begin2, T init, BOp1 bop1 = BOp1{},
                      BOp2 bop2 = BOp2{}, P1 proj1 = P1{}, P2 proj2 = P2{}) const
         {
@@ -110,7 +112,8 @@ namespace ranges
         template(typename Rng1, typename I2Ref, typename T, typename BOp1 = plus,
                  typename BOp2 = multiplies, typename P1 = identity,
                  typename P2 = identity, typename I1 = iterator_t<Rng1>,
-                 typename I2 = uncvref_t<I2Ref>)( //
+                 typename I2 = uncvref_t<I2Ref>)(
+            /// \pre
             requires range<Rng1> AND
                 inner_product_constraints<I1, I2, T, BOp1, BOp2, P1, P2>)
         T operator()(Rng1 && rng1, I2Ref && begin2, T init, BOp1 bop1 = BOp1{},
@@ -129,7 +132,8 @@ namespace ranges
         template(typename Rng1, typename Rng2, typename T, typename BOp1 = plus,
                  typename BOp2 = multiplies, typename P1 = identity,
                  typename P2 = identity, typename I1 = iterator_t<Rng1>,
-                 typename I2 = iterator_t<Rng2>)( //
+                 typename I2 = iterator_t<Rng2>)(
+            /// \pre
             requires range<Rng1> AND range<Rng2> AND
                 inner_product_constraints<I1, I2, T, BOp1, BOp2, P1, P2>)
         T operator()(Rng1 && rng1, Rng2 && rng2, T init, BOp1 bop1 = BOp1{},

--- a/include/range/v3/numeric/iota.hpp
+++ b/include/range/v3/numeric/iota.hpp
@@ -28,9 +28,10 @@ namespace ranges
     /// @{
     struct iota_fn
     {
-        template(typename O, typename S, typename T)( //
+        template(typename O, typename S, typename T)(
+            /// \pre
             requires output_iterator<O, T const &> AND sentinel_for<S, O> AND
-                weakly_incrementable<T>) //
+                weakly_incrementable<T>)
         O operator()(O first, S last, T val) const
         {
             for(; first != last; ++first, ++val)
@@ -38,8 +39,9 @@ namespace ranges
             return first;
         }
 
-        template(typename Rng, typename T)( //
-            requires output_range<Rng, T const &> AND weakly_incrementable<T>) //
+        template(typename Rng, typename T)(
+            /// \pre
+            requires output_range<Rng, T const &> AND weakly_incrementable<T>)
         borrowed_iterator_t<Rng> operator()(Rng && rng, T val) const //
         {
             return (*this)(begin(rng), end(rng), detail::move(val));

--- a/include/range/v3/numeric/partial_sum.hpp
+++ b/include/range/v3/numeric/partial_sum.hpp
@@ -90,9 +90,10 @@ namespace ranges
     struct partial_sum_fn
     {
         template(typename I, typename S1, typename O, typename S2, typename BOp = plus,
-                 typename P = identity)( //
+                 typename P = identity)(
+            /// \pre
             requires sentinel_for<S1, I> AND sentinel_for<S2, O> AND
-                partial_sum_constraints<I, O, BOp, P>) //
+                partial_sum_constraints<I, O, BOp, P>)
         partial_sum_result<I, O> operator()(I first,
                                             S1 last,
                                             O result,
@@ -120,8 +121,9 @@ namespace ranges
         }
 
         template(typename I, typename S, typename O, typename BOp = plus,
-                 typename P = identity)( //
-            requires sentinel_for<S, I> AND partial_sum_constraints<I, O, BOp, P>) //
+                 typename P = identity)(
+            /// \pre
+            requires sentinel_for<S, I> AND partial_sum_constraints<I, O, BOp, P>)
         partial_sum_result<I, O> //
         operator()(I first, S last, O result, BOp bop = BOp{}, P proj = P{}) const
         {
@@ -134,7 +136,8 @@ namespace ranges
         }
 
         template(typename Rng, typename ORef, typename BOp = plus, typename P = identity,
-                 typename I = iterator_t<Rng>, typename O = uncvref_t<ORef>)( //
+                 typename I = iterator_t<Rng>, typename O = uncvref_t<ORef>)(
+            /// \pre
             requires range<Rng> AND partial_sum_constraints<I, O, BOp, P>)
         partial_sum_result<borrowed_iterator_t<Rng>, O> //
         operator()(Rng && rng, ORef && result, BOp bop = BOp{}, P proj = P{}) const
@@ -147,7 +150,8 @@ namespace ranges
         }
 
         template(typename Rng, typename ORng, typename BOp = plus, typename P = identity,
-                 typename I = iterator_t<Rng>, typename O = iterator_t<ORng>)( //
+                 typename I = iterator_t<Rng>, typename O = iterator_t<ORng>)(
+            /// \pre
             requires range<Rng> AND range<ORng> AND partial_sum_constraints<I, O, BOp, P>)
         partial_sum_result<borrowed_iterator_t<Rng>, borrowed_iterator_t<ORng>> //
         operator()(Rng && rng, ORng && result, BOp bop = BOp{}, P proj = P{}) const

--- a/include/range/v3/range/access.hpp
+++ b/include/range/v3/range/access.hpp
@@ -76,8 +76,9 @@ namespace ranges
         template<typename T>
         void begin(std::initializer_list<T>) = delete;
 
-        template(typename I)( //
-            requires input_or_output_iterator<I>) //
+        template(typename I)(
+            /// \pre
+            requires input_or_output_iterator<I>)
         void is_iterator(I);
 
         // clang-format off
@@ -129,8 +130,9 @@ namespace ranges
                 return array;
             }
 
-            template(typename R)( //
-                requires detail::_borrowed_range<R> AND //
+            template(typename R)(
+                /// \pre
+                requires detail::_borrowed_range<R> AND
                     (has_member_begin<R> || has_non_member_begin<R>))
             constexpr auto operator()(R && r) const //
                 noexcept(noexcept(impl<R>::invoke(r)))
@@ -199,7 +201,8 @@ namespace ranges
         template<typename T>
         void end(std::initializer_list<T>) = delete;
 
-        template(typename I, typename S)( //
+        template(typename I, typename S)(
+            /// \pre
             requires sentinel_for<S, I>)
         void _is_sentinel(S, I);
 
@@ -258,8 +261,9 @@ namespace ranges
                 return array + N;
             }
 
-            template(typename R)( //
-                requires detail::_borrowed_range<R> AND //
+            template(typename R)(
+                /// \pre
+                requires detail::_borrowed_range<R> AND
                     (has_member_end<R> || has_non_member_end<R>))
             constexpr auto operator()(R && r) const //
                 noexcept(noexcept(impl<R>::invoke(r))) //
@@ -289,8 +293,9 @@ namespace ranges
                 return Fn{}(ref.get());
             }
 
-            template(typename Int)( //
-                requires detail::integer_like_<Int>) //
+            template(typename Int)(
+                /// \pre
+                requires detail::integer_like_<Int>)
             auto operator-(Int dist) const
                 -> detail::from_end_<iter_diff_t<Int>>
             {
@@ -437,8 +442,9 @@ namespace ranges
                 impl_<has_member_rbegin<R> ? 0 : has_non_member_rbegin<R> ? 1 : 2>;
 
         public:
-            template(typename R)( //
-                requires detail::_borrowed_range<R> AND //
+            template(typename R)(
+                /// \pre
+                requires detail::_borrowed_range<R> AND
                     (has_member_rbegin<R> ||
                      has_non_member_rbegin<R> ||
                      can_reverse_end<R>)) //
@@ -574,8 +580,9 @@ namespace ranges
             using impl = impl_<has_member_rend<R> ? 0 : has_non_member_rend<R> ? 1 : 2>;
 
         public:
-            template(typename R)( //
-                requires detail::_borrowed_range<R> AND //
+            template(typename R)(
+                /// \pre
+                requires detail::_borrowed_range<R> AND
                     (has_member_rend<R> || //
                      has_non_member_rend<R> || //
                      can_reverse_begin<R>)) //

--- a/include/range/v3/range/conversion.hpp
+++ b/include/range/v3/range/conversion.hpp
@@ -48,7 +48,8 @@ namespace ranges
             template<typename Rng, typename MetaFn>
             friend auto operator|(Rng && rng,
                                   closure<MetaFn, fn<MetaFn>> (*)(to_container))
-                -> CPP_broken_friend_ret(container_t<MetaFn, Rng>)( //
+                -> CPP_broken_friend_ret(container_t<MetaFn, Rng>)(
+                    /// \pre
                     requires invocable<fn<MetaFn>, Rng>)
             {
                 return fn<MetaFn>{}(static_cast<Rng &&>(rng));
@@ -58,7 +59,8 @@ namespace ranges
             friend auto operator|(closure<MetaFn, fn<MetaFn>> (*)(to_container),
                                   Pipeable pipe)
                 -> CPP_broken_friend_ret(
-                    closure<MetaFn, composed<Pipeable, fn<MetaFn>>>)( //
+                    closure<MetaFn, composed<Pipeable, fn<MetaFn>>>)(
+                    /// \pre
                     requires (is_pipeable_v<Pipeable>))
             {
                 return closure<MetaFn, composed<Pipeable, fn<MetaFn>>>{
@@ -117,6 +119,7 @@ namespace ranges
             CPP_member
             auto operator--() //
                 -> CPP_ret(to_container_iterator &)(
+                    /// \pre
                     requires derived_from<iterator_category,
                                           std::bidirectional_iterator_tag>)
             {
@@ -126,6 +129,7 @@ namespace ranges
             CPP_member
             auto operator--(int) //
                 -> CPP_ret(to_container_iterator &)(
+                    /// \pre
                     requires derived_from<iterator_category,
                                           std::bidirectional_iterator_tag>)
             {
@@ -136,6 +140,7 @@ namespace ranges
             CPP_member
             auto operator+=(difference_type n) //
                 -> CPP_ret(to_container_iterator &)(
+                    /// \pre
                     requires derived_from<iterator_category,
                                           std::random_access_iterator_tag>)
             {
@@ -145,6 +150,7 @@ namespace ranges
             CPP_member
             auto operator-=(difference_type n) //
                 -> CPP_ret(to_container_iterator &)(
+                    /// \pre
                     requires derived_from<iterator_category,
                                           std::random_access_iterator_tag>)
             {
@@ -154,6 +160,7 @@ namespace ranges
             CPP_broken_friend_member
             friend auto operator+(to_container_iterator i, difference_type n) //
                 -> CPP_broken_friend_ret(to_container_iterator)(
+                    /// \pre
                     requires derived_from<iterator_category,
                                           std::random_access_iterator_tag>)
             {
@@ -162,6 +169,7 @@ namespace ranges
             CPP_broken_friend_member
             friend auto operator-(to_container_iterator i, difference_type n) //
                 -> CPP_broken_friend_ret(to_container_iterator)(
+                    /// \pre
                     requires derived_from<iterator_category,
                                           std::random_access_iterator_tag>)
             {
@@ -170,6 +178,7 @@ namespace ranges
             CPP_broken_friend_member
             friend auto operator-(difference_type n, to_container_iterator i) //
                 -> CPP_broken_friend_ret(to_container_iterator)(
+                    /// \pre
                     requires derived_from<iterator_category,
                                           std::random_access_iterator_tag>)
             {
@@ -179,6 +188,7 @@ namespace ranges
             friend auto operator-(to_container_iterator const & i,
                                   to_container_iterator const & j) //
                 -> CPP_broken_friend_ret(difference_type)(
+                    /// \pre
                     requires derived_from<iterator_category,
                                           std::random_access_iterator_tag>)
             {
@@ -187,6 +197,7 @@ namespace ranges
             CPP_member
             auto operator[](difference_type n) const //
                 -> CPP_ret(reference)(
+                    /// \pre
                     requires derived_from<iterator_category,
                                           std::random_access_iterator_tag>)
             {
@@ -253,19 +264,21 @@ namespace ranges
         struct RANGES_STRUCT_WITH_ADL_BARRIER(to_container_closure_base)
         {
             // clang-format off
-            template(typename Rng, typename MetaFn, typename Fn)(  //
-                requires input_range<Rng> AND                      //
-                    convertible_to_cont<Rng, container_t<MetaFn, Rng>>) //
+            template(typename Rng, typename MetaFn, typename Fn)(
+                /// \pre
+                requires input_range<Rng> AND
+                    convertible_to_cont<Rng, container_t<MetaFn, Rng>>)
             friend constexpr auto
             operator|(Rng && rng, to_container::closure<MetaFn, Fn> fn)
             {
                 return static_cast<Fn &&>(fn)(static_cast<Rng &&>(rng));
             }
 
-            template(typename Rng, typename MetaFn, typename Fn)(             //
-                requires input_range<Rng> AND                                 //
-                    (!convertible_to_cont<Rng, container_t<MetaFn, Rng>>) AND //
-                    convertible_to_cont_cont<Rng, container_t<MetaFn, Rng>>)  //
+            template(typename Rng, typename MetaFn, typename Fn)(
+                /// \pre
+                requires input_range<Rng> AND
+                    (!convertible_to_cont<Rng, container_t<MetaFn, Rng>>) AND
+                    convertible_to_cont_cont<Rng, container_t<MetaFn, Rng>>)
             friend constexpr auto
             operator|(Rng && rng, to_container::closure<MetaFn, Fn> fn)
             {
@@ -276,7 +289,8 @@ namespace ranges
             friend constexpr auto operator|(to_container::closure<MetaFn, Fn> sh,
                                             Pipeable pipe)
                 -> CPP_broken_friend_ret(
-                    to_container::closure<MetaFn, composed<Pipeable, Fn>>)( //
+                    to_container::closure<MetaFn, composed<Pipeable, Fn>>)(
+                    /// \pre
                     requires is_pipeable_v<Pipeable>)
             {
                 return to_container::closure<MetaFn, composed<Pipeable, Fn>>{
@@ -318,9 +332,10 @@ namespace ranges
             }
 
         public:
-            template(typename Rng)( //
-                requires input_range<Rng> AND                                        //
-                    convertible_to_cont<Rng, container_t<MetaFn, Rng>>) //
+            template(typename Rng)(
+                /// \pre
+                requires input_range<Rng> AND
+                    convertible_to_cont<Rng, container_t<MetaFn, Rng>>)
             container_t<MetaFn, Rng> operator()(Rng && rng) const
             {
                 static_assert(!is_infinite<Rng>::value,
@@ -331,10 +346,11 @@ namespace ranges
                     meta::bool_<(bool)to_container_reserve<cont_t, iter_t, Rng>>;
                 return impl<cont_t, iter_t>(static_cast<Rng &&>(rng), use_reserve_t{});
             }
-            template(typename Rng)(                                           //
-                requires input_range<Rng> AND                                 //
-                    (!convertible_to_cont<Rng, container_t<MetaFn, Rng>>) AND //
-                    convertible_to_cont_cont<Rng, container_t<MetaFn, Rng>>)      //
+            template(typename Rng)(
+                /// \pre
+                requires input_range<Rng> AND
+                    (!convertible_to_cont<Rng, container_t<MetaFn, Rng>>) AND
+                    convertible_to_cont_cont<Rng, container_t<MetaFn, Rng>>)
             container_t<MetaFn, Rng> operator()(Rng && rng) const
             {
                 static_assert(!is_infinite<Rng>::value,
@@ -400,9 +416,10 @@ namespace ranges
         }
 
         /// \overload
-        template(template<typename...> class ContT, typename Rng)( //
+        template(template<typename...> class ContT, typename Rng)(
+            /// \pre
             requires range<Rng> AND
-                detail::convertible_to_cont<Rng, ContT<range_value_t<Rng>>>) //
+                detail::convertible_to_cont<Rng, ContT<range_value_t<Rng>>>)
         auto to(Rng && rng) -> ContT<range_value_t<Rng>>
         {
             return detail::to_container_fn<detail::from_range<ContT>>{}(
@@ -418,8 +435,9 @@ namespace ranges
         }
 
         /// \overload
-        template(typename Cont, typename Rng)( //
-            requires range<Rng> AND detail::convertible_to_cont<Rng, Cont>) //
+        template(typename Cont, typename Rng)(
+            /// \pre
+            requires range<Rng> AND detail::convertible_to_cont<Rng, Cont>)
         auto to(Rng && rng) -> Cont
         {
             return detail::to_container_fn<meta::id<Cont>>{}(static_cast<Rng &&>(rng));
@@ -427,14 +445,16 @@ namespace ranges
 
         /// \cond
         // Slightly odd initializer_list overloads, undocumented for now.
-        template(template<typename...> class ContT, typename T)( //
-            requires detail::convertible_to_cont<std::initializer_list<T>, ContT<T>>) //
+        template(template<typename...> class ContT, typename T)(
+            /// \pre
+            requires detail::convertible_to_cont<std::initializer_list<T>, ContT<T>>)
         auto to(std::initializer_list<T> il) -> ContT<T>
         {
             return detail::to_container_fn<detail::from_range<ContT>>{}(il);
         }
-        template(typename Cont, typename T)( //
-            requires detail::convertible_to_cont<std::initializer_list<T>, Cont>) //
+        template(typename Cont, typename T)(
+            /// \pre
+            requires detail::convertible_to_cont<std::initializer_list<T>, Cont>)
         auto to(std::initializer_list<T> il) -> Cont
         {
             return detail::to_container_fn<meta::id<Cont>>{}(il);
@@ -458,7 +478,8 @@ namespace ranges
         {
             return {};
         }
-        template(template<typename...> class ContT, typename Rng)( //
+        template(template<typename...> class ContT, typename Rng)(
+            /// \pre
             requires range<Rng> AND
                 detail::convertible_to_cont<Rng, ContT<range_value_t<Rng>>>)
         RANGES_DEPRECATED("Please use ranges::to (no underscore) instead.")
@@ -466,7 +487,8 @@ namespace ranges
         {
             return static_cast<Rng &&>(rng) | ranges::to_<ContT>();
         }
-        template(template<typename...> class ContT, typename T)( //
+        template(template<typename...> class ContT, typename T)(
+            /// \pre
             requires detail::convertible_to_cont<std::initializer_list<T>, ContT<T>>)
         RANGES_DEPRECATED("Please use ranges::to (no underscore) instead.")
         ContT<T> to_(std::initializer_list<T> il)
@@ -479,14 +501,16 @@ namespace ranges
         {
             return {};
         }
-        template(typename Cont, typename Rng)( //
+        template(typename Cont, typename Rng)(
+            /// \pre
             requires range<Rng> AND detail::convertible_to_cont<Rng, Cont>)
         RANGES_DEPRECATED("Please use ranges::to (no underscore) instead.")
         Cont to_(Rng && rng)
         {
             return static_cast<Rng &&>(rng) | ranges::to_<Cont>();
         }
-        template(typename Cont, typename T)( //
+        template(typename Cont, typename T)(
+            /// \pre
             requires detail::convertible_to_cont<std::initializer_list<T>, Cont>)
         RANGES_DEPRECATED("Please use ranges::to (no underscore) instead.")
         Cont to_(std::initializer_list<T> list)

--- a/include/range/v3/range/dangling.hpp
+++ b/include/range/v3/range/dangling.hpp
@@ -35,8 +35,9 @@ namespace ranges
     {
         dangling() = default;
         /// Implicit converting constructor; ignores argument
-        template(typename T)( //
-            requires not_same_as_<T, dangling>) //
+        template(typename T)(
+            /// \pre
+            requires not_same_as_<T, dangling>)
         constexpr dangling(T &&)
         {}
     };
@@ -44,8 +45,9 @@ namespace ranges
     /// \cond
     namespace detail
     {
-        template(class R, class U)( //
-            requires range<R>)          //
+        template(class R, class U)(
+            /// \pre
+            requires range<R>)
             using maybe_dangling_ =     //
                 meta::conditional_t<detail::_borrowed_range<R>, U, dangling>;
     }

--- a/include/range/v3/range/operations.hpp
+++ b/include/range/v3/range/operations.hpp
@@ -35,9 +35,10 @@ namespace ranges
     struct at_fn
     {
         /// \return `begin(rng)[n]`
-        template(typename Rng)( //
-            requires random_access_range<Rng> AND sized_range<Rng> AND //
-                borrowed_range<Rng>) //
+        template(typename Rng)(
+            /// \pre
+            requires random_access_range<Rng> AND sized_range<Rng> AND
+                borrowed_range<Rng>)
         constexpr range_reference_t<Rng> //
         operator()(Rng && rng, range_difference_t<Rng> n) const
         {
@@ -67,7 +68,8 @@ namespace ranges
     struct index_fn
     {
         /// \return `begin(rng)[n]`
-        template(typename Rng, typename Int)( //
+        template(typename Rng, typename Int)(
+            /// \pre
             requires random_access_range<Rng> AND integral<Int> AND borrowed_range<Rng>)
         constexpr range_reference_t<Rng> operator()(Rng && rng, Int n) const //
         {
@@ -89,9 +91,10 @@ namespace ranges
     struct back_fn
     {
         /// \return `*prev(end(rng))`
-        template(typename Rng)(                                   //
-            requires common_range<Rng> AND bidirectional_range<Rng> AND //
-                borrowed_range<Rng>)                                  //
+        template(typename Rng)(
+            /// \pre
+            requires common_range<Rng> AND bidirectional_range<Rng> AND
+                borrowed_range<Rng>)
         constexpr range_reference_t<Rng> operator()(Rng && rng) const
         {
             return *prev(end(rng));
@@ -106,8 +109,9 @@ namespace ranges
     struct front_fn
     {
         /// \return `*begin(rng)`
-        template(typename Rng)( //
-            requires forward_range<Rng> AND borrowed_range<Rng>) //
+        template(typename Rng)(
+            /// \pre
+            requires forward_range<Rng> AND borrowed_range<Rng>)
         constexpr range_reference_t<Rng> operator()(Rng && rng) const
         {
             return *begin(rng);

--- a/include/range/v3/range/primitives.hpp
+++ b/include/range/v3/range/primitives.hpp
@@ -63,8 +63,9 @@ namespace ranges
             }
 
             // Prefer member if it returns integral.
-            template(typename R)( //
-                requires integral<member_size_t<R>> AND //
+            template(typename R)(
+                /// \pre
+                requires integral<member_size_t<R>> AND
                     (!disable_sized_range<uncvref_t<R>>)) //
             static constexpr member_size_t<R> impl_(R && r, int) //
                 noexcept(noexcept(((R &&) r).size()))
@@ -73,8 +74,9 @@ namespace ranges
             }
 
             // Use ADL if it returns integral.
-            template(typename R)( //
-                requires integral<non_member_size_t<R>> AND //
+            template(typename R)(
+                /// \pre
+                requires integral<non_member_size_t<R>> AND
                     (!disable_sized_range<uncvref_t<R>>)) //
             static constexpr non_member_size_t<R> impl_(R && r, long) //
                 noexcept(noexcept(size((R &&) r)))
@@ -82,9 +84,10 @@ namespace ranges
                 return size((R &&) r);
             }
 
-            template(typename R)( //
-                requires forward_iterator<_begin_::_t<R>> AND //
-                    sized_sentinel_for<_end_::_t<R>, _begin_::_t<R>>) //
+            template(typename R)(
+                /// \pre
+                requires forward_iterator<_begin_::_t<R>> AND
+                    sized_sentinel_for<_end_::_t<R>, _begin_::_t<R>>)
             static constexpr auto impl_(R && r, ...)
                 -> detail::iter_size_t<_begin_::_t<R>>
             {
@@ -161,22 +164,25 @@ namespace ranges
             template<typename R>
             using member_data_t = detail::decay_t<decltype(std::declval<R>().data())>;
 
-            template(typename R)( //
+            template(typename R)(
+                /// \pre
                 requires std::is_pointer<member_data_t<R &>>::value) //
             static constexpr member_data_t<R &> impl_(R & r, detail::priority_tag<2>)
                 noexcept(noexcept(r.data())) 
             {
                 return r.data();
             }
-            template(typename R)( //
+            template(typename R)(
+                /// \pre
                 requires std::is_pointer<_begin_::_t<R>>::value) //
             static constexpr _begin_::_t<R> impl_(R && r, detail::priority_tag<1>)
                 noexcept(noexcept(ranges::begin((R &&) r)))
             {
                 return ranges::begin((R &&) r);
             }
-            template(typename R)( //
-                requires contiguous_iterator<_begin_::_t<R>>) //
+            template(typename R)(
+                /// \pre
+                requires contiguous_iterator<_begin_::_t<R>>)
             static constexpr auto impl_(R && r, detail::priority_tag<0>) noexcept(
                 noexcept(ranges::begin((R &&) r) == ranges::end((R &&) r)
                              ? nullptr
@@ -264,8 +270,9 @@ namespace ranges
             }
 
             // Fall further back to begin == end.
-            template(typename R)( //
-                requires forward_iterator<_begin_::_t<R>>) //
+            template(typename R)(
+                /// \pre
+                requires forward_iterator<_begin_::_t<R>>)
             static constexpr auto impl_(R && r, detail::priority_tag<0>) noexcept(
                 noexcept(bool(ranges::begin((R &&) r) == ranges::end((R &&) r))))
                 -> decltype(bool(ranges::begin((R &&) r) ==

--- a/include/range/v3/utility/addressof.hpp
+++ b/include/range/v3/utility/addressof.hpp
@@ -52,14 +52,16 @@ namespace ranges
                                    ignore_t);
         }
 
-        template(typename T)( //
+        template(typename T)(
+            /// \pre
             requires(has_bad_addressof<T>()))
         T * addressof(T & arg) noexcept
         {
             return std::addressof(arg);
         }
 
-        template(typename T)( //
+        template(typename T)(
+            /// \pre
             requires (!has_bad_addressof<T>()))
         constexpr T * addressof(T & arg) noexcept
         {

--- a/include/range/v3/utility/any.hpp
+++ b/include/range/v3/utility/any.hpp
@@ -122,7 +122,8 @@ namespace ranges
 
     public:
         any() noexcept = default;
-        template(typename TRef, typename T = detail::decay_t<TRef>)( //
+        template(typename TRef, typename T = detail::decay_t<TRef>)(
+            /// \pre
             requires copyable<T> AND (!same_as<T, any>)) //
         any(TRef && t)
           : ptr_(new impl<T>(static_cast<TRef &&>(t)))
@@ -137,7 +138,8 @@ namespace ranges
             ptr_.reset(that.ptr_ ? that.ptr_->clone() : nullptr);
             return *this;
         }
-        template(typename TRef, typename T = detail::decay_t<TRef>)( //
+        template(typename TRef, typename T = detail::decay_t<TRef>)(
+            /// \pre
             requires copyable<T> AND (!same_as<T, any>)) //
         any & operator=(TRef && t)
         {

--- a/include/range/v3/utility/box.hpp
+++ b/include/range/v3/utility/box.hpp
@@ -45,7 +45,8 @@ namespace ranges
         mutable T value;
 
         CPP_member
-        constexpr CPP_ctor(mutable_)()( //
+        constexpr CPP_ctor(mutable_)()(
+            /// \pre
             requires std::is_default_constructible<T>::value)
           : value{}
         {}
@@ -171,7 +172,8 @@ namespace ranges
           : value{}
         {}
 #if defined(__cpp_conditional_explicit) && __cpp_conditional_explicit > 0
-        template(typename E)( //
+        template(typename E)(
+            /// \pre
             requires (!same_as<box, detail::decay_t<E>>) AND
                 constructible_from<Element, E>)
         constexpr explicit(!convertible_to<E, Element>) box(E && e)
@@ -179,7 +181,8 @@ namespace ranges
           : value(static_cast<E &&>(e))
         {}
 #else
-        template(typename E)( //
+        template(typename E)(
+            /// \pre
             requires (!same_as<box, detail::decay_t<E>>) AND
                 constructible_from<Element, E> AND
                 convertible_to<E, Element>)
@@ -187,7 +190,8 @@ namespace ranges
             noexcept(std::is_nothrow_constructible<Element, E>::value)
           : value(static_cast<E &&>(e))
         {}
-        template(typename E)( //
+        template(typename E)(
+            /// \pre
             requires (!same_as<box, detail::decay_t<E>>) AND
                 constructible_from<Element, E> AND
                 (!convertible_to<E, Element>))
@@ -226,7 +230,8 @@ namespace ranges
           : Element{}
         {}
 #if defined(__cpp_conditional_explicit) && __cpp_conditional_explicit > 0
-        template(typename E)( //
+        template(typename E)(
+            /// \pre
             requires (!same_as<box, detail::decay_t<E>>) AND
                 constructible_from<Element, E>)
         constexpr explicit(!convertible_to<E, Element>) box(E && e)
@@ -234,7 +239,8 @@ namespace ranges
           : Element(static_cast<E &&>(e))
         {}
 #else
-        template(typename E)( //
+        template(typename E)(
+            /// \pre
             requires (!same_as<box, detail::decay_t<E>>) AND
                 constructible_from<Element, E> AND
                 convertible_to<E, Element>)
@@ -242,7 +248,8 @@ namespace ranges
             noexcept(std::is_nothrow_constructible<Element, E>::value) //
           : Element(static_cast<E &&>(e))
         {}
-        template(typename E)( //
+        template(typename E)(
+            /// \pre
             requires (!same_as<box, detail::decay_t<E>>) AND
                 constructible_from<Element, E> AND
                 (!convertible_to<E, Element>))
@@ -279,19 +286,22 @@ namespace ranges
         constexpr box() noexcept = default;
 
 #if defined(__cpp_conditional_explicit) && __cpp_conditional_explicit > 0
-        template(typename E)( //
+        template(typename E)(
+            /// \pre
             requires (!same_as<box, detail::decay_t<E>>) AND
                 constructible_from<Element, E>)
         constexpr explicit(!convertible_to<E, Element>) box(E &&) noexcept
         {}
 #else
-        template(typename E)( //
+        template(typename E)(
+            /// \pre
             requires (!same_as<box, detail::decay_t<E>>) AND
                 constructible_from<Element, E> AND
                 convertible_to<E, Element>)
         constexpr box(E &&) noexcept
         {}
-        template(typename E)( //
+        template(typename E)(
+            /// \pre
             requires (!same_as<box, detail::decay_t<E>>) AND
                 constructible_from<Element, E> AND
                 (!convertible_to<E, Element>))

--- a/include/range/v3/utility/common_tuple.hpp
+++ b/include/range/v3/utility/common_tuple.hpp
@@ -119,48 +119,55 @@ namespace ranges
                 requires default_constructible<std::tuple<Ts...>>)
           : common_tuple::forward_tuple_interface{}
         {}
-        template(typename... Us)(                                              //
-            requires constructible_from<detail::args<Ts...>, detail::args<Us...>>) //
+        template(typename... Us)(
+            /// \pre
+            requires constructible_from<detail::args<Ts...>, detail::args<Us...>>)
         explicit common_tuple(Us &&... us) //
             noexcept(meta::and_c<std::is_nothrow_constructible<Ts, Us>::value...>::value)
           : common_tuple::forward_tuple_interface{static_cast<Us &&>(us)...}
         {}
-        template(typename... Us)( //
-            requires constructible_from<detail::args<Ts...>, detail::rargs<Us...>>) //
+        template(typename... Us)(
+            /// \pre
+            requires constructible_from<detail::args<Ts...>, detail::rargs<Us...>>)
         common_tuple(std::tuple<Us...> & that) //
             noexcept(
                 meta::and_c<std::is_nothrow_constructible<Ts, Us &>::value...>::value) //
           : common_tuple(that, meta::make_index_sequence<sizeof...(Ts)>{})
         {}
-        template(typename... Us)( //
+        template(typename... Us)(
+            /// \pre
             requires constructible_from<detail::args<Ts...>, detail::rargs<Us const...>>)
         common_tuple(std::tuple<Us...> const & that) //
             noexcept(meta::and_c<
                      std::is_nothrow_constructible<Ts, Us const &>::value...>::value) //
           : common_tuple(that, meta::make_index_sequence<sizeof...(Ts)>{})
         {}
-        template(typename... Us)( //
-            requires constructible_from<detail::args<Ts...>, detail::args<Us...>>) //
+        template(typename... Us)(
+            /// \pre
+            requires constructible_from<detail::args<Ts...>, detail::args<Us...>>)
         common_tuple(std::tuple<Us...> && that) //
             noexcept(
                 meta::and_c<std::is_nothrow_constructible<Ts, Us>::value...>::value) //
           : common_tuple(std::move(that), meta::make_index_sequence<sizeof...(Ts)>{})
         {}
-        template(typename... Us)( //
-            requires constructible_from<detail::args<Ts...>, detail::rargs<Us...>>) //
+        template(typename... Us)(
+            /// \pre
+            requires constructible_from<detail::args<Ts...>, detail::rargs<Us...>>)
         common_tuple(common_tuple<Us...> & that) //
             noexcept(
                 meta::and_c<std::is_nothrow_constructible<Ts, Us &>::value...>::value) //
           : common_tuple(that, meta::make_index_sequence<sizeof...(Ts)>{})
         {}
-        template(typename... Us)( //
+        template(typename... Us)(
+            /// \pre
             requires constructible_from<detail::args<Ts...>, detail::rargs<Us const...>>)
         common_tuple(common_tuple<Us...> const & that) //
             noexcept(meta::and_c<
                      std::is_nothrow_constructible<Ts, Us const &>::value...>::value) //
           : common_tuple(that, meta::make_index_sequence<sizeof...(Ts)>{})
         {}
-        template(typename... Us)( //
+        template(typename... Us)(
+            /// \pre
             requires constructible_from<detail::args<Ts...>, detail::args<Us...>>)
         common_tuple(common_tuple<Us...> && that) //
             noexcept(
@@ -178,7 +185,8 @@ namespace ranges
         }
 
         // Assignment
-        template(typename... Us)( //
+        template(typename... Us)(
+            /// \pre
             requires std::is_assignable<detail::args<Ts...> &,
                                         detail::rargs<Us...>>::value) //
         common_tuple & operator=(std::tuple<Us...> & that) noexcept(
@@ -187,7 +195,8 @@ namespace ranges
             (void)tuple_transform(base(), that, element_assign_{});
             return *this;
         }
-        template(typename... Us)( //
+        template(typename... Us)(
+            /// \pre
             requires std::is_assignable<detail::args<Ts...> &,
                                         detail::rargs<Us const...>>::value) //
         common_tuple & operator=(std::tuple<Us...> const & that) noexcept(
@@ -196,7 +205,8 @@ namespace ranges
             (void)tuple_transform(base(), that, element_assign_{});
             return *this;
         }
-        template(typename... Us)( //
+        template(typename... Us)(
+            /// \pre
             requires std::is_assignable<detail::args<Ts...> &,
                                         detail::args<Us...>>::value) //
         common_tuple & operator=(std::tuple<Us...> && that) noexcept(
@@ -206,7 +216,8 @@ namespace ranges
             return *this;
         }
 
-        template(typename... Us)( //
+        template(typename... Us)(
+            /// \pre
             requires std::is_assignable<detail::args<Ts const...> &,
                                         detail::rargs<Us...>>::value)
         common_tuple const & operator=(std::tuple<Us...> & that) const noexcept(
@@ -215,7 +226,8 @@ namespace ranges
             (void)tuple_transform(base(), that, element_assign_{});
             return *this;
         }
-        template(typename... Us)( //
+        template(typename... Us)(
+            /// \pre
             requires std::is_assignable<detail::args<Ts const...> &,
                                         detail::rargs<Us const...>>::value)
         common_tuple const & operator=(std::tuple<Us...> const & that) const
@@ -225,7 +237,8 @@ namespace ranges
             (void)tuple_transform(base(), that, element_assign_{});
             return *this;
         }
-        template(typename... Us)( //
+        template(typename... Us)(
+            /// \pre
             requires std::is_assignable<detail::args<Ts const...> &,
                                         detail::args<Us...>>::value)
         common_tuple const & operator=(std::tuple<Us...> && that) const noexcept(
@@ -236,25 +249,28 @@ namespace ranges
         }
 
         // Conversion
-        template(typename... Us)(                                               //
-            requires constructible_from<detail::args<Us...>, detail::rargs<Ts...>>) //
+        template(typename... Us)(
+            /// \pre
+            requires constructible_from<detail::args<Us...>, detail::rargs<Ts...>>)
         operator std::tuple<Us...>() & noexcept(
                 meta::and_c<std::is_nothrow_constructible<Us, Ts &>::value...>::value)
         {
             return detail::to_std_tuple<Us...>(
                 *this, meta::make_index_sequence<sizeof...(Ts)>{});
         }
-        template(typename... Us)( //
+        template(typename... Us)(
+            /// \pre
             requires constructible_from<detail::args<Us...>,
-                                        detail::rargs<Ts const...>>) //
+                                        detail::rargs<Ts const...>>)
         operator std::tuple<Us...>() const & noexcept(
             meta::and_c<std::is_nothrow_constructible<Us, Ts const &>::value...>::value)
         {
             return detail::to_std_tuple<Us...>(
                 *this, meta::make_index_sequence<sizeof...(Ts)>{});
         }
-        template(typename... Us)(                                                  //
-            requires constructible_from<detail::args<Us...>, detail::args<Ts...>>) //
+        template(typename... Us)(
+            /// \pre
+            requires constructible_from<detail::args<Us...>, detail::args<Ts...>>)
         operator std::tuple<Us...>() &&
             noexcept(meta::and_c<std::is_nothrow_constructible<Us, Ts>::value...>::value)
         {
@@ -326,29 +342,33 @@ namespace ranges
             requires default_constructible<F> && default_constructible<S>)
           : std::pair<F, S>{}
         {}
-        template(typename F2, typename S2)( //
-            requires constructible_from<F, F2> AND constructible_from<S, S2>) //
+        template(typename F2, typename S2)(
+            /// \pre
+            requires constructible_from<F, F2> AND constructible_from<S, S2>)
         common_pair(F2 && f2, S2 && s2) //
             noexcept(std::is_nothrow_constructible<F, F2>::value &&
                      std::is_nothrow_constructible<S, S2>::value) //
           : std::pair<F, S>{static_cast<F2 &&>(f2), static_cast<S2 &&>(s2)}
         {}
-        template(typename F2, typename S2)( //
+        template(typename F2, typename S2)(
+            /// \pre
             requires constructible_from<F, F2 &> AND constructible_from<S, S2 &>)
         common_pair(std::pair<F2, S2> & that) //
             noexcept(std::is_nothrow_constructible<F, F2 &>::value &&
                      std::is_nothrow_constructible<S, S2 &>::value) //
           : std::pair<F, S>{that.first, that.second}
         {}
-        template(typename F2, typename S2)( //
+        template(typename F2, typename S2)(
+            /// \pre
             requires constructible_from<F, F2 const &> AND
-                constructible_from<S, S2 const &>) //
+                constructible_from<S, S2 const &>)
         common_pair(std::pair<F2, S2> const & that) //
             noexcept(std::is_nothrow_constructible<F, F2 const &>::value &&
                      std::is_nothrow_constructible<S, S2 const &>::value) //
           : std::pair<F, S>{that.first, that.second}
         {}
-        template(typename F2, typename S2)( //
+        template(typename F2, typename S2)(
+            /// \pre
             requires constructible_from<F, F2> AND constructible_from<S, S2>)
         common_pair(std::pair<F2, S2> && that) //
             noexcept(std::is_nothrow_constructible<F, F2>::value &&
@@ -357,25 +377,28 @@ namespace ranges
         {}
 
         // Conversion
-        template(typename F2, typename S2)( //
-            requires constructible_from<F2, F &> AND constructible_from<S2, S &>) //
+        template(typename F2, typename S2)(
+            /// \pre
+            requires constructible_from<F2, F &> AND constructible_from<S2, S &>)
         operator std::pair<F2, S2>() & //
             noexcept(std::is_nothrow_constructible<F2, F &>::value &&
                      std::is_nothrow_constructible<S2, S &>::value)
         {
             return {this->first, this->second};
         }
-        template(typename F2, typename S2)( //
+        template(typename F2, typename S2)(
+            /// \pre
             requires constructible_from<F2, F const &> AND
-                constructible_from<S2, S const &>) //
+                constructible_from<S2, S const &>)
         operator std::pair<F2, S2>() const & //
             noexcept(std::is_nothrow_constructible<F2, F const &>::value &&
                      std::is_nothrow_constructible<S2, S const &>::value)
         {
             return {this->first, this->second};
         }
-        template(typename F2, typename S2)( //
-            requires constructible_from<F2, F> AND constructible_from<S2, S>) //
+        template(typename F2, typename S2)(
+            /// \pre
+            requires constructible_from<F2, F> AND constructible_from<S2, S>)
         operator std::pair<F2, S2>() &&
             noexcept(std::is_nothrow_constructible<F2, F>::value &&
                      std::is_nothrow_constructible<S2, S>::value)
@@ -384,8 +407,9 @@ namespace ranges
         }
 
         // Assignment
-        template(typename F2, typename S2)( //
-            requires assignable_from<F &, F2 &> AND assignable_from<S &, S2 &>) //
+        template(typename F2, typename S2)(
+            /// \pre
+            requires assignable_from<F &, F2 &> AND assignable_from<S &, S2 &>)
         common_pair & operator=(std::pair<F2, S2> & that) //
             noexcept(std::is_nothrow_assignable<F &, F2 &>::value &&
                      std::is_nothrow_assignable<S &, S2 &>::value)
@@ -394,9 +418,10 @@ namespace ranges
             this->second = that.second;
             return *this;
         }
-        template(typename F2, typename S2)( //
+        template(typename F2, typename S2)(
+            /// \pre
             requires assignable_from<F &, F2 const &> AND
-                assignable_from<S &, S2 const &>) //
+                assignable_from<S &, S2 const &>)
         common_pair & operator=(std::pair<F2, S2> const & that) //
             noexcept(std::is_nothrow_assignable<F &, F2 const &>::value &&
                      std::is_nothrow_assignable<S &, S2 const &>::value)
@@ -405,8 +430,9 @@ namespace ranges
             this->second = that.second;
             return *this;
         }
-        template(typename F2, typename S2)( //
-            requires assignable_from<F &, F2> AND assignable_from<S &, S2>) //
+        template(typename F2, typename S2)(
+            /// \pre
+            requires assignable_from<F &, F2> AND assignable_from<S &, S2>)
         common_pair & operator=(std::pair<F2, S2> && that) //
             noexcept(std::is_nothrow_assignable<F &, F2>::value &&
                      std::is_nothrow_assignable<S &, S2>::value)
@@ -416,9 +442,10 @@ namespace ranges
             return *this;
         }
 
-        template(typename F2, typename S2)( //
+        template(typename F2, typename S2)(
+            /// \pre
             requires assignable_from<F const &, F2 &> AND
-                assignable_from<S const &, S2 &>) //
+                assignable_from<S const &, S2 &>)
         common_pair const & operator=(std::pair<F2, S2> & that) const //
             noexcept(std::is_nothrow_assignable<F const &, F2 &>::value &&
                      std::is_nothrow_assignable<S const &, S2 &>::value)
@@ -427,9 +454,10 @@ namespace ranges
             this->second = that.second;
             return *this;
         }
-        template(typename F2, typename S2)( //
+        template(typename F2, typename S2)(
+            /// \pre
             requires assignable_from<F const &, F2 const &> AND
-                        assignable_from<S const &, S2 const &>) //
+                        assignable_from<S const &, S2 const &>)
         common_pair const & operator=(std::pair<F2, S2> const & that) const //
             noexcept(std::is_nothrow_assignable<F const &, F2 const &>::value &&
                      std::is_nothrow_assignable<S const &, S2 const &>::value)
@@ -438,8 +466,9 @@ namespace ranges
             this->second = that.second;
             return *this;
         }
-        template(typename F2, typename S2)( //
-            requires assignable_from<F const &, F2> AND assignable_from<S const &, S2>) //
+        template(typename F2, typename S2)(
+            /// \pre
+            requires assignable_from<F const &, F2> AND assignable_from<S const &, S2>)
         common_pair const & operator=(std::pair<F2, S2> && that) const //
             noexcept(std::is_nothrow_assignable<F const &, F2 &&>::value &&
                      std::is_nothrow_assignable<S const &, S2 &&>::value)
@@ -451,38 +480,44 @@ namespace ranges
     };
 
     // Logical operators
-    template(typename F1, typename S1, typename F2, typename S2)( //
-        requires equality_comparable_with<F1, F2> AND equality_comparable_with<S1, S2>) //
+    template(typename F1, typename S1, typename F2, typename S2)(
+        /// \pre
+        requires equality_comparable_with<F1, F2> AND equality_comparable_with<S1, S2>)
     bool operator==(common_pair<F1, S1> const & a, common_pair<F2, S2> const & b)
     {
         return a.first == b.first && a.second == b.second;
     }
-    template(typename F1, typename S1, typename F2, typename S2)( //
-        requires equality_comparable_with<F1, F2> AND equality_comparable_with<S1, S2>) //
+    template(typename F1, typename S1, typename F2, typename S2)(
+        /// \pre
+        requires equality_comparable_with<F1, F2> AND equality_comparable_with<S1, S2>)
     bool operator==(common_pair<F1, S1> const & a, std::pair<F2, S2> const & b)
     {
         return a.first == b.first && a.second == b.second;
     }
-    template(typename F1, typename S1, typename F2, typename S2)( //
-        requires equality_comparable_with<F1, F2> AND equality_comparable_with<S1, S2>) //
+    template(typename F1, typename S1, typename F2, typename S2)(
+        /// \pre
+        requires equality_comparable_with<F1, F2> AND equality_comparable_with<S1, S2>)
     bool operator==(std::pair<F1, S1> const & a, common_pair<F2, S2> const & b)
     {
         return a.first == b.first && a.second == b.second;
     }
-    template(typename F1, typename S1, typename F2, typename S2)( //
-        requires totally_ordered_with<F1, F2> AND totally_ordered_with<S1, S2>) //
+    template(typename F1, typename S1, typename F2, typename S2)(
+        /// \pre
+        requires totally_ordered_with<F1, F2> AND totally_ordered_with<S1, S2>)
     bool operator<(common_pair<F1, S1> const & a, common_pair<F2, S2> const & b)
     {
         return a.first < b.first || (!(b.first < a.first) && a.second < b.second);
     }
-    template(typename F1, typename S1, typename F2, typename S2)( //
-        requires totally_ordered_with<F1, F2> AND totally_ordered_with<S1, S2>) //
+    template(typename F1, typename S1, typename F2, typename S2)(
+        /// \pre
+        requires totally_ordered_with<F1, F2> AND totally_ordered_with<S1, S2>)
     bool operator<(std::pair<F1, S1> const & a, common_pair<F2, S2> const & b)
     {
         return a.first < b.first || (!(b.first < a.first) && a.second < b.second);
     }
-    template(typename F1, typename S1, typename F2, typename S2)( //
-        requires totally_ordered_with<F1, F2> AND totally_ordered_with<S1, S2>) //
+    template(typename F1, typename S1, typename F2, typename S2)(
+        /// \pre
+        requires totally_ordered_with<F1, F2> AND totally_ordered_with<S1, S2>)
     bool operator<(common_pair<F1, S1> const & a, std::pair<F2, S2> const & b)
     {
         return a.first < b.first || (!(b.first < a.first) && a.second < b.second);

--- a/include/range/v3/utility/compressed_pair.hpp
+++ b/include/range/v3/utility/compressed_pair.hpp
@@ -127,8 +127,9 @@ namespace ranges
 
         compressed_pair() = default;
 
-        template(typename U, typename V)( //
-            requires constructible_from<First, U> AND constructible_from<Second, V>) //
+        template(typename U, typename V)(
+            /// \pre
+            requires constructible_from<First, U> AND constructible_from<Second, V>)
         constexpr compressed_pair(U && u, V && v) //
             noexcept(noexcept(First((U &&) u)) && noexcept(Second((V &&) v)))
           : box<First, meta::size_t<0>>{(U &&) u}
@@ -161,9 +162,10 @@ namespace ranges
             return static_cast<Second &&>(this->box<Second, meta::size_t<1>>::get());
         }
 
-        template(typename F, typename S)( //
+        template(typename F, typename S)(
+            /// \pre
             requires convertible_to<First const &, F> AND
-                convertible_to<Second const &, S>) //
+                convertible_to<Second const &, S>)
             constexpr
             operator std::pair<F, S>() const
         {

--- a/include/range/v3/utility/copy.hpp
+++ b/include/range/v3/utility/copy.hpp
@@ -30,8 +30,9 @@ namespace ranges
     {
         struct copy_fn : copy_tag
         {
-            template(typename T)( //
-                requires constructible_from<detail::decay_t<T>, T>) //
+            template(typename T)(
+                /// \pre
+                requires constructible_from<detail::decay_t<T>, T>)
             constexpr auto operator()(T && t) const -> detail::decay_t<T>
             {
                 return static_cast<T &&>(t);
@@ -41,7 +42,8 @@ namespace ranges
             /// \sa `copy_fn`
             template<typename T>
             friend constexpr auto operator|(T && t, copy_fn)
-                -> CPP_broken_friend_ret(detail::decay_t<T>)( //
+                -> CPP_broken_friend_ret(detail::decay_t<T>)(
+                    /// \pre
                     requires constructible_from<detail::decay_t<T>, T>)
             {
                 return static_cast<T &&>(t);

--- a/include/range/v3/utility/infinity.hpp
+++ b/include/range/v3/utility/infinity.hpp
@@ -36,28 +36,32 @@ namespace ranges
         }
         template<typename Integer>
         friend constexpr auto operator==(Integer, infinity) noexcept
-            -> CPP_broken_friend_ret(bool)( //
+            -> CPP_broken_friend_ret(bool)(
+                /// \pre
                 requires integral<Integer>)
         {
             return false;
         }
         template<typename Integer>
         friend constexpr auto operator==(infinity, Integer) noexcept
-            -> CPP_broken_friend_ret(bool)( //
+            -> CPP_broken_friend_ret(bool)(
+                /// \pre
                 requires integral<Integer>)
         {
             return false;
         }
         template<typename Integer>
         friend constexpr auto operator!=(Integer, infinity) noexcept
-            -> CPP_broken_friend_ret(bool)( //
+            -> CPP_broken_friend_ret(bool)(
+                /// \pre
                 requires integral<Integer>)
         {
             return true;
         }
         template<typename Integer>
         friend constexpr auto operator!=(infinity, Integer) noexcept
-            -> CPP_broken_friend_ret(bool)( //
+            -> CPP_broken_friend_ret(bool)(
+                /// \pre
                 requires integral<Integer>)
         {
             return true;

--- a/include/range/v3/utility/memory.hpp
+++ b/include/range/v3/utility/memory.hpp
@@ -88,7 +88,8 @@ namespace ranges
             }
         };
 
-        template(typename T, typename... Args)( //
+        template(typename T, typename... Args)(
+            /// \pre
             requires (!std::is_array<T>::value)) //
         std::unique_ptr<T> make_unique(Args &&... args)
         {
@@ -119,7 +120,8 @@ namespace ranges
         }
         CPP_member
         auto operator=(Val const & val) //
-            -> CPP_ret(raw_storage_iterator &)( //
+            -> CPP_ret(raw_storage_iterator &)(
+                /// \pre
                 requires copy_constructible<Val>)
         {
             ::new((void *)std::addressof(*out_)) Val(val);
@@ -127,7 +129,8 @@ namespace ranges
         }
         CPP_member
         auto operator=(Val && val) //
-            -> CPP_ret(raw_storage_iterator &)( //
+            -> CPP_ret(raw_storage_iterator &)(
+                /// \pre
                 requires move_constructible<Val>)
         {
             ::new((void *)std::addressof(*out_)) Val(std::move(val));
@@ -140,14 +143,16 @@ namespace ranges
         }
         CPP_member
         auto operator++(int) //
-            -> CPP_ret(void)( //
+            -> CPP_ret(void)(
+                /// \pre
                 requires (!forward_iterator<O>))
         {
             ++out_;
         }
         CPP_member
         auto operator++(int) //
-            -> CPP_ret(raw_storage_iterator)( //
+            -> CPP_ret(raw_storage_iterator)(
+                /// \pre
                 requires forward_iterator<O>)
         {
             auto tmp = *this;
@@ -206,8 +211,9 @@ namespace ranges
         }
     };
 
-    template(typename I)( //
-        requires input_or_output_iterator<I>) //
+    template(typename I)(
+        /// \pre
+        requires input_or_output_iterator<I>)
     iterator_wrapper<I> iter_ref(I & i)
     {
         return i;

--- a/include/range/v3/utility/optional.hpp
+++ b/include/range/v3/utility/optional.hpp
@@ -97,8 +97,9 @@ namespace ranges
                         meta::bool_<detail::is_trivially_default_constructible_v<T> &&
                                     detail::is_trivially_copyable_v<T>>{})
                 {}
-                template(typename... Args)(              //
-                    requires constructible_from<T, Args...>) //
+                template(typename... Args)(
+                    /// \pre
+                    requires constructible_from<T, Args...>)
                     constexpr explicit optional_storage(in_place_t,
                                                         Args &&... args) //
                     noexcept(std::is_nothrow_constructible<T, Args...>::value)
@@ -142,8 +143,9 @@ namespace ranges
                   : dummy_{}
                   , engaged_{false}
                 {}
-                template(typename... Args)(              //
-                    requires constructible_from<T, Args...>) //
+                template(typename... Args)(
+                    /// \pre
+                    requires constructible_from<T, Args...>)
                     constexpr explicit optional_storage(in_place_t,
                                                         Args &&... args) //
                     noexcept(std::is_nothrow_constructible<T, Args...>::value)
@@ -203,7 +205,8 @@ namespace ranges
                 constexpr auto swap(optional_base & that) //
                     noexcept(std::is_nothrow_move_constructible<T>::value &&
                              is_nothrow_swappable<T>::value) //
-                    -> CPP_ret(void)( //
+                    -> CPP_ret(void)(
+                        /// \pre
                         requires move_constructible<T> && swappable<T>)
                 {
                     constexpr bool can_swap_trivially =
@@ -215,8 +218,9 @@ namespace ranges
                 }
 
             protected:
-                template(typename... Args)( //
-                    requires constructible_from<T, Args...>) //
+                template(typename... Args)(
+                    /// \pre
+                    requires constructible_from<T, Args...>)
                 T & construct_from(Args &&... args)
                     noexcept(std::is_nothrow_constructible<T, Args...>::value)
                 {
@@ -277,7 +281,8 @@ namespace ranges
             struct optional_base<T &>
             {
                 optional_base() = default;
-                template(typename Arg)( //
+                template(typename Arg)(
+                    /// \pre
                     requires constructible_from<T &, Arg>)
                 constexpr explicit optional_base(in_place_t, Arg && arg) noexcept //
                   : ptr_(detail::addressof(arg))
@@ -301,7 +306,8 @@ namespace ranges
                 CPP_member
                 constexpr auto swap(optional_base & that) //
                     noexcept(is_nothrow_swappable<T>::value) //
-                    -> CPP_ret(void)( //
+                    -> CPP_ret(void)(
+                        /// \pre
                         requires swappable<T>)
                 {
                     if(ptr_ && that.ptr_)
@@ -311,8 +317,9 @@ namespace ranges
                 }
 
             protected:
-                template(typename U)( //
-                    requires convertible_to<U &, T &>) //
+                template(typename U)(
+                    /// \pre
+                    requires convertible_to<U &, T &>)
                 constexpr T & construct_from(U && ref) noexcept
                 {
                     RANGES_EXPECT(!ptr_);
@@ -505,8 +512,9 @@ namespace ranges
 
         using base_t::base_t;
 
-        template(typename E, typename... Args)(                              //
-            requires constructible_from<T, std::initializer_list<E> &, Args...>) //
+        template(typename E, typename... Args)(
+            /// \pre
+            requires constructible_from<T, std::initializer_list<E> &, Args...>)
         constexpr explicit optional(in_place_t, std::initializer_list<E> il,
                                     Args &&... args) //
             noexcept(std::is_nothrow_constructible<T, std::initializer_list<E> &,
@@ -515,7 +523,8 @@ namespace ranges
         {}
 
 #if defined(__cpp_conditional_explicit) && __cpp_conditional_explicit > 0
-        template(typename U = T)( //
+        template(typename U = T)(
+            /// \pre
             requires (!same_as<detail::decay_t<U>, in_place_t>) AND
                 (!same_as<detail::decay_t<U>, optional>) AND
                 constructible_from<T, U>)
@@ -523,7 +532,8 @@ namespace ranges
           : base_t(in_place, static_cast<U &&>(v))
         {}
 
-        template(typename U)( //
+        template(typename U)(
+            /// \pre
             requires optional_should_convert<U, T> AND
                 constructible_from<T, U const &>)
         explicit(!convertible_to<U const &, T>) optional(optional<U> const & that)
@@ -532,7 +542,8 @@ namespace ranges
                 base_t::construct_from(*that);
         }
 #else
-        template(typename U = T)( //
+        template(typename U = T)(
+            /// \pre
             requires (!same_as<detail::decay_t<U>, in_place_t>) AND
                 (!same_as<detail::decay_t<U>, optional>) AND
                 constructible_from<T, U> AND
@@ -540,7 +551,8 @@ namespace ranges
         constexpr optional(U && v)
           : base_t(in_place, static_cast<U &&>(v))
         {}
-        template(typename U = T)( //
+        template(typename U = T)(
+            /// \pre
             requires (!same_as<detail::decay_t<U>, in_place_t>) AND
                 (!same_as<detail::decay_t<U>, optional>) AND
                 constructible_from<T, U> AND
@@ -549,7 +561,8 @@ namespace ranges
           : base_t(in_place, static_cast<U &&>(v))
         {}
 
-        template(typename U)( //
+        template(typename U)(
+            /// \pre
             requires optional_should_convert<U, T> AND
                 constructible_from<T, U const &> AND
                 convertible_to<U const &, T>)
@@ -558,7 +571,8 @@ namespace ranges
             if(that.has_value())
                 base_t::construct_from(*that);
         }
-        template(typename U)( //
+        template(typename U)(
+            /// \pre
             requires optional_should_convert<U, T> AND
                 constructible_from<T, U const &> AND
                 (!convertible_to<U const &, T>))
@@ -569,16 +583,18 @@ namespace ranges
         }
 #endif
 
-        template(typename U)( //
-            requires optional_should_convert<U, T> AND constructible_from<T, U> AND //
-                convertible_to<U, T>) //
+        template(typename U)(
+            /// \pre
+            requires optional_should_convert<U, T> AND constructible_from<T, U> AND
+                convertible_to<U, T>)
         optional(optional<U> && that)
         {
             if(that.has_value())
                 base_t::construct_from(detail::move(*that));
         }
-        template(typename U)( //
-            requires optional_should_convert<U, T> AND constructible_from<T, U> AND //
+        template(typename U)(
+            /// \pre
+            requires optional_should_convert<U, T> AND constructible_from<T, U> AND
             (!convertible_to<U, T>)) //
         explicit optional(optional<U> && that)
         {
@@ -595,11 +611,12 @@ namespace ranges
         optional & operator=(optional const &) = default;
         optional & operator=(optional &&) = default;
 
-        template(typename U = T)( //
-            requires (!same_as<optional, detail::decay_t<U>>) AND //
-                (!(satisfies<T, std::is_scalar> && same_as<T, detail::decay_t<U>>)) AND //
-                constructible_from<T, U> AND //
-                assignable_from<T &, U>) //
+        template(typename U = T)(
+            /// \pre
+            requires (!same_as<optional, detail::decay_t<U>>) AND
+                (!(satisfies<T, std::is_scalar> && same_as<T, detail::decay_t<U>>)) AND
+                constructible_from<T, U> AND
+                assignable_from<T &, U>)
         constexpr optional & operator=(U && u) noexcept(
             std::is_nothrow_constructible<T, U>::value &&
                 std::is_nothrow_assignable<T &, U>::value)
@@ -611,36 +628,40 @@ namespace ranges
             return *this;
         }
 
-        template(typename U)( //
-            requires optional_should_convert_assign<U, T> AND //
-                constructible_from<T, const U &> AND //
-                assignable_from<T &, const U &>) //
+        template(typename U)(
+            /// \pre
+            requires optional_should_convert_assign<U, T> AND
+                constructible_from<T, const U &> AND
+                assignable_from<T &, const U &>)
         constexpr optional & operator=(optional<U> const & that)
         {
             base_t::assign_from(that);
             return *this;
         }
 
-        template(typename U)( //
-            requires optional_should_convert_assign<U, T> AND //
-                constructible_from<T, U> AND //
-                assignable_from<T &, U>) //
+        template(typename U)(
+            /// \pre
+            requires optional_should_convert_assign<U, T> AND
+                constructible_from<T, U> AND
+                assignable_from<T &, U>)
         constexpr optional & operator=(optional<U> && that)
         {
             base_t::assign_from(std::move(that));
             return *this;
         }
 
-        template(typename... Args)( //
-            requires constructible_from<T, Args...>) //
+        template(typename... Args)(
+            /// \pre
+            requires constructible_from<T, Args...>)
         T & emplace(Args &&... args) noexcept(
             std::is_nothrow_constructible<T, Args...>::value)
         {
             reset();
             return base_t::construct_from(static_cast<Args &&>(args)...);
         }
-        template(typename E, typename... Args)( //
-            requires constructible_from<T, std::initializer_list<E> &, Args...>) //
+        template(typename E, typename... Args)(
+            /// \pre
+            requires constructible_from<T, std::initializer_list<E> &, Args...>)
         T & emplace(std::initializer_list<E> il, Args &&... args) noexcept(
             std::is_nothrow_constructible<T, std::initializer_list<E> &, Args...>::value)
         {
@@ -677,14 +698,16 @@ namespace ranges
                    detail::move(**this);
         }
 
-        template(typename U)(                                   //
-            requires copy_constructible<T> AND convertible_to<U, T>) //
+        template(typename U)(
+            /// \pre
+            requires copy_constructible<T> AND convertible_to<U, T>)
         constexpr T value_or(U && u) const &
         {
             return has_value() ? **this : static_cast<T>((U &&) u);
         }
-        template(typename U)(                                   //
-            requires move_constructible<T> AND convertible_to<U, T>) //
+        template(typename U)(
+            /// \pre
+            requires move_constructible<T> AND convertible_to<U, T>)
         constexpr T value_or(U && u) &&
         {
             return has_value() ? detail::move(**this) : static_cast<T>((U &&) u);

--- a/include/range/v3/utility/random.hpp
+++ b/include/range/v3/utility/random.hpp
@@ -118,8 +118,9 @@ namespace ranges
                 return seeds;
             }
 
-            template(typename I)( //
-                requires unsigned_integral<I>) //
+            template(typename I)(
+                /// \pre
+                requires unsigned_integral<I>)
             constexpr I fast_exp(I x, I power, I result = I{1})
             {
                 return power == I{0}
@@ -218,9 +219,10 @@ namespace ranges
 
                 std::array<IntRep, count> mixer_;
 
-                template(typename I, typename S)( //
+                template(typename I, typename S)(
+                    /// \pre
                     requires input_iterator<I> AND sentinel_for<S, I> AND
-                        convertible_to<iter_reference_t<I>, IntRep>) //
+                        convertible_to<iter_reference_t<I>, IntRep>)
                 void mix_entropy(I first, S last)
                 {
                     auto hash_const = INIT_A;
@@ -260,23 +262,26 @@ namespace ranges
                 seed_seq_fe(const seed_seq_fe &) = delete;
                 void operator=(const seed_seq_fe &) = delete;
 
-                template(typename T)( //
-                    requires convertible_to<T const &, IntRep>) //
+                template(typename T)(
+                    /// \pre
+                    requires convertible_to<T const &, IntRep>)
                 seed_seq_fe(std::initializer_list<T> init)
                 {
                     seed(init.begin(), init.end());
                 }
 
-                template(typename I, typename S)( //
-                    requires input_iterator<I> AND sentinel_for<S, I> AND //
-                        convertible_to<iter_reference_t<I>, IntRep>) //
+                template(typename I, typename S)(
+                    /// \pre
+                    requires input_iterator<I> AND sentinel_for<S, I> AND
+                        convertible_to<iter_reference_t<I>, IntRep>)
                 seed_seq_fe(I first, S last)
                 {
                     seed(first, last);
                 }
 
                 // generating functions
-                template(typename I, typename S)( //
+                template(typename I, typename S)(
+                    /// \pre
                     requires random_access_iterator<I> AND sentinel_for<S, I>)
                 RANGES_INTENDED_MODULAR_ARITHMETIC //
                 void generate(I first, S const last) const
@@ -303,9 +308,10 @@ namespace ranges
                     return count;
                 }
 
-                template(typename O)( //
-                    requires weakly_incrementable<O> AND //
-                        indirectly_copyable<decltype(mixer_.begin()), O>) //
+                template(typename O)(
+                    /// \pre
+                    requires weakly_incrementable<O> AND
+                        indirectly_copyable<decltype(mixer_.begin()), O>)
                 RANGES_INTENDED_MODULAR_ARITHMETIC void param(O dest) const
                 {
                     constexpr IntRep INV_A = randutils::fast_exp(MULT_A, IntRep(-1));
@@ -352,9 +358,10 @@ namespace ranges
                     ranges::copy(mixer_copy, dest);
                 }
 
-                template(typename I, typename S)( //
+                template(typename I, typename S)(
+                    /// \pre
                     requires input_iterator<I> AND sentinel_for<S, I> AND
-                        convertible_to<iter_reference_t<I>, IntRep>) //
+                        convertible_to<iter_reference_t<I>, IntRep>)
                 void seed(I first, S last)
                 {
                     mix_entropy(first, last);

--- a/include/range/v3/utility/semiregular_box.hpp
+++ b/include/range/v3/utility/semiregular_box.hpp
@@ -135,31 +135,35 @@ namespace ranges
                 this->construct_from(that.data_);
         }
 #if defined(__cpp_conditional_explicit) && 0 < __cpp_conditional_explicit
-        template(typename U)( //
-            requires (!same_as<uncvref_t<U>, semiregular_box>) AND //
-                constructible_from<T, U>) //
+        template(typename U)(
+            /// \pre
+            requires (!same_as<uncvref_t<U>, semiregular_box>) AND
+                constructible_from<T, U>)
         explicit(!convertible_to<U, T>) constexpr semiregular_box(U && u)
             noexcept(std::is_nothrow_constructible<T, U>::value)
           : semiregular_box(in_place, static_cast<U &&>(u))
         {}
 #else
-        template(typename U)( //
-            requires (!same_as<uncvref_t<U>, semiregular_box>) AND //
+        template(typename U)(
+            /// \pre
+            requires (!same_as<uncvref_t<U>, semiregular_box>) AND
                 constructible_from<T, U> AND (!convertible_to<U, T>)) //
         constexpr explicit semiregular_box(U && u)
             noexcept(std::is_nothrow_constructible<T, U>::value)
           : semiregular_box(in_place, static_cast<U &&>(u))
         {}
-        template(typename U)( //
-            requires (!same_as<uncvref_t<U>, semiregular_box>) AND //
-                constructible_from<T, U> AND convertible_to<U, T>) //
+        template(typename U)(
+            /// \pre
+            requires (!same_as<uncvref_t<U>, semiregular_box>) AND
+                constructible_from<T, U> AND convertible_to<U, T>)
         constexpr semiregular_box(U && u)
             noexcept(std::is_nothrow_constructible<T, U>::value)
           : semiregular_box(in_place, static_cast<U &&>(u))
         {}
 #endif
-        template(typename... Args)(                            //
-            requires constructible_from<T, Args...>)               //
+        template(typename... Args)(
+            /// \pre
+            requires constructible_from<T, Args...>)
         constexpr semiregular_box(in_place_t, Args &&... args) //
             noexcept(std::is_nothrow_constructible<T, Args...>::value)
           : data_(static_cast<Args &&>(args)...)
@@ -222,22 +226,25 @@ namespace ranges
         }
         operator T const &&() const && = delete;
         // clang-format off
-        template(typename... Args)(       //
-            requires invocable<T &, Args...>) //
+        template(typename... Args)(
+            /// \pre
+            requires invocable<T &, Args...>)
         constexpr decltype(auto) operator()(Args &&... args) &
             noexcept(is_nothrow_invocable_v<T &, Args...>)
         {
             return invoke(data_, static_cast<Args &&>(args)...);
         }
-        template(typename... Args)(             //
-            requires invocable<T const &, Args...>) //
+        template(typename... Args)(
+            /// \pre
+            requires invocable<T const &, Args...>)
         constexpr decltype(auto) operator()(Args &&... args) const &
             noexcept(is_nothrow_invocable_v<T const &, Args...>)
         {
             return invoke(data_, static_cast<Args &&>(args)...);
         }
-        template(typename... Args)(     //
-            requires invocable<T, Args...>) //
+        template(typename... Args)(
+            /// \pre
+            requires invocable<T, Args...>)
         constexpr decltype(auto) operator()(Args &&... args) &&
             noexcept(is_nothrow_invocable_v<T, Args...>)
         {
@@ -254,7 +261,8 @@ namespace ranges
       , private detail::semiregular_get
     {
         semiregular_box() = default;
-        template(typename Arg)( //
+        template(typename Arg)(
+            /// \pre
             requires constructible_from<ranges::reference_wrapper<T &>, Arg &>)
         semiregular_box(in_place_t, Arg & arg) noexcept //
           : ranges::reference_wrapper<T &>(arg)
@@ -264,9 +272,10 @@ namespace ranges
         using ranges::reference_wrapper<T &>::operator();
 
 #if defined(_MSC_VER)
-        template(typename U)( //
+        template(typename U)(
+            /// \pre
             requires (!same_as<uncvref_t<U>, semiregular_box>) AND
-            constructible_from<ranges::reference_wrapper<T &>, U>) //
+            constructible_from<ranges::reference_wrapper<T &>, U>)
         constexpr semiregular_box(U && u) noexcept(
             std::is_nothrow_constructible<ranges::reference_wrapper<T &>, U>::value)
           : ranges::reference_wrapper<T &>{static_cast<U &&>(u)}
@@ -282,7 +291,8 @@ namespace ranges
       , private detail::semiregular_get
     {
         semiregular_box() = default;
-        template(typename Arg)( //
+        template(typename Arg)(
+            /// \pre
             requires constructible_from<ranges::reference_wrapper<T &&>, Arg>)
         semiregular_box(in_place_t, Arg && arg) noexcept //
           : ranges::reference_wrapper<T &&>(static_cast<Arg &&>(arg))
@@ -292,9 +302,10 @@ namespace ranges
         using ranges::reference_wrapper<T &&>::operator();
 
 #if defined(_MSC_VER)
-        template(typename U)( //
+        template(typename U)(
+            /// \pre
             requires (!same_as<uncvref_t<U>, semiregular_box>) AND
-            constructible_from<ranges::reference_wrapper<T &&>, U>) //
+            constructible_from<ranges::reference_wrapper<T &&>, U>)
         constexpr semiregular_box(U && u) noexcept(
             std::is_nothrow_constructible<ranges::reference_wrapper<T &&>, U>::value)
           : ranges::reference_wrapper<T &&>{static_cast<U &&>(u)}

--- a/include/range/v3/utility/tagged_pair.hpp
+++ b/include/range/v3/utility/tagged_pair.hpp
@@ -83,19 +83,22 @@ namespace ranges
     public:
         tagged() = default;
         using base_t::base_t;
-        template(typename Other)(                        //
+        template(typename Other)(
+            /// \pre
             requires can_convert<Other>::value)          //
         constexpr tagged(tagged<Other, Tags...> && that) //
             noexcept(std::is_nothrow_constructible<Base, Other>::value)
           : base_t(static_cast<Other &&>(that))
         {}
-        template(typename Other)(                             //
+        template(typename Other)(
+            /// \pre
             requires can_convert<Other>::value)               //
         constexpr tagged(tagged<Other, Tags...> const & that) //
             noexcept(std::is_nothrow_constructible<Base, Other const &>::value)
           : base_t(static_cast<Other const &>(that))
         {}
-        template(typename Other)( //
+        template(typename Other)(
+            /// \pre
             requires can_convert<Other>::value) //
         constexpr tagged & operator=(tagged<Other, Tags...> && that) //
             noexcept(
@@ -104,7 +107,8 @@ namespace ranges
             static_cast<Base &>(*this) = static_cast<Other &&>(that);
             return *this;
         }
-        template(typename Other)( //
+        template(typename Other)(
+            /// \pre
             requires can_convert<Other>::value) //
         constexpr tagged & operator=(tagged<Other, Tags...> const & that) //
             noexcept(
@@ -113,16 +117,18 @@ namespace ranges
             static_cast<Base &>(*this) = static_cast<Other const &>(that);
             return *this;
         }
-        template(typename U)( //
+        template(typename U)(
+            /// \pre
             requires (!same_as<tagged, detail::decay_t<U>>) AND
-                satisfies<Base &, std::is_assignable, U>) //
+                satisfies<Base &, std::is_assignable, U>)
         constexpr tagged & operator=(U && u) //
             noexcept(noexcept(std::declval<Base &>() = static_cast<U &&>(u)))
         {
             static_cast<Base &>(*this) = static_cast<U &&>(u);
             return *this;
         }
-        template(typename B = Base)( //
+        template(typename B = Base)(
+            /// \pre
             requires is_swappable<B>::value) //
         constexpr void swap(tagged & that) noexcept(is_nothrow_swappable<B>::value)
         {
@@ -132,7 +138,8 @@ namespace ranges
         template<typename B = Base>
         friend constexpr auto swap(tagged & x, tagged & y) //
             noexcept(is_nothrow_swappable<B>::value)
-            -> CPP_broken_friend_ret(void)( //
+            -> CPP_broken_friend_ret(void)(
+                /// \pre
                 requires is_swappable<B>::value)
         {
             x.swap(y);
@@ -143,7 +150,8 @@ namespace ranges
 #if RANGES_BROKEN_CPO_LOOKUP
     namespace _tagged_
     {
-        template(typename Base, typename... Tags)( //
+        template(typename Base, typename... Tags)(
+            /// \pre
             requires is_swappable<Base>::value) //
         constexpr void swap(tagged<Base, Tags...> & x, tagged<Base, Tags...> & y) //
             noexcept(is_nothrow_swappable<Base>::value)

--- a/include/range/v3/utility/variant.hpp
+++ b/include/range/v3/utility/variant.hpp
@@ -51,27 +51,31 @@ namespace ranges
 
         public:
             CPP_member
-            constexpr CPP_ctor(indexed_datum)(meta::nil_ = {})( //
+            constexpr CPP_ctor(indexed_datum)(meta::nil_ = {})(
+                /// \pre
                 requires default_constructible<T>)
               : data_{}
             {}
             CPP_member
-            CPP_ctor(indexed_datum)(indexed_datum && that)( //
+            CPP_ctor(indexed_datum)(indexed_datum && that)(
+                /// \pre
                 requires move_constructible<T>)
             {
                 std::uninitialized_copy_n(make_move_iterator(that.data_), N, data_);
             }
             CPP_member
-            CPP_ctor(indexed_datum)(indexed_datum const & that)( //
+            CPP_ctor(indexed_datum)(indexed_datum const & that)(
+                /// \pre
                 requires copy_constructible<T>)
             {
                 std::uninitialized_copy_n(that.data_, N, data_);
             }
             // \pre Requires distance(first, last) <= N
             // \pre Requires default_constructible<T> || distance(first, last) == N
-            template(typename I, typename S)( //
-                requires sentinel_for<S, I> AND input_iterator<I> AND //
-                    constructible_from<T, iter_reference_t<I>>) //
+            template(typename I, typename S)(
+                /// \pre
+                requires sentinel_for<S, I> AND input_iterator<I> AND
+                    constructible_from<T, iter_reference_t<I>>)
             indexed_datum(I first, S last)
             {
                 T * p = detail::uninitialized_copy(first, last, data_);
@@ -79,14 +83,16 @@ namespace ranges
             }
             // \pre Requires distance(r) <= N
             // \pre Requires default_constructible<T> || distance(r) == N
-            template(typename R)( //
+            template(typename R)(
+                /// \pre
                 requires input_range<R> AND constructible_from<T, range_reference_t<R>>)
             explicit indexed_datum(R && r)
               : indexed_datum{ranges::begin(r), ranges::end(r)}
             {}
             CPP_member
             auto operator=(indexed_datum && that) //
-                -> CPP_ret(indexed_datum &)( //
+                -> CPP_ret(indexed_datum &)(
+                    /// \pre
                     requires assignable_from<T &, T>)
             {
                 ranges::move(that.data_, data_);
@@ -94,15 +100,17 @@ namespace ranges
             }
             CPP_member
             auto operator=(indexed_datum const & that) //
-                -> CPP_ret(indexed_datum &)( //
+                -> CPP_ret(indexed_datum &)(
+                    /// \pre
                     requires assignable_from<T &, T const &>)
             {
                 ranges::copy(that.data_, data_);
                 return *this;
             }
             // \pre Requires ranges::distance(r) <= N
-            template(typename R)( //
-                requires input_range<R> AND assignable_from<T &, range_reference_t<R>>) //
+            template(typename R)(
+                /// \pre
+                requires input_range<R> AND assignable_from<T &, range_reference_t<R>>)
             indexed_datum & operator=(R && r)
             {
                 ranges::copy(r, data_);

--- a/include/range/v3/view/adaptor.hpp
+++ b/include/range/v3/view/adaptor.hpp
@@ -128,46 +128,53 @@ namespace ranges
             return ranges::end(rng.base())
         )
             // clang-format on
-            template(typename I)( //
-                requires equality_comparable<I>) //
+            template(typename I)(
+                /// \pre
+                requires equality_comparable<I>)
             static bool equal(I const & it0, I const & it1)
         {
             return it0 == it1;
         }
-        template(typename I)( //
-            requires input_or_output_iterator<I>) //
+        template(typename I)(
+            /// \pre
+            requires input_or_output_iterator<I>)
         static iter_reference_t<I> read(I const & it,
                                         detail::adaptor_base_current_mem_fn = {})
             noexcept(noexcept(iter_reference_t<I>(*it)))
         {
             return *it;
         }
-        template(typename I)( //
-            requires input_or_output_iterator<I>) //
+        template(typename I)(
+            /// \pre
+            requires input_or_output_iterator<I>)
         static void next(I & it)
         {
             ++it;
         }
-        template(typename I)( //
-            requires bidirectional_iterator<I>) //
+        template(typename I)(
+            /// \pre
+            requires bidirectional_iterator<I>)
         static void prev(I & it)
         {
             --it;
         }
-        template(typename I)( //
-            requires random_access_iterator<I>) //
+        template(typename I)(
+            /// \pre
+            requires random_access_iterator<I>)
         static void advance(I & it, iter_difference_t<I> n)
         {
             it += n;
         }
-        template(typename I)( //
-            requires sized_sentinel_for<I, I>) //
+        template(typename I)(
+            /// \pre
+            requires sized_sentinel_for<I, I>)
         static iter_difference_t<I> distance_to(I const & it0, I const & it1)
         {
             return it1 - it0;
         }
-        template(typename I, typename S)( //
-            requires sentinel_for<S, I>) //
+        template(typename I, typename S)(
+            /// \pre
+            requires sentinel_for<S, I>)
         static constexpr bool empty(I const & it, S const & last)
         {
             return it == last;
@@ -448,10 +455,11 @@ namespace ranges
         adaptor_cursor(BaseIter iter, Adapt adapt)
           : base_t{{std::move(iter), std::move(adapt)}}
         {}
-        template(typename OtherIter, typename OtherAdapt)( //
+        template(typename OtherIter, typename OtherAdapt)(
+            /// \pre
             requires //
                 (!same_as<adaptor_cursor<OtherIter, OtherAdapt>, adaptor_cursor>) AND
-                convertible_to<OtherIter, BaseIter> AND //
+                convertible_to<OtherIter, BaseIter> AND
                 convertible_to<OtherAdapt, Adapt>)
         adaptor_cursor(adaptor_cursor<OtherIter, OtherAdapt> that)
           : base_t{{std::move(that.data_.first()), std::move(that.data_.second())}}
@@ -501,16 +509,18 @@ namespace ranges
             auto pos = adapt.begin(d);
             return {std::move(pos), std::move(adapt)};
         }
-        template(typename D = Derived)( //
-            requires same_as<D, Derived>) //
+        template(typename D = Derived)(
+            /// \pre
+            requires same_as<D, Derived>)
         constexpr auto begin_cursor() noexcept(
             noexcept(view_adaptor::begin_cursor_(std::declval<D &>())))
             -> decltype(view_adaptor::begin_cursor_(std::declval<D &>()))
         {
             return view_adaptor::begin_cursor_(derived());
         }
-        template(typename D = Derived)( //
-            requires same_as<D, Derived> AND range<base_range_t const>) //
+        template(typename D = Derived)(
+            /// \pre
+            requires same_as<D, Derived> AND range<base_range_t const>)
         constexpr auto begin_cursor() const
             noexcept(noexcept(view_adaptor::begin_cursor_(std::declval<D const &>())))
                 -> decltype(view_adaptor::begin_cursor_(std::declval<D const &>()))
@@ -527,16 +537,18 @@ namespace ranges
             auto pos = adapt.end(d);
             return {std::move(pos), std::move(adapt)};
         }
-        template(typename D = Derived)( //
-            requires same_as<D, Derived>) //
+        template(typename D = Derived)(
+            /// \pre
+            requires same_as<D, Derived>)
         constexpr auto end_cursor() noexcept(
             noexcept(view_adaptor::end_cursor_(std::declval<D &>())))
             -> decltype(view_adaptor::end_cursor_(std::declval<D &>()))
         {
             return view_adaptor::end_cursor_(derived());
         }
-        template(typename D = Derived)( //
-            requires same_as<D, Derived> AND range<base_range_t const>) //
+        template(typename D = Derived)(
+            /// \pre
+            requires same_as<D, Derived> AND range<base_range_t const>)
         constexpr auto end_cursor() const noexcept(
             noexcept(view_adaptor::end_cursor_(std::declval<D const &>())))
             -> decltype(view_adaptor::end_cursor_(std::declval<D const &>()))

--- a/include/range/v3/view/addressof.hpp
+++ b/include/range/v3/view/addressof.hpp
@@ -44,8 +44,9 @@ namespace ranges
             };
 
         public:
-            template(typename Rng)( //
-                requires viewable_range<Rng> AND input_range<Rng> AND //
+            template(typename Rng)(
+                /// \pre
+                requires viewable_range<Rng> AND input_range<Rng> AND
                     std::is_lvalue_reference<range_reference_t<Rng>>::value) //
             constexpr auto CPP_auto_fun(operator())(Rng && rng)(const) //
             (

--- a/include/range/v3/view/adjacent_filter.hpp
+++ b/include/range/v3/view/adjacent_filter.hpp
@@ -74,7 +74,8 @@ namespace ranges
             constexpr adaptor(Parent * rng) noexcept
               : rng_(rng)
             {}
-            template(bool Other)(       //
+            template(bool Other)(
+                /// \pre
                 requires Const && CPP_NOT(Other)) //
                 constexpr adaptor(adaptor<Other> that)
               : rng_(that.rng_)
@@ -90,7 +91,8 @@ namespace ranges
             }
             CPP_member
             constexpr auto prev(iterator_t<CRng> & it) const //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires bidirectional_range<CRng>)
             {
                 auto const first = ranges::begin(rng_->base());
@@ -113,7 +115,8 @@ namespace ranges
         }
         CPP_member
         constexpr auto begin_adaptor() const noexcept //
-            -> CPP_ret(adaptor<true>)( //
+            -> CPP_ret(adaptor<true>)(
+                /// \pre
                 requires detail::adjacent_filter_constraints<Rng const, Pred const>)
         {
             return {this};
@@ -124,7 +127,8 @@ namespace ranges
         }
         CPP_member
         constexpr auto end_adaptor() const noexcept //
-            -> CPP_ret(adaptor<true>)( //
+            -> CPP_ret(adaptor<true>)(
+                /// \pre
                 requires detail::adjacent_filter_constraints<Rng const, Pred const>)
         {
             return {this};
@@ -139,7 +143,8 @@ namespace ranges
     };
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-    template(typename Rng, typename Fun)( //
+    template(typename Rng, typename Fun)(
+        /// \pre
         requires copy_constructible<Rng>)
         adjacent_filter_view(Rng &&, Fun)
             ->adjacent_filter_view<views::all_t<Rng>, Fun>;
@@ -149,8 +154,9 @@ namespace ranges
     {
         struct adjacent_filter_base_fn
         {
-            template(typename Rng, typename Pred)( //
-                requires detail::adjacent_filter_constraints<Rng, Pred>) //
+            template(typename Rng, typename Pred)(
+                /// \pre
+                requires detail::adjacent_filter_constraints<Rng, Pred>)
             constexpr adjacent_filter_view<all_t<Rng>, Pred> //
             operator()(Rng && rng, Pred pred) const
             {

--- a/include/range/v3/view/adjacent_remove_if.hpp
+++ b/include/range/v3/view/adjacent_remove_if.hpp
@@ -72,7 +72,8 @@ namespace ranges
             }
             CPP_member
             constexpr auto prev(iterator_t<Rng> & it) const //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires bidirectional_range<Rng>)
             {
                 rng_->satisfy_reverse(it);
@@ -87,7 +88,8 @@ namespace ranges
         }
         CPP_member
         constexpr auto end_adaptor() //
-            -> CPP_ret(adaptor)( //
+            -> CPP_ret(adaptor)(
+                /// \pre
                 requires common_range<Rng>)
         {
             if(bidirectional_range<Rng>)
@@ -96,7 +98,8 @@ namespace ranges
         }
         CPP_member
         constexpr auto end_adaptor() noexcept //
-            -> CPP_ret(adaptor_base)( //
+            -> CPP_ret(adaptor_base)(
+                /// \pre
                 requires (!common_range<Rng>))
         {
             return {};
@@ -140,7 +143,8 @@ namespace ranges
     };
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-    template(typename Rng, typename Fun)( //
+    template(typename Rng, typename Fun)(
+        /// \pre
         requires copy_constructible<Rng>)
     adjacent_remove_if_view(Rng &&, Fun)
         -> adjacent_remove_if_view<views::all_t<Rng>, Fun>;
@@ -150,9 +154,10 @@ namespace ranges
     {
         struct adjacent_remove_if_base_fn
         {
-            template(typename Rng, typename Pred)( //
+            template(typename Rng, typename Pred)(
+                /// \pre
                 requires viewable_range<Rng> AND forward_range<Rng> AND
-                    indirect_binary_predicate_<Pred, iterator_t<Rng>, iterator_t<Rng>>) //
+                    indirect_binary_predicate_<Pred, iterator_t<Rng>, iterator_t<Rng>>)
             constexpr adjacent_remove_if_view<all_t<Rng>, Pred> //
             operator()(Rng && rng, Pred pred) const
             {

--- a/include/range/v3/view/all.hpp
+++ b/include/range/v3/view/all.hpp
@@ -65,8 +65,9 @@ namespace ranges
             }
 
         public:
-            template(typename T)( //
-                requires range<T &> AND viewable_range<T>) //
+            template(typename T)(
+                /// \pre
+                requires range<T &> AND viewable_range<T>)
             constexpr auto operator()(T && t) const
             {
                 return all_fn::from_range_(static_cast<T &&>(t),
@@ -112,8 +113,9 @@ namespace ranges
             using ranges::views::all;
             using ranges::views::all_t;
         }
-        template(typename Rng)(       //
-            requires viewable_range<Rng>) //
+        template(typename Rng)(
+            /// \pre
+            requires viewable_range<Rng>)
         using all_view RANGES_DEPRECATED(
             "Please use ranges::cpp20::views::all_t instead.") =
                 ranges::views::all_t<Rng>;

--- a/include/range/v3/view/any_view.hpp
+++ b/include/range/v3/view/any_view.hpp
@@ -414,10 +414,11 @@ namespace ranges
 
         public:
             any_cursor() = default;
-            template(typename Rng)( //
-                requires (!same_as<detail::decay_t<Rng>, any_cursor>) AND //
-                    forward_range<Rng> AND //
-                    any_compatible_range<Rng, Ref>) //
+            template(typename Rng)(
+                /// \pre
+                requires (!same_as<detail::decay_t<Rng>, any_cursor>) AND
+                    forward_range<Rng> AND
+                    any_compatible_range<Rng, Ref>)
             explicit any_cursor(Rng && rng)
               : ptr_{detail::make_unique<impl_t<Rng>>(begin(rng))}
             {}
@@ -453,7 +454,8 @@ namespace ranges
             }
             CPP_member
             auto prev() //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires (category::bidirectional == (Cat & category::bidirectional)))
             {
                 RANGES_EXPECT(ptr_);
@@ -461,7 +463,8 @@ namespace ranges
             }
             CPP_member
             auto advance(std::ptrdiff_t n) //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires (category::random_access == (Cat & category::random_access)))
             {
                 RANGES_EXPECT(ptr_);
@@ -469,7 +472,8 @@ namespace ranges
             }
             CPP_member
             auto distance_to(any_cursor const & that) const //
-                -> CPP_ret(std::ptrdiff_t)( //
+                -> CPP_ret(std::ptrdiff_t)(
+                    /// \pre
                     requires (category::random_access == (Cat & category::random_access)))
             {
                 RANGES_EXPECT(!ptr_ == !that.ptr_);
@@ -549,11 +553,12 @@ namespace ranges
         CPP_assert((Cat & category::forward) == category::forward);
 
         any_view() = default;
-        template(typename Rng)( //
+        template(typename Rng)(
+            /// \pre
             requires //
-                (!same_as<detail::decay_t<Rng>, any_view>) AND //
-                input_range<Rng> AND //
-                detail::any_compatible_range<Rng, Ref>) //
+                (!same_as<detail::decay_t<Rng>, any_view>) AND
+                input_range<Rng> AND
+                detail::any_compatible_range<Rng, Ref>)
         any_view(Rng && rng)
           : any_view(static_cast<Rng &&>(rng),
                      meta::bool_<(get_categories<Rng>() & Cat) == Cat>{})
@@ -571,7 +576,8 @@ namespace ranges
 
         CPP_member
         auto size() //
-            -> CPP_ret(std::size_t)( //
+            -> CPP_ret(std::size_t)(
+                /// \pre
                 requires (category::sized == (Cat & category::sized)))
         {
             return ptr_ ? ptr_->size() : 0;
@@ -613,18 +619,20 @@ namespace ranges
         friend range_access;
 
         any_view() = default;
-        template(typename Rng)( //
+        template(typename Rng)(
+            /// \pre
             requires //
-                (!same_as<detail::decay_t<Rng>, any_view>) AND //
-                input_range<Rng> AND //
-                detail::any_compatible_range<Rng, Ref>) //
+                (!same_as<detail::decay_t<Rng>, any_view>) AND
+                input_range<Rng> AND
+                detail::any_compatible_range<Rng, Ref>)
         any_view(Rng && rng)
           : ptr_{std::make_shared<impl_t<Rng>>(views::all(static_cast<Rng &&>(rng)))}
         {}
 
         CPP_member
         auto size() //
-            -> CPP_ret(std::size_t)( //
+            -> CPP_ret(std::size_t)(
+                /// \pre
                 requires (category::sized == (Cat & category::sized)))
         {
             return ptr_ ? ptr_->size() : 0;
@@ -651,8 +659,9 @@ namespace ranges
     };
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-    template(typename Rng)( //
-        requires view_<Rng>)    //
+    template(typename Rng)(
+        /// \pre
+        requires view_<Rng>)
         any_view(Rng &&)
             ->any_view<range_reference_t<Rng>, get_categories<Rng>()>;
 #endif

--- a/include/range/v3/view/c_str.hpp
+++ b/include/range/v3/view/c_str.hpp
@@ -63,7 +63,8 @@ namespace ranges
         struct c_str_fn
         {
             // Fixed-length
-            template(typename Char, std::size_t N)( //
+            template(typename Char, std::size_t N)(
+                /// \pre
                 requires detail::is_char_type<Char>::value) //
             ranges::subrange<Char *> operator()(Char (&sz)[N]) const
             {
@@ -71,7 +72,8 @@ namespace ranges
             }
 
             // Null-terminated
-            template(typename Char)( //
+            template(typename Char)(
+                /// \pre
                 requires detail::is_char_type<Char>::value) //
             ranges::delimit_view<
                 ranges::subrange<Char *, ranges::unreachable_sentinel_t>,

--- a/include/range/v3/view/cache1.hpp
+++ b/include/range/v3/view/cache1.hpp
@@ -45,7 +45,8 @@ namespace ranges
 
         CPP_member
         auto update_(range_reference_t<Rng> && val) //
-            -> CPP_ret(void)( //
+            -> CPP_ret(void)(
+                /// \pre
                 requires assignable_from<range_value_t<Rng> &, range_reference_t<Rng>>)
         {
             if(!cache_)
@@ -55,7 +56,8 @@ namespace ranges
         }
         CPP_member
         auto update_(range_reference_t<Rng> && val) //
-            -> CPP_ret(void)( //
+            -> CPP_ret(void)(
+                /// \pre
                 requires (!assignable_from<range_value_t<Rng> &, range_reference_t<Rng>>))
         {
             cache_.emplace(static_cast<range_reference_t<Rng> &&>(val));
@@ -117,14 +119,16 @@ namespace ranges
             }
             CPP_member
             auto distance_to(cursor const & that) const //
-                -> CPP_ret(difference_type)( //
+                -> CPP_ret(difference_type)(
+                    /// \pre
                     requires sized_sentinel_for<iterator_t<Rng>, iterator_t<Rng>>)
             {
                 return that.current_ - current_;
             }
             CPP_member
             auto distance_to(sentinel const & that) const //
-                -> CPP_ret(difference_type)( //
+                -> CPP_ret(difference_type)(
+                    /// \pre
                     requires sized_sentinel_for<sentinel_t<Rng>, iterator_t<Rng>>)
             {
                 return that.last_ - current_;
@@ -156,7 +160,9 @@ namespace ranges
           : rng_{std::move(rng)}
         {}
         CPP_member
-        constexpr auto CPP_fun(size)()(requires sized_range<Rng>)
+        constexpr auto CPP_fun(size)()(
+            /// \pre
+            requires sized_range<Rng>)
         {
             return ranges::size(rng_);
         }
@@ -177,9 +183,10 @@ namespace ranges
             /// recomputation. This can be useful in adaptor pipelines that include
             /// combinations of \c view::filter and \c view::transform, for instance.
             /// \note \c views::cache1 is always single-pass.
-            template(typename Rng)( //
-                requires viewable_range<Rng> AND input_range<Rng> AND //
-                    constructible_from<range_value_t<Rng>, range_reference_t<Rng>>) //
+            template(typename Rng)(
+                /// \pre
+                requires viewable_range<Rng> AND input_range<Rng> AND
+                    constructible_from<range_value_t<Rng>, range_reference_t<Rng>>)
             constexpr cache1_view<all_t<Rng>> operator()(Rng && rng) const //
             {
                 return cache1_view<all_t<Rng>>{all(static_cast<Rng &&>(rng))};

--- a/include/range/v3/view/cartesian_product.hpp
+++ b/include/range/v3/view/cartesian_product.hpp
@@ -57,9 +57,10 @@ namespace ranges
 
         struct cartesian_size_fn
         {
-            template(typename Size, typename Rng)( //
-                requires integer_like_<Size> AND sized_range<Rng> AND //
-                    common_with<Size, range_size_t<Rng>>) //
+            template(typename Size, typename Rng)(
+                /// \pre
+                requires integer_like_<Size> AND sized_range<Rng> AND
+                    common_with<Size, range_size_t<Rng>>)
             common_type_t<Size, range_size_t<Rng>> operator()(Size s, Rng && rng) const
             {
                 using S = common_type_t<Size, range_size_t<Rng>>;
@@ -321,7 +322,8 @@ namespace ranges
                     meta::bool_<
                         common_range<meta::at_c<meta::list<constify_if<Views>...>, 0>>>{})
             {}
-            template(bool Other)( //
+            template(bool Other)(
+                /// \pre
                 requires IsConst_ AND CPP_NOT(Other)) //
             cursor(cursor<Other> that)
               : view_(that.view_)
@@ -344,7 +346,8 @@ namespace ranges
                 return equal_(that, meta::size_t<sizeof...(Views)>{});
             }
             CPP_member
-            auto prev() -> CPP_ret(void)( //
+            auto prev() -> CPP_ret(void)(
+                /// \pre
                 requires cartesian_produce_view_can_bidi<IsConst, Views...>)
             {
                 prev_(meta::size_t<sizeof...(Views)>{});
@@ -357,7 +360,8 @@ namespace ranges
             }
             CPP_member
             auto advance(difference_type n) //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires cartesian_produce_view_can_random<IsConst, Views...>)
             {
                 advance_(meta::size_t<sizeof...(Views)>{}, n);
@@ -369,28 +373,32 @@ namespace ranges
         }
         CPP_member
         auto begin_cursor() const //
-            -> CPP_ret(cursor<true>)( //
+            -> CPP_ret(cursor<true>)(
+                /// \pre
                 requires cartesian_produce_view_can_const<Views...>)
         {
             return cursor<true>{begin_tag{}, this};
         }
         CPP_member
         auto end_cursor() //
-            -> CPP_ret(cursor<false>)( //
+            -> CPP_ret(cursor<false>)(
+                /// \pre
                 requires cartesian_produce_view_can_bidi<std::false_type, Views...>)
         {
             return cursor<false>{end_tag{}, this};
         }
         CPP_member
         auto end_cursor() const //
-            -> CPP_ret(cursor<true>)( //
+            -> CPP_ret(cursor<true>)(
+                /// \pre
                 requires cartesian_produce_view_can_bidi<std::true_type, Views...>)
         {
             return cursor<true>{end_tag{}, this};
         }
         CPP_member
         auto end_cursor() const //
-            -> CPP_ret(default_sentinel_t)( //
+            -> CPP_ret(default_sentinel_t)(
+                /// \pre
                 requires (!cartesian_produce_view_can_bidi<std::true_type, Views...>))
         {
             return {};
@@ -401,7 +409,8 @@ namespace ranges
         constexpr explicit cartesian_product_view(Views... views)
           : views_{detail::move(views)...}
         {}
-        template(int = 42)(            //
+        template(int = 42)(
+            /// \pre
             requires (my_cardinality >= 0)) //
             static constexpr std::size_t size() noexcept
         {
@@ -415,8 +424,10 @@ namespace ranges
             return tuple_foldl(views_, std::uintmax_t{1}, detail::cartesian_size_fn{});
         }
         CPP_member
-        auto CPP_fun(size)()(requires(my_cardinality < 0) &&
-                             cartesian_produce_view_can_size<std::false_type, Views...>)
+        auto CPP_fun(size)()(
+            /// \pre
+            requires (my_cardinality < 0) &&
+                cartesian_produce_view_can_size<std::false_type, Views...>)
         {
             return tuple_foldl(views_, std::uintmax_t{1}, detail::cartesian_size_fn{});
         }
@@ -436,9 +447,10 @@ namespace ranges
             {
                 return {};
             }
-            template(typename... Rngs)( //
-                requires (sizeof...(Rngs) != 0) AND //
-                concepts::and_v<(forward_range<Rngs> && viewable_range<Rngs>)...>) //
+            template(typename... Rngs)(
+                /// \pre
+                requires (sizeof...(Rngs) != 0) AND
+                concepts::and_v<(forward_range<Rngs> && viewable_range<Rngs>)...>)
             constexpr cartesian_product_view<all_t<Rngs>...> operator()(Rngs &&... rngs)
                 const
             {
@@ -446,16 +458,18 @@ namespace ranges
                     all(static_cast<Rngs &&>(rngs))...};
             }
 #if defined(_MSC_VER)
-            template(typename Rng0)( //
-                requires forward_range<Rng0> AND viewable_range<Rng0>) //
+            template(typename Rng0)(
+                /// \pre
+                requires forward_range<Rng0> AND viewable_range<Rng0>)
             constexpr cartesian_product_view<all_t<Rng0>> operator()(Rng0 && rng0) const
             {
                 return cartesian_product_view<all_t<Rng0>>{
                     all(static_cast<Rng0 &&>(rng0))};
             }
-            template(typename Rng0, typename Rng1)( //
-                requires forward_range<Rng0> AND viewable_range<Rng0> AND   //
-                             forward_range<Rng1> AND viewable_range<Rng1>) //
+            template(typename Rng0, typename Rng1)(
+                /// \pre
+                requires forward_range<Rng0> AND viewable_range<Rng0> AND
+                             forward_range<Rng1> AND viewable_range<Rng1>)
             constexpr cartesian_product_view<all_t<Rng0>, all_t<Rng1>> //
             operator()(Rng0 && rng0, Rng1 && rng1) const
             {
@@ -463,10 +477,11 @@ namespace ranges
                     all(static_cast<Rng0 &&>(rng0)), //
                     all(static_cast<Rng1 &&>(rng1))};
             }
-            template(typename Rng0, typename Rng1, typename Rng2)( //
-                requires forward_range<Rng0> AND viewable_range<Rng0> AND //
-                    forward_range<Rng1> AND viewable_range<Rng1> AND //
-                    forward_range<Rng2> AND viewable_range<Rng2>) //
+            template(typename Rng0, typename Rng1, typename Rng2)(
+                /// \pre
+                requires forward_range<Rng0> AND viewable_range<Rng0> AND
+                    forward_range<Rng1> AND viewable_range<Rng1> AND
+                    forward_range<Rng2> AND viewable_range<Rng2>)
             constexpr cartesian_product_view<all_t<Rng0>, all_t<Rng1>, all_t<Rng2>> //
             operator()(Rng0 && rng0, Rng1 && rng1, Rng2 && rng2) const
             {

--- a/include/range/v3/view/chunk.hpp
+++ b/include/range/v3/view/chunk.hpp
@@ -126,7 +126,8 @@ namespace ranges
               , n_((RANGES_EXPECT(0 < cv->n_), cv->n_))
               , end_(ranges::end(cv->base()))
             {}
-            template(bool Other)( //
+            template(bool Other)(
+                /// \pre
                 requires Const AND CPP_NOT(Other)) //
             constexpr adaptor(adaptor<Other> that)
               : box<offset_t<Const>>(that.offset())
@@ -148,7 +149,8 @@ namespace ranges
             }
             CPP_member
             constexpr auto prev(iterator_t<CRng> & it) //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires bidirectional_range<CRng>)
             {
                 ranges::advance(it, -n_ + offset());
@@ -158,7 +160,8 @@ namespace ranges
             constexpr auto distance_to(iterator_t<CRng> const & here,
                                        iterator_t<CRng> const & there,
                                        adaptor const & that) const
-                -> CPP_ret(range_difference_t<Rng>)( //
+                -> CPP_ret(range_difference_t<Rng>)(
+                    /// \pre
                     requires (detail::can_sized_sentinel_<Rng, Const>()))
             {
                 auto const delta = (there - here) + (that.offset() - offset());
@@ -170,7 +173,8 @@ namespace ranges
             }
             CPP_member
             constexpr auto advance(iterator_t<CRng> & it, range_difference_t<Rng> n) //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires random_access_range<CRng>)
             {
                 using Limits = std::numeric_limits<range_difference_t<CRng>>;
@@ -197,7 +201,8 @@ namespace ranges
         }
         CPP_member
         constexpr auto begin_adaptor() const //
-            -> CPP_ret(adaptor<true>)( //
+            -> CPP_ret(adaptor<true>)(
+                /// \pre
                 requires forward_range<Rng const>)
         {
             return adaptor<true>{this};
@@ -216,12 +221,16 @@ namespace ranges
           , n_((RANGES_EXPECT(0 < n), n))
         {}
         CPP_member
-        constexpr auto CPP_fun(size)()(const requires sized_range<Rng const>)
+        constexpr auto CPP_fun(size)()(const
+            /// \pre
+            requires sized_range<Rng const>)
         {
             return size_(ranges::size(this->base()));
         }
         CPP_member
-        constexpr auto CPP_fun(size)()(requires sized_range<Rng>)
+        constexpr auto CPP_fun(size)()(
+            /// \pre
+            requires sized_range<Rng>)
         {
             return size_(ranges::size(this->base()));
         }
@@ -293,7 +302,8 @@ namespace ranges
                 }
                 CPP_member
                 constexpr auto distance_to(default_sentinel_t) const
-                    -> CPP_ret(range_difference_t<Rng>)( //
+                    -> CPP_ret(range_difference_t<Rng>)(
+                        /// \pre
                         requires sized_sentinel_for<sentinel_t<Rng>, iterator_t<Rng>>)
                 {
                     RANGES_EXPECT(rng_);
@@ -308,6 +318,7 @@ namespace ranges
                 {}
                 CPP_member
                 constexpr auto CPP_fun(size)()(
+                    /// \pre
                     requires sized_sentinel_for<sentinel_t<Rng>, iterator_t<Rng>>)
                 {
                     using size_type = detail::iter_size_t<iterator_t<Rng>>;
@@ -346,7 +357,8 @@ namespace ranges
             }
             CPP_member
             constexpr auto distance_to(default_sentinel_t) const
-                -> CPP_ret(range_difference_t<Rng>)( //
+                -> CPP_ret(range_difference_t<Rng>)(
+                    /// \pre
                     requires sized_sentinel_for<sentinel_t<Rng>, iterator_t<Rng>>)
             {
                 RANGES_EXPECT(rng_);
@@ -382,12 +394,16 @@ namespace ranges
           , it_cache_{nullopt}
         {}
         CPP_member
-        constexpr auto CPP_fun(size)()(const requires sized_range<Rng const>)
+        constexpr auto CPP_fun(size)()(const
+            /// \pre
+            requires sized_range<Rng const>)
         {
             return size_(ranges::size(base_));
         }
         CPP_member
-        constexpr auto CPP_fun(size)()(requires sized_range<Rng>)
+        constexpr auto CPP_fun(size)()(
+            /// \pre
+            requires sized_range<Rng>)
         {
             return size_(ranges::size(base_));
         }
@@ -413,7 +429,7 @@ namespace ranges
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
     template<typename Rng>
-    chunk_view(Rng &&, range_difference_t<Rng>) //
+    chunk_view(Rng &&, range_difference_t<Rng>)
         -> chunk_view<views::all_t<Rng>>;
 #endif
 
@@ -424,8 +440,9 @@ namespace ranges
         //                       The last range may have fewer.
         struct chunk_base_fn
         {
-            template(typename Rng)( //
-                requires viewable_range<Rng> AND input_range<Rng>) //
+            template(typename Rng)(
+                /// \pre
+                requires viewable_range<Rng> AND input_range<Rng>)
             constexpr chunk_view<all_t<Rng>> //
             operator()(Rng && rng, range_difference_t<Rng> n) const
             {
@@ -437,7 +454,8 @@ namespace ranges
         {
             using chunk_base_fn::operator();
 
-            template(typename Int)( //
+            template(typename Int)(
+                /// \pre
                 requires detail::integer_like_<Int>)
             constexpr auto operator()(Int n) const
             {

--- a/include/range/v3/view/common.hpp
+++ b/include/range/v3/view/common.hpp
@@ -71,14 +71,16 @@ namespace ranges
         {
             return ranges::begin(rng_) + ranges::distance(rng_);
         }
-        template(bool Const = true)( //
-            requires Const AND range<meta::const_if_c<Const, Rng>>) //
+        template(bool Const = true)(
+            /// \pre
+            requires Const AND range<meta::const_if_c<Const, Rng>>)
         sentinel_t<meta::const_if_c<Const, Rng>> end_(std::false_type) const
         {
             return ranges::end(rng_);
         }
-        template(bool Const = true)( //
-            requires Const AND range<meta::const_if_c<Const, Rng>>) //
+        template(bool Const = true)(
+            /// \pre
+            requires Const AND range<meta::const_if_c<Const, Rng>>)
         iterator_t<meta::const_if_c<Const, Rng>> end_(std::true_type) const
         {
             return ranges::begin(rng_) + ranges::distance(rng_);
@@ -104,21 +106,25 @@ namespace ranges
                 end_(meta::bool_<detail::random_access_and_sized_range<Rng>>{})};
         }
         CPP_member
-        auto CPP_fun(size)()(requires sized_range<Rng>)
+        auto CPP_fun(size)()(
+            /// \pre
+            requires sized_range<Rng>)
         {
             return ranges::size(rng_);
         }
 
-        template(bool Const = true)( //
-            requires range<meta::const_if_c<Const, Rng>>) //
+        template(bool Const = true)(
+            /// \pre
+            requires range<meta::const_if_c<Const, Rng>>)
         auto begin() const
             -> detail::common_view_iterator_t<meta::const_if_c<Const, Rng>>
         {
             return detail::common_view_iterator_t<meta::const_if_c<Const, Rng>>{
                 ranges::begin(rng_)};
         }
-        template(bool Const = true)( //
-            requires range<meta::const_if_c<Const, Rng>>) //
+        template(bool Const = true)(
+            /// \pre
+            requires range<meta::const_if_c<Const, Rng>>)
         auto end() const
             -> detail::common_view_iterator_t<meta::const_if_c<Const, Rng>>
         {
@@ -127,7 +133,9 @@ namespace ranges
                          meta::const_if_c<Const, Rng>>>{})};
         }
         CPP_member
-        auto CPP_fun(size)()(const requires sized_range<Rng const>)
+        auto CPP_fun(size)()(const
+            /// \pre
+            requires sized_range<Rng const>)
         {
             return ranges::size(rng_);
         }
@@ -138,7 +146,8 @@ namespace ranges
         enable_borrowed_range<Rng>;
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-    template(typename Rng)(       //
+    template(typename Rng)(
+        /// \pre
         requires (!common_range<Rng>)) //
         common_view(Rng &&)
             ->common_view<views::all_t<Rng>>;
@@ -155,14 +164,16 @@ namespace ranges
     {
         struct cpp20_common_fn
         {
-            template(typename Rng)( //
-                requires viewable_range<Rng> AND common_range<Rng>) //
+            template(typename Rng)(
+                /// \pre
+                requires viewable_range<Rng> AND common_range<Rng>)
             all_t<Rng> operator()(Rng && rng) const
             {
                 return all(static_cast<Rng &&>(rng));
             }
 
-            template(typename Rng)( //
+            template(typename Rng)(
+                /// \pre
                 requires viewable_range<Rng> AND (!common_range<Rng>)) //
             common_view<all_t<Rng>> operator()(Rng && rng) const
             {
@@ -172,8 +183,9 @@ namespace ranges
 
         struct common_fn
         {
-            template(typename Rng)( //
-                requires viewable_range<Rng>) //
+            template(typename Rng)(
+                /// \pre
+                requires viewable_range<Rng>)
             common_view<all_t<Rng>> operator()(Rng && rng) const
             {
                 return common_view<all_t<Rng>>{all(static_cast<Rng &&>(rng))};
@@ -217,7 +229,8 @@ namespace ranges
             RANGES_INLINE_VARIABLE(
                 ranges::views::view_closure<ranges::views::cpp20_common_fn>, common)
         }
-        template(typename Rng)(                      //
+        template(typename Rng)(
+            /// \pre
             requires view_<Rng> && (!common_range<Rng>)) //
             using common_view = ranges::common_view<Rng>;
     } // namespace cpp20

--- a/include/range/v3/view/concat.hpp
+++ b/include/range/v3/view/concat.hpp
@@ -93,7 +93,8 @@ namespace ranges
             sentinel(concat_view_t * rng, end_tag)
               : end_(end(std::get<cranges - 1>(rng->rngs_)))
             {}
-            template(bool Other)( //
+            template(bool Other)(
+                /// \pre
                 requires IsConst AND CPP_NOT(Other)) //
             sentinel(sentinel<Other> that)
               : end_(std::move(that.end_))
@@ -130,8 +131,9 @@ namespace ranges
             struct next_fun
             {
                 cursor * pos;
-                template(typename I, std::size_t N)( //
-                    requires input_iterator<I>) //
+                template(typename I, std::size_t N)(
+                    /// \pre
+                    requires input_iterator<I>)
                 void operator()(indexed_element<I, N> it) const
                 {
                     RANGES_ASSERT(it.get() != end(std::get<N>(pos->rng_->rngs_)));
@@ -142,15 +144,17 @@ namespace ranges
             struct prev_fun
             {
                 cursor * pos;
-                template(typename I)( //
-                    requires bidirectional_iterator<I>) //
+                template(typename I)(
+                    /// \pre
+                    requires bidirectional_iterator<I>)
                 void operator()(indexed_element<I, 0> it) const
                 {
                     RANGES_ASSERT(it.get() != begin(std::get<0>(pos->rng_->rngs_)));
                     --it.get();
                 }
-                template(typename I, std::size_t N)( //
-                    requires (N != 0) AND bidirectional_iterator<I>) //
+                template(typename I, std::size_t N)(
+                    /// \pre
+                    requires (N != 0) AND bidirectional_iterator<I>)
                 void operator()(indexed_element<I, N> it) const
                 {
                     if(it.get() == begin(std::get<N>(pos->rng_->rngs_)))
@@ -169,14 +173,16 @@ namespace ranges
             {
                 cursor * pos;
                 difference_type n;
-                template(typename I)( //
-                    requires random_access_iterator<I>) //
+                template(typename I)(
+                    /// \pre
+                    requires random_access_iterator<I>)
                 void operator()(indexed_element<I, cranges - 1> it) const
                 {
                     ranges::advance(it.get(), n);
                 }
-                template(typename I, std::size_t N)( //
-                    requires random_access_iterator<I>) //
+                template(typename I, std::size_t N)(
+                    /// \pre
+                    requires random_access_iterator<I>)
                 void operator()(indexed_element<I, N> it) const
                 {
                     auto last = ranges::end(std::get<N>(pos->rng_->rngs_));
@@ -194,14 +200,16 @@ namespace ranges
             {
                 cursor * pos;
                 difference_type n;
-                template(typename I)( //
-                    requires random_access_iterator<I>) //
+                template(typename I)(
+                    /// \pre
+                    requires random_access_iterator<I>)
                 void operator()(indexed_element<I, 0> it) const
                 {
                     ranges::advance(it.get(), n);
                 }
-                template(typename I, std::size_t N)( //
-                    requires random_access_iterator<I>) //
+                template(typename I, std::size_t N)(
+                    /// \pre
+                    requires random_access_iterator<I>)
                 void operator()(indexed_element<I, N> it) const
                 {
                     auto first = ranges::begin(std::get<N>(pos->rng_->rngs_));
@@ -265,7 +273,8 @@ namespace ranges
               : rng_(rng)
               , its_{emplaced_index<cranges - 1>, end(std::get<cranges - 1>(rng->rngs_))}
             {}
-            template(bool Other)(               //
+            template(bool Other)(
+                /// \pre
                 requires IsConst && CPP_NOT(Other)) //
             cursor(cursor<Other> that)
               : rng_(that.rng_)
@@ -283,7 +292,8 @@ namespace ranges
             }
             CPP_member
             auto equal(cursor const & pos) const //
-                -> CPP_ret(bool)( //
+                -> CPP_ret(bool)(
+                    /// \pre
                     requires //
                         equality_comparable<variant<iterator_t<constify_if<Rngs>>...>>)
             {
@@ -296,14 +306,16 @@ namespace ranges
             }
             CPP_member
             auto prev() //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires and_v<bidirectional_range<Rngs>...>)
             {
                 its_.visit_i(prev_fun{this});
             }
             CPP_member
             auto advance(difference_type n) //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires and_v<random_access_range<Rngs>...>)
             {
                 if(n > 0)
@@ -313,7 +325,8 @@ namespace ranges
             }
             CPP_member
             auto distance_to(cursor const & that) const //
-                -> CPP_ret(difference_type)( //
+                -> CPP_ret(difference_type)(
+                    /// \pre
                     requires and_v<sized_sentinel_for<iterator_t<Rngs>,
                                                       iterator_t<Rngs>>...>)
             {
@@ -335,7 +348,8 @@ namespace ranges
         }
         CPP_member
         auto begin_cursor() const //
-            -> CPP_ret(cursor<true>)( //
+            -> CPP_ret(cursor<true>)(
+                /// \pre
                 requires and_v<range<Rngs const>...>)
         {
             return {this, begin_tag{}};
@@ -345,7 +359,8 @@ namespace ranges
             -> CPP_ret(
                 meta::if_<meta::and_c<(bool)common_range<Rngs const>...>, //
                           cursor<true>, //
-                          sentinel<true>>)( //
+                          sentinel<true>>)(
+            /// \pre
             requires and_v<range<Rngs const>...>)
         {
             return {this, end_tag{}};
@@ -358,7 +373,8 @@ namespace ranges
         {}
         CPP_member
         constexpr auto size() const //
-            -> CPP_ret(std::size_t)( //
+            -> CPP_ret(std::size_t)(
+                /// \pre
                 requires (detail::concat_cardinality<Rngs...>::value >= 0))
         {
             return static_cast<std::size_t>(detail::concat_cardinality<Rngs...>::value);
@@ -377,6 +393,7 @@ namespace ranges
         }
         CPP_member
         constexpr auto CPP_fun(size)()(
+            /// \pre
             requires (detail::concat_cardinality<Rngs...>::value < 0) &&
             and_v<sized_range<Rngs>...>)
         {
@@ -399,23 +416,26 @@ namespace ranges
     {
         struct concat_fn
         {
-            template(typename... Rngs)( //
-                requires and_v<(viewable_range<Rngs> && input_range<Rngs>)...>) //
+            template(typename... Rngs)(
+                /// \pre
+                requires and_v<(viewable_range<Rngs> && input_range<Rngs>)...>)
             concat_view<all_t<Rngs>...> operator()(Rngs &&... rngs) const
             {
                 return concat_view<all_t<Rngs>...>{all(static_cast<Rngs &&>(rngs))...};
             }
-            template(typename Rng)( //
-                requires viewable_range<Rng> AND input_range<Rng>) //
+            template(typename Rng)(
+                /// \pre
+                requires viewable_range<Rng> AND input_range<Rng>)
             all_t<Rng> operator()(Rng && rng) const //
             {
                 return all(static_cast<Rng &&>(rng));
             }
             // MSVC doesn't like variadics in operator() for some reason
 #if defined(_MSC_VER)
-            template(typename Rng0, typename Rng1)( //
-                requires viewable_range<Rng0> AND input_range<Rng0> AND //
-                        viewable_range<Rng1> AND input_range<Rng1>) //
+            template(typename Rng0, typename Rng1)(
+                /// \pre
+                requires viewable_range<Rng0> AND input_range<Rng0> AND
+                        viewable_range<Rng1> AND input_range<Rng1>)
             concat_view<all_t<Rng0>, all_t<Rng1>> operator()(Rng0 && rng0, Rng1 && rng1)
                 const
             {
@@ -423,10 +443,11 @@ namespace ranges
                     all(static_cast<Rng0 &&>(rng0)),
                     all(static_cast<Rng1 &&>(rng1))};
             }
-            template(typename Rng0, typename Rng1, typename Rng2)( //
-                requires viewable_range<Rng0> AND input_range<Rng0> AND //
-                    viewable_range<Rng1> AND input_range<Rng1> AND //
-                    viewable_range<Rng2> AND input_range<Rng2>) //
+            template(typename Rng0, typename Rng1, typename Rng2)(
+                /// \pre
+                requires viewable_range<Rng0> AND input_range<Rng0> AND
+                    viewable_range<Rng1> AND input_range<Rng1> AND
+                    viewable_range<Rng2> AND input_range<Rng2>)
             concat_view<all_t<Rng0>, all_t<Rng1>, all_t<Rng2>> //
             operator()(Rng0 && rng0, Rng1 && rng1, Rng2 && rng2) const
             {

--- a/include/range/v3/view/const.hpp
+++ b/include/range/v3/view/const.hpp
@@ -50,7 +50,8 @@ namespace ranges
             using rvalue_reference_ =
                 common_reference_t<value_ const &&, range_rvalue_reference_t<CRng>>;
             adaptor() = default;
-            template(bool Other)(       //
+            template(bool Other)(
+                /// \pre
                 requires Const && CPP_NOT(Other)) //
                 constexpr adaptor(adaptor<Other>)
             {}
@@ -70,7 +71,8 @@ namespace ranges
         }
         CPP_member
         auto begin_adaptor() const //
-            -> CPP_ret(adaptor<true>)( //
+            -> CPP_ret(adaptor<true>)(
+                /// \pre
                 requires range<Rng const>)
         {
             return {};
@@ -81,7 +83,8 @@ namespace ranges
         }
         CPP_member
         auto end_adaptor() const //
-            -> CPP_ret(adaptor<true>)( //
+            -> CPP_ret(adaptor<true>)(
+                /// \pre
                 requires range<Rng const>)
         {
             return {};
@@ -93,12 +96,16 @@ namespace ranges
           : const_view::view_adaptor{std::move(rng)}
         {}
         CPP_member
-        constexpr auto CPP_fun(size)()(requires sized_range<Rng>)
+        constexpr auto CPP_fun(size)()(
+            /// \pre
+            requires sized_range<Rng>)
         {
             return ranges::size(this->base());
         }
         CPP_member
-        constexpr auto CPP_fun(size)()(const requires sized_range<Rng const>)
+        constexpr auto CPP_fun(size)()(const
+            /// \pre
+            requires sized_range<Rng const>)
         {
             return ranges::size(this->base());
         }
@@ -118,8 +125,9 @@ namespace ranges
     {
         struct const_fn
         {
-            template(typename Rng)( //
-                requires viewable_range<Rng> AND input_range<Rng>) //
+            template(typename Rng)(
+                /// \pre
+                requires viewable_range<Rng> AND input_range<Rng>)
             const_view<all_t<Rng>> operator()(Rng && rng) const
             {
                 return const_view<all_t<Rng>>{all(static_cast<Rng &&>(rng))};

--- a/include/range/v3/view/counted.hpp
+++ b/include/range/v3/view/counted.hpp
@@ -66,7 +66,7 @@ namespace ranges
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
     template<typename I>
-    counted_view(I, iter_difference_t<I>) //
+    counted_view(I, iter_difference_t<I>)
         -> counted_view<I>;
 #endif
 
@@ -74,15 +74,17 @@ namespace ranges
     {
         struct cpp20_counted_fn
         {
-            template(typename I)( //
+            template(typename I)(
+                /// \pre
                 requires input_or_output_iterator<I> AND (!random_access_iterator<I>)) //
             subrange<counted_iterator<I>, default_sentinel_t> //
             operator()(I it, iter_difference_t<I> n) const
             {
                 return {make_counted_iterator(std::move(it), n), default_sentinel};
             }
-            template(typename I)( //
-                requires random_access_iterator<I>) //
+            template(typename I)(
+                /// \pre
+                requires random_access_iterator<I>)
             subrange<I> operator()(I it, iter_difference_t<I> n) const
             {
                 return {it, it + n};
@@ -91,14 +93,16 @@ namespace ranges
 
         struct counted_fn
         {
-            template(typename I)( //
+            template(typename I)(
+                /// \pre
                 requires input_or_output_iterator<I> AND (!random_access_iterator<I>)) //
             counted_view<I> operator()(I it, iter_difference_t<I> n) const
             {
                 return {std::move(it), n};
             }
-            template(typename I)( //
-                requires random_access_iterator<I>) //
+            template(typename I)(
+                /// \pre
+                requires random_access_iterator<I>)
             subrange<I> operator()(I it, iter_difference_t<I> n) const
             {
                 return {it, it + n};

--- a/include/range/v3/view/cycle.hpp
+++ b/include/range/v3/view/cycle.hpp
@@ -100,7 +100,8 @@ namespace ranges
               : rng_(rng)
               , it_(ranges::begin(rng->rng_))
             {}
-            template(bool Other)( //
+            template(bool Other)(
+                /// \pre
                 requires IsConst AND CPP_NOT(Other)) //
             cursor(cursor<Other> that)
               : rng_(that.rng_)
@@ -114,7 +115,8 @@ namespace ranges
             // clang-format on
             CPP_member
             auto equal(cursor const & pos) const //
-                -> CPP_ret(bool)( //
+                -> CPP_ret(bool)(
+                    /// \pre
                     requires equality_comparable<iterator>)
             {
                 RANGES_EXPECT(rng_ == pos.rng_);
@@ -133,7 +135,8 @@ namespace ranges
             }
             CPP_member
             auto prev() //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires bidirectional_range<CRng>)
             {
                 if(it_ == ranges::begin(rng_->rng_))
@@ -144,7 +147,8 @@ namespace ranges
                 }
                 --it_;
             }
-            template(typename Diff)( //
+            template(typename Diff)(
+                /// \pre
                 requires random_access_range<CRng> AND
                     detail::integer_like_<Diff>) void advance(Diff n)
             {
@@ -174,14 +178,16 @@ namespace ranges
 
         CPP_member
         auto begin_cursor() //
-            -> CPP_ret(cursor<false>)( //
+            -> CPP_ret(cursor<false>)(
+                /// \pre
                 requires (!simple_view<Rng>() || !common_range<Rng const>))
         {
             return {this};
         }
         CPP_member
         auto begin_cursor() const //
-            -> CPP_ret(cursor<true>)( //
+            -> CPP_ret(cursor<true>)(
+                /// \pre
                 requires common_range<Rng const>)
         {
             return {this};
@@ -221,8 +227,9 @@ namespace ranges
         struct cycle_fn
         {
             /// \pre <tt>!empty(rng)</tt>
-            template(typename Rng)( //
-                requires viewable_range<Rng> AND forward_range<Rng>) //
+            template(typename Rng)(
+                /// \pre
+                requires viewable_range<Rng> AND forward_range<Rng>)
             cycled_view<all_t<Rng>> operator()(Rng && rng) const
             {
                 return cycled_view<all_t<Rng>>{all(static_cast<Rng &&>(rng))};

--- a/include/range/v3/view/delimit.hpp
+++ b/include/range/v3/view/delimit.hpp
@@ -77,7 +77,8 @@ namespace ranges
         enable_borrowed_range<Rng>;
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-    template(typename Rng, typename Val)( //
+    template(typename Rng, typename Val)(
+        /// \pre
         requires copy_constructible<Val>)
     delimit_view(Rng &&, Val)
         -> delimit_view<views::all_t<Rng>, Val>;
@@ -87,19 +88,21 @@ namespace ranges
     {
         struct delimit_base_fn
         {
-            template(typename I_, typename Val, typename I = detail::decay_t<I_>)( //
+            template(typename I_, typename Val, typename I = detail::decay_t<I_>)(
+                /// \pre
                 requires (!range<I_>) AND convertible_to<I_, I> AND input_iterator<I> AND
-                    semiregular<Val> AND //
-                    equality_comparable_with<Val, iter_reference_t<I>>) //
+                    semiregular<Val> AND
+                    equality_comparable_with<Val, iter_reference_t<I>>)
             constexpr auto operator()(I_ && begin_, Val value) const
                 -> delimit_view<subrange<I, unreachable_sentinel_t>, Val>
             {
                 return {{static_cast<I_ &&>(begin_), {}}, std::move(value)};
             }
 
-            template(typename Rng, typename Val)( //
+            template(typename Rng, typename Val)(
+                /// \pre
                 requires viewable_range<Rng> AND input_range<Rng> AND semiregular<
-                        Val> AND equality_comparable_with<Val, range_reference_t<Rng>>) //
+                        Val> AND equality_comparable_with<Val, range_reference_t<Rng>>)
             constexpr auto operator()(Rng && rng, Val value) const //
                 -> delimit_view<all_t<Rng>, Val>
             {

--- a/include/range/v3/view/drop.hpp
+++ b/include/range/v3/view/drop.hpp
@@ -52,8 +52,9 @@ namespace ranges
         Rng rng_;
         difference_type_ n_;
 
-        template(bool Const = true)( //
-            requires Const AND range<meta::const_if_c<Const, Rng>>) //
+        template(bool Const = true)(
+            /// \pre
+            requires Const AND range<meta::const_if_c<Const, Rng>>)
         iterator_t<meta::const_if_c<Const, Rng>> //
         get_begin_(std::true_type, std::true_type) const
         {
@@ -93,14 +94,16 @@ namespace ranges
         {
             return ranges::end(rng_);
         }
-        template(bool Const = true)( //
-            requires Const AND random_access_range<meta::const_if_c<Const, Rng>>) //
+        template(bool Const = true)(
+            /// \pre
+            requires Const AND random_access_range<meta::const_if_c<Const, Rng>>)
         iterator_t<meta::const_if_c<Const, Rng>> begin() const
         {
             return this->get_begin_(std::true_type{}, std::true_type{});
         }
-        template(bool Const = true)( //
-            requires Const AND random_access_range<meta::const_if_c<Const, Rng>>) //
+        template(bool Const = true)(
+            /// \pre
+            requires Const AND random_access_range<meta::const_if_c<Const, Rng>>)
         sentinel_t<meta::const_if_c<Const, Rng>> end() const
         {
             return ranges::end(rng_);
@@ -114,7 +117,8 @@ namespace ranges
             return s < n ? 0 : s - n;
         }
         CPP_member
-        auto CPP_fun(size)()( //
+        auto CPP_fun(size)()(
+            /// \pre
             requires sized_range<Rng>)
         {
             auto const s = ranges::size(rng_);
@@ -133,7 +137,7 @@ namespace ranges
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
     template<typename Rng>
-    drop_view(Rng &&, range_difference_t<Rng>) //
+    drop_view(Rng &&, range_difference_t<Rng>)
         -> drop_view<views::all_t<Rng>>;
 #endif
 
@@ -148,8 +152,9 @@ namespace ranges
             {
                 return {all(static_cast<Rng &&>(rng)), n};
             }
-            template(typename Rng)( //
-                requires borrowed_range<Rng> AND sized_range<Rng>) //
+            template(typename Rng)(
+                /// \pre
+                requires borrowed_range<Rng> AND sized_range<Rng>)
             static subrange<iterator_t<Rng>, sentinel_t<Rng>> //
             impl_(Rng && rng, range_difference_t<Rng> n, random_access_range_tag)
             {
@@ -157,7 +162,8 @@ namespace ranges
             }
 
         public:
-            template(typename Rng)( //
+            template(typename Rng)(
+                /// \pre
                 requires viewable_range<Rng> AND input_range<Rng>)
             auto operator()(Rng && rng, range_difference_t<Rng> n) const
             {
@@ -170,7 +176,8 @@ namespace ranges
         {
             using drop_base_fn::operator();
 
-            template(typename Int)( //
+            template(typename Int)(
+                /// \pre
                 requires detail::integer_like_<Int>)
             constexpr auto operator()(Int n) const
             {
@@ -189,8 +196,9 @@ namespace ranges
         {
             using ranges::views::drop;
         }
-        template(typename Rng)( //
-            requires view_<Rng>)    //
+        template(typename Rng)(
+            /// \pre
+            requires view_<Rng>)
             using drop_view = ranges::drop_view<Rng>;
     } // namespace cpp20
     /// @}

--- a/include/range/v3/view/drop_exactly.hpp
+++ b/include/range/v3/view/drop_exactly.hpp
@@ -52,8 +52,9 @@ namespace ranges
         difference_type_ n_;
 
         // random_access_range == true
-        template(bool Const = true)( //
-            requires Const AND random_access_range<meta::const_if_c<Const, Rng>>) //
+        template(bool Const = true)(
+            /// \pre
+            requires Const AND random_access_range<meta::const_if_c<Const, Rng>>)
         iterator_t<meta::const_if_c<Const, Rng>> get_begin_(std::true_type) const
         {
             return next(ranges::begin(rng_), n_);
@@ -89,25 +90,31 @@ namespace ranges
         {
             return ranges::end(rng_);
         }
-        template(bool Const = true)( //
-            requires Const AND random_access_range<meta::const_if_c<Const, Rng>>) //
+        template(bool Const = true)(
+            /// \pre
+            requires Const AND random_access_range<meta::const_if_c<Const, Rng>>)
         iterator_t<meta::const_if_c<Const, Rng>> begin() const
         {
             return this->get_begin_(std::true_type{});
         }
-        template(bool Const = true)( //
-            requires Const AND random_access_range<meta::const_if_c<Const, Rng>>) //
+        template(bool Const = true)(
+            /// \pre
+            requires Const AND random_access_range<meta::const_if_c<Const, Rng>>)
         sentinel_t<meta::const_if_c<Const, Rng>> end() const
         {
             return ranges::end(rng_);
         }
         CPP_member
-        auto CPP_fun(size)()(const requires sized_range<Rng const>)
+        auto CPP_fun(size)()(const
+            /// \pre
+            requires sized_range<Rng const>)
         {
             return ranges::size(rng_) - static_cast<range_size_t<Rng const>>(n_);
         }
         CPP_member
-        auto CPP_fun(size)()(requires sized_range<Rng>)
+        auto CPP_fun(size)()(
+            /// \pre
+            requires sized_range<Rng>)
         {
             return ranges::size(rng_) - static_cast<range_size_t<Rng>>(n_);
         }
@@ -138,8 +145,9 @@ namespace ranges
             {
                 return {all(static_cast<Rng &&>(rng)), n};
             }
-            template(typename Rng)( //
-                requires borrowed_range<Rng>) //
+            template(typename Rng)(
+                /// \pre
+                requires borrowed_range<Rng>)
             static subrange<iterator_t<Rng>, sentinel_t<Rng>> //
             impl_(Rng && rng, range_difference_t<Rng> n, random_access_range_tag)
             {
@@ -147,7 +155,8 @@ namespace ranges
             }
 
         public:
-            template(typename Rng)( //
+            template(typename Rng)(
+                /// \pre
                 requires viewable_range<Rng> AND input_range<Rng>)
             auto operator()(Rng && rng, range_difference_t<Rng> n) const
             {
@@ -160,7 +169,8 @@ namespace ranges
         {
             using drop_exactly_base_fn::operator();
 
-            template(typename Int)( //
+            template(typename Int)(
+                /// \pre
                 requires detail::integer_like_<Int>)
             constexpr auto operator()(Int n) const
             {

--- a/include/range/v3/view/drop_last.hpp
+++ b/include/range/v3/view/drop_last.hpp
@@ -54,15 +54,17 @@ namespace ranges
                 return initial_size > n ? initial_size - n : 0;
             }
 
-            template(typename Rng)( //
-                requires random_access_range<Rng> AND sized_range<Rng>) //
+            template(typename Rng)(
+                /// \pre
+                requires random_access_range<Rng> AND sized_range<Rng>)
             iterator_t<Rng> get_end(Rng & rng, range_difference_t<Rng> n, int)
             {
                 return begin(rng) + static_cast<range_difference_t<Rng>>(
                                         drop_last_view::get_size(rng, n));
             }
-            template(typename Rng)( //
-                requires bidirectional_range<Rng> AND common_range<Rng>) //
+            template(typename Rng)(
+                /// \pre
+                requires bidirectional_range<Rng> AND common_range<Rng>)
             iterator_t<Rng> get_end(Rng & rng, range_difference_t<Rng> n, long)
             {
                 return prev(end(rng), n, begin(rng));
@@ -158,21 +160,24 @@ namespace ranges
                 end_ = detail::drop_last_view::get_end(rng_, n_, 0);
             return *end_;
         }
-        template(typename CRng = Rng const)( //
-            requires random_access_range<CRng> AND sized_range<CRng>) //
+        template(typename CRng = Rng const)(
+            /// \pre
+            requires random_access_range<CRng> AND sized_range<CRng>)
         iterator_t<CRng> begin() const
         {
             return ranges::begin(rng_);
         }
-        template(typename CRng = Rng const)( //
-            requires random_access_range<CRng> AND sized_range<CRng>) //
+        template(typename CRng = Rng const)(
+            /// \pre
+            requires random_access_range<CRng> AND sized_range<CRng>)
         iterator_t<CRng> end() const
         {
             return detail::drop_last_view::get_end(rng_, n_, 0);
         }
 
         CPP_member
-        auto CPP_fun(size)()( //
+        auto CPP_fun(size)()(
+            /// \pre
             requires sized_range<Rng>)
         {
             return detail::drop_last_view::get_size(rng_, n_);
@@ -256,7 +261,8 @@ namespace ranges
         }
 
         CPP_member
-        auto CPP_fun(size)()( //
+        auto CPP_fun(size)()(
+            /// \pre
             requires sized_range<Rng>)
         {
             return detail::drop_last_view::get_size(this->base(), n_);
@@ -295,8 +301,9 @@ namespace ranges
         {
             return {ranges::begin(rng_), static_cast<difference_t>(size())};
         }
-        template(typename CRng = Rng const)( //
-            requires sized_range<CRng>) //
+        template(typename CRng = Rng const)(
+            /// \pre
+            requires sized_range<CRng>)
         counted_iterator<iterator_t<CRng>> begin() const
         {
             return {ranges::begin(rng_), static_cast<difference_t>(size())};
@@ -332,7 +339,7 @@ namespace ranges
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
     template<typename Rng>
-    drop_last_view(Rng &&, range_difference_t<Rng>) //
+    drop_last_view(Rng &&, range_difference_t<Rng>)
         -> drop_last_view<views::all_t<Rng>>;
 #endif
 
@@ -340,8 +347,9 @@ namespace ranges
     {
         struct drop_last_base_fn
         {
-            template(typename Rng)( //
-                requires sized_range<Rng> || forward_range<Rng>) //
+            template(typename Rng)(
+                /// \pre
+                requires sized_range<Rng> || forward_range<Rng>)
             constexpr auto operator()(Rng && rng, range_difference_t<Rng> n) const
                 -> drop_last_view<all_t<Rng>>
             {
@@ -353,7 +361,8 @@ namespace ranges
         {
             using drop_last_base_fn::operator();
 
-            template(typename Int)( //
+            template(typename Int)(
+                /// \pre
                 requires detail::integer_like_<Int>)
             constexpr auto operator()(Int n) const
             {

--- a/include/range/v3/view/drop_while.hpp
+++ b/include/range/v3/view/drop_while.hpp
@@ -82,7 +82,8 @@ namespace ranges
         enable_borrowed_range<Rng>;
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-    template(typename Rng, typename Fun)( //
+    template(typename Rng, typename Fun)(
+        /// \pre
         requires copy_constructible<Fun>)
     drop_while_view(Rng &&, Fun)
         -> drop_while_view<views::all_t<Rng>, Fun>;
@@ -96,17 +97,19 @@ namespace ranges
     {
         struct drop_while_base_fn
         {
-            template(typename Rng, typename Pred)( //
-                requires viewable_range<Rng> AND input_range<Rng> AND //
-                    indirect_unary_predicate<Pred, iterator_t<Rng>>) //
+            template(typename Rng, typename Pred)(
+                /// \pre
+                requires viewable_range<Rng> AND input_range<Rng> AND
+                    indirect_unary_predicate<Pred, iterator_t<Rng>>)
             auto operator()(Rng && rng, Pred pred) const
                 -> drop_while_view<all_t<Rng>, Pred>
             {
                 return {all(static_cast<Rng &&>(rng)), std::move(pred)};
             }
-            template(typename Rng, typename Pred, typename Proj)( //
-                requires viewable_range<Rng> AND input_range<Rng> AND //
-                    indirect_unary_predicate<composed<Pred, Proj>, iterator_t<Rng>>) //
+            template(typename Rng, typename Pred, typename Proj)(
+                /// \pre
+                requires viewable_range<Rng> AND input_range<Rng> AND
+                    indirect_unary_predicate<composed<Pred, Proj>, iterator_t<Rng>>)
             auto operator()(Rng && rng, Pred pred, Proj proj) const
                 -> drop_while_view<all_t<Rng>, composed<Pred, Proj>>
             {
@@ -123,7 +126,8 @@ namespace ranges
                 return make_view_closure(
                     bind_back(drop_while_base_fn{}, std::move(pred)));
             }
-            template(typename Pred, typename Proj)( //
+            template(typename Pred, typename Proj)(
+                /// \pre
                 requires (!range<Pred>)) // TODO: underconstrained
             constexpr auto operator()(Pred && pred, Proj proj) const
             {
@@ -150,9 +154,10 @@ namespace ranges
         {
             using ranges::views::drop_while;
         }
-        template(typename Rng, typename Pred)( //
+        template(typename Rng, typename Pred)(
+            /// \pre
             requires viewable_range<Rng> AND input_range<Rng> AND
-                indirect_unary_predicate<Pred, iterator_t<Rng>>) //
+                indirect_unary_predicate<Pred, iterator_t<Rng>>)
             using drop_while_view = ranges::drop_while_view<Rng, Pred>;
     } // namespace cpp20
     /// @}

--- a/include/range/v3/view/empty.hpp
+++ b/include/range/v3/view/empty.hpp
@@ -70,7 +70,8 @@ namespace ranges
         {
             using ranges::views::empty;
         }
-        template(typename T)(              //
+        template(typename T)(
+            /// \pre
             requires std::is_object<T>::value) //
             using empty_view = ranges::empty_view<T>;
     } // namespace cpp20

--- a/include/range/v3/view/enumerate.hpp
+++ b/include/range/v3/view/enumerate.hpp
@@ -95,7 +95,8 @@ namespace ranges
         /// its corresponding index.
         struct enumerate_fn
         {
-            template(typename Rng)( //
+            template(typename Rng)(
+                /// \pre
                 requires viewable_range<Rng>)
             auto operator()(Rng && rng) const
             {

--- a/include/range/v3/view/exclusive_scan.hpp
+++ b/include/range/v3/view/exclusive_scan.hpp
@@ -82,7 +82,8 @@ namespace ranges
             adaptor(exclusive_scan_view_t * rng)
               : rng_(rng)
             {}
-            template(bool Other)( //
+            template(bool Other)(
+                /// \pre
                 requires IsConst AND CPP_NOT(Other)) //
             adaptor(adaptor<Other> that)
               : rng_(that.rng_)
@@ -115,14 +116,16 @@ namespace ranges
         }
         CPP_member
         auto begin_adaptor() const //
-            -> CPP_ret(adaptor<true>)( //
+            -> CPP_ret(adaptor<true>)(
+                /// \pre
                 requires exclusive_scan_constraints<Rng const, T, Fun const>)
         {
             return {this};
         }
         CPP_member
         auto end_adaptor() const
-            -> CPP_ret(meta::if_<use_sentinel_t, adaptor_base, adaptor<true>>)( //
+            -> CPP_ret(meta::if_<use_sentinel_t, adaptor_base, adaptor<true>>)(
+                /// \pre
                 requires exclusive_scan_constraints<Rng const, T, Fun const>)
         {
             return {this};
@@ -136,21 +139,24 @@ namespace ranges
           , fun_(std::move(fun))
         {}
         CPP_member
-        auto CPP_fun(size)()(const //
+        auto CPP_fun(size)()(const
+            /// \pre
             requires sized_range<Rng const>)
         {
             return ranges::size(this->base());
         }
         CPP_member
-        auto CPP_fun(size)()(requires //
-            sized_range<Rng>)
+        auto CPP_fun(size)()(
+            /// \pre
+            requires sized_range<Rng>)
         {
             return ranges::size(this->base());
         }
     };
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-    template(typename Rng, typename T, typename Fun)( //
+    template(typename Rng, typename T, typename Fun)(
+        /// \pre
         requires copy_constructible<T> AND copy_constructible<Fun>)
     exclusive_scan_view(Rng &&, T, Fun) //
         -> exclusive_scan_view<views::all_t<Rng>, T, Fun>;
@@ -160,8 +166,9 @@ namespace ranges
     {
         struct exclusive_scan_base_fn
         {
-            template(typename Rng, typename T, typename Fun = plus)( //
-                requires exclusive_scan_constraints<Rng, T, Fun>) //
+            template(typename Rng, typename T, typename Fun = plus)(
+                /// \pre
+                requires exclusive_scan_constraints<Rng, T, Fun>)
             constexpr exclusive_scan_view<all_t<Rng>, T, Fun> //
             operator()(Rng && rng, T init, Fun fun = Fun{}) const
             {

--- a/include/range/v3/view/facade.hpp
+++ b/include/range/v3/view/facade.hpp
@@ -91,16 +91,18 @@ namespace ranges
         /// otherwise, let `b` be `d.begin_cursor()`. Let `B` be the type of
         /// `b`.
         /// \return `ranges::basic_iterator<B>(b)`
-        template(typename D = Derived)( //
-            requires same_as<D, Derived>) //
+        template(typename D = Derived)(
+            /// \pre
+            requires same_as<D, Derived>)
         constexpr auto begin() -> detail::facade_iterator_t<D>
         {
             return detail::facade_iterator_t<D>{
                 range_access::begin_cursor(*static_cast<Derived *>(this))};
         }
         /// \overload
-        template(typename D = Derived)( //
-            requires same_as<D, Derived>) //
+        template(typename D = Derived)(
+            /// \pre
+            requires same_as<D, Derived>)
         constexpr auto begin() const -> detail::facade_iterator_t<D const>
         {
             return detail::facade_iterator_t<D const>{
@@ -112,16 +114,18 @@ namespace ranges
         /// `e`.
         /// \return `ranges::basic_iterator<E>(e)` if `E` is the same
         /// as `B` computed above for `begin()`; otherwise, return `e`.
-        template(typename D = Derived)( //
-            requires same_as<D, Derived>) //
+        template(typename D = Derived)(
+            /// \pre
+            requires same_as<D, Derived>)
         constexpr auto end() -> detail::facade_sentinel_t<D>
         {
             return static_cast<detail::facade_sentinel_t<D>>(
                 range_access::end_cursor(*static_cast<Derived *>(this)));
         }
         /// \overload
-        template(typename D = Derived)( //
-            requires same_as<D, Derived>) //
+        template(typename D = Derived)(
+            /// \pre
+            requires same_as<D, Derived>)
         constexpr auto end() const -> detail::facade_sentinel_t<D const>
         {
             return static_cast<detail::facade_sentinel_t<D const>>(

--- a/include/range/v3/view/filter.hpp
+++ b/include/range/v3/view/filter.hpp
@@ -38,7 +38,8 @@ namespace ranges
     };
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-    template(typename Rng, typename Pred)( //
+    template(typename Rng, typename Pred)(
+        /// \pre
         requires input_range<Rng> AND indirect_unary_predicate<Pred, iterator_t<Rng>> AND
             view_<Rng> AND std::is_object<Pred>::value) //
         filter_view(Rng &&, Pred)
@@ -53,9 +54,10 @@ namespace ranges
         /// present a view of the elements that satisfy the predicate.
         struct cpp20_filter_base_fn
         {
-            template(typename Rng, typename Pred)( //
-                requires viewable_range<Rng> AND input_range<Rng> AND //
-                    indirect_unary_predicate<Pred, iterator_t<Rng>>) //
+            template(typename Rng, typename Pred)(
+                /// \pre
+                requires viewable_range<Rng> AND input_range<Rng> AND
+                    indirect_unary_predicate<Pred, iterator_t<Rng>>)
             constexpr filter_view<all_t<Rng>, Pred> operator()(Rng && rng, Pred pred) //
                 const
             {
@@ -82,9 +84,10 @@ namespace ranges
         {
             using cpp20_filter_base_fn::operator();
 
-            template(typename Rng, typename Pred, typename Proj)( //
-                requires viewable_range<Rng> AND input_range<Rng> AND //
-                    indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>) //
+            template(typename Rng, typename Pred, typename Proj)(
+                /// \pre
+                requires viewable_range<Rng> AND input_range<Rng> AND
+                    indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>)
             constexpr filter_view<all_t<Rng>, composed<Pred, Proj>> //
             operator()(Rng && rng, Pred pred, Proj proj) const
             {
@@ -104,7 +107,8 @@ namespace ranges
                 return make_view_closure(bind_back(filter_base_fn{}, std::move(pred)));
             }
 
-            template(typename Pred, typename Proj)( //
+            template(typename Pred, typename Proj)(
+                /// \pre
                 requires (!range<Pred>))
             constexpr auto operator()(Pred pred, Proj proj) const
             {
@@ -124,7 +128,8 @@ namespace ranges
         {
             RANGES_INLINE_VARIABLE(ranges::views::cpp20_filter_fn, filter)
         }
-        template(typename V, typename Pred)( //
+        template(typename V, typename Pred)(
+            /// \pre
             requires input_range<V> AND indirect_unary_predicate<Pred, iterator_t<V>> AND
                 view_<V> AND std::is_object<Pred>::value) //
             using filter_view = ranges::filter_view<V, Pred>;

--- a/include/range/v3/view/for_each.hpp
+++ b/include/range/v3/view/for_each.hpp
@@ -42,7 +42,8 @@ namespace ranges
         /// the result.
         struct for_each_base_fn
         {
-            template(typename Rng, typename Fun)( //
+            template(typename Rng, typename Fun)(
+                /// \pre
                 requires viewable_range<Rng> AND transformable_range<Rng, Fun> AND
                     joinable_range<transform_view<all_t<Rng>, Fun>>)
             constexpr auto operator()(Rng && rng, Fun fun) const
@@ -69,8 +70,9 @@ namespace ranges
 
     struct yield_fn
     {
-        template(typename V)( //
-            requires copy_constructible<V>) //
+        template(typename V)(
+            /// \pre
+            requires copy_constructible<V>)
         single_view<V> operator()(V v) const
         {
             return views::single(std::move(v));
@@ -83,8 +85,9 @@ namespace ranges
 
     struct yield_from_fn
     {
-        template(typename Rng)( //
-            requires view_<Rng>) //
+        template(typename Rng)(
+            /// \pre
+            requires view_<Rng>)
         Rng operator()(Rng rng) const
         {
             return rng;
@@ -110,8 +113,9 @@ namespace ranges
 
     struct lazy_yield_if_fn
     {
-        template(typename F)( //
-            requires invocable<F &>) //
+        template(typename F)(
+            /// \pre
+            requires invocable<F &>)
         generate_n_view<F> operator()(bool b, F f) const
         {
             return views::generate_n(std::move(f), b ? 1 : 0);
@@ -124,9 +128,10 @@ namespace ranges
     /// @}
 
     /// \cond
-    template(typename Rng, typename Fun)( //
+    template(typename Rng, typename Fun)(
+        /// \pre
         requires viewable_range<Rng> AND views::transformable_range<Rng, Fun> AND
-            input_range<invoke_result_t<Fun &, range_reference_t<Rng>>>) //
+            input_range<invoke_result_t<Fun &, range_reference_t<Rng>>>)
         auto
         operator>>=(Rng && rng, Fun fun)
     {

--- a/include/range/v3/view/for_each.hpp
+++ b/include/range/v3/view/for_each.hpp
@@ -35,6 +35,9 @@
 
 namespace ranges
 {
+    /// \addtogroup group-views
+    /// @{
+
     namespace views
     {
         /// Lazily applies an unary function to each element in the source
@@ -64,7 +67,6 @@ namespace ranges
         };
 
         /// \relates for_each_fn
-        /// \ingroup group-views
         RANGES_INLINE_VARIABLE(for_each_fn, for_each)
     } // namespace views
 
@@ -80,7 +82,6 @@ namespace ranges
     };
 
     /// \relates yield_fn
-    /// \ingroup group-views
     RANGES_INLINE_VARIABLE(yield_fn, yield)
 
     struct yield_from_fn
@@ -95,7 +96,6 @@ namespace ranges
     };
 
     /// \relates yield_from_fn
-    /// \ingroup group-views
     RANGES_INLINE_VARIABLE(yield_from_fn, yield_from)
 
     struct yield_if_fn
@@ -108,7 +108,6 @@ namespace ranges
     };
 
     /// \relates yield_if_fn
-    /// \ingroup group-views
     RANGES_INLINE_VARIABLE(yield_if_fn, yield_if)
 
     struct lazy_yield_if_fn
@@ -123,7 +122,6 @@ namespace ranges
     };
 
     /// \relates lazy_yield_if_fn
-    /// \ingroup group-views
     RANGES_INLINE_VARIABLE(lazy_yield_if_fn, lazy_yield_if)
     /// @}
 

--- a/include/range/v3/view/generate.hpp
+++ b/include/range/v3/view/generate.hpp
@@ -93,13 +93,14 @@ namespace ranges
     {
         struct generate_fn
         {
-            template(typename G)( //
+            template(typename G)(
+                /// \pre
                 requires invocable<G &> AND copy_constructible<G> AND
                     std::is_object<detail::decay_t<invoke_result_t<G &>>>::value AND
                     constructible_from<detail::decay_t<invoke_result_t<G &>>,
                                        invoke_result_t<G &>> AND
                     assignable_from<detail::decay_t<invoke_result_t<G &>> &,
-                                    invoke_result_t<G &>>) //
+                                    invoke_result_t<G &>>)
             generate_view<G> operator()(G g) const
             {
                 return generate_view<G>{std::move(g)};

--- a/include/range/v3/view/generate_n.hpp
+++ b/include/range/v3/view/generate_n.hpp
@@ -100,13 +100,14 @@ namespace ranges
     {
         struct generate_n_fn
         {
-            template(typename G)( //
+            template(typename G)(
+                /// \pre
                 requires invocable<G &> AND copy_constructible<G> AND
                     std::is_object<detail::decay_t<invoke_result_t<G &>>>::value AND
                     constructible_from<detail::decay_t<invoke_result_t<G &>>,
                                        invoke_result_t<G &>> AND
                     assignable_from<detail::decay_t<invoke_result_t<G &>> &,
-                                    invoke_result_t<G &>>) //
+                                    invoke_result_t<G &>>)
             generate_n_view<G> operator()(G g, std::size_t n) const
             {
                 return generate_n_view<G>{std::move(g), n};

--- a/include/range/v3/view/group_by.hpp
+++ b/include/range/v3/view/group_by.hpp
@@ -160,8 +160,9 @@ namespace ranges
     };
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-    template(typename Rng, typename Fun)( //
-        requires copy_constructible<Fun>)     //
+    template(typename Rng, typename Fun)(
+        /// \pre
+        requires copy_constructible<Fun>)
         group_by_view(Rng &&, Fun)
             ->group_by_view<views::all_t<Rng>, Fun>;
 #endif
@@ -170,9 +171,10 @@ namespace ranges
     {
         struct group_by_base_fn
         {
-            template(typename Rng, typename Fun)( //
-                requires viewable_range<Rng> AND forward_range<Rng> AND //
-                    indirect_relation<Fun, iterator_t<Rng>>) //
+            template(typename Rng, typename Fun)(
+                /// \pre
+                requires viewable_range<Rng> AND forward_range<Rng> AND
+                    indirect_relation<Fun, iterator_t<Rng>>)
             constexpr group_by_view<all_t<Rng>, Fun> operator()(Rng && rng, Fun fun) const
             {
                 return {all(static_cast<Rng &&>(rng)), std::move(fun)};

--- a/include/range/v3/view/indices.hpp
+++ b/include/range/v3/view/indices.hpp
@@ -34,14 +34,16 @@ namespace ranges
         {
             indices_fn() = default;
 
-            template(typename Val)( //
-                requires integral<Val>) //
+            template(typename Val)(
+                /// \pre
+                requires integral<Val>)
             iota_view<Val, Val> operator()(Val to) const
             {
                 return {Val(), to};
             }
-            template(typename Val)( //
-                requires integral<Val>) //
+            template(typename Val)(
+                /// \pre
+                requires integral<Val>)
             iota_view<Val, Val> operator()(Val from, Val to) const
             {
                 return {from, to};
@@ -51,14 +53,16 @@ namespace ranges
         /// Inclusive range of indices: [from, to].
         struct closed_indices_fn
         {
-            template(typename Val)( //
-                requires integral<Val>) //
+            template(typename Val)(
+                /// \pre
+                requires integral<Val>)
             closed_iota_view<Val> operator()(Val to) const
             {
                 return {Val(), to};
             }
-            template(typename Val)( //
-                requires integral<Val>) //
+            template(typename Val)(
+                /// \pre
+                requires integral<Val>)
             closed_iota_view<Val> operator()(Val from, Val to) const
             {
                 return {from, to};

--- a/include/range/v3/view/indirect.hpp
+++ b/include/range/v3/view/indirect.hpp
@@ -48,7 +48,8 @@ namespace ranges
             using CRng = meta::const_if_c<IsConst, Rng>;
 
             adaptor() = default;
-            template(bool Other)(               //
+            template(bool Other)(
+                /// \pre
                 requires IsConst && CPP_NOT(Other)) //
             constexpr adaptor(adaptor<Other>) noexcept
             {}
@@ -67,14 +68,16 @@ namespace ranges
 
         CPP_member
         constexpr auto begin_adaptor() noexcept //
-            -> CPP_ret(adaptor<false>)( //
+            -> CPP_ret(adaptor<false>)(
+                /// \pre
                 requires (!simple_view<Rng>()))
         {
             return {};
         }
         CPP_member
         constexpr auto begin_adaptor() const noexcept //
-            -> CPP_ret(adaptor<true>)( //
+            -> CPP_ret(adaptor<true>)(
+                /// \pre
                 requires range<Rng const>)
         {
             return {};
@@ -82,14 +85,16 @@ namespace ranges
 
         CPP_member
         constexpr auto end_adaptor() noexcept //
-            -> CPP_ret(adaptor<false>)( //
+            -> CPP_ret(adaptor<false>)(
+                /// \pre
                 requires (!simple_view<Rng>()))
         {
             return {};
         }
         CPP_member
         constexpr auto end_adaptor() const noexcept //
-            -> CPP_ret(adaptor<true>)( //
+            -> CPP_ret(adaptor<true>)(
+                /// \pre
                 requires range<Rng const>)
         {
             return {};
@@ -107,7 +112,8 @@ namespace ranges
             return ranges::size(this->base());
         }
         CPP_member
-        constexpr auto CPP_fun(size)()( //
+        constexpr auto CPP_fun(size)()(
+            /// \pre
             requires sized_range<Rng>)
         {
             return ranges::size(this->base());
@@ -128,7 +134,8 @@ namespace ranges
     {
         struct indirect_fn
         {
-            template(typename Rng)( //
+            template(typename Rng)(
+                /// \pre
                 requires viewable_range<Rng> AND input_range<Rng> AND
                 // We shouldn't need to strip references to test if something
                 // is readable. https://github.com/ericniebler/stl2/issues/594

--- a/include/range/v3/view/interface.hpp
+++ b/include/range/v3/view/interface.hpp
@@ -46,8 +46,9 @@ namespace ranges
         {
             From from;
             To to;
-            template(typename F, typename T)( //
-                requires convertible_to<F, From> AND convertible_to<T, To>) //
+            template(typename F, typename T)(
+                /// \pre
+                requires convertible_to<F, From> AND convertible_to<T, To>)
             constexpr slice_bounds(F f, T t)
               : from(static_cast<From>(f))
               , to(static_cast<To>(t))
@@ -63,7 +64,8 @@ namespace ranges
               : dist_(dist)
             {}
 
-            template(typename Other)( //
+            template(typename Other)(
+                /// \pre
                 requires integer_like_<Other> AND explicitly_convertible_to<Other, Int>)
             constexpr operator from_end_<Other>() const
             {
@@ -148,33 +150,37 @@ namespace ranges
         // A few ways of testing whether a range can be empty:
         CPP_member
         constexpr auto empty() const noexcept //
-            -> CPP_ret(bool)( //
+            -> CPP_ret(bool)(
+                /// \pre
                 requires (detail::has_fixed_size_<Cardinality>))
         {
             return Cardinality == 0;
         }
         /// \overload
-        template(bool True = true)( //
+        template(bool True = true)(
+            /// \pre
             requires True AND (Cardinality < 0) AND (Cardinality != infinite) AND
-                (!forward_range<D<True>>)&&sized_range<D<True>>) //
+                (!forward_range<D<True>>)&&sized_range<D<True>>)
         constexpr bool empty() //
             noexcept(noexcept(bool(ranges::size(std::declval<D<True> &>()) == 0)))
         {
             return ranges::size(derived()) == 0;
         }
         /// \overload
-        template(bool True = true)( //
+        template(bool True = true)(
+            /// \pre
             requires True AND (Cardinality < 0) AND (Cardinality != infinite) AND
-                (!forward_range<D<True> const>)&&sized_range<D<True> const>) //
+                (!forward_range<D<True> const>)&&sized_range<D<True> const>)
         constexpr bool empty() const //
             noexcept(noexcept(bool(ranges::size(std::declval<D<True> const &>()) == 0)))
         {
             return ranges::size(derived()) == 0;
         }
         /// \overload
-        template(bool True = true)( //
+        template(bool True = true)(
+            /// \pre
             requires True AND (!detail::has_fixed_size_<Cardinality>) AND
-                forward_range<D<True>>) //
+                forward_range<D<True>>)
         constexpr bool empty() noexcept(
             noexcept(bool(ranges::begin(std::declval<D<True> &>()) ==
                           ranges::end(std::declval<D<True> &>()))))
@@ -182,16 +188,18 @@ namespace ranges
             return bool(ranges::begin(derived()) == ranges::end(derived()));
         }
         /// \overload
-        template(bool True = true)( //
+        template(bool True = true)(
+            /// \pre
             requires True AND (!detail::has_fixed_size_<Cardinality>) AND
-                forward_range<D<True> const>) //
+                forward_range<D<True> const>)
         constexpr bool empty() const
             noexcept(noexcept(bool(ranges::begin(std::declval<D<True> const &>()) ==
                                    ranges::end(std::declval<D<True> const &>()))))
         {
             return bool(ranges::begin(derived()) == ranges::end(derived()));
         }
-        CPP_template_gcc_workaround(bool True = true)(    //
+        CPP_template_gcc_workaround(bool True = true)(
+            /// \pre
             requires True && detail::can_empty_<D<True>>) // clang-format off
         constexpr explicit operator bool()
             noexcept(noexcept(ranges::empty(std::declval<D<True> &>())))
@@ -200,7 +208,8 @@ namespace ranges
         }
         // clang-format on
         /// \overload
-        CPP_template_gcc_workaround(bool True = true)(          //
+        CPP_template_gcc_workaround(bool True = true)(
+            /// \pre
             requires True && detail::can_empty_<D<True> const>) // clang-format off
         constexpr explicit operator bool() const
             noexcept(noexcept(ranges::empty(std::declval<D<True> const &>())))
@@ -210,7 +219,8 @@ namespace ranges
         // clang-format on
         /// If the size of the range is known at compile-time and finite,
         /// return it.
-        template(bool True = true, int = 42)( //
+        template(bool True = true, int = 42)(
+            /// \pre
             requires True AND (Cardinality >= 0)) //
         static constexpr std::size_t size() noexcept
         {
@@ -219,65 +229,73 @@ namespace ranges
         /// If `sized_sentinel_for<sentinel_t<Derived>, iterator_t<Derived>>` is
         /// satisfied, and if `Derived` is a `forward_range`, then return
         /// `end - begin` cast to an unsigned integer.
-        template(bool True = true)( //
+        template(bool True = true)(
+            /// \pre
             requires True AND (Cardinality < 0) AND
                 sized_sentinel_for<sentinel_t<D<True>>, iterator_t<D<True>>> AND
-                forward_range<D<True>>) //
+                forward_range<D<True>>)
         constexpr detail::iter_size_t<iterator_t<D<True>>> size()
         {
             using size_type = detail::iter_size_t<iterator_t<D<True>>>;
             return static_cast<size_type>(derived().end() - derived().begin());
         }
         /// \overload
-        template(bool True = true)( //
+        template(bool True = true)(
+            /// \pre
             requires True AND (Cardinality < 0) AND
                 sized_sentinel_for<sentinel_t<D<True> const>,
                                    iterator_t<D<True> const>> AND
-                forward_range<D<True> const>) //
+                forward_range<D<True> const>)
         constexpr detail::iter_size_t<iterator_t<D<True>>> size() const //
         {
             using size_type = detail::iter_size_t<iterator_t<D<True>>>;
             return static_cast<size_type>(derived().end() - derived().begin());
         }
         /// Access the first element in a range:
-        template(bool True = true)( //
-            requires True AND forward_range<D<True>>) //
+        template(bool True = true)(
+            /// \pre
+            requires True AND forward_range<D<True>>)
         constexpr range_reference_t<D<True>> front()
         {
             return *derived().begin();
         }
         /// \overload
-        template(bool True = true)( //
-            requires True AND forward_range<D<True> const>) //
+        template(bool True = true)(
+            /// \pre
+            requires True AND forward_range<D<True> const>)
         constexpr range_reference_t<D<True> const> front() const
         {
             return *derived().begin();
         }
         /// Access the last element in a range:
-        template(bool True = true)( //
-            requires True AND common_range<D<True>> AND bidirectional_range<D<True>>) //
+        template(bool True = true)(
+            /// \pre
+            requires True AND common_range<D<True>> AND bidirectional_range<D<True>>)
         constexpr range_reference_t<D<True>> back()
         {
             return *prev(derived().end());
         }
         /// \overload
-        template(bool True = true)( //
+        template(bool True = true)(
+            /// \pre
             requires True AND common_range<D<True> const> AND
-                bidirectional_range<D<True> const>) //
+                bidirectional_range<D<True> const>)
         constexpr range_reference_t<D<True> const> back() const
         {
             return *prev(derived().end());
         }
         /// Simple indexing:
-        template(bool True = true)( //
-            requires True AND random_access_range<D<True>>) //
+        template(bool True = true)(
+            /// \pre
+            requires True AND random_access_range<D<True>>)
         constexpr range_reference_t<D<True>> operator[](range_difference_t<D<True>> n)
         {
             return derived().begin()[n];
         }
         /// \overload
-        template(bool True = true)( //
-            requires True AND random_access_range<D<True> const>) //
+        template(bool True = true)(
+            /// \pre
+            requires True AND random_access_range<D<True> const>)
         constexpr range_reference_t<D<True> const> //
         operator[](range_difference_t<D<True>> n) const
         {
@@ -285,23 +303,26 @@ namespace ranges
         }
         /// Returns a pointer to the block of memory
         /// containing the elements of a contiguous range:
-        template(bool True = true)( //
-            requires True AND contiguous_iterator<iterator_t<D<True>>>) //
+        template(bool True = true)(
+            /// \pre
+            requires True AND contiguous_iterator<iterator_t<D<True>>>)
         constexpr std::add_pointer_t<range_reference_t<D<True>>> data() //
         {
             return std::addressof(*ranges::begin(derived()));
         }
         /// \overload
-        template(bool True = true)( //
-            requires True AND contiguous_iterator<iterator_t<D<True> const>>) //
+        template(bool True = true)(
+            /// \pre
+            requires True AND contiguous_iterator<iterator_t<D<True> const>>)
         constexpr std::add_pointer_t<range_reference_t<D<True> const>> data() const //
         {
             return std::addressof(*ranges::begin(derived()));
         }
         /// Returns a reference to the element at specified location pos, with bounds
         /// checking.
-        template(bool True = true)( //
-            requires True AND random_access_range<D<True>> AND sized_range<D<True>>) //
+        template(bool True = true)(
+            /// \pre
+            requires True AND random_access_range<D<True>> AND sized_range<D<True>>)
         constexpr range_reference_t<D<True>> at(range_difference_t<D<True>> n)
         {
             using size_type = range_size_t<Derived>;
@@ -312,9 +333,10 @@ namespace ranges
             return derived().begin()[n];
         }
         /// \overload
-        template(bool True = true)( //
-            requires True AND random_access_range<D<True> const> AND //
-                sized_range<D<True> const>) //
+        template(bool True = true)(
+            /// \pre
+            requires True AND random_access_range<D<True> const> AND
+                sized_range<D<True> const>)
         constexpr range_reference_t<D<True> const> at(range_difference_t<D<True>> n) const
         {
             using size_type = range_size_t<Derived const>;
@@ -326,24 +348,27 @@ namespace ranges
         }
         /// Python-ic slicing:
         //      rng[{4,6}]
-        template(bool True = true, typename Slice = views::slice_fn)( //
-            requires True AND input_range<D<True> &>)                      //
+        template(bool True = true, typename Slice = views::slice_fn)(
+            /// \pre
+            requires True AND input_range<D<True> &>)
         constexpr auto
             operator[](detail::slice_bounds<range_difference_t<D<True>>> offs) &
         {
             return Slice{}(derived(), offs.from, offs.to);
         }
         /// \overload
-        template(bool True = true, typename Slice = views::slice_fn)( //
-            requires True AND input_range<D<True> const &>)                //
+        template(bool True = true, typename Slice = views::slice_fn)(
+            /// \pre
+            requires True AND input_range<D<True> const &>)
         constexpr auto
             operator[](detail::slice_bounds<range_difference_t<D<True>>> offs) const &
         {
             return Slice{}(derived(), offs.from, offs.to);
         }
         /// \overload
-        template(bool True = true, typename Slice = views::slice_fn)( //
-            requires True AND input_range<D<True>>)                        //
+        template(bool True = true, typename Slice = views::slice_fn)(
+            /// \pre
+            requires True AND input_range<D<True>>)
         constexpr auto
             operator[](detail::slice_bounds<range_difference_t<D<True>>> offs) &&
         {
@@ -351,8 +376,9 @@ namespace ranges
         }
         //      rng[{4,end-2}]
         /// \overload
-        template(bool True = true, typename Slice = views::slice_fn)(      //
-            requires True AND input_range<D<True> &> AND sized_range<D<True> &>) //
+        template(bool True = true, typename Slice = views::slice_fn)(
+            /// \pre
+            requires True AND input_range<D<True> &> AND sized_range<D<True> &>)
         constexpr auto //
         operator[](detail::slice_bounds<range_difference_t<D<True>>,
                                         detail::from_end_of_t<D<True>>> offs) &
@@ -360,9 +386,10 @@ namespace ranges
             return Slice{}(derived(), offs.from, offs.to);
         }
         /// \overload
-        template(bool True = true, typename Slice = views::slice_fn)( //
+        template(bool True = true, typename Slice = views::slice_fn)(
+            /// \pre
             requires True AND input_range<D<True> const &> AND
-                sized_range<D<True> const &>) //
+                sized_range<D<True> const &>)
         constexpr auto //
         operator[](detail::slice_bounds<range_difference_t<D<True>>,
                                         detail::from_end_of_t<D<True>>> offs) const &
@@ -370,8 +397,9 @@ namespace ranges
             return Slice{}(derived(), offs.from, offs.to);
         }
         /// \overload
-        template(bool True = true, typename Slice = views::slice_fn)(  //
-            requires True AND input_range<D<True>> AND sized_range<D<True>>) //
+        template(bool True = true, typename Slice = views::slice_fn)(
+            /// \pre
+            requires True AND input_range<D<True>> AND sized_range<D<True>>)
         constexpr auto //
         operator[](detail::slice_bounds<range_difference_t<D<True>>,
                                         detail::from_end_of_t<D<True>>> offs) &&
@@ -380,7 +408,8 @@ namespace ranges
         }
         //      rng[{end-4,end-2}]
         /// \overload
-        template(bool True = true, typename Slice = views::slice_fn)( //
+        template(bool True = true, typename Slice = views::slice_fn)(
+            /// \pre
             requires True AND (forward_range<D<True> &> ||
                               (input_range<D<True> &> && sized_range<D<True> &>))) //
         constexpr auto //
@@ -390,7 +419,8 @@ namespace ranges
             return Slice{}(derived(), offs.from, offs.to);
         }
         /// \overload
-        template(bool True = true, typename Slice = views::slice_fn)( //
+        template(bool True = true, typename Slice = views::slice_fn)(
+            /// \pre
             requires True AND
             (forward_range<D<True> const &> ||
              (input_range<D<True> const &> && sized_range<D<True> const &>))) //
@@ -401,7 +431,8 @@ namespace ranges
             return Slice{}(derived(), offs.from, offs.to);
         }
         /// \overload
-        template(bool True = true, typename Slice = views::slice_fn)( //
+        template(bool True = true, typename Slice = views::slice_fn)(
+            /// \pre
             requires True AND
                 (forward_range<D<True>> ||
                     (input_range<D<True>> && sized_range<D<True>>))) //
@@ -413,24 +444,27 @@ namespace ranges
         }
         //      rng[{4,end}]
         /// \overload
-        template(bool True = true, typename Slice = views::slice_fn)( //
-            requires True AND input_range<D<True> &>)                      //
+        template(bool True = true, typename Slice = views::slice_fn)(
+            /// \pre
+            requires True AND input_range<D<True> &>)
         constexpr auto //
         operator[](detail::slice_bounds<range_difference_t<D<True>>, end_fn> offs) &
         {
             return Slice{}(derived(), offs.from, offs.to);
         }
         /// \overload
-        template(bool True = true, typename Slice = views::slice_fn)( //
-            requires True AND input_range<D<True> const &>)                //
+        template(bool True = true, typename Slice = views::slice_fn)(
+            /// \pre
+            requires True AND input_range<D<True> const &>)
         constexpr auto //
         operator[](detail::slice_bounds<range_difference_t<D<True>>, end_fn> offs) const &
         {
             return Slice{}(derived(), offs.from, offs.to);
         }
         /// \overload
-        template(bool True = true, typename Slice = views::slice_fn)( //
-            requires True AND input_range<D<True>>)                        //
+        template(bool True = true, typename Slice = views::slice_fn)(
+            /// \pre
+            requires True AND input_range<D<True>>)
         constexpr auto //
         operator[](detail::slice_bounds<range_difference_t<D<True>>, end_fn> offs) &&
         {
@@ -438,8 +472,9 @@ namespace ranges
         }
         //      rng[{end-4,end}]
         /// \overload
-        template(bool True = true, typename Slice = views::slice_fn)( //
-            requires True AND //
+        template(bool True = true, typename Slice = views::slice_fn)(
+            /// \pre
+            requires True AND
                 (forward_range<D<True> &> ||
                     (input_range<D<True> &> && sized_range<D<True> &>))) //
         constexpr auto //
@@ -448,8 +483,9 @@ namespace ranges
             return Slice{}(derived(), offs.from, offs.to);
         }
         /// \overload
-        template(bool True = true, typename Slice = views::slice_fn)( //
-            requires True AND //
+        template(bool True = true, typename Slice = views::slice_fn)(
+            /// \pre
+            requires True AND
                 (forward_range<D<True> const &> ||
                     (input_range<D<True> const &> && sized_range<D<True> const &>))) //
         constexpr auto //
@@ -459,7 +495,8 @@ namespace ranges
             return Slice{}(derived(), offs.from, offs.to);
         }
         /// \overload
-        template(bool True = true, typename Slice = views::slice_fn)( //
+        template(bool True = true, typename Slice = views::slice_fn)(
+            /// \pre
             requires True AND
                 (forward_range<D<True>> ||
                     (input_range<D<True>> && sized_range<D<True>>))) //
@@ -472,7 +509,8 @@ namespace ranges
         /// \brief Print a range to an ostream
         template<bool True = true>
         friend auto operator<<(std::ostream & sout, Derived const & rng)
-            -> CPP_broken_friend_ret(std::ostream &)( //
+            -> CPP_broken_friend_ret(std::ostream &)(
+                /// \pre
                 requires True && input_range<D<True> const>)
         {
             return detail::print_rng_(sout, rng);
@@ -480,7 +518,8 @@ namespace ranges
         /// \overload
         template<bool True = true>
         friend auto operator<<(std::ostream & sout, Derived & rng)
-            -> CPP_broken_friend_ret(std::ostream &)( //
+            -> CPP_broken_friend_ret(std::ostream &)(
+                /// \pre
                 requires True && (!range<D<True> const>) && input_range<D<True>>)
         {
             return detail::print_rng_(sout, rng);
@@ -488,7 +527,8 @@ namespace ranges
         /// \overload
         template<bool True = true>
         friend auto operator<<(std::ostream & sout, Derived && rng)
-            -> CPP_broken_friend_ret(std::ostream &)( //
+            -> CPP_broken_friend_ret(std::ostream &)(
+                /// \pre
                 requires True && (!range<D<True> const>) && input_range<D<True>>)
         {
             return detail::print_rng_(sout, rng);
@@ -497,9 +537,10 @@ namespace ranges
 
     namespace cpp20
     {
-        template(typename Derived)( //
+        template(typename Derived)(
+            /// \pre
             requires std::is_class<Derived>::value AND
-                same_as<Derived, meta::_t<std::remove_cv<Derived>>>) //
+                same_as<Derived, meta::_t<std::remove_cv<Derived>>>)
         using view_interface = ranges::view_interface<Derived, ranges::unknown>;
     }
     /// @}

--- a/include/range/v3/view/interface.hpp
+++ b/include/range/v3/view/interface.hpp
@@ -147,7 +147,7 @@ namespace ranges
         view_interface(view_interface const &) = default;
         view_interface & operator=(view_interface &&) = default;
         view_interface & operator=(view_interface const &) = default;
-        // A few ways of testing whether a range can be empty:
+        /// \brief Test whether a range can be empty:
         CPP_member
         constexpr auto empty() const noexcept //
             -> CPP_ret(bool)(
@@ -160,7 +160,7 @@ namespace ranges
         template(bool True = true)(
             /// \pre
             requires True AND (Cardinality < 0) AND (Cardinality != infinite) AND
-                (!forward_range<D<True>>)&&sized_range<D<True>>)
+                (!forward_range<D<True>>) AND sized_range<D<True>>)
         constexpr bool empty() //
             noexcept(noexcept(bool(ranges::size(std::declval<D<True> &>()) == 0)))
         {
@@ -170,7 +170,7 @@ namespace ranges
         template(bool True = true)(
             /// \pre
             requires True AND (Cardinality < 0) AND (Cardinality != infinite) AND
-                (!forward_range<D<True> const>)&&sized_range<D<True> const>)
+                (!forward_range<D<True> const>) AND sized_range<D<True> const>)
         constexpr bool empty() const //
             noexcept(noexcept(bool(ranges::size(std::declval<D<True> const &>()) == 0)))
         {

--- a/include/range/v3/view/intersperse.hpp
+++ b/include/range/v3/view/intersperse.hpp
@@ -57,7 +57,8 @@ namespace ranges
             return n ? n * 2 - 1 : 0;
         }
         CPP_member
-        constexpr auto CPP_fun(size)()( //
+        constexpr auto CPP_fun(size)()(
+            /// \pre
             requires sized_range<Rng>)
         {
             auto const n = ranges::size(this->base());
@@ -80,7 +81,8 @@ namespace ranges
             constexpr explicit cursor_adaptor(range_value_t<Rng> const & val)
               : val_{val}
             {}
-            template(bool Other)( //
+            template(bool Other)(
+                /// \pre
                 requires Const AND CPP_NOT(Other)) //
             cursor_adaptor(cursor_adaptor<Other> that)
               : toggle_(that.toggle_)
@@ -101,7 +103,8 @@ namespace ranges
             constexpr auto equal(iterator_t<CRng> const & it0,
                                  iterator_t<CRng> const & it1,
                                  cursor_adaptor const & other) const //
-                -> CPP_ret(bool)( //
+                -> CPP_ret(bool)(
+                    /// \pre
                     requires sentinel_for<iterator_t<CRng>, iterator_t<CRng>>)
             {
                 return it0 == it1 && toggle_ == other.toggle_;
@@ -114,7 +117,8 @@ namespace ranges
             }
             CPP_member
             constexpr auto prev(iterator_t<CRng> & it) //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires bidirectional_range<CRng>)
             {
                 toggle_ = !toggle_;
@@ -125,14 +129,16 @@ namespace ranges
             constexpr auto distance_to(iterator_t<CRng> const & it,
                                        iterator_t<CRng> const & other_it,
                                        cursor_adaptor const & other) const
-                -> CPP_ret(range_difference_t<Rng>)( //
+                -> CPP_ret(range_difference_t<Rng>)(
+                    /// \pre
                     requires sized_sentinel_for<iterator_t<CRng>, iterator_t<CRng>>)
             {
                 return (other_it - it) * 2 + (other.toggle_ - toggle_);
             }
             CPP_member
             constexpr auto advance(iterator_t<CRng> & it, range_difference_t<CRng> n) //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires random_access_range<CRng>)
             {
                 ranges::advance(it, n >= 0 ? (n + toggle_) / 2 : (n - !toggle_) / 2);
@@ -148,7 +154,8 @@ namespace ranges
 
         public:
             sentinel_adaptor() = default;
-            template(bool Other)( //
+            template(bool Other)(
+                /// \pre
                 requires Const AND CPP_NOT(Other)) //
             sentinel_adaptor(sentinel_adaptor<Other>)
             {}
@@ -165,26 +172,30 @@ namespace ranges
         }
         CPP_member
         constexpr auto begin_adaptor() const //
-            -> CPP_ret(cursor_adaptor<true>)( //
+            -> CPP_ret(cursor_adaptor<true>)(
+                /// \pre
                 requires range<Rng const>)
         {
             return cursor_adaptor<true>{val_};
         }
         CPP_member
         constexpr auto end_adaptor() //
-            -> CPP_ret(cursor_adaptor<false>)( //
+            -> CPP_ret(cursor_adaptor<false>)(
+                /// \pre
                 requires common_range<Rng> && (!single_pass_iterator_<iterator_t<Rng>>))
         {
             return cursor_adaptor<false>{val_};
         }
         CPP_member
         constexpr auto end_adaptor() noexcept //
-            -> CPP_ret(sentinel_adaptor<false>)( //
+            -> CPP_ret(sentinel_adaptor<false>)(
+                /// \pre
                 requires (!common_range<Rng>) || single_pass_iterator_<iterator_t<Rng>>)
         {
             return {};
         }
-        template(bool Const = true)( //
+        template(bool Const = true)(
+            /// \pre
             requires Const AND range<meta::const_if_c<Const, Rng>> AND
                 common_range<meta::const_if_c<Const, Rng>> AND
             (!single_pass_iterator_<iterator_t<meta::const_if_c<Const, Rng>>>)) //
@@ -192,7 +203,8 @@ namespace ranges
         {
             return cursor_adaptor<true>{val_};
         }
-        template(bool Const = true)( //
+        template(bool Const = true)(
+            /// \pre
             requires Const AND range<meta::const_if_c<Const, Rng>> AND
                 (!common_range<meta::const_if_c<Const, Rng>> ||
                  single_pass_iterator_<iterator_t<meta::const_if_c<Const, Rng>>>)) //
@@ -210,7 +222,7 @@ namespace ranges
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
     template<typename Rng>
-    intersperse_view(Rng &&, range_value_t<Rng>) //
+    intersperse_view(Rng &&, range_value_t<Rng>)
         -> intersperse_view<views::all_t<Rng>>;
 #endif
 
@@ -218,10 +230,11 @@ namespace ranges
     {
         struct intersperse_base_fn
         {
-            template(typename Rng)( //
-                requires viewable_range<Rng> AND input_range<Rng> AND //
-                    convertible_to<range_reference_t<Rng>, range_value_t<Rng>> AND //
-                        semiregular<range_value_t<Rng>>) //
+            template(typename Rng)(
+                /// \pre
+                requires viewable_range<Rng> AND input_range<Rng> AND
+                    convertible_to<range_reference_t<Rng>, range_value_t<Rng>> AND
+                        semiregular<range_value_t<Rng>>)
             constexpr intersperse_view<all_t<Rng>> //
             operator()(Rng && rng, range_value_t<Rng> val) const
             {
@@ -233,7 +246,8 @@ namespace ranges
         {
             using intersperse_base_fn::operator();
 
-            template(typename T)( //
+            template(typename T)(
+                /// \pre
                 requires copyable<T>)
             constexpr auto operator()(T t) const
             {

--- a/include/range/v3/view/iota.hpp
+++ b/include/range/v3/view/iota.hpp
@@ -118,7 +118,8 @@ namespace ranges
             CPP_requires_ref(detail::_advanceable_, I);
         // clang-format on
 
-        template(typename I)( //
+        template(typename I)(
+            /// \pre
             requires (!unsigned_integral<I>)) //
         void iota_advance_(I & i, iota_difference_t<I> n)
         {
@@ -126,8 +127,9 @@ namespace ranges
             i += n;
         }
 
-        template(typename Int)( //
-            requires unsigned_integral<Int>) //
+        template(typename Int)(
+            /// \pre
+            requires unsigned_integral<Int>)
         void iota_advance_(Int & i, iota_difference_t<Int> n)
         {
             // TODO: bounds-check this
@@ -137,15 +139,17 @@ namespace ranges
                 i -= static_cast<Int>(-n);
         }
 
-        template(typename I)( //
+        template(typename I)(
+            /// \pre
             requires advanceable_<I> AND (!integral<I>)) //
         iota_difference_t<I> iota_distance_(I const & i, I const & s)
         {
             return static_cast<iota_difference_t<I>>(s - i);
         }
 
-        template(typename Int)( //
-            requires signed_integral<Int>) //
+        template(typename Int)(
+            /// \pre
+            requires signed_integral<Int>)
         iota_difference_t<Int> iota_distance_(Int i0, Int i1)
         {
             // TODO: bounds-check this
@@ -154,8 +158,9 @@ namespace ranges
                 static_cast<iota_difference_t<Int>>(i0));
         }
 
-        template(typename Int)( //
-            requires unsigned_integral<Int>) //
+        template(typename Int)(
+            /// \pre
+            requires unsigned_integral<Int>)
         iota_difference_t<Int> iota_distance_(Int i0, Int i1)
         {
             // TODO: bounds-check this
@@ -209,14 +214,16 @@ namespace ranges
             }
             CPP_member
             auto equal(cursor const & that) const //
-                -> CPP_ret(bool)( //
+                -> CPP_ret(bool)(
+                    /// \pre
                     requires equality_comparable<From>)
             {
                 return that.from_ == from_ && that.done_ == done_;
             }
             CPP_member
             auto prev() //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires detail::decrementable_<From>)
             {
                 if(done_)
@@ -226,7 +233,8 @@ namespace ranges
             }
             CPP_member
             auto advance(difference_type n) //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires detail::advanceable_<From>)
             {
                 if(n > 0)
@@ -241,7 +249,8 @@ namespace ranges
             }
             CPP_member
             auto distance_to(cursor const & that) const //
-                -> CPP_ret(difference_type)( //
+                -> CPP_ret(difference_type)(
+                    /// \pre
                     requires detail::advanceable_<From>)
             {
                 using D = difference_type;
@@ -250,7 +259,8 @@ namespace ranges
             }
             CPP_member
             auto distance_to(default_sentinel_t) const //
-                -> CPP_ret(difference_type)( //
+                -> CPP_ret(difference_type)(
+                    /// \pre
                     requires sized_sentinel_for<To, From>)
             {
                 return difference_type(to_ - from_) + !done_;
@@ -271,14 +281,16 @@ namespace ranges
         }
         CPP_member
         auto end_cursor() const //
-            -> CPP_ret(cursor)( //
+            -> CPP_ret(cursor)(
+                /// \pre
                 requires same_as<From, To>)
         {
             return {to_, to_, true};
         }
         CPP_member
         auto end_cursor() const //
-            -> CPP_ret(default_sentinel_t)( //
+            -> CPP_ret(default_sentinel_t)(
+                /// \pre
                 requires (!same_as<From, To>))
         {
             return {};
@@ -306,7 +318,8 @@ namespace ranges
         true;
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-    template(typename From, typename To)( //
+    template(typename From, typename To)(
+        /// \pre
         requires weakly_incrementable<From> AND semiregular<To> AND
         (!integral<From> || !integral<To> ||
          std::is_signed<From>::value == std::is_signed<To>::value)) //
@@ -364,21 +377,24 @@ namespace ranges
             }
             CPP_member
             auto equal(cursor const & that) const //
-                -> CPP_ret(bool)( //
+                -> CPP_ret(bool)(
+                    /// \pre
                     requires equality_comparable<From>)
             {
                 return that.from_ == from_;
             }
             CPP_member
             auto prev() //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires detail::decrementable_<From>)
             {
                 --from_;
             }
             CPP_member
             auto advance(difference_type n) //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires detail::advanceable_<From>)
             {
                 detail::iota_advance_(from_, n);
@@ -388,7 +404,8 @@ namespace ranges
             // Reimplement iota_view without view_facade or basic_iterator.
             CPP_member
             auto distance_to(cursor const & that) const //
-                -> CPP_ret(difference_type)( //
+                -> CPP_ret(difference_type)(
+                    /// \pre
                     requires detail::advanceable_<From>)
             {
                 return detail::iota_distance_(from_, that.from_);
@@ -396,7 +413,8 @@ namespace ranges
             // Extension: see https://github.com/ericniebler/stl2/issues/613
             CPP_member
             auto distance_to(sentinel const & that) const //
-                -> CPP_ret(difference_type)( //
+                -> CPP_ret(difference_type)(
+                    /// \pre
                     requires sized_sentinel_for<To, From>)
             {
                 return that.to_ - from_;
@@ -451,7 +469,8 @@ namespace ranges
     RANGES_INLINE_VAR constexpr bool enable_borrowed_range<iota_view<From, To>> = true;
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-    template(typename From, typename To)( //
+    template(typename From, typename To)(
+        /// \pre
         requires weakly_incrementable<From> AND semiregular<To> AND
         (!integral<From> || !integral<To> ||
          std::is_signed<From>::value == std::is_signed<To>::value)) //
@@ -463,13 +482,15 @@ namespace ranges
     {
         struct iota_fn
         {
-            template(typename From)( //
-                requires weakly_incrementable<From>) //
+            template(typename From)(
+                /// \pre
+                requires weakly_incrementable<From>)
             iota_view<From> operator()(From value) const
             {
                 return iota_view<From>{std::move(value)};
             }
-            template(typename From, typename To)( //
+            template(typename From, typename To)(
+                /// \pre
                 requires weakly_incrementable<From> AND semiregular<To> AND
                     detail::weakly_equality_comparable_with_<From, To> AND
                 (!integral<From> || !integral<To> ||
@@ -482,7 +503,8 @@ namespace ranges
 
         struct closed_iota_fn
         {
-            template(typename From, typename To)( //
+            template(typename From, typename To)(
+                /// \pre
                 requires weakly_incrementable<From> AND semiregular<To> AND
                         detail::weakly_equality_comparable_with_<From, To> AND
                     (!integral<From> || !integral<To> ||
@@ -505,7 +527,8 @@ namespace ranges
         {
             ints_fn() = default;
 
-            template(typename Val)( //
+            template(typename Val)(
+                /// \pre
                 requires integral<Val>)
             RANGES_DEPRECATED(
                 "This potentially confusing API is deprecated. Prefer to "
@@ -515,14 +538,16 @@ namespace ranges
             {
                 return iota_view<Val>{value};
             }
-            template(typename Val)( //
-                requires integral<Val>) //
+            template(typename Val)(
+                /// \pre
+                requires integral<Val>)
             constexpr iota_view<Val> operator()(Val value, unreachable_sentinel_t) const
             {
                 return iota_view<Val>{value};
             }
-            template(typename Val)( //
-                requires integral<Val>) //
+            template(typename Val)(
+                /// \pre
+                requires integral<Val>)
             constexpr iota_view<Val, Val> operator()(Val from, Val to) const
             {
                 return {from, to};

--- a/include/range/v3/view/istream.hpp
+++ b/include/range/v3/view/istream.hpp
@@ -99,8 +99,9 @@ namespace ranges
     namespace _istream_
     {
         /// \endcond
-        template(typename Val)( //
-            requires copy_constructible<Val> AND default_constructible<Val>) //
+        template(typename Val)(
+            /// \pre
+            requires copy_constructible<Val> AND default_constructible<Val>)
         inline istream_view<Val> istream(std::istream & sin)
         {
             return istream_view<Val>{sin};

--- a/include/range/v3/view/join.hpp
+++ b/include/range/v3/view/join.hpp
@@ -149,14 +149,16 @@ namespace ranges
         // Not to spec
         CPP_member
         static constexpr auto size() //
-            -> CPP_ret(std::size_t)( //
+            -> CPP_ret(std::size_t)(
+                /// \pre
                 requires (detail::join_cardinality<Rng>() >= 0))
         {
             return static_cast<std::size_t>(detail::join_cardinality<Rng>());
         }
         // Not to spec
         CPP_member
-        constexpr auto CPP_fun(size)()(//
+        constexpr auto CPP_fun(size)()(
+            /// \pre
             requires(detail::join_cardinality<Rng>() < 0) &&
                 (range_cardinality<Rng>::value >= 0) &&
                 forward_range<Rng> &&
@@ -215,11 +217,12 @@ namespace ranges
             {
                 satisfy();
             }
-            template(bool Other)( //
+            template(bool Other)(
+                /// \pre
                 requires Const AND CPP_NOT(Other) AND
                 convertible_to<iterator_t<Rng>, iterator_t<COuter>> AND
                 convertible_to<iterator_t<range_reference_t<Rng>>,
-                               iterator_t<CInner>>) //
+                               iterator_t<CInner>>)
             constexpr cursor(cursor<Other> that)
               : rng_(that.rng_)
               , outer_it_(std::move(that.outer_it_))
@@ -227,7 +230,8 @@ namespace ranges
             {}
             CPP_member
             constexpr auto arrow() //
-                -> CPP_ret(iterator_t<CInner>)( //
+                -> CPP_ret(iterator_t<CInner>)(
+                    /// \pre
                     requires detail::has_arrow_<iterator_t<CInner>>)
             {
                 return inner_it_;
@@ -238,7 +242,8 @@ namespace ranges
             }
             CPP_member
             constexpr auto equal(cursor const & that) const //
-                -> CPP_ret(bool)( //
+                -> CPP_ret(bool)(
+                    /// \pre
                     requires ref_is_glvalue::value && //
                         equality_comparable<iterator_t<COuter>> && //
                         equality_comparable<iterator_t<CInner>>)
@@ -256,7 +261,8 @@ namespace ranges
             }
             CPP_member
             constexpr auto prev() //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires ref_is_glvalue::value && //
                         bidirectional_range<COuter> && //
                         bidirectional_range<CInner> && //
@@ -311,7 +317,8 @@ namespace ranges
             return {this, ranges::begin};
         }
 
-        template(bool Const = true)( //
+        template(bool Const = true)(
+            /// \pre
             requires Const AND input_range<meta::const_if_c<Const, Rng>> AND
                 std::is_reference<range_reference_t<meta::const_if_c<Const, Rng>>>::value)
         constexpr cursor<Const> begin_cursor() const
@@ -328,7 +335,8 @@ namespace ranges
             return end_cursor_fn{}(this, cond{});
         }
 
-        template(bool Const = true)( //
+        template(bool Const = true)(
+            /// \pre
             requires Const AND input_range<meta::const_if_c<Const, Rng>> AND
                 std::is_reference<range_reference_t<meta::const_if_c<Const, Rng>>>::value)
         constexpr auto end_cursor() const
@@ -364,7 +372,8 @@ namespace ranges
         {}
         CPP_member
         static constexpr auto size() //
-            -> CPP_ret(std::size_t)( //
+            -> CPP_ret(std::size_t)(
+                /// \pre
                 requires (detail::join_cardinality<Rng, ValRng>() >= 0))
         {
             return static_cast<std::size_t>(detail::join_cardinality<Rng, ValRng>());
@@ -532,8 +541,9 @@ namespace ranges
 
         struct cpp20_join_fn
         {
-            template(typename Rng)( //
-                requires joinable_range<Rng>) //
+            template(typename Rng)(
+                /// \pre
+                requires joinable_range<Rng>)
             join_view<all_t<Rng>> operator()(Rng && rng) const
             {
                 return join_view<all_t<Rng>>{all(static_cast<Rng &&>(rng))};
@@ -548,16 +558,18 @@ namespace ranges
         public:
             using cpp20_join_fn::operator();
 
-            template(typename Rng)( //
-                requires joinable_with_range<Rng, single_view<inner_value_t<Rng>>>) //
+            template(typename Rng)(
+                /// \pre
+                requires joinable_with_range<Rng, single_view<inner_value_t<Rng>>>)
             join_with_view<all_t<Rng>, single_view<inner_value_t<Rng>>> //
             operator()(Rng && rng, inner_value_t<Rng> v) const
             {
                 return {all(static_cast<Rng &&>(rng)), single(std::move(v))};
             }
 
-            template(typename Rng, typename ValRng)( //
-                requires joinable_with_range<Rng, ValRng>) //
+            template(typename Rng, typename ValRng)(
+                /// \pre
+                requires joinable_with_range<Rng, ValRng>)
             join_with_view<all_t<Rng>, all_t<ValRng>> //
             operator()(Rng && rng, ValRng && val) const
             {
@@ -576,13 +588,15 @@ namespace ranges
 
         struct join_bind_fn
         {
-            template(typename T)( //
+            template(typename T)(
+                /// \pre
                 requires (!joinable_range<T>)) // TODO: underconstrained
             constexpr auto operator()(T && t)const
             {
                 return make_view_closure(bind_back(join_base_fn{}, static_cast<T &&>(t)));
             }
-            template(typename T)( //
+            template(typename T)(
+                /// \pre
                 requires (!joinable_range<T &>) AND range<T &>)
             constexpr auto operator()(T & t) const
             {
@@ -605,13 +619,15 @@ namespace ranges
     /// @}
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-    template(typename Rng)(              //
-        requires views::joinable_range<Rng>) //
+    template(typename Rng)(
+        /// \pre
+        requires views::joinable_range<Rng>)
         explicit join_view(Rng &&)
             ->join_view<views::all_t<Rng>>;
 
-    template(typename Rng, typename ValRng)(          //
-        requires views::joinable_with_range<Rng, ValRng>) //
+    template(typename Rng, typename ValRng)(
+        /// \pre
+        requires views::joinable_with_range<Rng, ValRng>)
         explicit join_with_view(Rng &&, ValRng &&)
             ->join_with_view<views::all_t<Rng>, views::all_t<ValRng>>;
 #endif
@@ -623,7 +639,8 @@ namespace ranges
             RANGES_INLINE_VARIABLE(
                 ranges::views::view_closure<ranges::views::cpp20_join_fn>, join)
         }
-        template(typename Rng)( //
+        template(typename Rng)(
+            /// \pre
             requires input_range<Rng> AND view_<Rng> AND
                 input_range<iter_reference_t<iterator_t<Rng>>> AND
             (std::is_reference<iter_reference_t<iterator_t<Rng>>>::value ||

--- a/include/range/v3/view/linear_distribute.hpp
+++ b/include/range/v3/view/linear_distribute.hpp
@@ -99,7 +99,8 @@ namespace ranges
         /// If `n == 1` returns `to`.
         struct linear_distribute_fn
         {
-            template(typename T)( //
+            template(typename T)(
+                /// \pre
                 requires std::is_arithmetic<T>::value)
             constexpr auto operator()(T from, T to, std::ptrdiff_t n) const
             {

--- a/include/range/v3/view/map.hpp
+++ b/include/range/v3/view/map.hpp
@@ -42,8 +42,9 @@ namespace ranges
             return t;
         }
 
-        template(typename T)( //
-            requires move_constructible<T>) //
+        template(typename T)(
+            /// \pre
+            requires move_constructible<T>)
         constexpr T get_first_second_helper(T & t, std::false_type) //
             noexcept(std::is_nothrow_move_constructible<T>::value)
         {
@@ -95,9 +96,10 @@ namespace ranges
     {
         struct keys_fn
         {
-            template(typename Rng)( //
+            template(typename Rng)(
+                /// \pre
                 requires viewable_range<Rng> AND input_range<Rng> AND
-                    detail::kv_pair_like_<range_reference_t<Rng>>) //
+                    detail::kv_pair_like_<range_reference_t<Rng>>)
             keys_range_view<all_t<Rng>> operator()(Rng && rng) const
             {
                 return {all(static_cast<Rng &&>(rng)), detail::get_first{}};
@@ -106,9 +108,10 @@ namespace ranges
 
         struct values_fn
         {
-            template(typename Rng)( //
+            template(typename Rng)(
+                /// \pre
                 requires viewable_range<Rng> AND input_range<Rng> AND
-                    detail::kv_pair_like_<range_reference_t<Rng>>) //
+                    detail::kv_pair_like_<range_reference_t<Rng>>)
             values_view<all_t<Rng>> operator()(Rng && rng) const
             {
                 return {all(static_cast<Rng &&>(rng)), detail::get_second{}};

--- a/include/range/v3/view/move.hpp
+++ b/include/range/v3/view/move.hpp
@@ -43,7 +43,8 @@ namespace ranges
         struct adaptor : adaptor_base
         {
             adaptor() = default;
-            template(bool Other)( //
+            template(bool Other)(
+                /// \pre
                 requires Const AND CPP_NOT(Other)) //
             constexpr adaptor(adaptor<Other>)
             {}
@@ -68,14 +69,16 @@ namespace ranges
         }
         CPP_member
         auto begin_adaptor() const //
-            -> CPP_ret(adaptor<true>)( //
+            -> CPP_ret(adaptor<true>)(
+                /// \pre
                 requires input_range<Rng const>)
         {
             return {};
         }
         CPP_member
         auto end_adaptor() const //
-            -> CPP_ret(adaptor<true>)( //
+            -> CPP_ret(adaptor<true>)(
+                /// \pre
                 requires input_range<Rng const>)
         {
             return {};
@@ -93,7 +96,8 @@ namespace ranges
             return ranges::size(this->base());
         }
         CPP_member
-        auto CPP_fun(size)()( //
+        auto CPP_fun(size)()(
+            /// \pre
             requires sized_range<Rng>)
         {
             return ranges::size(this->base());
@@ -114,8 +118,9 @@ namespace ranges
     {
         struct move_fn
         {
-            template(typename Rng)( //
-                requires viewable_range<Rng> AND input_range<Rng>) //
+            template(typename Rng)(
+                /// \pre
+                requires viewable_range<Rng> AND input_range<Rng>)
             move_view<all_t<Rng>> operator()(Rng && rng) const
             {
                 return move_view<all_t<Rng>>{all(static_cast<Rng &&>(rng))};

--- a/include/range/v3/view/partial_sum.hpp
+++ b/include/range/v3/view/partial_sum.hpp
@@ -100,10 +100,11 @@ namespace ranges
                 if(current_ != ranges::end(rng->base_))
                     sum_ = *current_;
             }
-            template(bool Other)( //
+            template(bool Other)(
+                /// \pre
                 requires IsConst AND CPP_NOT(Other) AND
                 convertible_to<iterator_t<Rng> const &,
-                               iterator_t<Base>>) //
+                               iterator_t<Base>>)
             constexpr cursor(cursor<Other> const & that)
               : parent_{that.parent_}
               , current_(that.current_)
@@ -143,8 +144,9 @@ namespace ranges
         {
             return cursor<false>{this};
         }
-        template(typename CRng = Rng const)( //
-            requires detail::partial_sum_view_constraints<CRng, Fun const>) //
+        template(typename CRng = Rng const)(
+            /// \pre
+            requires detail::partial_sum_view_constraints<CRng, Fun const>)
         constexpr cursor<true> begin_cursor() const
         {
             return cursor<true>{this};
@@ -159,7 +161,8 @@ namespace ranges
           , fun_(std::move(fun))
         {}
         CPP_member
-        constexpr auto CPP_fun(size)()( //
+        constexpr auto CPP_fun(size)()(
+            /// \pre
             requires sized_range<Rng>)
         {
             return ranges::size(base_);
@@ -173,7 +176,8 @@ namespace ranges
     };
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-    template(typename Rng, typename Fun)( //
+    template(typename Rng, typename Fun)(
+        /// \pre
         requires copy_constructible<Fun>)
     partial_sum_view(Rng &&, Fun)
         -> partial_sum_view<views::all_t<Rng>, Fun>;
@@ -183,8 +187,9 @@ namespace ranges
     {
         struct partial_sum_base_fn
         {
-            template(typename Rng, typename Fun = plus)( //
-                requires detail::partial_sum_view_constraints<all_t<Rng>, Fun>) //
+            template(typename Rng, typename Fun = plus)(
+                /// \pre
+                requires detail::partial_sum_view_constraints<all_t<Rng>, Fun>)
             constexpr partial_sum_view<all_t<Rng>, Fun> //
             operator()(Rng && rng, Fun fun = {}) const
             {
@@ -196,7 +201,8 @@ namespace ranges
         {
             using partial_sum_base_fn::operator();
 
-            template(typename Fun)( //
+            template(typename Fun)(
+                /// \pre
                 requires (!range<Fun>))
             constexpr auto operator()(Fun && fun) const
             {

--- a/include/range/v3/view/ref.hpp
+++ b/include/range/v3/view/ref.hpp
@@ -62,7 +62,8 @@ namespace ranges
         }
         CPP_member
         constexpr auto empty() const noexcept(noexcept(ranges::empty(*rng_)))
-            -> CPP_ret(bool)( //
+            -> CPP_ret(bool)(
+                /// \pre
                 requires detail::can_empty_<Rng>)
         {
             return ranges::empty(*rng_);
@@ -84,7 +85,8 @@ namespace ranges
     };
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-    template(typename R)( //
+    template(typename R)(
+        /// \pre
         requires range<R>)
     ref_view(R &) //
         -> ref_view<R>;
@@ -94,8 +96,9 @@ namespace ranges
     {
         struct ref_fn
         {
-            template(typename Rng)( //
-                requires range<Rng>) //
+            template(typename Rng)(
+                /// \pre
+                requires range<Rng>)
             constexpr ref_view<Rng> operator()(Rng & rng) const noexcept
             {
                 return ref_view<Rng>(rng);
@@ -111,7 +114,8 @@ namespace ranges
 
     namespace cpp20
     {
-        template(typename Rng)(              //
+        template(typename Rng)(
+            /// \pre
             requires std::is_object<Rng>::value) //
             using ref_view = ranges::ref_view<Rng>;
     }

--- a/include/range/v3/view/remove.hpp
+++ b/include/range/v3/view/remove.hpp
@@ -43,8 +43,9 @@ namespace ranges
             struct pred_
             {
                 Value value_;
-                template(typename T)( //
-                    requires equality_comparable_with<T, Value const &>) //
+                template(typename T)(
+                    /// \pre
+                    requires equality_comparable_with<T, Value const &>)
                 bool operator()(T && other) const
                 {
                     return static_cast<T &&>(other) == value_;
@@ -52,7 +53,8 @@ namespace ranges
             };
 
         public:
-            template(typename Rng, typename Value)( //
+            template(typename Rng, typename Value)(
+                /// \pre
                 requires move_constructible<Value> AND viewable_range<Rng> AND
                     input_range<Rng> AND
                     indirectly_comparable<iterator_t<Rng>, Value const *, equal_to>)
@@ -62,9 +64,10 @@ namespace ranges
                                  pred_<Value>{std::move(value)});
             }
 
-            template(typename Rng, typename Value, typename Proj)( //
+            template(typename Rng, typename Value, typename Proj)(
+                /// \pre
                 requires move_constructible<Value> AND viewable_range<Rng> AND
-                    input_range<Rng> AND //
+                    input_range<Rng> AND
                     indirectly_comparable<iterator_t<Rng>, Value const *, equal_to, Proj>)
             constexpr auto operator()(Rng && rng, Value value, Proj proj) const
             {
@@ -81,7 +84,8 @@ namespace ranges
             {
                 return make_view_closure(bind_back(remove_base_fn{}, std::move(value)));
             }
-            template(typename Value, typename Proj)( //
+            template(typename Value, typename Proj)(
+                /// \pre
                 requires (!range<Value>)) // TODO: underconstrained
             constexpr auto operator()(Value && value, Proj proj) const
             {

--- a/include/range/v3/view/remove_if.hpp
+++ b/include/range/v3/view/remove_if.hpp
@@ -72,7 +72,8 @@ namespace ranges
             }
             CPP_member
             constexpr auto prev(iterator_t<Rng> & it) const //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires bidirectional_range<Rng>)
             {
                 rng_->satisfy_reverse(it);
@@ -90,14 +91,16 @@ namespace ranges
         }
         CPP_member
         constexpr auto end_adaptor() const noexcept //
-            -> CPP_ret(adaptor_base)( //
+            -> CPP_ret(adaptor_base)(
+                /// \pre
                 requires (!common_range<Rng>))
         {
             return {};
         }
         CPP_member
         constexpr auto end_adaptor() //
-            -> CPP_ret(adaptor)( //
+            -> CPP_ret(adaptor)(
+                /// \pre
                 requires common_range<Rng>)
         {
             if(bidirectional_range<Rng>)
@@ -138,7 +141,8 @@ namespace ranges
     };
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-    template(typename Rng, typename Pred)( //
+    template(typename Rng, typename Pred)(
+        /// \pre
         requires copy_constructible<Pred>)
     remove_if_view(Rng &&, Pred)
         -> remove_if_view<views::all_t<Rng>, Pred>;
@@ -150,18 +154,20 @@ namespace ranges
         /// present a view of the elements that do not satisfy the predicate.
         struct remove_if_base_fn
         {
-            template(typename Rng, typename Pred)( //
-                requires viewable_range<Rng> AND input_range<Rng> AND //
-                    indirect_unary_predicate<Pred, iterator_t<Rng>>) //
+            template(typename Rng, typename Pred)(
+                /// \pre
+                requires viewable_range<Rng> AND input_range<Rng> AND
+                    indirect_unary_predicate<Pred, iterator_t<Rng>>)
             constexpr remove_if_view<all_t<Rng>, Pred> operator()(Rng && rng, Pred pred)
                 const
             {
                 return remove_if_view<all_t<Rng>, Pred>{all(static_cast<Rng &&>(rng)),
                                                         std::move(pred)};
             }
-            template(typename Rng, typename Pred, typename Proj)( //
-                requires viewable_range<Rng> AND input_range<Rng> AND //
-                    indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>) //
+            template(typename Rng, typename Pred, typename Proj)(
+                /// \pre
+                requires viewable_range<Rng> AND input_range<Rng> AND
+                    indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>)
             constexpr remove_if_view<all_t<Rng>, composed<Pred, Proj>> //
             operator()(Rng && rng, Pred pred, Proj proj) const
             {
@@ -178,7 +184,8 @@ namespace ranges
             {
                 return make_view_closure(bind_back(remove_if_base_fn{}, std::move(pred)));
             }
-            template(typename Pred, typename Proj)( //
+            template(typename Pred, typename Proj)(
+                /// \pre
                 requires (!range<Pred>)) // TODO: underconstrained
             constexpr auto operator()(Pred && pred, Proj proj) const
             {

--- a/include/range/v3/view/repeat.hpp
+++ b/include/range/v3/view/repeat.hpp
@@ -101,8 +101,9 @@ namespace ranges
     {
         struct repeat_fn
         {
-            template(typename Val)( //
-                requires copy_constructible<Val>) //
+            template(typename Val)(
+                /// \pre
+                requires copy_constructible<Val>)
             repeat_view<Val> operator()(Val value) const
             {
                 return repeat_view<Val>{std::move(value)};

--- a/include/range/v3/view/repeat_n.hpp
+++ b/include/range/v3/view/repeat_n.hpp
@@ -109,8 +109,9 @@ namespace ranges
     {
         struct repeat_n_fn
         {
-            template(typename Val)( //
-                requires copy_constructible<Val>) //
+            template(typename Val)(
+                /// \pre
+                requires copy_constructible<Val>)
             repeat_n_view<Val> operator()(Val value, std::ptrdiff_t n) const
             {
                 return repeat_n_view<Val>{std::move(value), n};

--- a/include/range/v3/view/replace.hpp
+++ b/include/range/v3/view/replace.hpp
@@ -88,8 +88,9 @@ namespace ranges
     {
         struct replace_base_fn
         {
-            template(typename Rng, typename Val1, typename Val2)( //
-                requires viewable_range<Rng> AND input_range<Rng> AND //
+            template(typename Rng, typename Val1, typename Val2)(
+                /// \pre
+                requires viewable_range<Rng> AND input_range<Rng> AND
                     same_as<
                         detail::decay_t<unwrap_reference_t<Val1>>,
                         detail::decay_t<unwrap_reference_t<Val2>>> AND
@@ -102,7 +103,7 @@ namespace ranges
                                             range_reference_t<Rng>> AND
                     common_reference_with<
                         unwrap_reference_t<Val2 const &>,
-                        range_rvalue_reference_t<Rng>>) //
+                        range_rvalue_reference_t<Rng>>)
             constexpr replace_view< //
                 all_t<Rng>, //
                 detail::decay_t<Val1>, //
@@ -120,7 +121,8 @@ namespace ranges
         {
             using replace_base_fn::operator();
 
-            template(typename Val1, typename Val2)( //
+            template(typename Val1, typename Val2)(
+                /// \pre
                 requires same_as<detail::decay_t<unwrap_reference_t<Val1>>,
                                  detail::decay_t<unwrap_reference_t<Val2>>>)
             constexpr auto operator()(Val1 old_value, Val2 new_value) const

--- a/include/range/v3/view/replace_if.hpp
+++ b/include/range/v3/view/replace_if.hpp
@@ -61,7 +61,8 @@ namespace ranges
                 RANGES_EXPECT(false);
             }
 
-            template(typename I)( //
+            template(typename I)(
+                /// \pre
                 requires (!invocable<Pred const &, iter_reference_t<I>>))
             common_reference_t<unwrap_reference_t<Val const &>, iter_reference_t<I>> //
             operator()(I const & i)
@@ -71,7 +72,8 @@ namespace ranges
                     return unwrap_reference(second());
                 return (decltype(x) &&)x;
             }
-            template(typename I)( //
+            template(typename I)(
+                /// \pre
                 requires invocable<Pred const &, iter_reference_t<I>>)
             common_reference_t<unwrap_reference_t<Val const &>, iter_reference_t<I>> //
             operator()(I const & i) const
@@ -82,7 +84,8 @@ namespace ranges
                 return (decltype(x) &&)x;
             }
 
-            template(typename I)( //
+            template(typename I)(
+                /// \pre
                 requires (!invocable<Pred const &, iter_rvalue_reference_t<I>>))
             common_reference_t<
                 unwrap_reference_t<Val const &>, //
@@ -94,7 +97,8 @@ namespace ranges
                     return unwrap_reference(second());
                 return (decltype(x) &&)x;
             }
-            template(typename I)( //
+            template(typename I)(
+                /// \pre
                 requires invocable<Pred const &, iter_rvalue_reference_t<I>>)
             common_reference_t< //
                 unwrap_reference_t<Val const &>, //
@@ -116,7 +120,8 @@ namespace ranges
     {
         struct replace_if_base_fn
         {
-            template(typename Rng, typename Pred, typename Val)( //
+            template(typename Rng, typename Pred, typename Val)(
+                /// \pre
                 requires viewable_range<Rng> AND input_range<Rng> AND
                     indirect_unary_predicate<Pred, iterator_t<Rng>> AND
                     common_with<detail::decay_t<unwrap_reference_t<Val const &>>,
@@ -124,7 +129,7 @@ namespace ranges
                     common_reference_with<unwrap_reference_t<Val const &>,
                                           range_reference_t<Rng>> AND
                     common_reference_with<unwrap_reference_t<Val const &>,
-                                          range_rvalue_reference_t<Rng>>) //
+                                          range_rvalue_reference_t<Rng>>)
             constexpr replace_if_view<all_t<Rng>, Pred, Val> //
             operator()(Rng && rng, Pred pred, Val new_value) const
             {

--- a/include/range/v3/view/reverse.hpp
+++ b/include/range/v3/view/reverse.hpp
@@ -86,8 +86,9 @@ namespace ranges
         {
             return begin_(meta::bool_<(bool)common_range<Rng>>{});
         }
-        template(bool Const = true)( //
-            requires Const AND common_range<meta::const_if_c<Const, Rng>>) //
+        template(bool Const = true)(
+            /// \pre
+            requires Const AND common_range<meta::const_if_c<Const, Rng>>)
         constexpr reverse_iterator<iterator_t<meta::const_if_c<Const, Rng>>> begin() const
         {
             return make_reverse_iterator(ranges::end(rng_));
@@ -96,14 +97,16 @@ namespace ranges
         {
             return make_reverse_iterator(ranges::begin(rng_));
         }
-        template(bool Const = true)( //
-            requires Const AND common_range<meta::const_if_c<Const, Rng>>) //
+        template(bool Const = true)(
+            /// \pre
+            requires Const AND common_range<meta::const_if_c<Const, Rng>>)
         constexpr reverse_iterator<iterator_t<meta::const_if_c<Const, Rng>>> end() const
         {
             return make_reverse_iterator(ranges::begin(rng_));
         }
         CPP_member
-        constexpr auto CPP_fun(size)()( //
+        constexpr auto CPP_fun(size)()(
+            /// \pre
             requires sized_range<Rng>)
         {
             return ranges::size(rng_);
@@ -145,7 +148,7 @@ namespace ranges
         -> reverse_view<views::all_t<Rng>>;
 
     template<typename Rng>
-    reverse_view(reverse_view<Rng>) //
+    reverse_view(reverse_view<Rng>)
         -> reverse_view<reverse_view<Rng>>;
 #endif
 
@@ -153,8 +156,9 @@ namespace ranges
     {
         struct reverse_fn
         {
-            template(typename Rng)( //
-                requires viewable_range<Rng> AND bidirectional_range<Rng>) //
+            template(typename Rng)(
+                /// \pre
+                requires viewable_range<Rng> AND bidirectional_range<Rng>)
             constexpr reverse_view<all_t<Rng>> operator()(Rng && rng) const
             {
                 return reverse_view<all_t<Rng>>{all(static_cast<Rng &&>(rng))};
@@ -172,8 +176,9 @@ namespace ranges
         {
             using ranges::views::reverse;
         }
-        template(typename Rng)(                          //
-            requires view_<Rng> AND bidirectional_range<Rng>) //
+        template(typename Rng)(
+            /// \pre
+            requires view_<Rng> AND bidirectional_range<Rng>)
         using reverse_view = ranges::reverse_view<Rng>;
     } // namespace cpp20
     /// @}

--- a/include/range/v3/view/sample.hpp
+++ b/include/range/v3/view/sample.hpp
@@ -138,7 +138,8 @@ namespace ranges
                     rng->size_ = n;
                 advance();
             }
-            template(bool Other)( //
+            template(bool Other)(
+                /// \pre
                 requires IsConst AND CPP_NOT(Other)) //
             cursor(cursor<Other> that)
               : parent_(that.parent_)
@@ -170,7 +171,8 @@ namespace ranges
         {
             return cursor<false>{this};
         }
-        template(bool Const = true)( //
+        template(bool Const = true)(
+            /// \pre
             requires Const AND
             (sized_range<meta::const_if_c<Const, Rng>> ||
              sized_sentinel_for<sentinel_t<meta::const_if_c<Const, Rng>>,
@@ -209,7 +211,8 @@ namespace ranges
         /// Returns a random sample of a range of length `size(range)`.
         struct sample_base_fn
         {
-            template(typename Rng, typename URNG = detail::default_random_engine)( //
+            template(typename Rng, typename URNG = detail::default_random_engine)(
+                /// \pre
                 requires viewable_range<Rng> AND input_range<Rng> AND
                     uniform_random_bit_generator<URNG> AND
                     convertible_to<invoke_result_t<URNG &>, range_difference_t<Rng>> AND
@@ -242,8 +245,9 @@ namespace ranges
         {
             using sample_base_fn::operator();
 
-            template(typename Size, typename URNG = detail::default_random_engine)( //
-                requires integral<Size> AND uniform_random_bit_generator<URNG>) //
+            template(typename Size, typename URNG = detail::default_random_engine)(
+                /// \pre
+                requires integral<Size> AND uniform_random_bit_generator<URNG>)
             constexpr auto operator()(
                 Size n,
                 URNG & urng = detail::get_random_engine()) const //

--- a/include/range/v3/view/set_algorithm.hpp
+++ b/include/range/v3/view/set_algorithm.hpp
@@ -74,7 +74,8 @@ namespace ranges
             }
             CPP_member
             auto begin_cursor() const //
-                -> CPP_ret(cursor<true>)( //
+                -> CPP_ret(cursor<true>)(
+                    /// \pre
                     requires range<Rng1 const> && range<Rng2 const>)
             {
                 return {pred_,
@@ -158,7 +159,8 @@ namespace ranges
             {
                 satisfy();
             }
-            template(bool Other)(         //
+            template(bool Other)(
+                /// \pre
                 requires IsConst && CPP_NOT(Other)) //
                 set_difference_cursor(
                     set_difference_cursor<Other, Rng1, Rng2, C, P1, P2> that)
@@ -183,7 +185,8 @@ namespace ranges
             }
             CPP_member
             auto equal(set_difference_cursor const & that) const //
-                -> CPP_ret(bool)( //
+                -> CPP_ret(bool)(
+                    /// \pre
                     requires forward_range<Rng1>)
             {
                 // does not support comparing iterators from different ranges
@@ -223,13 +226,14 @@ namespace ranges
         struct set_difference_base_fn
         {
             template(typename Rng1, typename Rng2, typename C = less,
-                     typename P1 = identity, typename P2 = identity)( //
+                     typename P1 = identity, typename P2 = identity)(
+                /// \pre
                 requires //
                     viewable_range<Rng1> AND input_range<Rng1> AND
                     viewable_range<Rng2> AND input_range<Rng2> AND
                     indirect_relation<C,
                                       projected<iterator_t<Rng1>, P1>,
-                                      projected<iterator_t<Rng2>, P2>>) //
+                                      projected<iterator_t<Rng2>, P2>>)
             set_difference_view<all_t<Rng1>, all_t<Rng2>, C, P1, P2> //
             operator()(Rng1 && rng1,
                        Rng2 && rng2,
@@ -250,7 +254,8 @@ namespace ranges
             using set_difference_base_fn::operator();
 
             template(typename Rng2, typename C = less, typename P1 = identity,
-                     typename P2 = identity)( //
+                     typename P2 = identity)(
+                /// \pre
                 requires viewable_range<Rng2> AND input_range<Rng2> AND (!range<C>))
             constexpr auto operator()(Rng2 && rng2,
                                       C && pred = C{},
@@ -333,7 +338,8 @@ namespace ranges
             {
                 satisfy();
             }
-            template(bool Other)(         //
+            template(bool Other)(
+                /// \pre
                 requires IsConst && CPP_NOT(Other)) //
                 set_intersection_cursor(
                     set_intersection_cursor<Other, Rng1, Rng2, C, P1, P2> that)
@@ -359,7 +365,8 @@ namespace ranges
             }
             CPP_member
             auto equal(set_intersection_cursor const & that) const //
-                -> CPP_ret(bool)( //
+                -> CPP_ret(bool)(
+                    /// \pre
                     requires forward_range<Rng1>)
             {
                 // does not support comparing iterators from different ranges
@@ -399,13 +406,14 @@ namespace ranges
         struct set_intersection_base_fn
         {
             template(typename Rng1, typename Rng2, typename C = less,
-                     typename P1 = identity, typename P2 = identity)( //
+                     typename P1 = identity, typename P2 = identity)(
+                /// \pre
                 requires viewable_range<Rng1> AND input_range<Rng1> AND
                     viewable_range<Rng2> AND input_range<Rng2> AND
                     indirect_relation<
                         C,
                         projected<iterator_t<Rng1>, P1>,
-                        projected<iterator_t<Rng2>, P2>>) //
+                        projected<iterator_t<Rng2>, P2>>)
             set_intersection_view<all_t<Rng1>, all_t<Rng2>, C, P1, P2>
             operator()(Rng1 && rng1,
                        Rng2 && rng2,
@@ -426,7 +434,8 @@ namespace ranges
             using set_intersection_base_fn::operator();
 
             template(typename Rng2, typename C = less, typename P1 = identity,
-                     typename P2 = identity)( //
+                     typename P2 = identity)(
+                /// \pre
                 requires viewable_range<Rng2> AND input_range<Rng2> AND (!range<C>))
             constexpr auto operator()(Rng2 && rng2,
                                       C && pred = C{},
@@ -531,7 +540,8 @@ namespace ranges
             {
                 satisfy();
             }
-            template(bool Other)( //
+            template(bool Other)(
+                /// \pre
                 requires IsConst AND CPP_NOT(Other))
                 set_union_cursor(set_union_cursor<Other, Rng1, Rng2, C, P1, P2> that)
               : pred_(std::move(that.pred_))
@@ -559,7 +569,8 @@ namespace ranges
             }
             CPP_member
             auto equal(set_union_cursor const & that) const //
-                -> CPP_ret(bool)( //
+                -> CPP_ret(bool)(
+                    /// \pre
                     requires forward_range<Rng1> && forward_range<Rng2>)
             {
                 // does not support comparing iterators from different ranges
@@ -602,7 +613,8 @@ namespace ranges
         {
         public:
             template(typename Rng1, typename Rng2, typename C = less,
-                     typename P1 = identity, typename P2 = identity)( //
+                     typename P1 = identity, typename P2 = identity)(
+                /// \pre
                 requires //
                     viewable_range<Rng1> AND input_range<Rng1> AND
                     viewable_range<Rng2> AND input_range<Rng2> AND
@@ -613,7 +625,7 @@ namespace ranges
                                           range_rvalue_reference_t<Rng2>> AND
                     indirect_relation<C,
                                       projected<iterator_t<Rng1>, P1>,
-                                      projected<iterator_t<Rng2>, P2>>) //
+                                      projected<iterator_t<Rng2>, P2>>)
             set_union_view<all_t<Rng1>, all_t<Rng2>, C, P1, P2> //
             operator()(Rng1 && rng1,
                        Rng2 && rng2,
@@ -634,7 +646,8 @@ namespace ranges
             using set_union_base_fn::operator();
 
             template(typename Rng2, typename C = less, typename P1 = identity,
-                     typename P2 = identity)( //
+                     typename P2 = identity)(
+                /// \pre
                 requires viewable_range<Rng2> AND input_range<Rng2> AND (!range<C>))
             constexpr auto operator()(Rng2 && rng2,
                                       C && pred = C{},
@@ -750,7 +763,8 @@ namespace ranges
             {
                 satisfy();
             }
-            template(bool Other)(         //
+            template(bool Other)(
+                /// \pre
                 requires IsConst && CPP_NOT(Other)) //
                 set_symmetric_difference_cursor(
                     set_symmetric_difference_cursor<Other, Rng1, Rng2, C, P1, P2> that)
@@ -792,7 +806,8 @@ namespace ranges
             }
             CPP_member
             auto equal(set_symmetric_difference_cursor const & that) const
-                -> CPP_ret(bool)( //
+                -> CPP_ret(bool)(
+                    /// \pre
                     requires forward_range<R1> && forward_range<R2>)
             {
                 // does not support comparing iterators from different ranges:
@@ -836,7 +851,8 @@ namespace ranges
         struct set_symmetric_difference_base_fn
         {
             template(typename Rng1, typename Rng2, typename C = less,
-                     typename P1 = identity, typename P2 = identity)( //
+                     typename P1 = identity, typename P2 = identity)(
+                /// \pre
                 requires //
                     viewable_range<Rng1> AND input_range<Rng1> AND
                     viewable_range<Rng2> AND input_range<Rng2> AND
@@ -847,7 +863,7 @@ namespace ranges
                                           range_rvalue_reference_t<Rng2>> AND
                     indirect_relation<C,
                                       projected<iterator_t<Rng1>, P1>,
-                                      projected<iterator_t<Rng2>, P2>>) //
+                                      projected<iterator_t<Rng2>, P2>>)
             set_symmetric_difference_view<all_t<Rng1>, all_t<Rng2>, C, P1, P2>
             operator()(Rng1 && rng1,
                        Rng2 && rng2,
@@ -868,7 +884,8 @@ namespace ranges
             using set_symmetric_difference_base_fn::operator();
 
             template(typename Rng2, typename C = less, typename P1 = identity,
-                     typename P2 = identity)( //
+                     typename P2 = identity)(
+                /// \pre
                 requires viewable_range<Rng2> AND input_range<Rng2> AND (!range<C>))
             constexpr auto operator()(Rng2 && rng2,
                                       C && pred = C{},

--- a/include/range/v3/view/set_algorithm.hpp
+++ b/include/range/v3/view/set_algorithm.hpp
@@ -42,6 +42,9 @@
 
 namespace ranges
 {
+    /// \addtogroup group-views
+    /// @{
+
     /// \cond
     namespace detail
     {
@@ -177,8 +180,8 @@ namespace ranges
             (
                 return *it1_
             )
-                // clang-format on
-                void next()
+            // clang-format on
+            void next()
             {
                 ++it1_;
                 satisfy();
@@ -271,10 +274,8 @@ namespace ranges
         };
 
         /// \relates set_difference_fn
-        /// \ingroup group-views
         RANGES_INLINE_VARIABLE(set_difference_fn, set_difference)
     } // namespace views
-    /// @}
 
     /// \cond
     namespace detail
@@ -356,8 +357,8 @@ namespace ranges
             (
                 return *it1_
             )
-                // clang-format on
-                void next()
+            // clang-format on
+            void next()
             {
                 ++it1_;
                 ++it2_;
@@ -451,10 +452,8 @@ namespace ranges
         };
 
         /// \relates set_intersection_fn
-        /// \ingroup group-views
         RANGES_INLINE_VARIABLE(set_intersection_fn, set_intersection)
     } // namespace views
-    /// @}
 
     /// \cond
     namespace detail
@@ -596,7 +595,6 @@ namespace ranges
                        ? infinite
                        : (c1 == unknown) || (c2 == unknown) ? unknown : finite;
         }
-
     } // namespace detail
     /// \endcond
 
@@ -663,10 +661,8 @@ namespace ranges
         };
 
         /// \relates set_union_fn
-        /// \ingroup group-views
         RANGES_INLINE_VARIABLE(set_union_fn, set_union)
     } // namespace views
-    /// @}
 
     /// \cond
     namespace detail
@@ -766,7 +762,7 @@ namespace ranges
             template(bool Other)(
                 /// \pre
                 requires IsConst && CPP_NOT(Other)) //
-                set_symmetric_difference_cursor(
+            set_symmetric_difference_cursor(
                     set_symmetric_difference_cursor<Other, Rng1, Rng2, C, P1, P2> that)
               : pred_(std::move(that.pred_))
               , proj1_(std::move(that.proj1_))
@@ -901,7 +897,6 @@ namespace ranges
         };
 
         /// \relates set_symmetric_difference_fn
-        /// \ingroup group-views
         RANGES_INLINE_VARIABLE(set_symmetric_difference_fn, set_symmetric_difference)
     } // namespace views
     /// @}

--- a/include/range/v3/view/single.hpp
+++ b/include/range/v3/view/single.hpp
@@ -61,8 +61,9 @@ namespace ranges
         constexpr explicit single_view(T && t)
           : value_(std::move(t))
         {}
-        template(class... Args)(                 //
-            requires constructible_from<T, Args...>) //
+        template(class... Args)(
+            /// \pre
+            requires constructible_from<T, Args...>)
             constexpr single_view(in_place_t, Args &&... args)
           : single_view{in_place,
                         meta::bool_<(bool)semiregular<T>>{},
@@ -108,8 +109,9 @@ namespace ranges
     {
         struct single_fn
         {
-            template(typename Val)( //
-                requires copy_constructible<Val>) //
+            template(typename Val)(
+                /// \pre
+                requires copy_constructible<Val>)
             single_view<Val> operator()(Val value) const
             {
                 return single_view<Val>{std::move(value)};
@@ -127,7 +129,8 @@ namespace ranges
         {
             using ranges::views::single;
         }
-        template(typename T)(              //
+        template(typename T)(
+            /// \pre
             requires std::is_object<T>::value) //
             using single_view = ranges::single_view<T>;
     } // namespace cpp20

--- a/include/range/v3/view/slice.hpp
+++ b/include/range/v3/view/slice.hpp
@@ -144,15 +144,17 @@ namespace ranges
                            rng_, from_, range_tag_of<Rng>{}, is_infinite<Rng>{}) +
                        count_;
             }
-            template(typename BaseRng = Rng)( //
-                requires range<BaseRng const>) //
+            template(typename BaseRng = Rng)(
+                /// \pre
+                requires range<BaseRng const>)
             iterator_t<BaseRng const> begin() const
             {
                 return detail::pos_at_(
                     rng_, from_, range_tag_of<Rng>{}, is_infinite<Rng>{});
             }
-            template(typename BaseRng = Rng)( //
-                requires range<BaseRng const>) //
+            template(typename BaseRng = Rng)(
+                /// \pre
+                requires range<BaseRng const>)
             iterator_t<BaseRng const> end() const
             {
                 return detail::pos_at_(
@@ -202,8 +204,9 @@ namespace ranges
             {
                 return {all(static_cast<Rng &&>(rng)), from, count};
             }
-            template(typename Rng)( //
-                requires borrowed_range<Rng>) //
+            template(typename Rng)(
+                /// \pre
+                requires borrowed_range<Rng>)
             static subrange<iterator_t<Rng>> impl_(Rng && rng,
                                                    range_difference_t<Rng> from,
                                                    range_difference_t<Rng> count,
@@ -217,7 +220,8 @@ namespace ranges
 
         public:
             // slice(rng, 2, 4)
-            template(typename Rng)( //
+            template(typename Rng)(
+                /// \pre
                 requires viewable_range<Rng> AND input_range<Rng>)
             constexpr auto operator()(Rng && rng,
                                       range_difference_t<Rng> from,
@@ -230,7 +234,8 @@ namespace ranges
             // slice(rng, 4, end-2)
             //  TODO Support Forward, non-Sized ranges by returning a range that
             //       doesn't know it's size?
-            template(typename Rng)( //
+            template(typename Rng)(
+                /// \pre
                 requires viewable_range<Rng> AND input_range<Rng> AND sized_range<Rng>)
             auto operator()(Rng && rng,
                             range_difference_t<Rng> from,
@@ -246,7 +251,8 @@ namespace ranges
                                             range_tag_of<Rng>{});
             }
             // slice(rng, end-4, end-2)
-            template(typename Rng)( //
+            template(typename Rng)(
+                /// \pre
                 requires viewable_range<Rng> AND
                     (forward_range<Rng> || (input_range<Rng> && sized_range<Rng>)))
             auto operator()(Rng && rng,
@@ -263,7 +269,8 @@ namespace ranges
                                             common_range_tag_of<Rng>{});
             }
             // slice(rng, 4, end)
-            template(typename Rng)( //
+            template(typename Rng)(
+                /// \pre
                 requires viewable_range<Rng> AND input_range<Rng>)
             auto operator()(Rng && rng, range_difference_t<Rng> from, end_fn) const
             {
@@ -271,7 +278,8 @@ namespace ranges
                 return ranges::views::drop_exactly(static_cast<Rng &&>(rng), from);
             }
             // slice(rng, end-4, end)
-            template(typename Rng)( //
+            template(typename Rng)(
+                /// \pre
                 requires viewable_range<Rng> AND
                     (forward_range<Rng> || (input_range<Rng> && sized_range<Rng>)))
             auto operator()(Rng && rng,
@@ -293,33 +301,38 @@ namespace ranges
             using slice_base_fn::operator();
 
             // Overloads for the pipe syntax: rng | views::slice(from,to)
-            template(typename Int)( //
+            template(typename Int)(
+                /// \pre
                 requires detail::integer_like_<Int>)
             constexpr auto operator()(Int from, Int to) const
             {
                 return make_view_closure(bind_back(slice_base_fn{}, from, to));
             }
-            template(typename Int)( //
+            template(typename Int)(
+                /// \pre
                 requires detail::integer_like_<Int>)
             constexpr auto operator()(Int from, detail::from_end_<Int> to) const
             {
                 return make_view_closure(bind_back(slice_base_fn{}, from, to));
             }
-            template(typename Int)( //
+            template(typename Int)(
+                /// \pre
                 requires detail::integer_like_<Int>)
             constexpr auto operator()(detail::from_end_<Int> from,
                                       detail::from_end_<Int> to) const
             {
                 return make_view_closure(bind_back(slice_base_fn{}, from, to));
             }
-            template(typename Int)( //
+            template(typename Int)(
+                /// \pre
                 requires detail::integer_like_<Int>)
             constexpr auto operator()(Int from, end_fn) const
             {
                 return make_view_closure(
                     bind_back(ranges::views::drop_exactly_base_fn{}, from));
             }
-            template(typename Int)( //
+            template(typename Int)(
+                /// \pre
                 requires detail::integer_like_<Int>)
             constexpr auto operator()(detail::from_end_<Int> from, end_fn to) const
             {

--- a/include/range/v3/view/sliding.hpp
+++ b/include/range/v3/view/sliding.hpp
@@ -86,7 +86,8 @@ namespace ranges
             }
             CPP_member
             auto prev() //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires bidirectional_range<Rng>)
             {
                 --it_;
@@ -137,7 +138,8 @@ namespace ranges
                 return count < n ? 0 : count - n + 1;
             }
             CPP_member
-            auto CPP_fun(size)()( //
+            auto CPP_fun(size)()(
+                /// \pre
                 requires sized_range<Rng>)
             {
                 auto const count = ranges::size(this->base());
@@ -213,7 +215,8 @@ namespace ranges
             }
             CPP_member
             auto prev(iterator_t<Rng> & it) //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires bidirectional_range<Rng>)
             {
                 base_t::prev();
@@ -221,7 +224,8 @@ namespace ranges
             }
             CPP_member
             auto advance(iterator_t<Rng> & it, range_difference_t<Rng> n)
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires random_access_range<Rng>)
             {
                 it += n;
@@ -313,7 +317,8 @@ namespace ranges
             adaptor(range_difference_t<Rng> n)
               : n_(n)
             {}
-            template(bool Other)( //
+            template(bool Other)(
+                /// \pre
                 requires Const AND CPP_NOT(Other)) //
             adaptor(adaptor<Other> that)
               : n_(that.n_)
@@ -337,7 +342,8 @@ namespace ranges
         }
         CPP_member
         auto begin_adaptor() const //
-            -> CPP_ret(adaptor<true>)( //
+            -> CPP_ret(adaptor<true>)(
+                /// \pre
                 requires range<Rng const>)
         {
             return {this->n_};
@@ -348,7 +354,8 @@ namespace ranges
         }
         CPP_member
         auto end_adaptor() const //
-            -> CPP_ret(adaptor<true>)( //
+            -> CPP_ret(adaptor<true>)(
+                /// \pre
                 requires range<Rng const>)
         {
             return {this->n_};
@@ -364,7 +371,7 @@ namespace ranges
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
     template<typename Rng>
-    sliding_view(Rng &&, range_difference_t<Rng>) //
+    sliding_view(Rng &&, range_difference_t<Rng>)
         -> sliding_view<views::all_t<Rng>>;
 #endif
 
@@ -374,8 +381,9 @@ namespace ranges
         // Out: range<range<T>>, where each inner range has $n$ elements.
         struct sliding_base_fn
         {
-            template(typename Rng)( //
-                requires viewable_range<Rng> AND forward_range<Rng>) //
+            template(typename Rng)(
+                /// \pre
+                requires viewable_range<Rng> AND forward_range<Rng>)
             constexpr sliding_view<all_t<Rng>> //
             operator()(Rng && rng, range_difference_t<Rng> n) const
             {

--- a/include/range/v3/view/span.hpp
+++ b/include/range/v3/view/span.hpp
@@ -48,8 +48,9 @@ namespace ranges
     /// \cond
     namespace detail
     {
-        template(typename To, typename From)( //
-            requires integral<To> AND integral<From>) //
+        template(typename To, typename From)(
+            /// \pre
+            requires integral<To> AND integral<From>)
         constexpr To narrow_cast(From from) noexcept
         {
             using C = common_type_t<To, From>;
@@ -167,19 +168,21 @@ namespace ranges
           : span{first, last - first}
         {}
 
-        template(typename Rng)( //
-            requires (!same_as<span, uncvref_t<Rng>>) AND //
-                span_compatible_range<Rng, T> AND //
-                span_dynamic_conversion<Rng, N>) //
+        template(typename Rng)(
+            /// \pre
+            requires (!same_as<span, uncvref_t<Rng>>) AND
+                span_compatible_range<Rng, T> AND
+                span_dynamic_conversion<Rng, N>)
         constexpr span(Rng && rng) noexcept(noexcept(ranges::data(rng),
                                                         ranges::size(rng)))
           : span{ranges::data(rng), detail::narrow_cast<index_type>(ranges::size(rng))}
         {}
 
-        template(typename Rng)( //
-            requires (!same_as<span, uncvref_t<Rng>>) AND //
-                span_compatible_range<Rng, T> AND //
-                span_static_conversion<Rng, N>) //
+        template(typename Rng)(
+            /// \pre
+            requires (!same_as<span, uncvref_t<Rng>>) AND
+                span_compatible_range<Rng, T> AND
+                span_static_conversion<Rng, N>)
         constexpr span(Rng && rng) noexcept(noexcept(ranges::data(rng)))
           : span{ranges::data(rng), N}
         {}
@@ -304,43 +307,49 @@ namespace ranges
             return reverse_iterator{begin()};
         }
 
-        template(typename U, index_type M)( //
-            requires equality_comparable_with<T, U>) //
+        template(typename U, index_type M)(
+            /// \pre
+            requires equality_comparable_with<T, U>)
         bool operator==(span<U, M> const & that) const
         {
             RANGES_EXPECT(!size() || data());
             RANGES_EXPECT(!that.size() || that.data());
             return ranges::equal(*this, that);
         }
-        template(typename U, index_type M)( //
-            requires equality_comparable_with<T, U>) //
+        template(typename U, index_type M)(
+            /// \pre
+            requires equality_comparable_with<T, U>)
         bool operator!=(span<U, M> const & that) const
         {
             return !(*this == that);
         }
 
-        template(typename U, index_type M)( //
-            requires totally_ordered_with<T, U>) //
+        template(typename U, index_type M)(
+            /// \pre
+            requires totally_ordered_with<T, U>)
         bool operator<(span<U, M> const & that) const
         {
             RANGES_EXPECT(!size() || data());
             RANGES_EXPECT(!that.size() || that.data());
             return ranges::lexicographical_compare(*this, that);
         }
-        template(typename U, index_type M)( //
-            requires totally_ordered_with<T, U>) //
+        template(typename U, index_type M)(
+            /// \pre
+            requires totally_ordered_with<T, U>)
         bool operator>(span<U, M> const & that) const
         {
             return that < *this;
         }
-        template(typename U, index_type M)( //
-            requires totally_ordered_with<T, U>) //
+        template(typename U, index_type M)(
+            /// \pre
+            requires totally_ordered_with<T, U>)
         bool operator<=(span<U, M> const & that) const
         {
             return !(that < *this);
         }
-        template(typename U, index_type M)( //
-            requires totally_ordered_with<T, U>) //
+        template(typename U, index_type M)(
+            /// \pre
+            requires totally_ordered_with<T, U>)
         bool operator>=(span<U, M> const & that) const
         {
             return !(*this < that);
@@ -357,8 +366,9 @@ namespace ranges
     constexpr detail::span_index_t span<T, N>::extent;
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-    template(typename Rng)(         //
-        requires contiguous_range<Rng>) //
+    template(typename Rng)(
+        /// \pre
+        requires contiguous_range<Rng>)
         span(Rng && rng)
             ->span<detail::element_t<Rng>, (range_cardinality<Rng>::value < cardinality()
                                                 ? dynamic_extent
@@ -389,7 +399,8 @@ namespace ranges
     {
         return span<ElementType>{first, last};
     }
-    template(typename Rng)( //
+    template(typename Rng)(
+        /// \pre
         requires contiguous_range<Rng> AND
         (range_cardinality<Rng>::value < cardinality())) //
         constexpr span<detail::element_t<Rng>> make_span(Rng && rng) noexcept(
@@ -398,7 +409,8 @@ namespace ranges
         return {ranges::data(rng),
                 detail::narrow_cast<detail::span_index_t>(ranges::size(rng))};
     }
-    template(typename Rng)( //
+    template(typename Rng)(
+        /// \pre
         requires contiguous_range<Rng> AND
         (range_cardinality<Rng>::value >= cardinality())) //
         constexpr span<

--- a/include/range/v3/view/split.hpp
+++ b/include/range/v3/view/split.hpp
@@ -245,7 +245,8 @@ namespace ranges
             CPP_broken_friend_member
             friend constexpr auto operator==(split_inner_iterator const & x,
                                              split_inner_iterator const & y)
-                -> CPP_broken_friend_ret(bool)( //
+                -> CPP_broken_friend_ret(bool)(
+                    /// \pre
                     requires forward_range<Base>)
             {
                 return x.i_.curr_ == y.i_.curr_;
@@ -253,7 +254,8 @@ namespace ranges
             CPP_broken_friend_member
             friend constexpr auto operator!=(split_inner_iterator const & x,
                                              split_inner_iterator const & y)
-                -> CPP_broken_friend_ret(bool)( //
+                -> CPP_broken_friend_ret(bool)(
+                    /// \pre
                     requires forward_range<Base>)
             {
                 return x.i_.curr_ != y.i_.curr_;
@@ -304,7 +306,8 @@ namespace ranges
                 split_inner_iterator const & x,
                 split_inner_iterator const &
                     y) noexcept(noexcept(ranges::iter_swap(x.current_(), y.current_())))
-                -> CPP_broken_friend_ret(void)( //
+                -> CPP_broken_friend_ret(void)(
+                    /// \pre
                     requires indirectly_swappable<iterator_t<Base>>)
             {
                 ranges::iter_swap(x.current_(), y.current_());
@@ -386,22 +389,25 @@ namespace ranges
             split_outer_iterator() = default;
 
             CPP_member
-            constexpr explicit CPP_ctor(split_outer_iterator)(Parent & parent)( //
+            constexpr explicit CPP_ctor(split_outer_iterator)(Parent & parent)(
+                /// \pre
                 requires (!forward_range<Base>))
               : parent_(&parent)
             {}
 
             CPP_member
             constexpr CPP_ctor(split_outer_iterator)(Parent & parent,
-                                                     iterator_t<Base> current)( //
+                                                     iterator_t<Base> current)(
+                /// \pre
                 requires forward_range<Base>)
               : Current{std::move(current)}
               , parent_(&parent)
             {}
 
-            template(bool Other)( //
+            template(bool Other)(
+                /// \pre
                 requires Const AND CPP_NOT(Other) AND
-                convertible_to<iterator_t<V>, iterator_t<Base>>) //
+                convertible_to<iterator_t<V>, iterator_t<Base>>)
             constexpr split_outer_iterator(
                 split_outer_iterator<split_view<V, Pattern>, Other> i)
               : Current{std::move(i.curr_)}
@@ -455,7 +461,8 @@ namespace ranges
             CPP_broken_friend_member
             friend constexpr auto operator==(split_outer_iterator const & x,
                                              split_outer_iterator const & y)
-                -> CPP_broken_friend_ret(bool)( //
+                -> CPP_broken_friend_ret(bool)(
+                    /// \pre
                     requires forward_range<Base>)
             {
                 return x.curr_ == y.curr_;
@@ -463,7 +470,8 @@ namespace ranges
             CPP_broken_friend_member
             friend constexpr auto operator!=(split_outer_iterator const & x,
                                              split_outer_iterator const & y)
-                -> CPP_broken_friend_ret(bool)( //
+                -> CPP_broken_friend_ret(bool)(
+                    /// \pre
                     requires forward_range<Base>)
             {
                 return x.curr_ != y.curr_;
@@ -557,6 +565,7 @@ namespace ranges
 
         CPP_member
         constexpr CPP_ctor(split_view)(V base, range_value_t<V> e)(
+            /// \pre
             requires constructible_from<Pattern, range_value_t<V>>)
           : base_(std::move(base))
           , pattern_(e)
@@ -583,14 +592,16 @@ namespace ranges
         }
         CPP_member
         constexpr auto begin() const //
-            -> CPP_ret(outer_iterator<true>)( //
+            -> CPP_ret(outer_iterator<true>)(
+                /// \pre
                 requires forward_range<V> && forward_range<const V>)
         {
             return {*this, ranges::begin(base_)};
         }
         CPP_member
         constexpr auto end() //
-            -> CPP_ret(outer_iterator<simple_view<V>()>)( //
+            -> CPP_ret(outer_iterator<simple_view<V>()>)(
+                /// \pre
                 requires forward_range<V> && common_range<V>)
         {
             return outer_iterator<simple_view<V>()>{*this, ranges::end(base_)};
@@ -611,7 +622,8 @@ namespace ranges
     };
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-    template(typename R, typename P)( //
+    template(typename R, typename P)(
+        /// \pre
         requires input_range<R> AND forward_range<P> AND viewable_range<R> AND
             viewable_range<P> AND
             indirectly_comparable<iterator_t<R>, iterator_t<P>, ranges::equal_to> AND
@@ -619,8 +631,9 @@ namespace ranges
     split_view(R &&, P &&)
             ->split_view<views::all_t<R>, views::all_t<P>>;
 
-    template(typename R)(    //
-        requires input_range<R>) //
+    template(typename R)(
+        /// \pre
+        requires input_range<R>)
         split_view(R &&, range_value_t<R>)
             ->split_view<views::all_t<R>, single_view<range_value_t<R>>>;
 #endif
@@ -629,18 +642,20 @@ namespace ranges
     {
         struct split_base_fn
         {
-            template(typename Rng)( //
+            template(typename Rng)(
+                /// \pre
                 requires viewable_range<Rng> AND input_range<Rng> AND
                     indirectly_comparable<iterator_t<Rng>,
                                           range_value_t<Rng> const *,
-                                          ranges::equal_to>) //
+                                          ranges::equal_to>)
             constexpr split_view<all_t<Rng>, single_view<range_value_t<Rng>>> //
             operator()(Rng && rng, range_value_t<Rng> val) const
             {
                 return {all(static_cast<Rng &&>(rng)), single(std::move(val))};
             }
 
-            template(typename Rng, typename Pattern)( //
+            template(typename Rng, typename Pattern)(
+                /// \pre
                 requires viewable_range<Rng> AND input_range<Rng> AND
                     viewable_range<Pattern> AND forward_range<Pattern> AND
                     indirectly_comparable<
@@ -677,9 +692,10 @@ namespace ranges
         {
             using ranges::views::split;
         }
-        template(typename Rng, typename Pattern)( //
+        template(typename Rng, typename Pattern)(
+            /// \pre
             requires input_range<Rng> AND forward_range<Pattern> AND view_<Rng> AND
-                view_<Pattern> AND //
+                view_<Pattern> AND
                 indirectly_comparable<
                     iterator_t<Rng>,
                     iterator_t<Pattern>,

--- a/include/range/v3/view/split_when.hpp
+++ b/include/range/v3/view/split_when.hpp
@@ -126,7 +126,8 @@ namespace ranges
 
         public:
             cursor() = default;
-            template(bool Other)( //
+            template(bool Other)(
+                /// \pre
                 requires IsConst AND CPP_NOT(Other)) //
             cursor(cursor<Other> that)
               : cursor{std::move(that.cur_), std::move(that.last_), std::move(that.fun_)}
@@ -136,10 +137,11 @@ namespace ranges
         {
             return {fun_, ranges::begin(rng_), ranges::end(rng_)};
         }
-        template(bool Const = true)( //
+        template(bool Const = true)(
+            /// \pre
             requires Const AND range<meta::const_if_c<Const, Rng>> AND
                 invocable<Fun const &, iterator_t<meta::const_if_c<Const, Rng>>,
-                          sentinel_t<meta::const_if_c<Const, Rng>>>) //
+                          sentinel_t<meta::const_if_c<Const, Rng>>>)
         cursor<Const> begin_cursor() const
         {
             return {fun_, ranges::begin(rng_), ranges::end(rng_)};
@@ -154,7 +156,8 @@ namespace ranges
     };
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-    template(typename Rng, typename Fun)( //
+    template(typename Rng, typename Fun)(
+        /// \pre
         requires copy_constructible<Fun>)
     split_when_view(Rng &&, Fun)
         -> split_when_view<views::all_t<Rng>, Fun>;
@@ -170,8 +173,9 @@ namespace ranges
             {
                 semiregular_box_t<Pred> pred_;
 
-                template(typename I, typename S)( //
-                    requires sentinel_for<S, I>) //
+                template(typename I, typename S)(
+                    /// \pre
+                    requires sentinel_for<S, I>)
                 std::pair<bool, I> operator()(I cur, S last) const
                 {
                     auto where = ranges::find_if_not(cur, last, std::ref(pred_));
@@ -180,22 +184,24 @@ namespace ranges
             };
 
         public:
-            template(typename Rng, typename Fun)( //
+            template(typename Rng, typename Fun)(
+                /// \pre
                 requires viewable_range<Rng> AND forward_range<Rng> AND
                     invocable<Fun &, iterator_t<Rng>, sentinel_t<Rng>> AND
                     invocable<Fun &, iterator_t<Rng>, iterator_t<Rng>> AND
                     copy_constructible<Fun> AND
                     convertible_to<
                         invoke_result_t<Fun &, iterator_t<Rng>, sentinel_t<Rng>>,
-                        std::pair<bool, iterator_t<Rng>>>) //
+                        std::pair<bool, iterator_t<Rng>>>)
             split_when_view<all_t<Rng>, Fun> operator()(Rng && rng, Fun fun) const //
             {
                 return {all(static_cast<Rng &&>(rng)), std::move(fun)};
             }
-            template(typename Rng, typename Fun)( //
-                requires viewable_range<Rng> AND forward_range<Rng> AND //
+            template(typename Rng, typename Fun)(
+                /// \pre
+                requires viewable_range<Rng> AND forward_range<Rng> AND
                     predicate<Fun const &, range_reference_t<Rng>> AND
-                    copy_constructible<Fun>) //
+                    copy_constructible<Fun>)
             split_when_view<all_t<Rng>, predicate_pred_<Fun>> //
             operator()(Rng && rng, Fun fun) const
             {

--- a/include/range/v3/view/stride.hpp
+++ b/include/range/v3/view/stride.hpp
@@ -169,7 +169,8 @@ namespace ranges
             constexpr adaptor(stride_view_t * rng) noexcept
               : rng_(rng)
             {}
-            template(bool Other)( //
+            template(bool Other)(
+                /// \pre
                 requires Const AND CPP_NOT(Other)) //
             adaptor(adaptor<Other> that)
               : rng_(that.rng_)
@@ -186,7 +187,8 @@ namespace ranges
             }
             CPP_member
             constexpr auto prev(iterator_t<CRng> & it) //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires bidirectional_range<CRng>)
             {
                 RANGES_EXPECT(it != ranges::begin(rng_->base()));
@@ -198,8 +200,9 @@ namespace ranges
                 }
                 ranges::advance(it, delta);
             }
-            template(typename Other)( //
-                requires sized_sentinel_for<Other, iterator_t<CRng>>) //
+            template(typename Other)(
+                /// \pre
+                requires sized_sentinel_for<Other, iterator_t<CRng>>)
             constexpr range_difference_t<Rng> distance_to(iterator_t<CRng> const & here,
                                                           Other const & there) const
             {
@@ -212,7 +215,8 @@ namespace ranges
             }
             CPP_member
             constexpr auto advance(iterator_t<CRng> & it, range_difference_t<Rng> n) //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires random_access_range<CRng>)
             {
                 if(0 == n)
@@ -252,7 +256,8 @@ namespace ranges
         }
         CPP_member
         constexpr auto begin_adaptor() const noexcept
-            -> CPP_ret(adaptor<true>)( //
+            -> CPP_ret(adaptor<true>)(
+                /// \pre
                 requires(const_iterable()))
         {
             return adaptor<true>{this};
@@ -265,7 +270,8 @@ namespace ranges
         }
         CPP_member
         constexpr auto end_adaptor() const noexcept //
-            -> CPP_ret(meta::if_c<can_bound<true>(), adaptor<true>, adaptor_base>)( //
+            -> CPP_ret(meta::if_c<can_bound<true>(), adaptor<true>, adaptor_base>)(
+                /// \pre
                 requires (const_iterable()))
         {
             return {this};
@@ -277,7 +283,8 @@ namespace ranges
           : detail::stride_view_base<Rng>{std::move(rng), stride}
         {}
         CPP_member
-        constexpr auto CPP_fun(size)()( //
+        constexpr auto CPP_fun(size)()(
+            /// \pre
             requires sized_range<Rng>)
         {
             using size_type = range_size_t<Rng>;
@@ -298,7 +305,7 @@ namespace ranges
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
     template<typename Rng>
-    stride_view(Rng &&, range_difference_t<Rng>) //
+    stride_view(Rng &&, range_difference_t<Rng>)
         -> stride_view<views::all_t<Rng>>;
 #endif
 
@@ -306,8 +313,9 @@ namespace ranges
     {
         struct stride_base_fn
         {
-            template(typename Rng)( //
-                requires viewable_range<Rng> AND input_range<Rng>) //
+            template(typename Rng)(
+                /// \pre
+                requires viewable_range<Rng> AND input_range<Rng>)
             constexpr stride_view<all_t<Rng>> //
             operator()(Rng && rng, range_difference_t<Rng> step) const
             {
@@ -319,7 +327,8 @@ namespace ranges
         {
             using stride_base_fn::operator();
 
-            template(typename Difference)( //
+            template(typename Difference)(
+                /// \pre
                 requires detail::integer_like_<Difference>)
             constexpr auto operator()(Difference step) const
             {

--- a/include/range/v3/view/subrange.hpp
+++ b/include/range/v3/view/subrange.hpp
@@ -81,8 +81,8 @@ namespace ranges
 
         template(typename T)( //
         concept (pair_like_)(T), //
-            is_complete_<std::tuple_size<T>> AND //
-            derived_from<std::tuple_size<T>, meta::size_t<2>> AND //
+            is_complete_<std::tuple_size<T>> AND
+            derived_from<std::tuple_size<T>, meta::size_t<2>> AND
             detail::pair_like_impl_<T>);
 
         template<typename T>
@@ -121,8 +121,9 @@ namespace ranges
             CPP_concept_ref(detail::range_convertible_to_impl_, R, I, S);
         // clang-format on
 
-        template(typename S, typename I)( //
-            requires sentinel_for<S, I>) //
+        template(typename S, typename I)(
+            /// \pre
+            requires sentinel_for<S, I>)
         constexpr bool is_sized_sentinel_() noexcept
         {
             return (bool)sized_sentinel_for<S, I>;
@@ -151,13 +152,15 @@ namespace ranges
         struct adl_hook
         {};
 
-        template(std::size_t N, typename I, typename S, subrange_kind K)( //
+        template(std::size_t N, typename I, typename S, subrange_kind K)(
+            /// \pre
             requires (N == 0)) //
         constexpr I get(subrange<I, S, K> const & r)
         {
             return r.begin();
         }
-        template(std::size_t N, typename I, typename S, subrange_kind K)( //
+        template(std::size_t N, typename I, typename S, subrange_kind K)(
+            /// \pre
             requires (N == 1)) //
         constexpr S get(subrange<I, S, K> const & r)
         {
@@ -185,15 +188,17 @@ namespace ranges
 
         subrange() = default;
 
-        template(typename I2)( //
-            requires detail::convertible_to_not_slicing_<I2, I> AND //
+        template(typename I2)(
+            /// \pre
+            requires detail::convertible_to_not_slicing_<I2, I> AND
             (!detail::store_size_<K, S, I>())) //
         constexpr subrange(I2 && i, S s)
           : data_{static_cast<I2 &&>(i), std::move(s)}
         {}
 
-        template(typename I2)( //
-            requires detail::convertible_to_not_slicing_<I2, I> AND //
+        template(typename I2)(
+            /// \pre
+            requires detail::convertible_to_not_slicing_<I2, I> AND
             (detail::store_size_<K, S, I>())) //
         constexpr subrange(I2 && i, S s, size_type n)
           : data_{static_cast<I2 &&>(i), std::move(s), n}
@@ -205,9 +210,10 @@ namespace ranges
                 RANGES_EXPECT(ranges::next(first_(), (D)n) == last_());
             }
         }
-        template(typename I2)( //
-            requires detail::convertible_to_not_slicing_<I2, I> AND //
-                sized_sentinel_for<S, I>) //
+        template(typename I2)(
+            /// \pre
+            requires detail::convertible_to_not_slicing_<I2, I> AND
+                sized_sentinel_for<S, I>)
         constexpr subrange(I2 && i, S s, size_type n)
           : data_{static_cast<I2 &&>(i), std::move(s)}
         {
@@ -215,25 +221,28 @@ namespace ranges
         }
 
         template(typename R)(
-            requires (!same_as<detail::decay_t<R>, subrange>) AND //
-                detail::range_convertible_to_<R, I, S> AND //
+            /// \pre
+            requires (!same_as<detail::decay_t<R>, subrange>) AND
+                detail::range_convertible_to_<R, I, S> AND
                 (!detail::store_size_<K, S, I>()))
         constexpr subrange(R && r)
           : subrange{ranges::begin(r), ranges::end(r)}
         {}
 
-        template(typename R)( //
-            requires (!same_as<detail::decay_t<R>, subrange>) AND //
-                detail::range_convertible_to_<R, I, S> AND //
-                (detail::store_size_<K, S, I>()) AND //
-                sized_range<R>) //
+        template(typename R)(
+            /// \pre
+            requires (!same_as<detail::decay_t<R>, subrange>) AND
+                detail::range_convertible_to_<R, I, S> AND
+                (detail::store_size_<K, S, I>()) AND
+                sized_range<R>)
         constexpr subrange(R && r)
           : subrange{ranges::begin(r), ranges::end(r), ranges::size(r)}
         {}
 
-        template(typename R)( //
-            requires (K == subrange_kind::sized) AND //
-                detail::range_convertible_to_<R, I, S>) //
+        template(typename R)(
+            /// \pre
+            requires (K == subrange_kind::sized) AND
+                detail::range_convertible_to_<R, I, S>)
         constexpr subrange(R && r, size_type n) //
           : subrange{ranges::begin(r), ranges::end(r), n}
         {
@@ -243,9 +252,10 @@ namespace ranges
             }
         }
 
-        template(typename PairLike)( //
-            requires (!same_as<PairLike, subrange>) AND //
-                detail::pair_like_convertible_from_<PairLike, I const &, S const &>) //
+        template(typename PairLike)(
+            /// \pre
+            requires (!same_as<PairLike, subrange>) AND
+                detail::pair_like_convertible_from_<PairLike, I const &, S const &>)
         constexpr operator PairLike() const
         {
             return PairLike(first_(), last_());
@@ -266,7 +276,8 @@ namespace ranges
 
         CPP_member
         constexpr auto size() const //
-            -> CPP_ret(size_type)( //
+            -> CPP_ret(size_type)(
+                /// \pre
                 requires (K == subrange_kind::sized))
         {
             return get_size_();
@@ -282,7 +293,8 @@ namespace ranges
 
         CPP_member
         RANGES_NODISCARD constexpr auto prev(iter_difference_t<I> n = 1) const
-            -> CPP_ret(subrange)( //
+            -> CPP_ret(subrange)(
+                /// \pre
                 requires bidirectional_iterator<I>)
         {
             auto tmp = *this;
@@ -323,14 +335,16 @@ namespace ranges
         }
         CPP_member
         constexpr auto get_size_() const //
-            -> CPP_ret(size_type)( //
+            -> CPP_ret(size_type)(
+                /// \pre
                 requires sized_sentinel_for<S, I>)
         {
             return static_cast<size_type>(last_() - first_());
         }
         CPP_member
         constexpr auto get_size_() const noexcept //
-            -> CPP_ret(size_type)( //
+            -> CPP_ret(size_type)(
+                /// \pre
                 requires (detail::store_size_<K, S, I>()))
         {
             return std::get<2>(data_);
@@ -339,7 +353,8 @@ namespace ranges
         {}
         CPP_member
         constexpr auto set_size_(size_type n) noexcept //
-            -> CPP_ret(void)( //
+            -> CPP_ret(void)(
+                /// \pre
                 requires (detail::store_size_<K, S, I>()))
         {
             std::get<2>(data_) = n;
@@ -351,13 +366,15 @@ namespace ranges
     subrange(I, S) //
         -> subrange<I, S>;
 
-    template(typename I, typename S)(                           //
-        requires input_or_output_iterator<I> AND sentinel_for<S, I>) //
-    subrange(I, S, detail::iter_size_t<I>) //
+    template(typename I, typename S)(
+        /// \pre
+        requires input_or_output_iterator<I> AND sentinel_for<S, I>)
+    subrange(I, S, detail::iter_size_t<I>)
         -> subrange<I, S, subrange_kind::sized>;
 
-    template(typename R)(   //
-        requires borrowed_range<R>) //
+    template(typename R)(
+        /// \pre
+        requires borrowed_range<R>)
     subrange(R &&) //
         -> subrange<iterator_t<R>, sentinel_t<R>,
                     (sized_range<R> ||
@@ -365,9 +382,10 @@ namespace ranges
                            ? subrange_kind::sized
                            : subrange_kind::unsized>;
 
-    template(typename R)(   //
-        requires borrowed_range<R>) //
-    subrange(R &&, detail::iter_size_t<iterator_t<R>>) //
+    template(typename R)(
+        /// \pre
+        requires borrowed_range<R>)
+    subrange(R &&, detail::iter_size_t<iterator_t<R>>)
         -> subrange<iterator_t<R>, sentinel_t<R>, subrange_kind::sized>;
 #endif
 
@@ -379,15 +397,17 @@ namespace ranges
         {
             return {i, s};
         }
-        template(typename I, typename S)( //
-            requires input_or_output_iterator<I> AND sentinel_for<S, I>) //
+        template(typename I, typename S)(
+            /// \pre
+            requires input_or_output_iterator<I> AND sentinel_for<S, I>)
         constexpr subrange<I, S, subrange_kind::sized> //
         operator()(I i, S s, detail::iter_size_t<I> n) const
         {
             return {i, s, n};
         }
-        template(typename R)( //
-            requires borrowed_range<R>) //
+        template(typename R)(
+            /// \pre
+            requires borrowed_range<R>)
         constexpr auto operator()(R && r) const
             -> subrange<iterator_t<R>, sentinel_t<R>,
                      (sized_range<R> || sized_sentinel_for<sentinel_t<R>, iterator_t<R>>)
@@ -396,8 +416,9 @@ namespace ranges
         {
             return {(R &&) r};
         }
-        template(typename R)( //
-            requires borrowed_range<R>) //
+        template(typename R)(
+            /// \pre
+            requires borrowed_range<R>)
         constexpr subrange<iterator_t<R>, sentinel_t<R>, subrange_kind::sized> //
         operator()(R && r, detail::iter_size_t<iterator_t<R>> n) const
         {
@@ -420,8 +441,9 @@ namespace ranges
                  typename S = I,                                            //
                  subrange_kind K =                                          //
                  static_cast<subrange_kind>(                                //
-                     detail::is_sized_sentinel_<S, I>()))(                  //
-            requires input_or_output_iterator<I> AND sentinel_for<S, I> AND //
+                     detail::is_sized_sentinel_<S, I>()))(
+            /// \pre
+            requires input_or_output_iterator<I> AND sentinel_for<S, I> AND
                 (K == subrange_kind::sized || !sized_sentinel_for<S, I>))   //
         using subrange = ranges::subrange<I, S, K>;
 

--- a/include/range/v3/view/tail.hpp
+++ b/include/range/v3/view/tail.hpp
@@ -65,8 +65,9 @@ namespace ranges
         {
             return next(ranges::begin(rng_), 1, ranges::end(rng_));
         }
-        template(bool Const = true)( //
-            requires Const AND range<meta::const_if_c<Const, Rng>>) //
+        template(bool Const = true)(
+            /// \pre
+            requires Const AND range<meta::const_if_c<Const, Rng>>)
         iterator_t<meta::const_if_c<Const, Rng>> begin() const
         {
             return next(ranges::begin(rng_), 1, ranges::end(rng_));
@@ -75,15 +76,17 @@ namespace ranges
         {
             return ranges::end(rng_);
         }
-        template(bool Const = true)( //
-            requires Const AND range<meta::const_if_c<Const, Rng>>) //
+        template(bool Const = true)(
+            /// \pre
+            requires Const AND range<meta::const_if_c<Const, Rng>>)
         sentinel_t<meta::const_if_c<Const, Rng>> end() const
         {
             return ranges::end(rng_);
         }
         // Strange cast to bool in the requires clause is to work around gcc bug.
         CPP_member
-        constexpr auto CPP_fun(size)()( //
+        constexpr auto CPP_fun(size)()(
+            /// \pre
             requires(bool(sized_range<Rng>)))
         {
             using size_type = range_size_t<Rng>;
@@ -111,8 +114,9 @@ namespace ranges
         enable_borrowed_range<Rng>;
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-    template(typename Rng)(       //
-        requires viewable_range<Rng>) //
+    template(typename Rng)(
+        /// \pre
+        requires viewable_range<Rng>)
         tail_view(Rng &&)
             ->tail_view<views::all_t<Rng>>;
 #endif
@@ -121,8 +125,9 @@ namespace ranges
     {
         struct tail_fn
         {
-            template(typename Rng)( //
-                requires viewable_range<Rng> AND input_range<Rng>) //
+            template(typename Rng)(
+                /// \pre
+                requires viewable_range<Rng> AND input_range<Rng>)
             meta::if_c<range_cardinality<Rng>::value == 0,
                        all_t<Rng>,
                        tail_view<all_t<Rng>>> //

--- a/include/range/v3/view/take.hpp
+++ b/include/range/v3/view/take.hpp
@@ -52,10 +52,11 @@ namespace ranges
             constexpr explicit sentinel(sentinel_t<Base> last)
               : end_(std::move(last))
             {}
-            template(bool Other)( //
+            template(bool Other)(
+                /// \pre
                 requires Const AND CPP_NOT(Other) AND
                 convertible_to<sentinel_t<Rng>,
-                               sentinel_t<Base>>) //
+                               sentinel_t<Base>>)
                 constexpr sentinel(sentinel<Other> that)
               : end_(std::move(that.end_))
             {}
@@ -161,7 +162,8 @@ namespace ranges
         }
 
         CPP_member
-        constexpr auto CPP_fun(begin)()( //
+        constexpr auto CPP_fun(begin)()(
+            /// \pre
             requires(!simple_view<Rng>()))
         {
 #if RANGES_CXX_IF_CONSTEXPR >= RANGES_CXX_IF_CONSTEXPR_17
@@ -208,7 +210,8 @@ namespace ranges
         }
 
         CPP_member
-        constexpr auto CPP_fun(end)()( //
+        constexpr auto CPP_fun(end)()(
+            /// \pre
             requires(!simple_view<Rng>()))
         {
 #if RANGES_CXX_IF_CONSTEXPR >= RANGES_CXX_IF_CONSTEXPR_17
@@ -251,7 +254,8 @@ namespace ranges
         }
 
         CPP_member
-        constexpr auto CPP_fun(size)()( //
+        constexpr auto CPP_fun(size)()(
+            /// \pre
             requires sized_range<Rng>)
         {
             auto n = ranges::size(base_);
@@ -272,7 +276,7 @@ namespace ranges
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
     template<typename Rng>
-    take_view(Rng &&, range_difference_t<Rng>) //
+    take_view(Rng &&, range_difference_t<Rng>)
         -> take_view<views::all_t<Rng>>;
 #endif
 
@@ -280,8 +284,9 @@ namespace ranges
     {
         struct take_base_fn
         {
-            template(typename Rng)( //
-                requires viewable_range<Rng>) //
+            template(typename Rng)(
+                /// \pre
+                requires viewable_range<Rng>)
             take_view<all_t<Rng>> operator()(Rng && rng, range_difference_t<Rng> n) const
             {
                 return {all(static_cast<Rng &&>(rng)), n};
@@ -292,7 +297,8 @@ namespace ranges
         {
             using take_base_fn::operator();
 
-            template(typename Int)( //
+            template(typename Int)(
+                /// \pre
                 requires detail::integer_like_<Int>)
             constexpr auto operator()(Int n) const
             {
@@ -311,8 +317,9 @@ namespace ranges
         {
             using ranges::views::take;
         }
-        template(typename Rng)( //
-            requires view_<Rng>)    //
+        template(typename Rng)(
+            /// \pre
+            requires view_<Rng>)
             using take_view = ranges::take_view<Rng>;
     } // namespace cpp20
     /// @}

--- a/include/range/v3/view/take.hpp
+++ b/include/range/v3/view/take.hpp
@@ -32,6 +32,9 @@
 
 namespace ranges
 {
+    /// \addtogroup group-views
+    /// @{
+
     template<typename Rng>
     struct take_view : view_interface<take_view<Rng>, finite>
     {
@@ -307,7 +310,6 @@ namespace ranges
         };
 
         /// \relates take_fn
-        /// \ingroup group-views
         RANGES_INLINE_VARIABLE(take_fn, take)
     } // namespace views
 
@@ -320,7 +322,7 @@ namespace ranges
         template(typename Rng)(
             /// \pre
             requires view_<Rng>)
-            using take_view = ranges::take_view<Rng>;
+        using take_view = ranges::take_view<Rng>;
     } // namespace cpp20
     /// @}
 } // namespace ranges

--- a/include/range/v3/view/take_exactly.hpp
+++ b/include/range/v3/view/take_exactly.hpp
@@ -68,8 +68,9 @@ namespace ranges
             {
                 return {ranges::begin(rng_), n_};
             }
-            template(typename BaseRng = Rng)( //
-                requires range<BaseRng const>) //
+            template(typename BaseRng = Rng)(
+                /// \pre
+                requires range<BaseRng const>)
             counted_iterator<iterator_t<BaseRng const>> begin() const
             {
                 return {ranges::begin(rng_), n_};
@@ -158,8 +159,9 @@ namespace ranges
             {
                 return {all(static_cast<Rng &&>(rng)), n};
             }
-            template(typename Rng)( //
-                requires borrowed_range<Rng>) //
+            template(typename Rng)(
+                /// \pre
+                requires borrowed_range<Rng>)
             static constexpr subrange<iterator_t<Rng>> impl_(Rng && rng,
                                                              range_difference_t<Rng> n,
                                                              random_access_range_tag)
@@ -168,7 +170,8 @@ namespace ranges
             }
 
         public:
-            template(typename Rng)( //
+            template(typename Rng)(
+                /// \pre
                 requires viewable_range<Rng> AND input_range<Rng>)
             constexpr auto operator()(Rng && rng, range_difference_t<Rng> n) const
             {
@@ -181,7 +184,8 @@ namespace ranges
         {
             using take_exactly_base_fn::operator();
 
-            template(typename Int)( //
+            template(typename Int)(
+                /// \pre
                 requires detail::integer_like_<Int>)
             constexpr auto operator()(Int n) const
             {

--- a/include/range/v3/view/take_last.hpp
+++ b/include/range/v3/view/take_last.hpp
@@ -31,7 +31,8 @@ namespace ranges
     {
         struct take_last_base_fn
         {
-            template(typename Rng)( //
+            template(typename Rng)(
+                /// \pre
                 requires viewable_range<Rng> AND sized_range<Rng>)
             auto operator()(Rng && rng, range_difference_t<Rng> n) const
             {
@@ -44,7 +45,8 @@ namespace ranges
         {
             using take_last_base_fn::operator();
 
-            template(typename Int)( //
+            template(typename Int)(
+                /// \pre
                 requires detail::integer_like_<Int>)
             constexpr auto operator()(Int n) const
             {

--- a/include/range/v3/view/take_last.hpp
+++ b/include/range/v3/view/take_last.hpp
@@ -27,6 +27,9 @@
 
 namespace ranges
 {
+    /// \addtogroup group-views
+    /// @{
+
     namespace views
     {
         struct take_last_base_fn
@@ -55,7 +58,6 @@ namespace ranges
         };
 
         /// \relates take_last_fn
-        /// \ingroup group-views
         RANGES_INLINE_VARIABLE(take_last_fn, take_last)
     } // namespace views
     /// @}

--- a/include/range/v3/view/take_while.hpp
+++ b/include/range/v3/view/take_while.hpp
@@ -60,7 +60,8 @@ namespace ranges
             sentinel_adaptor(semiregular_box_ref_or_val_t<Pred, IsConst> pred)
               : pred_(std::move(pred))
             {}
-            template(bool Other)( //
+            template(bool Other)(
+                /// \pre
                 requires IsConst AND CPP_NOT(Other)) //
                 sentinel_adaptor(sentinel_adaptor<Other> that)
               : pred_(std::move(that.pred_))
@@ -74,9 +75,10 @@ namespace ranges
         {
             return {pred_};
         }
-        template(bool Const = true)( //
+        template(bool Const = true)(
+            /// \pre
             requires Const AND range<meta::const_if_c<Const, Rng>> AND
-                invocable<Pred const &, iterator_t<meta::const_if_c<Const, Rng>>>) //
+                invocable<Pred const &, iterator_t<meta::const_if_c<Const, Rng>>>)
         sentinel_adaptor<Const> end_adaptor() const
         {
             return {pred_};
@@ -101,7 +103,8 @@ namespace ranges
     };
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-    template(typename Rng, typename Fun)( //
+    template(typename Rng, typename Fun)(
+        /// \pre
         requires copy_constructible<Fun>)
     take_while_view(Rng &&, Fun)
         -> take_while_view<views::all_t<Rng>, Fun>;
@@ -111,9 +114,10 @@ namespace ranges
     {
         struct iter_take_while_base_fn
         {
-            template(typename Rng, typename Pred)( //
-                requires viewable_range<Rng> AND input_range<Rng> AND //
-                    predicate<Pred &, iterator_t<Rng>> AND copy_constructible<Pred>) //
+            template(typename Rng, typename Pred)(
+                /// \pre
+                requires viewable_range<Rng> AND input_range<Rng> AND
+                    predicate<Pred &, iterator_t<Rng>> AND copy_constructible<Pred>)
             constexpr iter_take_while_view<all_t<Rng>, Pred> //
             operator()(Rng && rng, Pred pred) const
             {
@@ -135,17 +139,19 @@ namespace ranges
 
         struct take_while_base_fn
         {
-            template(typename Rng, typename Pred)( //
-                requires viewable_range<Rng> AND input_range<Rng> AND //
-                    indirect_unary_predicate<Pred &, iterator_t<Rng>>) //
+            template(typename Rng, typename Pred)(
+                /// \pre
+                requires viewable_range<Rng> AND input_range<Rng> AND
+                    indirect_unary_predicate<Pred &, iterator_t<Rng>>)
             constexpr take_while_view<all_t<Rng>, Pred> //
             operator()(Rng && rng, Pred pred) const
             {
                 return {all(static_cast<Rng &&>(rng)), std::move(pred)};
             }
-            template(typename Rng, typename Pred, typename Proj)( //
-                requires viewable_range<Rng> AND input_range<Rng> AND //
-                    indirect_unary_predicate<composed<Pred, Proj> &, iterator_t<Rng>>) //
+            template(typename Rng, typename Pred, typename Proj)(
+                /// \pre
+                requires viewable_range<Rng> AND input_range<Rng> AND
+                    indirect_unary_predicate<composed<Pred, Proj> &, iterator_t<Rng>>)
             constexpr take_while_view<all_t<Rng>, composed<Pred, Proj>> //
             operator()(Rng && rng, Pred pred, Proj proj) const
             {
@@ -162,7 +168,8 @@ namespace ranges
                 return make_view_closure(
                     bind_back(take_while_base_fn{}, std::move(pred)));
             }
-            template(typename Pred, typename Proj)( //
+            template(typename Pred, typename Proj)(
+                /// \pre
                 requires (!range<Pred>)) // TODO: underconstrained
             constexpr auto operator()(Pred && pred, Proj proj) const
                                                           
@@ -194,9 +201,10 @@ namespace ranges
         {
             using ranges::views::take_while;
         }
-        template(typename Rng, typename Pred)( //
+        template(typename Rng, typename Pred)(
+            /// \pre
             requires viewable_range<Rng> AND input_range<Rng> AND
-                predicate<Pred &, iterator_t<Rng>> AND copy_constructible<Pred>) //
+                predicate<Pred &, iterator_t<Rng>> AND copy_constructible<Pred>)
             using take_while_view = ranges::take_while_view<Rng, Pred>;
     } // namespace cpp20
     /// @}

--- a/include/range/v3/view/tokenize.hpp
+++ b/include/range/v3/view/tokenize.hpp
@@ -68,8 +68,9 @@ namespace ranges
             meta::const_if_c<simple_view<Rng>(), Rng> & rng = rng_;
             return {ranges::begin(rng), ranges::end(rng), rex_, subs_, flags_};
         }
-        template(bool Const = true)( //
-            requires range<Rng const>) //
+        template(bool Const = true)(
+            /// \pre
+            requires range<Rng const>)
         iterator_t<Const> begin() const
         {
             return {ranges::begin(rng_), ranges::end(rng_), rex_, subs_, flags_};
@@ -78,8 +79,9 @@ namespace ranges
         {
             return {};
         }
-        template(bool Const = true)( //
-            requires range<Rng const>) //
+        template(bool Const = true)(
+            /// \pre
+            requires range<Rng const>)
         iterator_t<Const> end() const
         {
             return {};
@@ -91,7 +93,8 @@ namespace ranges
     };
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-    template(typename Rng, typename Regex, typename SubMatchRange)( //
+    template(typename Rng, typename Regex, typename SubMatchRange)(
+        /// \pre
         requires copy_constructible<Regex> AND copy_constructible<SubMatchRange>)
         tokenize_view(Rng &&, Regex, SubMatchRange)
             ->tokenize_view<views::all_t<Rng>, Regex, SubMatchRange>;
@@ -101,11 +104,12 @@ namespace ranges
     {
         struct tokenize_base_fn
         {
-            template(typename Rng, typename Regex)( //
-                requires bidirectional_range<Rng> AND common_range<Rng> AND //
+            template(typename Rng, typename Regex)(
+                /// \pre
+                requires bidirectional_range<Rng> AND common_range<Rng> AND
                     same_as< //
                         range_value_t<Rng>, //
-                        typename detail::decay_t<Regex>::value_type>) //
+                        typename detail::decay_t<Regex>::value_type>)
             tokenize_view<all_t<Rng>, detail::decay_t<Regex>, int> //
             operator()(Rng && rng,
                        Regex && rex,
@@ -119,10 +123,11 @@ namespace ranges
                         flags};
             }
 
-            template(typename Rng, typename Regex)( //
-                requires bidirectional_range<Rng> AND common_range<Rng> AND //
+            template(typename Rng, typename Regex)(
+                /// \pre
+                requires bidirectional_range<Rng> AND common_range<Rng> AND
                     same_as<range_value_t<Rng>,
-                            typename detail::decay_t<Regex>::value_type>) //
+                            typename detail::decay_t<Regex>::value_type>)
             tokenize_view<all_t<Rng>, detail::decay_t<Regex>, std::vector<int>> //
             operator()(Rng && rng,
                        Regex && rex,
@@ -136,10 +141,11 @@ namespace ranges
                         flags};
             }
 
-            template(typename Rng, typename Regex)( //
-                requires bidirectional_range<Rng> AND common_range<Rng> AND //
+            template(typename Rng, typename Regex)(
+                /// \pre
+                requires bidirectional_range<Rng> AND common_range<Rng> AND
                     same_as<range_value_t<Rng>,
-                            typename detail::decay_t<Regex>::value_type>) //
+                            typename detail::decay_t<Regex>::value_type>)
             tokenize_view<all_t<Rng>,
                           detail::decay_t<Regex>,
                           std::initializer_list<int>> //

--- a/include/range/v3/view/transform.hpp
+++ b/include/range/v3/view/transform.hpp
@@ -125,7 +125,8 @@ namespace ranges
             adaptor(fun_ref_ fun)
               : fun_(std::move(fun))
             {}
-            template(bool Other)( //
+            template(bool Other)(
+                /// \pre
                 requires IsConst AND CPP_NOT(Other)) //
             adaptor(adaptor<Other> that)
               : fun_(std::move(that.fun_))
@@ -147,10 +148,11 @@ namespace ranges
         {
             return {fun_};
         }
-        template(bool Const = true)( //
+        template(bool Const = true)(
+            /// \pre
             requires Const AND range<meta::const_if_c<Const, Rng>> AND
                 detail::iter_transform_1_readable<Fun const,
-                                                  meta::const_if_c<Const, Rng>>) //
+                                                  meta::const_if_c<Const, Rng>>)
         adaptor<Const> begin_adaptor() const
         {
             return {fun_};
@@ -159,10 +161,11 @@ namespace ranges
         {
             return {fun_};
         }
-        template(bool Const = true)( //
+        template(bool Const = true)(
+            /// \pre
             requires Const AND range<meta::const_if_c<Const, Rng>> AND
                     detail::iter_transform_1_readable<Fun const,
-                                                      meta::const_if_c<Const, Rng>>) //
+                                                      meta::const_if_c<Const, Rng>>)
         meta::if_<use_sentinel_t<Const>, adaptor_base, adaptor<Const>> end_adaptor() const
         {
             return {fun_};
@@ -175,7 +178,8 @@ namespace ranges
           , fun_(std::move(fun))
         {}
         CPP_member
-        constexpr auto CPP_fun(size)()( //
+        constexpr auto CPP_fun(size)()(
+            /// \pre
             requires sized_range<Rng>)
         {
             return ranges::size(this->base());
@@ -199,7 +203,8 @@ namespace ranges
     };
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-    template(typename Rng, typename Fun)( //
+    template(typename Rng, typename Fun)(
+        /// \pre
         requires copy_constructible<Fun>)
     transform_view(Rng &&, Fun)
         -> transform_view<views::all_t<Rng>, Fun>;
@@ -240,7 +245,8 @@ namespace ranges
               : end1_(end(parent->rng1_))
               , end2_(end(parent->rng2_))
             {}
-            template(bool Other)( //
+            template(bool Other)(
+                /// \pre
                 requires Const AND CPP_NOT(Other)) //
             sentinel(sentinel<Other> that)
               : end1_(std::move(that.end1_))
@@ -275,7 +281,8 @@ namespace ranges
               , it1_(begin_end(parent->rng1_))
               , it2_(begin_end(parent->rng2_))
             {}
-            template(bool Other)( //
+            template(bool Other)(
+                /// \pre
                 requires Const AND CPP_NOT(Other)) //
             cursor(cursor<Other> that)
               : fun_(std::move(that.fun_))
@@ -295,7 +302,8 @@ namespace ranges
             }
             CPP_member
             auto equal(cursor const & that) const //
-                -> CPP_ret(bool)( //
+                -> CPP_ret(bool)(
+                    /// \pre
                     requires forward_range<Rng1> && forward_range<Rng2>)
             {
                 // By returning true if *any* of the iterators are equal, we allow
@@ -312,14 +320,16 @@ namespace ranges
             }
             CPP_member
             auto prev() //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires bidirectional_range<R1> && bidirectional_range<R2>)
             {
                 --it1_;
                 --it2_;
             }
             CPP_member
-            auto advance(difference_type n) -> CPP_ret(void)( //
+            auto advance(difference_type n) -> CPP_ret(void)(
+                /// \pre
                 requires random_access_range<R1> && random_access_range<R2>)
             {
                 ranges::advance(it1_, n);
@@ -327,7 +337,8 @@ namespace ranges
             }
             CPP_member
             auto distance_to(cursor const & that) const //
-                -> CPP_ret(difference_type)( //
+                -> CPP_ret(difference_type)(
+                    /// \pre
                     requires sized_sentinel_for<iterator_t<R1>, iterator_t<R1>> &&
                         sized_sentinel_for<iterator_t<R2>, iterator_t<R2>>)
             {
@@ -360,24 +371,26 @@ namespace ranges
         {
             return {this, ranges::end};
         }
-        template(bool Const = true)( //
+        template(bool Const = true)(
+            /// \pre
             requires Const AND range<meta::const_if_c<Const, Rng1>> AND
-                range<meta::const_if_c<Const, Rng2>> AND //
+                range<meta::const_if_c<Const, Rng2>> AND
                 detail::iter_transform_2_readable< //
                     Fun const, //
                     meta::const_if_c<Const, Rng1>, //
-                    meta::const_if_c<Const, Rng2>>) //
+                    meta::const_if_c<Const, Rng2>>)
         cursor<true> begin_cursor() const
         {
             return {this, ranges::begin};
         }
-        template(bool Const = true)( //
+        template(bool Const = true)(
+            /// \pre
             requires Const AND range<meta::const_if_c<Const, Rng1>> AND
-                range<meta::const_if_c<Const, Rng2>> AND //
+                range<meta::const_if_c<Const, Rng2>> AND
                 detail::iter_transform_2_readable< //
                     Fun const, //
                     meta::const_if_c<Const, Rng1>, //
-                    meta::const_if_c<Const, Rng2>>) //
+                    meta::const_if_c<Const, Rng2>>)
         end_cursor_t<Const> end_cursor() const
         {
             return {this, ranges::end};
@@ -404,22 +417,25 @@ namespace ranges
         {}
         CPP_member
         static constexpr auto size() //
-            -> CPP_ret(std::size_t)( //
+            -> CPP_ret(std::size_t)(
+                /// \pre
                 requires (my_cardinality >= 0))
         {
             return static_cast<std::size_t>(my_cardinality);
         }
-        template(bool True = true)( //
+        template(bool True = true)(
+            /// \pre
             requires (my_cardinality < 0) AND sized_range<Rng1 const> AND
             sized_range<Rng2 const> AND
-            common_with<range_size_t<R1<True>>, range_size_t<R2<True>>>) //
+            common_with<range_size_t<R1<True>>, range_size_t<R2<True>>>)
             constexpr auto size() const
         {
             return size_(*this);
         }
-        template(bool True = true)( //
+        template(bool True = true)(
+            /// \pre
             requires (my_cardinality < 0) AND sized_range<Rng1> AND sized_range<Rng2> AND
-            common_with<range_size_t<R1<True>>, range_size_t<R2<True>>>) //
+            common_with<range_size_t<R1<True>>, range_size_t<R2<True>>>)
             constexpr auto size()
         {
             return size_(*this);
@@ -441,22 +457,24 @@ namespace ranges
     {
         struct iter_transform_base_fn
         {
-            template(typename Rng, typename Fun)( //
-                requires viewable_range<Rng> AND input_range<Rng> AND //
-                    copy_constructible<Fun> AND //
-                    detail::iter_transform_1_readable<Fun, Rng>) //
+            template(typename Rng, typename Fun)(
+                /// \pre
+                requires viewable_range<Rng> AND input_range<Rng> AND
+                    copy_constructible<Fun> AND
+                    detail::iter_transform_1_readable<Fun, Rng>)
             constexpr iter_transform_view<all_t<Rng>, Fun> //
             operator()(Rng && rng, Fun fun) const
             {
                 return {all(static_cast<Rng &&>(rng)), std::move(fun)};
             }
 
-            template(typename Rng1, typename Rng2, typename Fun)( //
+            template(typename Rng1, typename Rng2, typename Fun)(
+                /// \pre
                 requires viewable_range<Rng1> AND input_range<Rng1> AND
                     viewable_range<Rng2> AND input_range<Rng2> AND
                     copy_constructible<Fun> AND
                     common_with<range_difference_t<Rng1>, range_difference_t<Rng1>> AND
-                    detail::iter_transform_2_readable<Fun, Rng1, Rng2>) //
+                    detail::iter_transform_2_readable<Fun, Rng1, Rng2>)
             constexpr iter_transform2_view<all_t<Rng1>, all_t<Rng2>, Fun> //
             operator()(Rng1 && rng1, Rng2 && rng2, Fun fun) const
             {
@@ -512,16 +530,18 @@ namespace ranges
 
         struct transform_base_fn
         {
-            template(typename Rng, typename Fun)( //
-                requires transformable_range<Rng, Fun>) //
+            template(typename Rng, typename Fun)(
+                /// \pre
+                requires transformable_range<Rng, Fun>)
             constexpr transform_view<all_t<Rng>, Fun> operator()(Rng && rng, Fun fun)
                 const
             {
                 return {all(static_cast<Rng &&>(rng)), std::move(fun)};
             }
 
-            template(typename Rng1, typename Rng2, typename Fun)( //
-                requires transformable_ranges<Rng1, Rng2, Fun>) //
+            template(typename Rng1, typename Rng2, typename Fun)(
+                /// \pre
+                requires transformable_ranges<Rng1, Rng2, Fun>)
             constexpr transform2_view<all_t<Rng1>, all_t<Rng2>, Fun> //
             operator()(Rng1 && rng1, Rng2 && rng2, Fun fun) const
             {
@@ -553,10 +573,11 @@ namespace ranges
         {
             using ranges::views::transform;
         }
-        template(typename Rng, typename F)( //
+        template(typename Rng, typename F)(
+            /// \pre
             requires input_range<Rng> AND copy_constructible<F> AND view_<Rng> AND
                 std::is_object<F>::value AND
-                    regular_invocable<F &, iter_reference_t<iterator_t<Rng>>>) //
+                    regular_invocable<F &, iter_reference_t<iterator_t<Rng>>>)
             using transform_view = ranges::transform_view<Rng, F>;
     } // namespace cpp20
     /// @}

--- a/include/range/v3/view/trim.hpp
+++ b/include/range/v3/view/trim.hpp
@@ -104,19 +104,21 @@ namespace ranges
     {
         struct trim_base_fn
         {
-            template(typename Rng, typename Pred)( //
-                requires viewable_range<Rng> AND bidirectional_range<Rng> AND //
-                    indirect_unary_predicate<Pred, iterator_t<Rng>> AND //
-                        common_range<Rng>) //
+            template(typename Rng, typename Pred)(
+                /// \pre
+                requires viewable_range<Rng> AND bidirectional_range<Rng> AND
+                    indirect_unary_predicate<Pred, iterator_t<Rng>> AND
+                        common_range<Rng>)
             constexpr trim_view<all_t<Rng>, Pred> //
             operator()(Rng && rng, Pred pred) const //
             {
                 return {all(static_cast<Rng &&>(rng)), std::move(pred)};
             }
-            template(typename Rng, typename Pred, typename Proj)( //
-                requires viewable_range<Rng> AND bidirectional_range<Rng> AND //
-                    indirect_unary_predicate<composed<Pred, Proj>, iterator_t<Rng>> AND //
-                    common_range<Rng>) //
+            template(typename Rng, typename Pred, typename Proj)(
+                /// \pre
+                requires viewable_range<Rng> AND bidirectional_range<Rng> AND
+                    indirect_unary_predicate<composed<Pred, Proj>, iterator_t<Rng>> AND
+                    common_range<Rng>)
             constexpr trim_view<all_t<Rng>, composed<Pred, Proj>> //
             operator()(Rng && rng, Pred pred, Proj proj) const
             {
@@ -132,7 +134,8 @@ namespace ranges
             {
                 return make_view_closure(bind_back(trim_base_fn{}, std::move(pred)));
             }
-            template(typename Pred, typename Proj)( //
+            template(typename Pred, typename Proj)(
+                /// \pre
                 requires (!range<Pred>)) // TODO: underconstrained
             constexpr auto operator()(Pred && pred, Proj proj) const
             {

--- a/include/range/v3/view/unbounded.hpp
+++ b/include/range/v3/view/unbounded.hpp
@@ -52,8 +52,9 @@ namespace ranges
     {
         struct unbounded_fn
         {
-            template(typename I)( //
-                requires input_iterator<I>) //
+            template(typename I)(
+                /// \pre
+                requires input_iterator<I>)
             constexpr unbounded_view<I> operator()(I it) const
             {
                 return unbounded_view<I>{detail::move(it)};

--- a/include/range/v3/view/unique.hpp
+++ b/include/range/v3/view/unique.hpp
@@ -37,9 +37,10 @@ namespace ranges
     {
         struct unique_base_fn
         {
-            template(typename Rng, typename C = equal_to)( //
-                requires viewable_range<Rng> AND forward_range<Rng> AND //
-                    indirect_relation<C, iterator_t<Rng>>) //
+            template(typename Rng, typename C = equal_to)(
+                /// \pre
+                requires viewable_range<Rng> AND forward_range<Rng> AND
+                    indirect_relation<C, iterator_t<Rng>>)
             constexpr adjacent_filter_view<all_t<Rng>, logical_negate<C>> //
             operator()(Rng && rng, C pred = {}) const
             {
@@ -51,7 +52,8 @@ namespace ranges
         {
             using unique_base_fn::operator();
 
-            template(typename C)( //
+            template(typename C)(
+                /// \pre
                 requires (!range<C>))
             constexpr auto operator()(C && pred) const
             {

--- a/include/range/v3/view/view.hpp
+++ b/include/range/v3/view/view.hpp
@@ -103,9 +103,10 @@ namespace ranges
         {
             // Piping requires viewable_ranges. Pipeing a value into a closure
             // should not yield another closure.
-            template(typename Rng, typename ViewFn)( //
-                requires viewable_range<Rng> AND     //
-                    invocable_view_closure<ViewFn, Rng>) //
+            template(typename Rng, typename ViewFn)(
+                /// \pre
+                requires viewable_range<Rng> AND
+                    invocable_view_closure<ViewFn, Rng>)
             friend constexpr auto operator|(Rng && rng, view_closure<ViewFn> vw)
             {
                 return static_cast<ViewFn &&>(vw)(static_cast<Rng &&>(rng));
@@ -133,6 +134,7 @@ namespace ranges
             template<typename ViewFn, typename Pipeable>
             friend constexpr auto operator|(view_closure<ViewFn> vw, Pipeable pipe)
                 -> CPP_broken_friend_ret(view_closure<composed<Pipeable, ViewFn>>)(
+                    /// \pre
                     requires (is_pipeable_v<Pipeable>))
             {
                 return make_view_closure(
@@ -229,7 +231,8 @@ namespace ranges
             friend pipeable_access;
 
             // Piping requires range arguments or lvalue containers.
-            template(typename Rng, typename Vw)( //
+            template(typename Rng, typename Vw)(
+                /// \pre
                 requires viewable_range<Rng> AND invocable<ViewFn &, Rng>)
             static constexpr auto pipe(Rng && rng, Vw && v)
             {
@@ -245,7 +248,8 @@ namespace ranges
             {}
 
             // Calling directly requires a viewable_range.
-            template(typename Rng, typename... Rest)( //
+            template(typename Rng, typename... Rest)(
+                /// \pre
                 requires viewable_range<Rng> AND invocable<ViewFn const &, Rng, Rest...>)
             constexpr invoke_result_t<ViewFn const &, Rng, Rest...> //
             operator()(Rng && rng, Rest &&... rest) const

--- a/include/range/v3/view/zip.hpp
+++ b/include/range/v3/view/zip.hpp
@@ -38,7 +38,8 @@ namespace ranges
         struct indirect_zip_fn_
         {
             // tuple value
-            template(typename... Its)( //
+            template(typename... Its)(
+                /// \pre
                 requires (sizeof...(Its) != 2) AND and_v<indirectly_readable<Its>...>)
             std::tuple<iter_value_t<Its>...> operator()(copy_tag, Its...) const
             {
@@ -46,7 +47,8 @@ namespace ranges
             }
 
             // tuple reference
-            template(typename... Its)( //
+            template(typename... Its)(
+                /// \pre
                 requires (sizeof...(Its) != 2) AND and_v<indirectly_readable<Its>...>)
             common_tuple<iter_reference_t<Its>...>
             operator()(Its const &... its) const //
@@ -56,7 +58,8 @@ namespace ranges
             }
 
             // tuple rvalue reference
-            template(typename... Its)( //
+            template(typename... Its)(
+                /// \pre
                 requires (sizeof...(Its) != 2) AND and_v<indirectly_readable<Its>...>)
             common_tuple<iter_rvalue_reference_t<Its>...> //
             operator()(move_tag, Its const &... its) const //
@@ -67,8 +70,9 @@ namespace ranges
             }
 
             // pair value
-            template(typename It1, typename It2)( //
-                requires indirectly_readable<It1> AND indirectly_readable<It2>) //
+            template(typename It1, typename It2)(
+                /// \pre
+                requires indirectly_readable<It1> AND indirectly_readable<It2>)
             std::pair<iter_value_t<It1>, iter_value_t<It2>> //
             operator()(copy_tag, It1, It2) const
             {
@@ -76,8 +80,9 @@ namespace ranges
             }
 
             // pair reference
-            template(typename It1, typename It2)( //
-                requires indirectly_readable<It1> AND indirectly_readable<It2>) //
+            template(typename It1, typename It2)(
+                /// \pre
+                requires indirectly_readable<It1> AND indirectly_readable<It2>)
             common_pair<iter_reference_t<It1>, iter_reference_t<It2>>
             operator()(It1 const & it1, It2 const & it2) const //
                 noexcept( //
@@ -88,8 +93,9 @@ namespace ranges
             }
 
             // pair rvalue reference
-            template(typename It1, typename It2)( //
-                requires indirectly_readable<It1> AND indirectly_readable<It2>) //
+            template(typename It1, typename It2)(
+                /// \pre
+                requires indirectly_readable<It1> AND indirectly_readable<It2>)
             common_pair<iter_rvalue_reference_t<It1>, iter_rvalue_reference_t<It2>>
             operator()(move_tag, It1 const & it1, It2 const & it2) const
                 noexcept(noexcept(iter_rvalue_reference_t<It1>(iter_move(it1))) &&
@@ -134,24 +140,27 @@ namespace ranges
             {
                 return {};
             }
-            template(typename... Rngs)( //
-                requires and_v<viewable_range<Rngs>...> AND //
-                and_v<input_range<Rngs>...> AND //
+            template(typename... Rngs)(
+                /// \pre
+                requires and_v<viewable_range<Rngs>...> AND
+                and_v<input_range<Rngs>...> AND
                 (sizeof...(Rngs) != 0)) //
             zip_view<all_t<Rngs>...> operator()(Rngs &&... rngs) const
             {
                 return zip_view<all_t<Rngs>...>{all(static_cast<Rngs &&>(rngs))...};
             }
 #if defined(_MSC_VER)
-            template(typename Rng0)( //
-                requires input_range<Rng0> AND viewable_range<Rng0>) //
+            template(typename Rng0)(
+                /// \pre
+                requires input_range<Rng0> AND viewable_range<Rng0>)
             constexpr zip_view<all_t<Rng0>> operator()(Rng0 && rng0) const
             {
                 return zip_view<all_t<Rng0>>{all(static_cast<Rng0 &&>(rng0))};
             }
-            template(typename Rng0, typename Rng1)( //
-                requires input_range<Rng0> AND viewable_range<Rng0> AND //
-                    input_range<Rng1> AND viewable_range<Rng1>) //
+            template(typename Rng0, typename Rng1)(
+                /// \pre
+                requires input_range<Rng0> AND viewable_range<Rng0> AND
+                    input_range<Rng1> AND viewable_range<Rng1>)
             constexpr zip_view<all_t<Rng0>, all_t<Rng1>> //
             operator()(Rng0 && rng0, Rng1 && rng1) const
             {
@@ -159,10 +168,11 @@ namespace ranges
                     all(static_cast<Rng0 &&>(rng0)),       //
                     all(static_cast<Rng1 &&>(rng1))};
             }
-            template(typename Rng0, typename Rng1, typename Rng2)( //
-                requires input_range<Rng0> AND viewable_range<Rng0> AND    //
-                    input_range<Rng1> AND viewable_range<Rng1> AND    //
-                    input_range<Rng2> AND viewable_range<Rng2>) //
+            template(typename Rng0, typename Rng1, typename Rng2)(
+                /// \pre
+                requires input_range<Rng0> AND viewable_range<Rng0> AND
+                    input_range<Rng1> AND viewable_range<Rng1> AND
+                    input_range<Rng2> AND viewable_range<Rng2>)
             constexpr zip_view<all_t<Rng0>, all_t<Rng1>, all_t<Rng2>> //
             operator()(Rng0 && rng0, Rng1 && rng1, Rng2 && rng2) const
             {

--- a/include/range/v3/view/zip_with.hpp
+++ b/include/range/v3/view/zip_with.hpp
@@ -77,8 +77,9 @@ namespace ranges
 
         struct _advance_
         {
-            template(typename I, typename Diff)( //
-                requires input_or_output_iterator<I> AND integer_like_<Diff>) //
+            template(typename I, typename Diff)(
+                /// \pre
+                requires input_or_output_iterator<I> AND integer_like_<Diff>)
             void operator()(I & i, Diff n) const
             {
                 advance(i, static_cast<iter_difference_t<I>>(n));
@@ -186,7 +187,8 @@ namespace ranges
                      std::tuple<sentinel_t<meta::const_if_c<Const, Rngs>>...> ends)
               : ends_(std::move(ends))
             {}
-            template(bool Other)( //
+            template(bool Other)(
+                /// \pre
                 requires Const AND CPP_NOT(Other)) //
             sentinel(sentinel<Other> that)
               : ends_(std::move(that.ends_))
@@ -216,7 +218,8 @@ namespace ranges
               : fun_(std::move(fun))
               , its_(std::move(its))
             {}
-            template(bool Other)( //
+            template(bool Other)(
+                /// \pre
                 requires Const AND CPP_NOT(Other)) //
             cursor(cursor<Other> that)
               : fun_(std::move(that.fun_))
@@ -234,7 +237,8 @@ namespace ranges
             }
             CPP_member
             auto equal(cursor const & that) const //
-                -> CPP_ret(bool)( //
+                -> CPP_ret(bool)(
+                    /// \pre
                     requires and_v<
                         sentinel_for<iterator_t<meta::const_if_c<Const, Rngs>>,
                                     iterator_t<meta::const_if_c<Const, Rngs>>>...>)
@@ -257,21 +261,24 @@ namespace ranges
             }
             CPP_member
             auto prev() //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires and_v<bidirectional_range<meta::const_if_c<Const, Rngs>>...>)
             {
                 tuple_for_each(its_, detail::dec);
             }
             CPP_member
             auto advance(difference_type n) //
-                -> CPP_ret(void)( //
+                -> CPP_ret(void)(
+                    /// \pre
                     requires and_v<random_access_range<meta::const_if_c<Const, Rngs>>...>)
             {
                 tuple_for_each(its_, bind_back(detail::advance_, n));
             }
             CPP_member
             auto distance_to(cursor const & that) const //
-                -> CPP_ret(difference_type)( //
+                -> CPP_ret(difference_type)(
+                    /// \pre
                     requires and_v<
                         sized_sentinel_for<iterator_t<meta::const_if_c<Const, Rngs>>,
                                            iterator_t<meta::const_if_c<Const, Rngs>>>...>)
@@ -319,16 +326,18 @@ namespace ranges
         {
             return {fun_, tuple_transform(rngs_, ranges::end)};
         }
-        template(bool Const = true)( //
+        template(bool Const = true)(
+            /// \pre
             requires Const AND and_v<range<Rngs const>...> AND
-                views::zippable_with<Fun, meta::if_c<Const, Rngs const>...>) //
+                views::zippable_with<Fun, meta::if_c<Const, Rngs const>...>)
         cursor<Const> begin_cursor() const
         {
             return {fun_, tuple_transform(rngs_, ranges::begin)};
         }
-        template(bool Const = true)( //
+        template(bool Const = true)(
+            /// \pre
             requires Const AND and_v<range<Rngs const>...> AND
-                views::zippable_with<Fun, meta::if_c<Const, Rngs const>...>) //
+                views::zippable_with<Fun, meta::if_c<Const, Rngs const>...>)
         end_cursor_t<Const> end_cursor() const
         {
             return {fun_, tuple_transform(rngs_, ranges::end)};
@@ -377,7 +386,8 @@ namespace ranges
     };
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-    template(typename Fun, typename... Rng)( //
+    template(typename Fun, typename... Rng)(
+        /// \pre
         requires copy_constructible<Fun>)
     zip_with_view(Fun, Rng &&...)
         -> zip_with_view<Fun, views::all_t<Rng>...>;
@@ -387,8 +397,9 @@ namespace ranges
     {
         struct iter_zip_with_fn
         {
-            template(typename... Rngs, typename Fun)( //
-                requires and_v<viewable_range<Rngs>...> AND //
+            template(typename... Rngs, typename Fun)(
+                /// \pre
+                requires and_v<viewable_range<Rngs>...> AND
                     zippable_with<Fun, Rngs...> AND (sizeof...(Rngs) != 0)) //
             iter_zip_with_view<Fun, all_t<Rngs>...> //
             operator()(Fun fun, Rngs &&... rngs) const
@@ -397,8 +408,9 @@ namespace ranges
                     std::move(fun), all(static_cast<Rngs &&>(rngs))...};
             }
 
-            template(typename Fun)( //
-                requires zippable_with<Fun>) //
+            template(typename Fun)(
+                /// \pre
+                requires zippable_with<Fun>)
             constexpr empty_view<std::tuple<>> operator()(Fun) const noexcept
             {
                 return {};
@@ -411,7 +423,8 @@ namespace ranges
 
         struct zip_with_fn
         {
-            template(typename... Rngs, typename Fun)( //
+            template(typename... Rngs, typename Fun)(
+                /// \pre
                 requires and_v<viewable_range<Rngs>...> AND
                     and_v<input_range<Rngs>...> AND copy_constructible<Fun> AND
                     invocable<Fun &, range_reference_t<Rngs>...> AND
@@ -422,8 +435,9 @@ namespace ranges
                     std::move(fun), all(static_cast<Rngs &&>(rngs))...};
             }
 
-            template(typename Fun)( //
-                requires copy_constructible<Fun> AND invocable<Fun &>) //
+            template(typename Fun)(
+                /// \pre
+                requires copy_constructible<Fun> AND invocable<Fun &>)
             constexpr empty_view<std::tuple<>> operator()(Fun) const noexcept
             {
                 return {};

--- a/test/debug_view.hpp
+++ b/test/debug_view.hpp
@@ -138,7 +138,9 @@ struct debug_input_view : ranges::view_base
         }
         CPP_member
         friend auto operator-(sentinel const& s, iterator const& i) ->
-            CPP_ret(difference_type)(requires Sized)
+            CPP_ret(difference_type)(
+                /// \pre
+                requires Sized)
         {
             RANGES_ENSURE(i.view_ == s.view_);
             RANGES_ENSURE(i.version_ == s.version_);
@@ -147,7 +149,9 @@ struct debug_input_view : ranges::view_base
         }
         CPP_member
         friend auto operator-(iterator const& i, sentinel const& s) ->
-            CPP_ret(difference_type)(requires Sized)
+            CPP_ret(difference_type)(
+                /// \pre
+                requires Sized)
         {
             return -(s - i);
         }
@@ -165,7 +169,9 @@ struct debug_input_view : ranges::view_base
         return sentinel{*this};
     }
     CPP_member
-    auto size() const noexcept -> CPP_ret(std::size_t)(requires Sized)
+    auto size() const noexcept -> CPP_ret(std::size_t)(
+        /// \pre
+        requires Sized)
     {
         RANGES_ENSURE(data_);
         RANGES_ENSURE(data_->offset_ == -1);

--- a/test/iterator/basic_iterator.cpp
+++ b/test/iterator/basic_iterator.cpp
@@ -47,7 +47,8 @@ namespace test_weak_input
         explicit cursor(I i)
           : it_(i)
         {}
-        CPP_template(class J)(                      //
+        CPP_template(class J)(
+            /// \pre
             requires ranges::convertible_to<J, I>)  //
         cursor(cursor<J> that)
           : it_(std::move(that.it_))
@@ -118,7 +119,8 @@ namespace test_random_access
         explicit cursor(I i)
           : it_(i)
         {}
-        CPP_template(class J)(                      //
+        CPP_template(class J)(
+            /// \pre
             requires ranges::convertible_to<J, I>)  //
         cursor(cursor<J> that)
           : it_(std::move(that.it_))
@@ -128,7 +130,8 @@ namespace test_random_access
         {
             return *it_;
         }
-        CPP_template(class J)(                      //
+        CPP_template(class J)(
+            /// \pre
             requires ranges::sentinel_for<J, I>)    //
         bool equal(cursor<J> const & that) const
         {
@@ -146,7 +149,8 @@ namespace test_random_access
         {
             it_ += n;
         }
-        CPP_template(class J)(                          //
+        CPP_template(class J)(
+            /// \pre
             requires ranges::sized_sentinel_for<J, I>)  //
         ranges::iter_difference_t<I> distance_to(cursor<J> const & that) const
         {
@@ -281,7 +285,8 @@ namespace test_random_access
         explicit cursor(I i)
           : it_(i)
         {}
-        CPP_template(class J)(                      //
+        CPP_template(class J)(
+            /// \pre
             requires ranges::convertible_to<J, I>)  //
         cursor(cursor<J> that)
           : it_(std::move(that.it_))
@@ -380,7 +385,8 @@ namespace test_random_access
         explicit zip1_cursor(I i)
           : it_(i)
         {}
-        CPP_template(class J)(                      //
+        CPP_template(class J)(
+            /// \pre
             requires ranges::convertible_to<J, I>)  //
         zip1_cursor(zip1_cursor<J> that)
           : it_(std::move(that.it_))
@@ -462,7 +468,8 @@ namespace test_random_access
         explicit cursor(I i)
           : it_(i)
         {}
-        CPP_template(class J)(                      //
+        CPP_template(class J)(
+            /// \pre
             requires ranges::convertible_to<J, I>)  //
         cursor(cursor<J> that)
           : it_(std::move(that.it_))
@@ -472,7 +479,8 @@ namespace test_random_access
         {
             return *it_;
         }
-        CPP_template(class J)(                      //
+        CPP_template(class J)(
+            /// \pre
             requires ranges::sentinel_for<J, I>)    //
         bool equal(cursor<J> const & that) const
         {
@@ -482,7 +490,8 @@ namespace test_random_access
         {
             ++it_;
         }
-        CPP_template(class J)(                          //
+        CPP_template(class J)(
+            /// \pre
             requires ranges::sized_sentinel_for<J, I>)  //
         ranges::iter_difference_t<I> distance_to(cursor<J> const & that) const
         {

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -84,7 +84,8 @@ CPP_concept both_ranges = ranges::input_range<T> && ranges::input_range<U>;
 
 struct check_equal_fn
 {
-    CPP_template(typename T, typename U)( //
+    CPP_template(typename T, typename U)(
+        /// \pre
         requires(!both_ranges<T, U>))     //
     void operator()(
         T && actual, U && expected,
@@ -93,8 +94,9 @@ struct check_equal_fn
         CHECK_SLOC(sloc, (T &&) actual == (U &&) expected);
     }
 
-    CPP_template(typename Rng1, typename Rng2)( //
-        requires both_ranges<Rng1, Rng2>)       //
+    CPP_template(typename Rng1, typename Rng2)(
+        /// \pre
+        requires both_ranges<Rng1, Rng2>)
     void operator()(
         Rng1 && actual, Rng2 && expected,
         source_location sloc = source_location::current()) const
@@ -109,8 +111,9 @@ struct check_equal_fn
         CHECK_SLOC(sloc, begin1 == end1);
     }
 
-    CPP_template(typename Rng, typename Val)( //
-        requires ranges::input_range<Rng>)    //
+    CPP_template(typename Rng, typename Val)(
+        /// \pre
+        requires ranges::input_range<Rng>)
     void operator()(
         Rng && actual, std::initializer_list<Val> && expected,
         source_location sloc = source_location::current()) const


### PR DESCRIPTION
Doxygen doesn't natively grok `requires` clauses, so turn them into something it _does_ understand: preconditions, as specified with the `\pre` special command.

This uses an unholy mix of bash, perl, and clang as a preprocessor for Doxygen.