### PR TITLE
Fix read of uninitialized bool in cache1

### DIFF
--- a/include/range/v3/view/cache1.hpp
+++ b/include/range/v3/view/cache1.hpp
@@ -40,7 +40,7 @@ namespace ranges
         CPP_assert(constructible_from<range_value_t<Rng>, range_reference_t<Rng>>);
         friend range_access;
         Rng rng_;
-        bool dirty_;
+        bool dirty_ = true;
         detail::non_propagating_cache<range_value_t<Rng>> cache_;
 
         CPP_member


### PR DESCRIPTION
For #1603: Undefined behavior caught by GCC 9 on Ubuntu 20.04 when using `views::cache1`

Ensure that cache1's dirty_ member is initialized to avoid UB found by
UBSan:
range-v3-0.11.0/include/range/v3/view/cache1.hpp:35:12: runtime error: load of value 39, which is not a valid value for type 'bool'