### PR TITLE
zip_with on no ranges should derive its value_type from the callable.

### DIFF
--- a/include/range/v3/view/zip_with.hpp
+++ b/include/range/v3/view/zip_with.hpp
@@ -410,8 +410,9 @@ namespace ranges
 
             template(typename Fun)(
                 /// \pre
-                requires zippable_with<Fun>)
-            constexpr empty_view<std::tuple<>> operator()(Fun) const noexcept
+                requires zippable_with<
+                    Fun>) constexpr empty_view<detail::decay_t<invoke_result_t<Fun &>>>
+            operator()(Fun) const noexcept
             {
                 return {};
             }
@@ -437,8 +438,9 @@ namespace ranges
 
             template(typename Fun)(
                 /// \pre
-                requires copy_constructible<Fun> AND invocable<Fun &>)
-            constexpr empty_view<std::tuple<>> operator()(Fun) const noexcept
+                requires copy_constructible<Fun> AND invocable<
+                    Fun &>) constexpr empty_view<detail::decay_t<invoke_result_t<Fun &>>>
+            operator()(Fun) const noexcept
             {
                 return {};
             }

--- a/include/range/v3/view/zip_with.hpp
+++ b/include/range/v3/view/zip_with.hpp
@@ -410,9 +410,9 @@ namespace ranges
 
             template(typename Fun)(
                 /// \pre
-                requires zippable_with<
-                    Fun>) constexpr empty_view<detail::decay_t<invoke_result_t<Fun &>>>
-            operator()(Fun) const noexcept
+                requires zippable_with<Fun>) //
+                constexpr empty_view<detail::decay_t<invoke_result_t<Fun &>>>
+                operator()(Fun) const noexcept
             {
                 return {};
             }
@@ -438,9 +438,9 @@ namespace ranges
 
             template(typename Fun)(
                 /// \pre
-                requires copy_constructible<Fun> AND invocable<
-                    Fun &>) constexpr empty_view<detail::decay_t<invoke_result_t<Fun &>>>
-            operator()(Fun) const noexcept
+                requires copy_constructible<Fun> AND invocable<Fun &>) //
+                constexpr empty_view<detail::decay_t<invoke_result_t<Fun &>>>
+                operator()(Fun) const noexcept
             {
                 return {};
             }

--- a/test/view/zip.cpp
+++ b/test/view/zip.cpp
@@ -131,6 +131,9 @@ int main()
         std::vector<std::string> expected;
         copy(rng, ranges::back_inserter(expected));
         ::check_equal(expected, {"ax","by","cz"});
+
+        auto rng2 = views::zip_with([] { return 42; });
+        static_assert(std::is_same<range_value_t<decltype(rng2)>, int>::value, "");
     }
 
     // Move from a zip view


### PR DESCRIPTION
Currently, `zip_with(f)` is hardcoded to yield `empty_view<tuple<>>` but it should really be based on the callable itself. This fixes `zip_with([]{ return 42; })` to provide `empty_view<int>` instead. 