### PR TITLE
Only find doxygen if building the docs

### DIFF
--- a/cmake/ranges_env.cmake
+++ b/cmake/ranges_env.cmake
@@ -84,5 +84,7 @@ else()
   set(RANGES_RELEASE_BUILD TRUE)
 endif()
 
-find_package(Doxygen)
+if(RANGE_V3_DOCS)
+  find_package(Doxygen)
+endif()
 find_package(Git)


### PR DESCRIPTION
Ran into the issue of trying to build without documentation but cmake still failed. The problem in my case is that `doxygen` is present, but `dot` is to be missing from the build environment. This makes `find_package(Doxygen)` fail because cmake treats it as a required component by default: https://cmake.org/cmake/help/v3.23/module/FindDoxygen.html