### PR TITLE
Fix subrange::next with unsized subrange

### DIFF
--- a/include/range/v3/view/subrange.hpp
+++ b/include/range/v3/view/subrange.hpp
@@ -312,8 +312,7 @@ namespace ranges
 
         constexpr subrange & advance(iter_difference_t<I> n)
         {
-            set_size_(get_size_() -
-                      static_cast<size_type>(n - ranges::advance(first_(), n, last_())));
+            set_size_(static_cast<size_type>(n - ranges::advance(first_(), n, last_())));
             return *this;
         }
 
@@ -362,7 +361,7 @@ namespace ranges
             -> CPP_ret(void)(
                 requires (detail::store_size_<K, S, I>()))
         {
-            std::get<2>(data_) = n;
+            std::get<2>(data_) = get_size_() - n;
         }
     };
 

--- a/test/view/subrange.cpp
+++ b/test/view/subrange.cpp
@@ -199,7 +199,6 @@ RANGES_DIAGNOSTIC_IGNORE_UNDEFINED_FUNC_TEMPLATE
         CPP_assert(same_as<decltype(l0), decltype(s2)>);
     }
     {
-        std::list<int> li{1, 2, 3};
         subrange s(li.begin(), li.end());
         subrange s2 = s.next();
         CHECK(s2.begin() == std::next(li.begin()));

--- a/test/view/subrange.cpp
+++ b/test/view/subrange.cpp
@@ -198,6 +198,13 @@ RANGES_DIAGNOSTIC_IGNORE_UNDEFINED_FUNC_TEMPLATE
         CPP_assert(same_as<decltype(l0), decltype(s1)>);
         CPP_assert(same_as<decltype(l0), decltype(s2)>);
     }
+    {
+        std::list<int> li{1, 2, 3};
+        subrange s(li.begin(), li.end());
+        subrange s2 = s.next();
+        CHECK(s2.begin() == std::next(li.begin()));
+        CHECK(s2.end() == li.end());
+    }
 #if defined(__clang__) && __clang_major__ < 6
 RANGES_DIAGNOSTIC_POP
 #endif // clang bug workaround


### PR DESCRIPTION
Fixes #1718 