### PR TITLE
relax ranges::view_ concept

### DIFF
--- a/include/range/v3/range/concepts.hpp
+++ b/include/range/v3/range/concepts.hpp
@@ -207,7 +207,7 @@ namespace ranges
     template<typename T>
     CPP_concept view_ =
         range<T> &&
-        semiregular<T> &&
+        copyable<T> &&
         enable_view<T>;
 
     template<typename T>


### PR DESCRIPTION
See discussion at https://github.com/ericniebler/range-v3/issues/1662#issuecomment-936423357

@ericniebler I think this is a trade-off between the current concept definition in the standard and the non-ability of the range-v3 views to handle move-only views. Most range-v3 views should just be fine to copy existing views.

Do you know out of your head, what views might need default initializable?