### PR TITLE
Removing bogus assert in drop_last.

### DIFF
--- a/include/range/v3/view/drop_last.hpp
+++ b/include/range/v3/view/drop_last.hpp
@@ -50,7 +50,6 @@ namespace ranges
                 RANGES_EXPECT(n_ >= 0);
                 range_size_t<Rng> const initial_size = ranges::size(rng);
                 range_size_t<Rng> const n = static_cast<range_size_t<Rng>>(n_);
-                RANGES_EXPECT(initial_size >= n);
                 return initial_size > n ? initial_size - n : 0;
             }
 

--- a/test/view/drop_last.cpp
+++ b/test/view/drop_last.cpp
@@ -75,6 +75,11 @@ void test_range(Rng&& src)
         auto list = src_ | views::drop_last(4);
         CHECK(list.empty());
     }
+    {
+        auto src_ = src;
+        auto list = src_ | views::drop_last(5);
+        CHECK(list.empty());
+    }
 }
 
 template<class Rng>
@@ -83,6 +88,7 @@ void test_size(Rng&& src)
     CHECK( (src | views::drop_last(0)).size() == std::size_t(4) );
     CHECK( (src | views::drop_last(2)).size() == std::size_t(2) );
     CHECK( (src | views::drop_last(4)).size() == std::size_t(0) );
+    CHECK( (src | views::drop_last(5)).size() == std::size_t(0) );
 }
 
 template<class Rng>


### PR DESCRIPTION
The documentation states:

> Given a source range and an integral count, return a range consisting of all but the last count elements from the source range, or an empty range if it has fewer elements. 

But there's currently an assert that prevents the empty range case from working.