### PR TITLE
Fix zip/zip_with distance_to

### DIFF
--- a/include/range/v3/view/zip_with.hpp
+++ b/include/range/v3/view/zip_with.hpp
@@ -282,7 +282,11 @@ namespace ranges
             {
                 // Return the smallest distance (in magnitude) of any of the iterator
                 // pairs. This is to accommodate zippers of sequences of different length.
-                if(0 < std::get<0>(that.its_) - std::get<0>(its_))
+                auto first_size = std::get<0>(that.its_) - std::get<0>(its_);
+                if(!first_size)
+                    return static_cast<difference_type>(0);
+
+                if(0 < first_size)
                     return tuple_foldl(
                         tuple_transform(its_, that.its_, detail::distance_to),
                         (std::numeric_limits<difference_type>::max)(),

--- a/include/range/v3/view/zip_with.hpp
+++ b/include/range/v3/view/zip_with.hpp
@@ -283,7 +283,7 @@ namespace ranges
                 // Return the smallest distance (in magnitude) of any of the iterator
                 // pairs. This is to accommodate zippers of sequences of different length.
                 auto first_size = std::get<0>(that.its_) - std::get<0>(its_);
-                if(!first_size)
+                if(first_size == 0)
                     return static_cast<difference_type>(0);
 
                 if(0 < first_size)

--- a/test/view/zip.cpp
+++ b/test/view/zip.cpp
@@ -302,6 +302,29 @@ int main()
 
         has_cardinality<cardinality::unknown>(rng);
     }
+    
+    {
+        std::vector<int> v0{1, 2, 3};
+        std::vector<int> v1{};
+
+        auto rng0 = views::zip(v0, v1);
+        auto rng1 = views::zip(v1, v0);
+
+        CHECK(ranges::distance(ranges::begin(rng0), ranges::end(rng0)) == 0);
+        CHECK(ranges::distance(ranges::begin(rng1), ranges::end(rng1)) == 0);
+        CHECK(ranges::distance(ranges::end(rng0), ranges::begin(rng0)) == 0);
+        CHECK(ranges::distance(ranges::end(rng1), ranges::begin(rng1)) == 0);
+    }
+
+    {
+        std::vector<int> v0{1, 2, 3};
+        std::vector<int> v1{1, 2, 3, 4, 5};
+
+        auto rng = views::zip(v0, v1);
+
+        CHECK(ranges::distance(ranges::begin(rng), ranges::end(rng)) == 3);
+        CHECK(ranges::distance(ranges::end(rng), ranges::begin(rng)) == -3);
+    }
 
     return test_result();
 }


### PR DESCRIPTION
The distance between iterators is wrongly calculated when the first zipped range is empty:

```cpp
    std::vector<int> a = {1, 2, 3, 4, 5};
    std::vector<int> b;

    auto z0 = zip(b, a);
    auto z1 = zip(a, b);

    auto d0 = ranges::distance(ranges::begin(z0), ranges::end(z0));
    auto d1 = ranges::distance(ranges::begin(z1), ranges::end(z1));
    
    assert(d0 == 0); // failed d0 == 5
    assert(d1 == 0); // pass
 ```
 With MSVC
 ```cpp
    std::vector<int> a = {1, 2, 3, 4, 5};
    std::vector<int> b; 
    auto v = zip(b, a) | ranges::to_vector; // access violation
```