### PR TITLE
Add missing calls to test_result()

### DIFF
--- a/test/view/enumerate.cpp
+++ b/test/view/enumerate.cpp
@@ -102,4 +102,6 @@ int main()
         CPP_assert(same_as<range_difference_t<X>, detail::diffmax_t>);
         CPP_assert(same_as<range_value_t<X>, std::pair<detail::diffmax_t, char const*>>);
     }
+
+    return ::test_result();
 }

--- a/test/view/span.cpp
+++ b/test/view/span.cpp
@@ -1096,4 +1096,6 @@ int main() {
     CPP_assert(ranges::contiguous_range<span<int>>);
     CPP_assert(ranges::view_<span<int, 42>>);
     CPP_assert(ranges::contiguous_range<span<int, 42>>);
+
+    return ::test_result();
 }

--- a/test/view/take_last.cpp
+++ b/test/view/take_last.cpp
@@ -32,4 +32,6 @@ int main()
 
     auto rng1 = rgi | views::take_last(7);
     ::check_equal(rng1, {0, 1, 2, 3, 4, 5});
+
+    return ::test_result();
 }


### PR DESCRIPTION
Some tests lack a call to `test_result`. In effect, these tests could fail without setting nonzero exit code. 