### PR TITLE
algorithm/fold: renames `fold[lr]1?`

### DIFF
--- a/include/range/v3/algorithm.hpp
+++ b/include/range/v3/algorithm.hpp
@@ -36,6 +36,7 @@
 #include <range/v3/algorithm/find_first_of.hpp>
 #include <range/v3/algorithm/find_if.hpp>
 #include <range/v3/algorithm/find_if_not.hpp>
+#include <range/v3/algorithm/fold.hpp>
 #include <range/v3/algorithm/for_each.hpp>
 #include <range/v3/algorithm/for_each_n.hpp>
 #include <range/v3/algorithm/generate.hpp>

--- a/include/range/v3/algorithm/fold.hpp
+++ b/include/range/v3/algorithm/fold.hpp
@@ -13,7 +13,7 @@
 #ifndef RANGES_V3_ALGORITHM_FOLD_HPP
 #define RANGES_V3_ALGORITHM_FOLD_HPP
 
-#include <range/v3/algorithm/foldl.hpp>
-#include <range/v3/algorithm/foldr.hpp>
+#include <range/v3/algorithm/fold_left.hpp>
+#include <range/v3/algorithm/fold_right.hpp>
 
 #endif

--- a/include/range/v3/algorithm/fold_left.hpp
+++ b/include/range/v3/algorithm/fold_left.hpp
@@ -10,15 +10,13 @@
 //
 // Project home: https://github.com/ericniebler/range-v3
 
-#ifndef RANGES_V3_ALGORITHM_FOLDR_HPP
-#define RANGES_V3_ALGORITHM_FOLDR_HPP
+#ifndef RANGES_V3_ALGORITHM_FOLD_LEFT_HPP
+#define RANGES_V3_ALGORITHM_FOLD_LEFT_HPP
 
 #include <meta/meta.hpp>
 
-#include <range/v3/algorithm/foldl.hpp>
 #include <range/v3/functional/identity.hpp>
 #include <range/v3/functional/invoke.hpp>
-#include <range/v3/iterator/operations.hpp>
 #include <range/v3/range/access.hpp>
 #include <range/v3/range/concepts.hpp>
 #include <range/v3/utility/optional.hpp>
@@ -27,56 +25,55 @@
 
 namespace ranges
 {
-    namespace detail
-    {
-        template<typename F>
-        struct flipped
-        {
-            F f;
-
-            template(class T, class U)(requires invocable<F &, U, T>) //
-                invoke_result_t<F &, U, T>
-                operator()(T &&, U &&);
-        };
-    } // namespace detail
-
     // clang-format off
+    template<class F, class T, class I, class U>
+    CPP_concept indirectly_binary_left_foldable_impl =
+        movable<T> &&
+        movable<U> &&
+        convertible_to<T, U> &&
+        invocable<F&, U, iter_reference_t<I>> &&
+        assignable_from<U&, invoke_result_t<F&, U, iter_reference_t<I>>>;
+
     template <class F, class T, class I>
-    CPP_concept indirectly_binary_right_foldable =
-        indirectly_binary_left_foldable<detail::flipped<F>, T, I>;
+    CPP_concept indirectly_binary_left_foldable =
+        copy_constructible<F> &&
+        indirectly_readable<I> &&
+        invocable<F&, T, iter_reference_t<I>> &&
+        convertible_to<invoke_result_t<F&, T, iter_reference_t<I>>,
+          std::decay_t<invoke_result_t<F&, T, iter_reference_t<I>>>> &&
+        indirectly_binary_left_foldable_impl<F, T, I, std::decay_t<invoke_result_t<F&, T, iter_reference_t<I>>>>;
     // clang-format on
 
     /// \addtogroup group-algorithms
     /// @{
-    struct foldr_fn
+    struct fold_left_fn
     {
         template(typename I, typename S, typename T, typename Op, typename P = identity)(
             /// \pre
-            requires sentinel_for<S, I> AND bidirectional_iterator<I> AND
-                indirectly_binary_right_foldable<Op, T, projected<I, P>>) //
+            requires sentinel_for<S, I> AND input_iterator<I> AND
+                indirectly_binary_left_foldable<Op, T, projected<I, P>>) //
             constexpr auto
             operator()(I first, S last, T init, Op op, P proj = P{}) const
         {
-            using U = std::decay_t<invoke_result_t<Op &, indirect_result_t<P &, I>, T>>;
+            using U = std::decay_t<invoke_result_t<Op &, T, indirect_result_t<P&, I>>>;
 
             if(first == last)
             {
                 return U(std::move(init));
             }
 
-            I tail = next(first, last);
-            U accum = invoke(op, invoke(proj, *--tail), std::move(init));
-            while(first != tail)
+            U accum = invoke(op, std::move(init), *first);
+            for(++first; first != last; ++first)
             {
-                accum = invoke(op, invoke(proj, *--tail), std::move(accum));
+                accum = invoke(op, std::move(accum), invoke(proj, *first));
             }
             return accum;
         }
 
         template(typename Rng, typename T, typename Op, typename P = identity)(
             /// \pre
-            requires bidirectional_range<Rng> AND
-                indirectly_binary_right_foldable<Op, T, projected<iterator_t<Rng>, P>>) //
+            requires input_range<Rng> AND
+                indirectly_binary_left_foldable<Op, T, projected<iterator_t<Rng>, P>>) //
             constexpr auto
             operator()(Rng && rng, T init, Op op, P proj = P{}) const
         {
@@ -88,36 +85,34 @@ namespace ranges
         }
     };
 
