### PR TITLE
Avoid including empty <span> header when using MSVC and C++17

### DIFF
--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -280,6 +280,11 @@ namespace ranges
 #define RANGES_WORKAROUND_MSVC_OLD_LAMBDA
 #endif
 
+#if _MSVC_LANG <= 201703L
+#define RANGES_WORKAROUND_MSVC_UNUSABLE_SPAN // MSVC provides a <span> header that is
+                                             // guarded against use with std <= 17
+#endif
+
 #elif defined(__GNUC__) || defined(__clang__)
 #define RANGES_PRAGMA(X) _Pragma(#X)
 #define RANGES_DIAGNOSTIC_PUSH RANGES_PRAGMA(GCC diagnostic push)

--- a/include/range/v3/range/access.hpp
+++ b/include/range/v3/range/access.hpp
@@ -14,6 +14,8 @@
 #ifndef RANGES_V3_RANGE_ACCESS_HPP
 #define RANGES_V3_RANGE_ACCESS_HPP
 
+#include <range/v3/detail/config.hpp>
+
 #include <functional> // for reference_wrapper (whose use with begin/end is deprecated)
 #include <initializer_list>
 #include <iterator>
@@ -21,7 +23,7 @@
 #include <utility>
 
 #ifdef __has_include
-#if __has_include(<span>)
+#if __has_include(<span>) && !defined(RANGES_WORKAROUND_MSVC_UNUSABLE_SPAN)
 #include <span>
 #endif
 #if __has_include(<string_view>)

--- a/include/range/v3/range/concepts.hpp
+++ b/include/range/v3/range/concepts.hpp
@@ -14,12 +14,14 @@
 #ifndef RANGES_V3_RANGE_CONCEPTS_HPP
 #define RANGES_V3_RANGE_CONCEPTS_HPP
 
+#include <range/v3/detail/config.hpp>
+
 #include <initializer_list>
 #include <type_traits>
 #include <utility>
 
 #ifdef __has_include
-#if __has_include(<span>)
+#if __has_include(<span>) && !defined(RANGES_WORKAROUND_MSVC_UNUSABLE_SPAN)
 #include <span>
 #endif
 #if __has_include(<string_view>)


### PR DESCRIPTION
While compiling the latest `master` with MSVC and C++17 the same warning shows over and over:
```
...
[build] [14/483   0% :: 4.966] Building CXX object test\algorithm\CMakeFiles\range.v3.alg.for_each_n.dir\for_each_n.cpp.obj
[build] The contents of <span> are available only with C++20 or later.
[build] [15/483   0% :: 5.069] Building CXX object test\algorithm\CMakeFiles\range.v3.alg.generate.dir\generate.cpp.obj
[build] The contents of <span> are available only with C++20 or later.
[build] [16/483   0% :: 5.826] Building CXX object test\algorithm\CMakeFiles\range.v3.alg.make_heap.dir\make_heap.cpp.obj
[build] The contents of <span> are available only with C++20 or later.
[build] [17/483   0% :: 6.051] Building CXX object test\algorithm\CMakeFiles\range.v3.alg.max_element.dir\max_element.cpp.obj
[build] The contents of <span> are available only with C++20 or later.
...
```

This is due to the `<span>` header being available to include (but not to use) with C++17:
```c++
// MSVC's <span> header
// (...)
#if !_HAS_CXX20
#pragma message("The contents of <span> are available only with C++20 or later.")
#else // ^^^ !_HAS_CXX20 / _HAS_CXX20 vvv
#include <cstddef>
// (...)
```

The current implementation guards against the use of `std::span` by checking the `__cpp_lib_span` feature-test macro, but `#include <span>` is only guarded by `__has_include()`

This PR adds a workaround macro so that we don't include `<span>` when compiling with MSVC and C++17 or lower