### PR TITLE
Fixing ranges::to<std::map>(v)

### DIFF
--- a/.github/workflows/range-v3-ci.yml
+++ b/.github/workflows/range-v3-ci.yml
@@ -319,37 +319,37 @@ jobs:
             cxx_standard: 20,
           }
 
-        # MSVC 2019
+        # MSVC 2022
         - {
-            name: "Windows MSVC 2019 Debug (C++17)", artifact: "Windows-MSVC.tar.xz",
+            name: "Windows MSVC 2022 Debug (C++17)", artifact: "Windows-MSVC.tar.xz",
             os: windows-latest,
             build_type: Debug,
             cc: "cl", cxx: "cl",
-            environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
+            environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
             cxx_standard: 17,
           }
         - {
-            name: "Windows MSVC 2019 Release (C++17)", artifact: "Windows-MSVC.tar.xz",
+            name: "Windows MSVC 2022 Release (C++17)", artifact: "Windows-MSVC.tar.xz",
             os: windows-latest,
             build_type: RelWithDebInfo,
             cc: "cl", cxx: "cl",
-            environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
+            environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
             cxx_standard: 17,
           }
         - {
-            name: "Windows MSVC 2019 Debug (C++20)", artifact: "Windows-MSVC.tar.xz",
+            name: "Windows MSVC 2022 Debug (C++20)", artifact: "Windows-MSVC.tar.xz",
             os: windows-latest,
             build_type: Debug,
             cc: "cl", cxx: "cl",
-            environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
+            environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
             cxx_standard: 20,
           }
         - {
-            name: "Windows MSVC 2019 Release (C++20)", artifact: "Windows-MSVC.tar.xz",
+            name: "Windows MSVC 2022 Release (C++20)", artifact: "Windows-MSVC.tar.xz",
             os: windows-latest,
             build_type: RelWithDebInfo,
             cc: "cl", cxx: "cl",
-            environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
+            environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
             cxx_standard: 20,
           }
 

--- a/include/range/v3/range/conversion.hpp
+++ b/include/range/v3/range/conversion.hpp
@@ -416,11 +416,11 @@ namespace ranges
         }
 
         /// \overload
-        template(template<typename...> class ContT, typename Rng)(
+        template(template<typename...> class ContT, typename Rng, typename C = meta::invoke<detail::from_range<ContT>, Rng>)(
             /// \pre
             requires range<Rng> AND
-                detail::convertible_to_cont<Rng, ContT<range_value_t<Rng>>>)
-        auto to(Rng && rng) -> ContT<range_value_t<Rng>>
+                detail::convertible_to_cont<Rng, C>)
+        auto to(Rng && rng) -> C
         {
             return detail::to_container_fn<detail::from_range<ContT>>{}(
                 static_cast<Rng &&>(rng));

--- a/test/range/conversion.cpp
+++ b/test/range/conversion.cpp
@@ -221,5 +221,26 @@ int main()
         check_equal(d, v);
     }
 
+    {
+        std::vector<std::pair<int, int>> v = {{1, 2}, {3, 4}};
+        auto m1 = ranges::to<std::map<int, int>>(v);
+        auto m2 = v | ranges::to<std::map<int, int>>();
+
+        CPP_assert(same_as<decltype(m1), std::map<int, int>>);
+        CPP_assert(same_as<decltype(m2), std::map<int, int>>);
+        check_equal(m1, std::map<int, int>{{1, 2}, {3, 4}});
+        check_equal(m1, m2);
+
+#if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
+        auto m3 = ranges::to<std::map>(v);
+        auto m4 = v | ranges::to<std::map>();
+        CPP_assert(same_as<decltype(m3), std::map<int, int>>);
+        CPP_assert(same_as<decltype(m4), std::map<int, int>>);
+        check_equal(m1, m3);
+        check_equal(m1, m4);
+#endif
+
+    }
+
     return ::test_result();
 }

--- a/test/range/conversion.cpp
+++ b/test/range/conversion.cpp
@@ -115,6 +115,21 @@ template<typename Rng>
 void test_zip_to_map(Rng &&, long)
 {}
 
+template<typename K, typename V>
+struct map_like : std::map<K, V>
+{
+    template<typename Iter>
+    map_like(Iter f, Iter l)
+      : std::map<K, V>(f, l)
+    {}
+};
+
+#if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
+template<typename Iter>
+map_like(Iter, Iter) -> map_like<typename ranges::iter_value_t<Iter>::first_type,
+                                 typename ranges::iter_value_t<Iter>::second_type>;
+#endif
+
 int main()
 {
     using namespace ranges;
@@ -223,23 +238,22 @@ int main()
 
     {
         std::vector<std::pair<int, int>> v = {{1, 2}, {3, 4}};
-        auto m1 = ranges::to<std::map<int, int>>(v);
-        auto m2 = v | ranges::to<std::map<int, int>>();
+        auto m1 = ranges::to<map_like<int, int>>(v);
+        auto m2 = v | ranges::to<map_like<int, int>>();
 
-        CPP_assert(same_as<decltype(m1), std::map<int, int>>);
-        CPP_assert(same_as<decltype(m2), std::map<int, int>>);
+        CPP_assert(same_as<decltype(m1), map_like<int, int>>);
+        CPP_assert(same_as<decltype(m2), map_like<int, int>>);
         check_equal(m1, std::map<int, int>{{1, 2}, {3, 4}});
         check_equal(m1, m2);
 
 #if RANGES_CXX_DEDUCTION_GUIDES >= RANGES_CXX_DEDUCTION_GUIDES_17
-        auto m3 = ranges::to<std::map>(v);
-        auto m4 = v | ranges::to<std::map>();
-        CPP_assert(same_as<decltype(m3), std::map<int, int>>);
-        CPP_assert(same_as<decltype(m4), std::map<int, int>>);
+        auto m3 = ranges::to<map_like>(v);
+        auto m4 = v | ranges::to<map_like>();
+        CPP_assert(same_as<decltype(m3), map_like<int, int>>);
+        CPP_assert(same_as<decltype(m4), map_like<int, int>>);
         check_equal(m1, m3);
         check_equal(m1, m4);
 #endif
-
     }
 
     return ::test_result();


### PR DESCRIPTION
The current overload set is inconsistent:

```cpp
std::vector<std::pair<int, int>> v = {{1, 2}, {3, 4}};

auto m1 = ranges::to<std::map<int, int>>(v); // ok
auto m2 = v | ranges::to<std::map<int, int>>(); // ok
auto m3 = ranges::to<std::map>(v); // compile error
auto m4 = v | ranges::to<std::map>(); // ok
```

`m3` fails because the logic here tries to instantiate `std::map<std::pair<int, int>>` (specifically, `Cont<range_value_t<Rng>>`) instead of actually using the existing deduction machinery (which is what the `m4` overload correctly uses).