### PR TITLE
linear_distribute improvement

### DIFF
--- a/include/range/v3/view/linear_distribute.hpp
+++ b/include/range/v3/view/linear_distribute.hpp
@@ -84,7 +84,7 @@ namespace ranges
             constexpr linear_distribute_view(T from, T to, std::ptrdiff_t n) noexcept
               : from_(from)
               , to_(to)
-              , delta_((to - from) / Calc(n - 1))
+              , delta_(n > 1 ? (to - from) / Calc(n - 1) : 0)
               , n_(n)
             {
                 RANGES_EXPECT(n_ > 0);

--- a/include/range/v3/view/linear_distribute.hpp
+++ b/include/range/v3/view/linear_distribute.hpp
@@ -17,6 +17,8 @@
 
 #include <type_traits>
 
+#include <meta/meta.hpp>
+
 #include <range/v3/range_fwd.hpp>
 
 #include <range/v3/iterator/default_sentinel.hpp>
@@ -39,8 +41,10 @@ namespace ranges
 
         private:
             friend range_access;
+            using Calc = meta::conditional_t<std::is_floating_point<T>::value, T, double>;
 
             T from_, to_;
+            Calc delta_;
             std::ptrdiff_t n_;
 
             constexpr T read() const noexcept
@@ -71,15 +75,16 @@ namespace ranges
                 }
                 else
                 {
-                    from_ += (to_ - from_) / T(n_);
+                    from_ = T(to_ - (delta_ * (n_ - 1)));
                 }
             }
 
         public:
             constexpr linear_distribute_view() = default;
-            constexpr linear_distribute_view(T from, T to__, std::ptrdiff_t n) noexcept
+            constexpr linear_distribute_view(T from, T to, std::ptrdiff_t n) noexcept
               : from_(from)
-              , to_(to__)
+              , to_(to)
+              , delta_((to - from) / Calc(n - 1))
               , n_(n)
             {
                 RANGES_EXPECT(n_ > 0);

--- a/include/range/v3/view/linear_distribute.hpp
+++ b/include/range/v3/view/linear_distribute.hpp
@@ -75,7 +75,7 @@ namespace ranges
                 }
                 else
                 {
-                    from_ = T(to_ - (delta_ * (n_ - 1)));
+                    from_ = T(to_ - (delta_ * Calc(n_ - 1)));
                 }
             }
 

--- a/test/view/linear_distribute.cpp
+++ b/test/view/linear_distribute.cpp
@@ -79,12 +79,16 @@ int main()
         CHECK(ranges::size(frng) == std::size_t{3});
         CHECK(ranges::equal(frng, std::initializer_list<double>{0.,0.,0.}, float_eq));
     }
-
     {   // regression test for #1088
         auto ld = linear_distribute(1, 10, 10);
         auto const first = ranges::begin(ld);
         auto const i = ranges::next(first, 4);
         CHECK(ranges::distance(first, i) == 4);
+    }
+    {   // integral numbers spacing
+        auto irng = linear_distribute(0, 10, 22);
+        auto frng = linear_distribute(0., 10., 22);
+        check_equal(irng, frng | ranges::views::transform(ranges::convert_to<int>{}));
     }
 
     return test_result();


### PR DESCRIPTION
`linear_distribute` has an unexpected behavior for integral values when number of values to be calculated is greater than distance between `from` and `to`. My expectation was similar to `numpy` behavior where calculated values are "evenly" distributed with integral precision.

Expectation: 
```
linear_distribute(0, 10, 20) == linear_distribute(0.0, 10.0, 20) | transform(convert_to<int>{})
```

Current implementation:
```
linear_distribute(0, 3, 7)     = [0, 0,   0, 0,   1, 2,   3]
linear_distribute(0.0, 3.0, 7) = [0, 0.5, 1, 1.5, 2, 2.5, 3]
```

Improved implementation:

```
linear_distribute(0, 3, 7)     = [0, 0,   1, 1,   2, 2,   3]
linear_distribute(0.0, 3.0, 7) = [0, 0.5, 1, 1.5, 2, 2.5, 3]
```