### PR TITLE
Don't provide `any_view` when static RTTI is disabled

### DIFF
--- a/.github/workflows/range-v3-ci.yml
+++ b/.github/workflows/range-v3-ci.yml
@@ -185,6 +185,22 @@ jobs:
             os: ubuntu-latest,
             build_type: Debug,
             cc: "gcc-10", cxx: "g++-10",
+            cxx_standard: 20,
+            cxx_no_rtti: true,
+          }
+        - {
+            name: "Linux GCC 10 Release (C++20, Concepts)", artifact: "Linux.tar.xz",
+            os: ubuntu-latest,
+            build_type: RelWithDebInfo,
+            cc: "gcc-10", cxx: "g++-10",
+            cxx_standard: 20,
+            cxx_no_rtti: true,
+          }
+        - {
+            name: "Linux GCC 10 Debug (C++20, Concepts)", artifact: "Linux.tar.xz",
+            os: ubuntu-latest,
+            build_type: Debug,
+            cc: "gcc-10", cxx: "g++-10",
             cxx_standard: 20
           }
         - {
@@ -277,6 +293,24 @@ jobs:
             cc: "clang-10", cxx: "clang++-10",
             cxx_standard: 20,
             cxx_asan: true,
+            cxx_concepts: false,
+            cxx_no_rtti: true,
+          }
+        - {
+            name: "Linux Clang 10 Release (C++20 / Concepts)", artifact: "Linux.tar.xz",
+            os: ubuntu-latest,
+            build_type: RelWithDebInfo,
+            cc: "clang-10", cxx: "clang++-10",
+            cxx_standard: 20,
+            cxx_no_rtti: true,
+          }
+        - {
+            name: "Linux Clang 10 Debug (C++20 / ASAN)", artifact: "Linux.tar.xz",
+            os: ubuntu-latest,
+            build_type: Debug,
+            cc: "clang-10", cxx: "clang++-10",
+            cxx_standard: 20,
+            cxx_asan: true,
             cxx_concepts: false
           }
         - {
@@ -302,6 +336,23 @@ jobs:
             build_type: RelWithDebInfo,
             cc: "clang", cxx: "clang++",
             cxx_standard: 17,
+          }
+        - {
+            name: "macOS Clang Debug (C++20 / ASAN)", artifact: "macOS.tar.xz",
+            os: macos-latest,
+            build_type: Debug,
+            cc: "clang", cxx: "clang++",
+            cxx_standard: 20,
+            cxx_asan: true,
+            cxx_no_rtti: true,
+          }
+        - {
+            name: "macOS Clang Release (C++20)", artifact: "macOS.tar.xz",
+            os: macos-latest,
+            build_type: RelWithDebInfo,
+            cc: "clang", cxx: "clang++",
+            cxx_standard: 20,
+            cxx_no_rtti: true,
           }
         - {
             name: "macOS Clang Debug (C++20 / ASAN)", artifact: "macOS.tar.xz",
@@ -460,6 +511,10 @@ jobs:
         set(cxx_concepts ON)
         if ("x${{ matrix.config.cxx_concepts }}" STREQUAL "xfalse")
           set(cxx_concepts OFF)
+        endif()
+
+        if ("x${{ matrix.config.cxx_no_rtti }}" STREQUAL "xtrue")
+          set(cxx_flags "${cxx_flags} -fno-rtti")
         endif()
 
         execute_process(

--- a/include/range/v3/view/any_view.hpp
+++ b/include/range/v3/view/any_view.hpp
@@ -15,6 +15,28 @@
 #ifndef RANGES_V3_VIEW_ANY_VIEW_HPP
 #define RANGES_V3_VIEW_ANY_VIEW_HPP
 
+#ifndef RANGES_V3_VIEW_ANY_VIEW_AVAILABLE
+#if defined(__cpp_rtti) || defined(__RTTI) || defined(__INTEL_RTTI__) || \
+    defined(__GXX_RTTI) || defined(_CPPRTTI)
+#define RANGES_V3_VIEW_ANY_VIEW_AVAILABLE 1
+#elif defined(__has_feature)
+#if __has_feature(cxx_rtti)
+#define RANGES_V3_VIEW_ANY_VIEW_AVAILABLE 1
+#else
+#define RANGES_V3_VIEW_ANY_VIEW_AVAILABLE 0
+#endif
+#elif defined(_MSVC_STL_VERSION)
+#if _HAS_STATIC_RTTI
+#define RANGES_V3_VIEW_ANY_VIEW_AVAILABLE 1
+#else
+#define RANGES_V3_VIEW_ANY_VIEW_AVAILABLE 0
+#endif
+#else
+#define RANGES_V3_VIEW_ANY_VIEW_AVAILABLE 0
+#endif
+
+#if RANGES_V3_VIEW_ANY_VIEW_AVAILABLE
+
 #include <type_traits>
 #include <typeinfo>
 #include <utility>
@@ -688,5 +710,7 @@ RANGES_SATISFY_BOOST_RANGE(::ranges::any_view)
 RANGES_DIAGNOSTIC_POP
 
 #include <range/v3/detail/epilogue.hpp>
+
+#endif
 
 #endif

--- a/test/view/any_view.cpp
+++ b/test/view/any_view.cpp
@@ -25,6 +25,8 @@
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 
+#if RANGES_V3_VIEW_ANY_VIEW_AVAILABLE
+
 namespace
 {
     template<typename S, typename T, typename = void>
@@ -225,3 +227,5 @@ int main()
 
     return test_result();
 }
+
+#endif


### PR DESCRIPTION
Also tries adding test coverage in workflows.

Fixes #1764.