### PR TITLE
build2 support: Added instructions for build2 users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,44 @@ cmake ../
 cmake --build .
 ```
 
+Building range-v3 - Using `build2`
+----------------------------------
+
+You can use [`build2`](https://build2.org), a dependency manager and a build-system combined, to use `range-v3` (or work on it):
+
+Currently this package is available in these package repositories:
+ - **https://cppget.org/range-v3/** for released and published versions.
+ - [**The git repository with the sources of the `build2` package of `range-v3`**](https://github.com/build2-packaging/range-v3.git) for unreleased or custom revisions of `range-v3`, or for working on it with `build2`.
+
+### Usage:
+
+ - `build2` package name: `range-v3`
+ - Library target name : `lib{range-v3}`
+ - [Detailed use cases and instructions in this document](https://github.com/build2-packaging/range-v3/NOTES-build2.md).
+
+For example, to make your `build2` project depend on `range-v3`:
+  - Add one of the repositories to your configurations, or in your `repositories.manifest`, if not already there; for example:
+    ```
+    :
+    role: prerequisite
+    location: https://pkg.cppget.org/1/alpha # v0.11.0 is there.
+    ```
+  - Add this package as a dependency to your `manifest` file (example for `v0.11.x`):
+    ```
+    depends: range-v3 ~0.11.0
+    ```
+  - Import the target and use it as a prerequisite to your own target using `range-v3` in the appropriate `buildfile`:
+    ```
+    import range_v3 = range-v3%lib{range-v3}
+
+    lib{mylib} : cxx{**} ... $range_v3
+    ```
+
+Then just build your project as usual (with `b` or `bdep update`), `build2` will figure out the rest.
+
+For `build2` newcomers or to get more details and use cases, you can read [this document](https://github.com/build2-packaging/range-v3/NOTES-build2.md) and the [`build2` toolchain introduction](https://build2.org/build2-toolchain/doc/build2-toolchain-intro.xhtml).
+
+
 Say Thanks!
 -----------
 


### PR DESCRIPTION
As per https://github.com/ericniebler/range-v3/pull/1554 I moved the `build2` package definition (and build) into another repository which will be handled by the `build2` community: https://github.com/build2-packaging/range-v3

That repository can also be used to develop `range-v3` itself, it's not much different than having the files here. Most users might use it for building revisions which are not parts of a release.

Using that repository, I published `range-v3` `v0.11.0` (matching the tag in this repository). This package and all the future packages will be available there: https://cppget.org/range-v3/0.11.0

I will make sure the future released get published too.

Meanwhile, this PR just adds instruction for using the package in `build2` projects. It also points to the instruction to other use cases.
