### PR TITLE
[FIX] circular swap concept

### DIFF
--- a/include/range/v3/utility/any.hpp
+++ b/include/range/v3/utility/any.hpp
@@ -124,7 +124,7 @@ namespace ranges
         any() noexcept = default;
         template(typename TRef, typename T = detail::decay_t<TRef>)(
             /// \pre
-            requires copyable<T> AND (!same_as<T, any>)) //
+            requires copy_constructible<T> AND (!same_as<T, any>)) //
         any(TRef && t)
           : ptr_(new impl<T>(static_cast<TRef &&>(t)))
         {}
@@ -140,7 +140,7 @@ namespace ranges
         }
         template(typename TRef, typename T = detail::decay_t<TRef>)(
             /// \pre
-            requires copyable<T> AND (!same_as<T, any>)) //
+            requires copy_constructible<T> AND (!same_as<T, any>)) //
         any & operator=(TRef && t)
         {
             any{static_cast<TRef &&>(t)}.swap(*this);


### PR DESCRIPTION
Fixes https://github.com/ericniebler/range-v3/issues/1672

I'm not too sure about whether the replacement is correct (let's see what CI says).

Type is `ranges::any`, and we check for `swappable`.
In the end, we want to use the `any` constructor with `copyable` restriction.

`copyable` requires `movable`, and `movable` requires `swappable`
