### PR TITLE
Update deprecation message

### DIFF
--- a/include/range/v3/view/empty.hpp
+++ b/include/range/v3/view/empty.hpp
@@ -47,7 +47,7 @@ namespace ranges
             return nullptr;
         }
         RANGES_DEPRECATED(
-            "Replace views::empty<T>() with views::empty<>. "
+            "Replace views::empty<T>() with views::empty<T>. "
             "It is now a variable template.")
         empty_view operator()() const
         {


### PR DESCRIPTION
The following code triggers a CLANGTIDY lint:
```
return ranges::views::empty<int64_t>();
```
> is deprecated Replace views::empty<T>() with views::empty<>. It is now a variable template.

If I do as the lint suggests, I get a template error:
```
return ranges::views::empty<>;
```
> error: too few template arguments for variable template 'empty'

I suspect we actually want the lint message to be:

> is deprecated Replace views::empty<T>() with views::empty<**T**>. It is now a variable template.
