### PR TITLE
Relax indirect callable constraints

### DIFF
--- a/include/range/v3/iterator/concepts.hpp
+++ b/include/range/v3/iterator/concepts.hpp
@@ -463,11 +463,11 @@ namespace ranges
 
         template(typename F, typename I)(
         concept (indirectly_unary_invocable_impl_)(F, I),
-            invocable<F &, iter_value_t<I> &> AND
+            invocable<F &, indirect_value_t<I>> AND
             invocable<F &, iter_reference_t<I>> AND
             invocable<F &, iter_common_reference_t<I>> AND
             common_reference_with<
-                invoke_result_t<F &, iter_value_t<I> &>,
+                invoke_result_t<F &, indirect_value_t<I>>,
                 invoke_result_t<F &, iter_reference_t<I>>>
         );
 
@@ -487,11 +487,11 @@ namespace ranges
 
     template(typename F, typename I)(
     concept (indirectly_regular_unary_invocable_)(F, I),
-        regular_invocable<F &, iter_value_t<I> &> AND
+        regular_invocable<F &, indirect_value_t<I>> AND
         regular_invocable<F &, iter_reference_t<I>> AND
         regular_invocable<F &, iter_common_reference_t<I>> AND
         common_reference_with<
-            invoke_result_t<F &, iter_value_t<I> &>,
+            invoke_result_t<F &, indirect_value_t<I>>,
             invoke_result_t<F &, iter_reference_t<I>>>
     );
 
@@ -505,15 +505,15 @@ namespace ranges
     // Non-standard indirect invocable concepts
     template(typename F, typename I1, typename I2)(
     concept (indirectly_binary_invocable_impl_)(F, I1, I2),
-        invocable<F &, iter_value_t<I1> &, iter_value_t<I2> &> AND
-        invocable<F &, iter_value_t<I1> &, iter_reference_t<I2>> AND
-        invocable<F &, iter_reference_t<I1>, iter_value_t<I2> &> AND
+        invocable<F &, indirect_value_t<I1>, indirect_value_t<I2>> AND
+        invocable<F &, indirect_value_t<I1>, iter_reference_t<I2>> AND
+        invocable<F &, iter_reference_t<I1>, indirect_value_t<I2>> AND
         invocable<F &, iter_reference_t<I1>, iter_reference_t<I2>> AND
         invocable<F &, iter_common_reference_t<I1>, iter_common_reference_t<I2>> AND
         detail::common_reference_with_4_<
-            invoke_result_t<F &, iter_value_t<I1> &, iter_value_t<I2> &>,
-            invoke_result_t<F &, iter_value_t<I1> &, iter_reference_t<I2>>,
-            invoke_result_t<F &, iter_reference_t<I1>, iter_value_t<I2> &>,
+            invoke_result_t<F &, indirect_value_t<I1>, indirect_value_t<I2>>,
+            invoke_result_t<F &, indirect_value_t<I1>, iter_reference_t<I2>>,
+            invoke_result_t<F &, iter_reference_t<I1>, indirect_value_t<I2>>,
             invoke_result_t<F &, iter_reference_t<I1>, iter_reference_t<I2>>>
     );
 
@@ -525,15 +525,15 @@ namespace ranges
 
     template(typename F, typename I1, typename I2)(
     concept (indirectly_regular_binary_invocable_impl_)(F, I1, I2),
-        regular_invocable<F &, iter_value_t<I1> &, iter_value_t<I2> &> AND
-        regular_invocable<F &, iter_value_t<I1> &, iter_reference_t<I2>> AND
-        regular_invocable<F &, iter_reference_t<I1>, iter_value_t<I2> &> AND
+        regular_invocable<F &, indirect_value_t<I1>, indirect_value_t<I2>> AND
+        regular_invocable<F &, indirect_value_t<I1>, iter_reference_t<I2>> AND
+        regular_invocable<F &, iter_reference_t<I1>, indirect_value_t<I2>> AND
         regular_invocable<F &, iter_reference_t<I1>, iter_reference_t<I2>> AND
         regular_invocable<F &, iter_common_reference_t<I1>, iter_common_reference_t<I2>> AND
         detail::common_reference_with_4_<
-            invoke_result_t<F &, iter_value_t<I1> &, iter_value_t<I2> &>,
-            invoke_result_t<F &, iter_value_t<I1> &, iter_reference_t<I2>>,
-            invoke_result_t<F &, iter_reference_t<I1>, iter_value_t<I2> &>,
+            invoke_result_t<F &, indirect_value_t<I1>, indirect_value_t<I2>>,
+            invoke_result_t<F &, indirect_value_t<I1>, iter_reference_t<I2>>,
+            invoke_result_t<F &, iter_reference_t<I1>, indirect_value_t<I2>>,
             invoke_result_t<F &, iter_reference_t<I1>, iter_reference_t<I2>>>
     );
 
