### PR TITLE
CMake: Fix find_package and_add subdirectory. Fixes #1621

### DIFF
--- a/cmake/range-v3-config.cmake
+++ b/cmake/range-v3-config.cmake
@@ -1,8 +1,8 @@
-include("${CMAKE_CURRENT_LIST_DIR}/range-v3-targets.cmake")
-
 if (TARGET range-v3::meta)
   return()
 endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/range-v3-targets.cmake")
 
 add_library(range-v3::meta INTERFACE IMPORTED)
 add_library(range-v3::concepts INTERFACE IMPORTED)


### PR DESCRIPTION
Full description in issue #1621. CMakeLists.txt to reproduse bug and check fix is:
```
cmake_minimum_required(VERSION 3.5)
project(testCmake)

add_subdirectory(range-v3)

list(APPEND CMAKE_PREFIX_PATH ${CMAKE_CURRENT_SOURCE_DIR}/range-v3)
find_package(range-v3 REQUIRED)

add_executable(${PROJECT_NAME} "main.cc")
target_link_libraries(${PROJECT_NAME} range-v3::range-v3)

target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)

```