### PR TITLE
accommodate libgcc-9's unusual value for the __cpp_lib_string_view feature test macro - part 2

### DIFF
--- a/include/range/v3/range/access.hpp
+++ b/include/range/v3/range/access.hpp
@@ -42,7 +42,7 @@
 
 namespace ranges
 {
-#if defined(__cpp_lib_string_view) && __cpp_lib_string_view >= 201606L
+#if defined(__cpp_lib_string_view) && __cpp_lib_string_view >= 201603L
     template<class CharT, class Traits>
     RANGES_INLINE_VAR constexpr bool
         enable_borrowed_range<std::basic_string_view<CharT, Traits>> = true;

--- a/test/range/access.cpp
+++ b/test/range/access.cpp
@@ -238,7 +238,7 @@ using CI = int const *;
 CPP_assert(ranges::input_or_output_iterator<I>);
 CPP_assert(ranges::input_or_output_iterator<CI>);
 
-#if defined(__cpp_lib_string_view) && __cpp_lib_string_view >= 201606L
+#if defined(__cpp_lib_string_view) && __cpp_lib_string_view >= 201603L
 void test_string_view_p0970()
 {
     // basic_string_views are non-dangling
@@ -308,7 +308,7 @@ int main()
     test_array<int const>(std::make_integer_sequence<int, 3>{});
     begin_testing::test();
 
-#if defined(__cpp_lib_string_view) && __cpp_lib_string_view >= 201606L
+#if defined(__cpp_lib_string_view) && __cpp_lib_string_view >= 201603L
     test_string_view_p0970();
 #endif
 


### PR DESCRIPTION

Follow up of https://github.com/ericniebler/range-v3/pull/1609