### PR TITLE
make group_by evaluate the predicate on adjacent elements

### DIFF
--- a/test/view/group_by.cpp
+++ b/test/view/group_by.cpp
@@ -89,12 +89,12 @@ int main()
     }
 
     {
-        std::vector<int> v2 {0,1,2,3,4,5,6,7,8,9};
-        auto rng0 = ranges::views::group_by(v2, [](int i, int j){ return j - i < 3; });
+        std::vector<int> v2{0, 1, 2, 6, 8, 10, 15, 17, 18, 29};
+        auto rng0 = ranges::views::group_by(v2, [](int i, int j) { return j - i < 3; });
         check_equal(*rng0.begin(), {0, 1, 2});
-        check_equal(*next(rng0.begin()), {3, 4, 5});
-        check_equal(*next(rng0.begin(), 2), {6, 7, 8});
-        check_equal(*next(rng0.begin(), 3), {9});
+        check_equal(*next(rng0.begin()), {6, 8, 10});
+        check_equal(*next(rng0.begin(), 2), {15, 17, 18});
+        check_equal(*next(rng0.begin(), 3), {29});
         CHECK(distance(rng0) == 4);
     }
 
@@ -151,6 +151,16 @@ int main()
 
         CHECK(distance(rng) == 1);
         check_equal(*rng.begin(), {2});
+    }
+
+    {
+        std::vector<int> v6 = {3, 6, 9, 4, 5, 0, 3, 2};
+        auto rng = v6 | views::group_by(std::less<>{});
+        check_equal(*rng.begin(), {3, 6, 9});
+        check_equal(*next(rng.begin()), {4, 5});
+        check_equal(*next(rng.begin(), 2), {0, 3});
+        check_equal(*next(rng.begin(), 3), {2});
+        CHECK(distance(rng) == 4);
     }
 
     return test_result();


### PR DESCRIPTION
as mentioned in
http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2214r0.html#the-group_by-family

to be consistent with Haskell/Elixir/D and make it more familiar and useful, I've updated the `group_by` view to evaluate the predicate on adjacent elements