### PR TITLE
Re-enable no_unique_address on GCC

### DIFF
--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -693,9 +693,7 @@ namespace ranges
 #define RANGES_IS_SAME(...) std::is_same<__VA_ARGS__>::value
 #endif
 
-// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=93667
-#if defined(__has_cpp_attribute) && __has_cpp_attribute(no_unique_address) && \
-    !(defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 10)
+#if defined(__has_cpp_attribute) && __has_cpp_attribute(no_unique_address)
 #define RANGES_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #else
 #define RANGES_NO_UNIQUE_ADDRESS


### PR DESCRIPTION
ICE on GCC 10 prerelease has been fixed in GCC 10 release series.