-    struct foldr1_fn
+    struct fold_left_first_fn
     {
         template(typename I, typename S, typename Op, typename P = identity)(
             /// \pre
-            requires sentinel_for<S, I> AND bidirectional_iterator<I> AND
-                indirectly_binary_right_foldable<Op, iter_value_t<I>, projected<I, P>>
+            requires sentinel_for<S, I> AND input_iterator<I> AND
+                indirectly_binary_left_foldable<Op, iter_value_t<I>, projected<I, P>>
                     AND constructible_from<iter_value_t<I>, iter_reference_t<I>>) //
             constexpr auto
             operator()(I first, S last, Op op, P proj = P{}) const
         {
-            using U = invoke_result_t<foldr_fn, I, S, iter_value_t<I>, Op, P>;
+            using U = invoke_result_t<fold_left_fn, I, S, iter_value_t<I>, Op, P>;
             if(first == last)
             {
                 return optional<U>();
             }
 
-            I tail = prev(next(first, std::move(last)));
-            return optional<U>(in_place,
-                               foldr_fn{}(std::move(first),
-                                          tail,
-                                          iter_value_t<I>(*tail),
-                                          std::move(op),
-                                          std::move(proj)));
+            iter_value_t<I> init = *first;
+            ++first;
+            return optional<U>(
+                in_place,
+                fold_left_fn{}(std::move(first), std::move(last), std::move(init), op, proj));
         }
 
         template(typename R, typename Op, typename P = identity)(
             /// \pre
-            requires bidirectional_range<R> AND indirectly_binary_right_foldable<
-                Op, range_value_t<R>, projected<iterator_t<R>, P>>
-                AND constructible_from<range_value_t<R>, range_reference_t<R>>) //
+            requires input_range<R> AND
+                indirectly_binary_left_foldable<Op, range_value_t<R>, projected<iterator_t<R>, P>>
+                    AND constructible_from<range_value_t<R>, range_reference_t<R>>) //
             constexpr auto
             operator()(R && rng, Op op, P proj = P{}) const
         {
@@ -125,11 +120,11 @@ namespace ranges
         }
     };
 
-    RANGES_INLINE_VARIABLE(foldr_fn, foldr)
-    RANGES_INLINE_VARIABLE(foldr1_fn, foldr1)
+    RANGES_INLINE_VARIABLE(fold_left_fn, fold_left)
+    RANGES_INLINE_VARIABLE(fold_left_first_fn, fold_left_first)
     /// @}
 } // namespace ranges
 
 #include <range/v3/detail/epilogue.hpp>
 
-#endif
+#endif // RANGES_V3_ALGORITHM_FOLD_LEFT_HPP

--- a/include/range/v3/algorithm/fold_right.hpp
+++ b/include/range/v3/algorithm/fold_right.hpp
@@ -10,13 +10,15 @@
 //
 // Project home: https://github.com/ericniebler/range-v3
 
-#ifndef RANGES_V3_ALGORITHM_FOLDL_HPP
-#define RANGES_V3_ALGORITHM_FOLDL_HPP
+#ifndef RANGES_V3_ALGORITHM_FOLD_RIGHT_HPP
+#define RANGES_V3_ALGORITHM_FOLD_RIGHT_HPP
 
 #include <meta/meta.hpp>
 
+#include <range/v3/algorithm/fold_left.hpp>
 #include <range/v3/functional/identity.hpp>
 #include <range/v3/functional/invoke.hpp>
+#include <range/v3/iterator/operations.hpp>
 #include <range/v3/range/access.hpp>
 #include <range/v3/range/concepts.hpp>
 #include <range/v3/utility/optional.hpp>
