### PR TITLE
adds `noexcept` to coro detection `final_suspend`

### DIFF
--- a/cmake/coro_test_code.cpp
+++ b/cmake/coro_test_code.cpp
@@ -20,7 +20,7 @@ struct present
 
         present get_return_object() { return {*this}; }
         std_coro::suspend_never initial_suspend() { return {}; }
-        std_coro::suspend_never final_suspend() { return {}; }
+        std_coro::suspend_never final_suspend() noexcept { return {}; }
         void return_value(int i) { result = i; }
         void unhandled_exception() {}
     };


### PR DESCRIPTION
The CMake coroutine-detection test fails for recent versions of Clang
because `present::promis_type::final_suspend` wasn't `noexcept`.