### PR TITLE
Fix name meaning change in nested class

### DIFF
--- a/include/meta/meta.hpp
+++ b/include/meta/meta.hpp
@@ -3189,7 +3189,7 @@ namespace meta
                         void_<bool_<invoke<Fn, A>::type::value>>>
 #endif
             {
-                using type = if_<invoke<Fn, A>, pair<list<Yes..., A>, list<No...>>,
+                using type = if_<meta::invoke<Fn, A>, pair<list<Yes..., A>, list<No...>>,
                                     pair<list<Yes...>, list<No..., A>>>;
             };
 


### PR DESCRIPTION
C++20 [basic.scope.class]: A name N used in a class S shall refer to the
same declaration in its context and when re-evaluated in the completed scope
of S. No diagnostic is required for a violation of this rule.

This rule is violated by the unqualified use of meta::invoke followed by the
declaration of partition_<Fn>::invoke.