@@ -546,7 +546,7 @@ namespace ranges
 
     template(typename F, typename I)(
     concept (indirect_unary_predicate_)(F, I),
-        predicate<F &, iter_value_t<I> &> AND
+        predicate<F &, indirect_value_t<I>> AND
         predicate<F &, iter_reference_t<I>> AND
         predicate<F &, iter_common_reference_t<I>>
     );
@@ -559,9 +559,9 @@ namespace ranges
 
     template(typename F, typename I1, typename I2)(
     concept (indirect_binary_predicate_impl_)(F, I1, I2),
-        predicate<F &, iter_value_t<I1> &, iter_value_t<I2> &> AND
-        predicate<F &, iter_value_t<I1> &, iter_reference_t<I2>> AND
-        predicate<F &, iter_reference_t<I1>, iter_value_t<I2> &> AND
+        predicate<F &, indirect_value_t<I1>, indirect_value_t<I2>> AND
+        predicate<F &, indirect_value_t<I1>, iter_reference_t<I2>> AND
+        predicate<F &, iter_reference_t<I1>, indirect_value_t<I2>> AND
         predicate<F &, iter_reference_t<I1>, iter_reference_t<I2>> AND
         predicate<F &, iter_common_reference_t<I1>, iter_common_reference_t<I2>>
     );
@@ -574,9 +574,9 @@ namespace ranges
 
     template(typename F, typename I1, typename I2)(
     concept (indirect_relation_)(F, I1, I2),
-        relation<F &, iter_value_t<I1> &, iter_value_t<I2> &> AND
-        relation<F &, iter_value_t<I1> &, iter_reference_t<I2>> AND
-        relation<F &, iter_reference_t<I1>, iter_value_t<I2> &> AND
+        relation<F &, indirect_value_t<I1>, indirect_value_t<I2>> AND
+        relation<F &, indirect_value_t<I1>, iter_reference_t<I2>> AND
+        relation<F &, iter_reference_t<I1>, indirect_value_t<I2>> AND
         relation<F &, iter_reference_t<I1>, iter_reference_t<I2>> AND
         relation<F &, iter_common_reference_t<I1>, iter_common_reference_t<I2>>
     );
@@ -589,9 +589,9 @@ namespace ranges
 
     template(typename F, typename I1, typename I2)(
     concept (indirect_strict_weak_order_)(F, I1, I2),
-        strict_weak_order<F &, iter_value_t<I1> &, iter_value_t<I2> &> AND
-        strict_weak_order<F &, iter_value_t<I1> &, iter_reference_t<I2>> AND
-        strict_weak_order<F &, iter_reference_t<I1>, iter_value_t<I2> &> AND
+        strict_weak_order<F &, indirect_value_t<I1>, indirect_value_t<I2>> AND
+        strict_weak_order<F &, indirect_value_t<I1>, iter_reference_t<I2>> AND
+        strict_weak_order<F &, iter_reference_t<I1>, indirect_value_t<I2>> AND
         strict_weak_order<F &, iter_reference_t<I1>, iter_reference_t<I2>> AND
         strict_weak_order<F &, iter_common_reference_t<I1>, iter_common_reference_t<I2>>
     );
@@ -618,6 +618,8 @@ namespace ranges
                 using reference = indirect_result_t<Proj &, I>;
                 using value_type = uncvref_t<reference>;
                 reference operator*() const;
+
+                using indirect_value_type = invoke_result_t<Proj &, iter_value_t<I> &>;
             };
         };
         RANGES_DIAGNOSTIC_POP
@@ -626,11 +628,9 @@ namespace ranges
         struct select_projected_
         {
             template<typename I>
-            using apply =
-                meta::_t<
-                    detail::enable_if_t<
-                        (bool)indirectly_regular_unary_invocable<Proj, I>,
-                        detail::projected_<I, Proj>>>;
+            using apply = meta::_t<
+                detail::enable_if_t<(bool)indirectly_regular_unary_invocable<Proj, I>,
+                                    detail::projected_<I, Proj>>>;
         };
 
         template<>
