### PR TITLE
Minor change to avoid 'unused variable' compiler warning/error

### DIFF
--- a/test/bug-guard.cpp
+++ b/test/bug-guard.cpp
@@ -16,4 +16,5 @@ int main()
 {
     // make sure, that `utility.hpp` is included correctly
     ranges::optional<int> a;
+    return a ? 1 : 0;
 }


### PR DESCRIPTION
fixes many of the github actions failures.
2 macOs github actions still remain as failures with segFault in example/range.v3.comprehensions