### PR TITLE
Updated fold to P2322R5 (no projections, rename)

### DIFF
--- a/include/range/v3/algorithm.hpp
+++ b/include/range/v3/algorithm.hpp
@@ -36,6 +36,7 @@
 #include <range/v3/algorithm/find_first_of.hpp>
 #include <range/v3/algorithm/find_if.hpp>
 #include <range/v3/algorithm/find_if_not.hpp>
+#include <range/v3/algorithm/fold.hpp>
 #include <range/v3/algorithm/for_each.hpp>
 #include <range/v3/algorithm/for_each_n.hpp>
 #include <range/v3/algorithm/generate.hpp>

--- a/include/range/v3/algorithm/fold.hpp
+++ b/include/range/v3/algorithm/fold.hpp
@@ -13,7 +13,7 @@
 #ifndef RANGES_V3_ALGORITHM_FOLD_HPP
 #define RANGES_V3_ALGORITHM_FOLD_HPP
 
-#include <range/v3/algorithm/foldl.hpp>
-#include <range/v3/algorithm/foldr.hpp>
+#include <range/v3/algorithm/fold_left.hpp>
+#include <range/v3/algorithm/fold_right.hpp>
 
 #endif

--- a/include/range/v3/algorithm/fold_right.hpp
+++ b/include/range/v3/algorithm/fold_right.hpp
@@ -10,12 +10,12 @@
 //
 // Project home: https://github.com/ericniebler/range-v3
 
-#ifndef RANGES_V3_ALGORITHM_FOLDR_HPP
-#define RANGES_V3_ALGORITHM_FOLDR_HPP
+#ifndef RANGES_V3_ALGORITHM_FOLD_RIGHT_HPP
+#define RANGES_V3_ALGORITHM_FOLD_RIGHT_HPP
 
 #include <meta/meta.hpp>
 
-#include <range/v3/algorithm/foldl.hpp>
+#include <range/v3/algorithm/fold_left.hpp>
 #include <range/v3/functional/identity.hpp>
 #include <range/v3/functional/invoke.hpp>
 #include <range/v3/iterator/operations.hpp>
@@ -48,16 +48,16 @@ namespace ranges
 
     /// \addtogroup group-algorithms
     /// @{
-    struct foldr_fn
+    struct fold_right_fn
     {
-        template(typename I, typename S, typename T, typename Op, typename P = identity)(
+        template(typename I, typename S, typename T, typename Op)(
             /// \pre
             requires sentinel_for<S, I> AND bidirectional_iterator<I> AND
-                indirectly_binary_right_foldable<Op, T, projected<I, P>>) //
+                indirectly_binary_right_foldable<Op, T, I>) //
             constexpr auto
-            operator()(I first, S last, T init, Op op, P proj = P{}) const
+            operator()(I first, S last, T init, Op op) const
         {
-            using U = std::decay_t<invoke_result_t<Op &, indirect_result_t<P &, I>, T>>;
+            using U = std::decay_t<invoke_result_t<Op &, iter_reference_t<I>, T>>;
 
             if(first == last)
             {
@@ -65,68 +65,62 @@ namespace ranges
             }
 
             I tail = next(first, last);
-            U accum = invoke(op, invoke(proj, *--tail), std::move(init));
+            U accum = invoke(op, *--tail, std::move(init));
             while(first != tail)
             {
-                accum = invoke(op, invoke(proj, *--tail), std::move(accum));
+                accum = invoke(op, *--tail, std::move(accum));
             }
             return accum;
         }
 
-        template(typename Rng, typename T, typename Op, typename P = identity)(
+        template(typename Rng, typename T, typename Op)(
             /// \pre
             requires bidirectional_range<Rng> AND
-                indirectly_binary_right_foldable<Op, T, projected<iterator_t<Rng>, P>>) //
+                indirectly_binary_right_foldable<Op, T, iterator_t<Rng>>) //
             constexpr auto
-            operator()(Rng && rng, T init, Op op, P proj = P{}) const
+            operator()(Rng && rng, T init, Op op) const
         {
-            return (*this)(begin(rng),
-                           end(rng),
-                           std::move(init),
-                           std::move(op),
-                           std::move(proj));
+            return (*this)(begin(rng), end(rng), std::move(init), std::move(op));
         }
     };
 
-    struct foldr1_fn
+    struct fold_right_last_fn
     {
-        template(typename I, typename S, typename Op, typename P = identity)(
+        template(typename I, typename S, typename Op)(
             /// \pre
             requires sentinel_for<S, I> AND bidirectional_iterator<I> AND
-                indirectly_binary_right_foldable<Op, iter_value_t<I>, projected<I, P>>
+                indirectly_binary_right_foldable<Op, iter_value_t<I>, I>
                     AND constructible_from<iter_value_t<I>, iter_reference_t<I>>) //
             constexpr auto
-            operator()(I first, S last, Op op, P proj = P{}) const
+            operator()(I first, S last, Op op) const
         {
-            using U = invoke_result_t<foldr_fn, I, S, iter_value_t<I>, Op, P>;
+            using U = invoke_result_t<fold_right_fn, I, S, iter_value_t<I>, Op>;
             if(first == last)
             {
                 return optional<U>();
             }
 
             I tail = prev(next(first, std::move(last)));
-            return optional<U>(in_place,
-                               foldr_fn{}(std::move(first),
-                                          tail,
-                                          iter_value_t<I>(*tail),
-                                          std::move(op),
-                                          std::move(proj)));
+            return optional<U>(
+                in_place,
+                fold_right_fn{}(
+                    std::move(first), tail, iter_value_t<I>(*tail), std::move(op)));
         }
 
-        template(typename R, typename Op, typename P = identity)(
+        template(typename R, typename Op)(
             /// \pre
-            requires bidirectional_range<R> AND indirectly_binary_right_foldable<
-                Op, range_value_t<R>, projected<iterator_t<R>, P>>
-                AND constructible_from<range_value_t<R>, range_reference_t<R>>) //
+            requires bidirectional_range<R> AND
+                indirectly_binary_right_foldable<Op, range_value_t<R>, iterator_t<R>>
+                    AND constructible_from<range_value_t<R>, range_reference_t<R>>) //
             constexpr auto
-            operator()(R && rng, Op op, P proj = P{}) const
+            operator()(R && rng, Op op) const
         {
-            return (*this)(begin(rng), end(rng), std::move(op), std::move(proj));
+            return (*this)(begin(rng), end(rng), std::move(op));
         }
     };
 
-    RANGES_INLINE_VARIABLE(foldr_fn, foldr)
-    RANGES_INLINE_VARIABLE(foldr1_fn, foldr1)
+    RANGES_INLINE_VARIABLE(fold_right_fn, fold_right)
+    RANGES_INLINE_VARIABLE(fold_right_last_fn, fold_right_last)
     /// @}
 } // namespace ranges
 

