### PR TITLE
Disabled three_way_comparable[_with] concepts when no C++20 concepts.

### DIFF
--- a/include/concepts/compare.hpp
+++ b/include/concepts/compare.hpp
@@ -17,7 +17,8 @@
 #ifndef CPP_COMPARE_HPP
 #define CPP_COMPARE_HPP
 
-#if __cplusplus > 201703L && defined(__cpp_impl_three_way_comparison) && __has_include(<compare>)
+#if __cplusplus > 201703L && __has_include(<compare>) && \
+    defined(__cpp_concepts) && defined(__cpp_impl_three_way_comparison)
 
 #include <compare>
 #include <concepts/concepts.hpp>

--- a/include/range/v3/compare.hpp
+++ b/include/range/v3/compare.hpp
@@ -17,7 +17,8 @@
 #ifndef RANGES_V3_COMPARE_HPP
 #define RANGES_V3_COMPARE_HPP
 
-#if __cplusplus > 201703L && defined(__cpp_impl_three_way_comparison) && __has_include(<compare>)
+#if __cplusplus > 201703L && __has_include(<compare>) && \
+    defined(__cpp_concepts) && defined(__cpp_impl_three_way_comparison)
 
 #include <compare>
 #include <type_traits>

--- a/include/range/v3/functional/comparisons.hpp
+++ b/include/range/v3/functional/comparisons.hpp
@@ -99,8 +99,8 @@ namespace ranges
     using ordered_less RANGES_DEPRECATED(
         "Repace uses of ranges::ordered_less with ranges::less") = less;
 
-#if __cplusplus > 201703L && defined(__cpp_impl_three_way_comparison) && \
-    __has_include(<compare>)
+#if __cplusplus > 201703L && __has_include(<compare>) && \
+    defined(__cpp_concepts) && defined(__cpp_impl_three_way_comparison)
     struct compare_three_way
     {
         template(typename T, typename U)(

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -499,7 +499,8 @@ namespace ranges
     struct not_equal_to;
     struct equal_to;
     struct less;
-#if __cplusplus > 201703L && defined(__cpp_impl_three_way_comparison) && __has_include(<compare>)
+#if __cplusplus > 201703L && __has_include(<compare>) && \
+    defined(__cpp_concepts) && defined(__cpp_impl_three_way_comparison)
     struct compare_three_way;
 #endif // __cplusplus
     struct identity;

--- a/test/utility/compare.cpp
+++ b/test/utility/compare.cpp
@@ -14,7 +14,8 @@
 //
 // Project home: https://github.com/ericniebler/range-v3
 //
-#if __cplusplus > 201703L && defined(__cpp_impl_three_way_comparison) && __has_include(<compare>)
+#if __cplusplus > 201703L && __has_include(<compare>) && \
+    defined(__cpp_concepts) && defined(__cpp_impl_three_way_comparison)
 
 #include <compare>
 #include <range/v3/compare.hpp>

--- a/test/utility/concepts.cpp
+++ b/test/utility/concepts.cpp
@@ -277,7 +277,8 @@ static_assert(ranges::equality_comparable_with<int, int>, "");
 static_assert(ranges::equality_comparable_with<int, IntComparable>, "");
 static_assert(ranges::equality_comparable_with<int &, IntComparable &>, "");
 
-#if __cplusplus > 201703L && defined(__cpp_impl_three_way_comparison) && __has_include(<compare>)
+#if __cplusplus > 201703L && __has_include(<compare>) && \
+    defined(__cpp_concepts) && defined(__cpp_impl_three_way_comparison)
 #include <compare>
 
 static_assert(ranges::three_way_comparable<int>);


### PR DESCRIPTION
Fortunately, the Apple clang 12.0.0 from the latest stable version of Xcode 12.0 supports the three-way comparison now, but unfortunately, it still has no concepts.
That leads to build error (Github CI run [github.com/23rd/range-v3/runs/1137532483](https://github.com/23rd/range-v3/runs/1137532483)).
So this PR adds a workaround for the Apple clang.

Related PR: #1508.