@@ -25,55 +27,56 @@
 
 namespace ranges
 {
-    // clang-format off
-    template<class F, class T, class I, class U>
-    CPP_concept indirectly_binary_left_foldable_impl =
-        movable<T> &&
-        movable<U> &&
-        convertible_to<T, U> &&
-        invocable<F&, U, iter_reference_t<I>> &&
-        assignable_from<U&, invoke_result_t<F&, U, iter_reference_t<I>>>;
+    namespace detail
+    {
+        template<typename F>
+        struct flipped
+        {
+            F f;
 
+            template(class T, class U)(requires invocable<F &, U, T>) //
+                invoke_result_t<F &, U, T>
+                operator()(T &&, U &&);
+        };
+    } // namespace detail
+
+    // clang-format off
     template <class F, class T, class I>
-    CPP_concept indirectly_binary_left_foldable =
-        copy_constructible<F> &&
-        indirectly_readable<I> &&
-        invocable<F&, T, iter_reference_t<I>> &&
-        convertible_to<invoke_result_t<F&, T, iter_reference_t<I>>,
-          std::decay_t<invoke_result_t<F&, T, iter_reference_t<I>>>> &&
-        indirectly_binary_left_foldable_impl<F, T, I, std::decay_t<invoke_result_t<F&, T, iter_reference_t<I>>>>;
+    CPP_concept indirectly_binary_right_foldable =
+        indirectly_binary_left_foldable<detail::flipped<F>, T, I>;
     // clang-format on
 
     /// \addtogroup group-algorithms
     /// @{
-    struct foldl_fn
+    struct fold_right_fn
     {
         template(typename I, typename S, typename T, typename Op, typename P = identity)(
             /// \pre
-            requires sentinel_for<S, I> AND input_iterator<I> AND
-                indirectly_binary_left_foldable<Op, T, projected<I, P>>) //
+            requires sentinel_for<S, I> AND bidirectional_iterator<I> AND
+                indirectly_binary_right_foldable<Op, T, projected<I, P>>) //
             constexpr auto
             operator()(I first, S last, T init, Op op, P proj = P{}) const
         {
-            using U = std::decay_t<invoke_result_t<Op &, T, indirect_result_t<P&, I>>>;
+            using U = std::decay_t<invoke_result_t<Op &, indirect_result_t<P &, I>, T>>;
 
             if(first == last)
             {
                 return U(std::move(init));
             }
 
-            U accum = invoke(op, std::move(init), *first);
-            for(++first; first != last; ++first)
+            I tail = next(first, last);
+            U accum = invoke(op, invoke(proj, *--tail), std::move(init));
+            while(first != tail)
             {
-                accum = invoke(op, std::move(accum), invoke(proj, *first));
+                accum = invoke(op, invoke(proj, *--tail), std::move(accum));
             }
             return accum;
         }
 
         template(typename Rng, typename T, typename Op, typename P = identity)(
             /// \pre
-            requires input_range<Rng> AND
-                indirectly_binary_left_foldable<Op, T, projected<iterator_t<Rng>, P>>) //
+            requires bidirectional_range<Rng> AND
+                indirectly_binary_right_foldable<Op, T, projected<iterator_t<Rng>, P>>) //
             constexpr auto
             operator()(Rng && rng, T init, Op op, P proj = P{}) const
         {
@@ -85,34 +88,36 @@ namespace ranges
         }
     };
 
-    struct foldl1_fn
+    struct fold_right_last_fn
     {
         template(typename I, typename S, typename Op, typename P = identity)(
             /// \pre
-            requires sentinel_for<S, I> AND input_iterator<I> AND
-                indirectly_binary_left_foldable<Op, iter_value_t<I>, projected<I, P>>
+            requires sentinel_for<S, I> AND bidirectional_iterator<I> AND
+                indirectly_binary_right_foldable<Op, iter_value_t<I>, projected<I, P>>
                     AND constructible_from<iter_value_t<I>, iter_reference_t<I>>) //
             constexpr auto
             operator()(I first, S last, Op op, P proj = P{}) const
         {
-            using U = invoke_result_t<foldl_fn, I, S, iter_value_t<I>, Op, P>;
+            using U = invoke_result_t<fold_right_fn, I, S, iter_value_t<I>, Op, P>;
             if(first == last)
             {
                 return optional<U>();
             }
 
-            iter_value_t<I> init = *first;
-            ++first;
-            return optional<U>(
-                in_place,
-                foldl_fn{}(std::move(first), std::move(last), std::move(init), op, proj));
+            I tail = prev(next(first, std::move(last)));
+            return optional<U>(in_place,
+                               fold_right_fn{}(std::move(first),
+                                          tail,
+                                          iter_value_t<I>(*tail),
+                                          std::move(op),
+                                          std::move(proj)));
         }
 
         template(typename R, typename Op, typename P = identity)(
             /// \pre
-            requires input_range<R> AND
-                indirectly_binary_left_foldable<Op, range_value_t<R>, projected<iterator_t<R>, P>>
-                    AND constructible_from<range_value_t<R>, range_reference_t<R>>) //
+            requires bidirectional_range<R> AND indirectly_binary_right_foldable<
+                Op, range_value_t<R>, projected<iterator_t<R>, P>>
+                AND constructible_from<range_value_t<R>, range_reference_t<R>>) //
             constexpr auto
             operator()(R && rng, Op op, P proj = P{}) const
         {
@@ -120,8 +125,8 @@ namespace ranges
         }
     };
 
