### PR TITLE
Allow upper_bound to work in the presence operator &

### DIFF
--- a/include/range/v3/algorithm/aux_/upper_bound_n.hpp
+++ b/include/range/v3/algorithm/aux_/upper_bound_n.hpp
@@ -34,13 +34,13 @@ namespace ranges
         template<typename Pred, typename Val>
         struct upper_bound_predicate
         {
-            Pred * pred_;
-            Val * val_;
+            Pred & pred_;
+            Val & val_;
 
             template<typename T>
             bool operator()(T && t) const
             {
-                return !invoke(*pred_, *val_, static_cast<T &&>(t));
+                return !invoke(pred_, val_, static_cast<T &&>(t));
             }
         };
 
@@ -48,7 +48,7 @@ namespace ranges
         upper_bound_predicate<Pred, Val> make_upper_bound_predicate(Pred & pred,
                                                                     Val & val)
         {
-            return {&pred, &val};
+            return {pred, val};
         }
     } // namespace detail
     /// \endcond


### PR DESCRIPTION
Fixes ericniebler/range-v3#1631

upper_bound and lower bound were both implemented with references.
lower_bound retains that design, whereas upper_bound was changed to
pointers in commit 5b8594dcd41a781d0490cf1ea8d555782cea0cd8.

That looks like a mistake, which this commit undoes.