@@ -644,6 +644,13 @@ namespace ranges
 
     template<typename I, typename Proj>
     using projected = typename detail::select_projected_<Proj>::template apply<I>;
+
+    template<typename T>
+    struct indirect_value<T,
+                          decltype(std::declval<typename T::indirect_value_type>(), void())>
+    {
+        using type = typename T::indirect_value_type;
+    };
 
     template<typename I, typename Proj>
     struct incrementable_traits<detail::projected_<I, Proj>> : incrementable_traits<I>

--- a/include/range/v3/iterator/traits.hpp
+++ b/include/range/v3/iterator/traits.hpp
@@ -63,9 +63,19 @@ namespace ranges
     template<typename I>
     using iter_rvalue_reference_t = detail::iter_rvalue_reference_t<I>;
 
+    //////////////////////////////////////////////////////////////////////////////////////
+    // indirect_value_t
+    template<typename I,typename = void>
+    struct indirect_value
+    {
+        using type = iter_value_t<I> &;
+    };
+    template<typename I>
+    using indirect_value_t = typename indirect_value<I>::type;
+
     template<typename I>
     using iter_common_reference_t =
-        common_reference_t<iter_reference_t<I>, iter_value_t<I> &>;
+        common_reference_t<iter_reference_t<I>, indirect_value_t<I>>;
 
 #if defined(RANGES_DEEP_STL_INTEGRATION) && RANGES_DEEP_STL_INTEGRATION && \
     !defined(RANGES_DOXYGEN_INVOKED)

--- a/test/algorithm/for_each.cpp
+++ b/test/algorithm/for_each.cpp
@@ -9,9 +9,11 @@
 //
 // Project home: https://github.com/ericniebler/range-v3
 
+#include <memory>
 #include <vector>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/for_each.hpp>
+#include <range/v3/view/iota.hpp>
 
 #include "../array.hpp"
 #include "../simple_test.hpp"
@@ -58,6 +60,12 @@ int main()
         constexpr auto rng = test::array<int, 4>{{0, 2, 4, 6}};
         STATIC_CHECK(ranges::for_each(rng, void_f).in == ranges::end(rng));
     }
+    sum = 0;
+    auto v3 = ranges::views::iota(0,3);
+    auto vfun = [&](std::unique_ptr<int> i){ sum += *i; };
+    auto moproj = [&](int i){ return std::make_unique<int>(i); };
+    CHECK(ranges::for_each(v3, vfun, moproj).in == v3.end());
+    CHECK(sum == 3);
 
     return ::test_result();
 }

--- a/test/iterator/iterator.cpp
+++ b/test/iterator/iterator.cpp
@@ -177,6 +177,16 @@ CPP_assert(indirectly_movable<int const *, int *>);
 CPP_assert(!indirectly_swappable<int const *, int const *>);
 CPP_assert(!indirectly_movable<int const *, int const *>);
 
+using IntToFloat = float(*)(int &);
+static_assert(std::is_same<ranges::indirect_value_t<int *>,int &>::value,"");
+static_assert(std::is_same<ranges::indirect_value_t<projected<int *,ranges::identity>>,int &>::value,"");
+static_assert(std::is_same<ranges::indirect_value_t<projected<int *,IntToFloat>>,float>::value,"");
+
+using MoveOnlyIterator = std::vector<MoveOnlyString>::iterator;
+using MoveOnlyMove = MoveOnlyString &&(*)(MoveOnlyString&);
+static_assert(std::is_same<ranges::indirect_value_t<MoveOnlyIterator>,MoveOnlyString &>::value,"");
+static_assert(std::is_same<ranges::indirect_value_t<projected<MoveOnlyIterator,MoveOnlyMove>>,MoveOnlyString &&>::value,"");
+
 namespace Boost
 {
     struct S {}; // just to have a type from Boost namespace


### PR DESCRIPTION
Introduces a new indirect-callable-trait called 'indirect_value_t' to ensure correct value-type computation for algorithms that take projections. Instead of forming a reference to the invoke-result of the projection, it now computes the invoke-result of the projection with a reference to the iterators value-type.

Projections are discriminated from iterators by the existence of a nested typedef `indirect_value_type`.

More details here:
https://jehelset.gitlab.io/cpp/relaxing-ranges-just-a-smidge/

I was a bit unsure what was the idiomatic way to check for the existence of a nested member-type in ranges-v3.