-    RANGES_INLINE_VARIABLE(foldl_fn, foldl)
-    RANGES_INLINE_VARIABLE(foldl1_fn, foldl1)
+    RANGES_INLINE_VARIABLE(fold_right_fn, fold_right)
+    RANGES_INLINE_VARIABLE(fold_right_last_fn, fold_right_last)
     /// @}
 } // namespace ranges
 

--- a/test/algorithm/fold.cpp
+++ b/test/algorithm/fold.cpp
@@ -50,38 +50,38 @@ template<class Iter, class Sent = Iter>
 void test_left()
 {
     double da[] = {0.25, 0.75};
-    CHECK(ranges::foldl(Iter(da), Sent(da), 1, std::plus<>()) == Approx{1.0});
-    CHECK(ranges::foldl(Iter(da), Sent(da + 2), 1, std::plus<>()) == Approx{2.0});
+    CHECK(ranges::fold_left(Iter(da), Sent(da), 1, std::plus<>()) == Approx{1.0});
+    CHECK(ranges::fold_left(Iter(da), Sent(da + 2), 1, std::plus<>()) == Approx{2.0});
 
-    CHECK(ranges::foldl1(Iter(da), Sent(da), ranges::min) == ranges::nullopt);
-    CHECK(ranges::foldl1(Iter(da), Sent(da + 2), ranges::min) ==
+    CHECK(ranges::fold_left_first(Iter(da), Sent(da), ranges::min) == ranges::nullopt);
+    CHECK(ranges::fold_left_first(Iter(da), Sent(da + 2), ranges::min) ==
           ranges::optional<Approx>(0.25));
 
     using ranges::make_subrange;
-    CHECK(ranges::foldl(make_subrange(Iter(da), Sent(da)), 1, std::plus<>()) ==
+    CHECK(ranges::fold_left(make_subrange(Iter(da), Sent(da)), 1, std::plus<>()) ==
           Approx{1.0});
-    CHECK(ranges::foldl(make_subrange(Iter(da), Sent(da + 2)), 1, std::plus<>()) ==
+    CHECK(ranges::fold_left(make_subrange(Iter(da), Sent(da + 2)), 1, std::plus<>()) ==
           Approx{2.0});
-    CHECK(ranges::foldl1(make_subrange(Iter(da), Sent(da)), ranges::min) ==
+    CHECK(ranges::fold_left_first(make_subrange(Iter(da), Sent(da)), ranges::min) ==
           ranges::nullopt);
-    CHECK(ranges::foldl1(make_subrange(Iter(da), Sent(da + 2)), ranges::min) ==
+    CHECK(ranges::fold_left_first(make_subrange(Iter(da), Sent(da + 2)), ranges::min) ==
           ranges::optional<Approx>(0.25));
 }
 
 void test_right()
 {
     double da[] = {0.25, 0.75};
-    CHECK(ranges::foldr(da, da + 2, 1, std::plus<>()) == Approx{2.0});
-    CHECK(ranges::foldr(da, 1, std::plus<>()) == Approx{2.0});
+    CHECK(ranges::fold_right(da, da + 2, 1, std::plus<>()) == Approx{2.0});
+    CHECK(ranges::fold_right(da, 1, std::plus<>()) == Approx{2.0});
 
     // f(0.25, f(0.75, 1))
-    CHECK(ranges::foldr(da, da + 2, 1, std::minus<>()) == Approx{0.5});
-    CHECK(ranges::foldr(da, 1, std::minus<>()) == Approx{0.5});
+    CHECK(ranges::fold_right(da, da + 2, 1, std::minus<>()) == Approx{0.5});
+    CHECK(ranges::fold_right(da, 1, std::minus<>()) == Approx{0.5});
 
     int xs[] = {1, 2, 3};
     auto concat = [](int i, std::string s) { return s + std::to_string(i); };
-    CHECK(ranges::foldr(xs, xs + 2, std::string(), concat) == "21");
-    CHECK(ranges::foldr(xs, std::string(), concat) == "321");
+    CHECK(ranges::fold_right(xs, xs + 2, std::string(), concat) == "21");
+    CHECK(ranges::fold_right(xs, std::string(), concat) == "321");
 }
 
 int main()


### PR DESCRIPTION
* renames `foldl` to `fold_left`
* renames `foldl1` to `fold_left_first`
* renames `foldr` to `fold_right`
* renames `foldr1` to `fold_right_last`
* adds `<range/v3/algorithm/fold.hpp>` to algorithm header

These changes bring the fold family in line with the latest revision of
[wg21.link/p2322].