--- a/test/algorithm/fold.cpp
+++ b/test/algorithm/fold.cpp
@@ -50,38 +50,38 @@ template<class Iter, class Sent = Iter>
 void test_left()
 {
     double da[] = {0.25, 0.75};
-    CHECK(ranges::foldl(Iter(da), Sent(da), 1, std::plus<>()) == Approx{1.0});
-    CHECK(ranges::foldl(Iter(da), Sent(da + 2), 1, std::plus<>()) == Approx{2.0});
+    CHECK(ranges::fold_left(Iter(da), Sent(da), 1, std::plus<>()) == Approx{1.0});
+    CHECK(ranges::fold_left(Iter(da), Sent(da + 2), 1, std::plus<>()) == Approx{2.0});
 
-    CHECK(ranges::foldl1(Iter(da), Sent(da), ranges::min) == ranges::nullopt);
-    CHECK(ranges::foldl1(Iter(da), Sent(da + 2), ranges::min) ==
+    CHECK(ranges::fold_left_first(Iter(da), Sent(da), ranges::min) == ranges::nullopt);
+    CHECK(ranges::fold_left_first(Iter(da), Sent(da + 2), ranges::min) ==
           ranges::optional<Approx>(0.25));
 
     using ranges::make_subrange;
-    CHECK(ranges::foldl(make_subrange(Iter(da), Sent(da)), 1, std::plus<>()) ==
+    CHECK(ranges::fold_left(make_subrange(Iter(da), Sent(da)), 1, std::plus<>()) ==
           Approx{1.0});
-    CHECK(ranges::foldl(make_subrange(Iter(da), Sent(da + 2)), 1, std::plus<>()) ==
+    CHECK(ranges::fold_left(make_subrange(Iter(da), Sent(da + 2)), 1, std::plus<>()) ==
           Approx{2.0});
-    CHECK(ranges::foldl1(make_subrange(Iter(da), Sent(da)), ranges::min) ==
+    CHECK(ranges::fold_left_first(make_subrange(Iter(da), Sent(da)), ranges::min) ==
           ranges::nullopt);
-    CHECK(ranges::foldl1(make_subrange(Iter(da), Sent(da + 2)), ranges::min) ==
+    CHECK(ranges::fold_left_first(make_subrange(Iter(da), Sent(da + 2)), ranges::min) ==
           ranges::optional<Approx>(0.25));
 }
 
 void test_right()
 {
     double da[] = {0.25, 0.75};
-    CHECK(ranges::foldr(da, da + 2, 1, std::plus<>()) == Approx{2.0});
-    CHECK(ranges::foldr(da, 1, std::plus<>()) == Approx{2.0});
+    CHECK(ranges::fold_right(da, da + 2, 1, std::plus<>()) == Approx{2.0});
+    CHECK(ranges::fold_right(da, 1, std::plus<>()) == Approx{2.0});
 
     // f(0.25, f(0.75, 1))
-    CHECK(ranges::foldr(da, da + 2, 1, std::minus<>()) == Approx{0.5});
-    CHECK(ranges::foldr(da, 1, std::minus<>()) == Approx{0.5});
+    CHECK(ranges::fold_right(da, da + 2, 1, std::minus<>()) == Approx{0.5});
+    CHECK(ranges::fold_right(da, 1, std::minus<>()) == Approx{0.5});
 
     int xs[] = {1, 2, 3};
     auto concat = [](int i, std::string s) { return s + std::to_string(i); };
-    CHECK(ranges::foldr(xs, xs + 2, std::string(), concat) == "21");
-    CHECK(ranges::foldr(xs, std::string(), concat) == "321");
+    CHECK(ranges::fold_right(xs, xs + 2, std::string(), concat) == "21");
+    CHECK(ranges::fold_right(xs, std::string(), concat) == "321");
 }
 
 int main()


### PR DESCRIPTION
Per LEWG telecon, renaming `foldl`/`foldr` to `fold_left`/`fold_right` and the `*1` suffix to `_first` for the left fold and `_last` for the right fold. Names not finalized yet, but seem more likely to be the final names than `foldl`/`foldl1`/`foldr`/`foldr1`.

Also removing the projections. First, they were implemented incorrectly anyway. Second, for the variants with no initial value, the projection doesn't really work. This is explained in P2322R5 (see [here](https://isocpp.org/files/papers/P2322R5.html#no-projections) until that one is published).