### PR TITLE
Enumerate with arbitrary starting index

### DIFF
--- a/include/range/v3/view/enumerate.hpp
+++ b/include/range/v3/view/enumerate.hpp
@@ -35,6 +35,7 @@ namespace ranges
         {
         private:
             friend range_access;
+            size_t start_{0};
 
             struct cursor
             {
@@ -72,10 +73,12 @@ namespace ranges
 
             public:
                 cursor() = default;
+                cursor(size_t n) : index_{n}
+                {}
             };
             cursor begin_cursor() const
             {
-                return cursor{};
+                return cursor{start_};
             }
             unreachable_sentinel_t end_cursor() const
             {
@@ -84,6 +87,8 @@ namespace ranges
 
         public:
             index_view() = default;
+            index_view(size_t n) : start_{n}
+            {}
         };
 
     } // namespace detail
@@ -103,11 +108,11 @@ namespace ranges
         {
             template(typename Rng)(
                 requires viewable_range<Rng>)
-            auto operator()(Rng && rng) const
+            auto operator()(Rng && rng, size_t n = 0) const
             {
                 using D = range_difference_t<Rng>;
                 using S = detail::iter_size_t<iterator_t<Rng>>;
-                return zip(detail::index_view<S, D>(), all(static_cast<Rng &&>(rng)));
+                return zip(detail::index_view<S, D>(n), all(static_cast<Rng &&>(rng)));
             }
         };
 

--- a/test/view/enumerate.cpp
+++ b/test/view/enumerate.cpp
@@ -25,12 +25,12 @@
 using std::begin;
 
 template<class RangeT>
-void test_enumerate_with(RangeT &&range)
+void test_enumerate_with(RangeT &&range, int n = 0)
 {
-    auto enumerated_range = ranges::views::enumerate(range);
+    auto enumerated_range = ranges::views::enumerate(range, n);
     CPP_assert(ranges::borrowed_range<decltype(enumerated_range)>);
 
-    std::size_t idx_ref = 0;
+    std::size_t idx_ref = n;
     auto it_ref = begin( range );
 
     for(auto it = enumerated_range.begin(); it != enumerated_range.end(); ++it)
@@ -50,6 +50,11 @@ int main()
         test_enumerate_with(es);
     }
 
+    { // test array with starting index
+        int const es[] = { 9,8,7,6,5,4,3,2,1,0 };
+        test_enumerate_with(es, 7);
+    }
+
     { // test with vector of complex value type
         std::vector<std::list<int>> range{ {1, 2, 3}, { 3,5,6,7 }, { 10,5,6,1 }, { 1,2,3,4 } };
         const auto rcopy = range;
@@ -64,6 +69,20 @@ int main()
         test_enumerate_with(range);
     }
 
+    { // test with vector of complex value type with starting index
+        std::vector<std::list<int>> range{ {1, 2, 3}, { 3,5,6,7 }, { 10,5,6,1 }, { 1,2,3,4 } };
+        const auto rcopy = range;
+
+        test_enumerate_with(range, 2);
+
+        // check that range hasn't accidentally been modified
+        CHECK(rcopy == range);
+
+        // check with empty range
+        range.clear();
+        test_enumerate_with(range, 2);
+    }
+
     { // test with list
         std::list<int> range{ 9,8,7,6,5,4,3,2,1 };
         test_enumerate_with(range);
@@ -72,8 +91,20 @@ int main()
         test_enumerate_with(range);
     }
 
+    { // test with list with starting index
+        std::list<int> range{ 9,8,7,6,5,4,3,2,1 };
+        test_enumerate_with(range, 1);
+
+        range.clear();
+        test_enumerate_with(range, 1);
+    }
+
     { // test with initializer_list
         test_enumerate_with(std::initializer_list<int>{9, 8, 7, 6, 5, 4, 3, 2, 1});
+    }
+
+    { // test with initializer_list with starting index
+        test_enumerate_with(std::initializer_list<int>{9, 8, 7, 6, 5, 4, 3, 2, 1}, 49);
     }
 
     {
@@ -85,11 +116,27 @@ int main()
     }
 
     {
+        auto range = ranges::views::iota(0, 0);
+        test_enumerate_with(range, 2);
+
+        range = ranges::views::iota(-10000, 10000);
+        test_enumerate_with(range, 2);
+    }
+
+    {
         auto range = ranges::views::iota((std::uintmax_t)0, (std::uintmax_t)0);
         test_enumerate_with(range);
 
         auto range2 = ranges::views::iota((std::intmax_t) -10000, (std::intmax_t) 10000);
         test_enumerate_with(range2);
+    }
+
+    {
+        auto range = ranges::views::iota((std::uintmax_t)0, (std::uintmax_t)0);
+        test_enumerate_with(range, 42);
+
+        auto range2 = ranges::views::iota((std::intmax_t) -10000, (std::intmax_t) 10000);
+        test_enumerate_with(range2, 42);
     }
 
     // https://github.com/ericniebler/range-v3/issues/1141

--- a/test/view/enumerate.cpp
+++ b/test/view/enumerate.cpp
@@ -61,7 +61,7 @@ int main()
 
         test_enumerate_with(range);
 
-        // check that range hasn't accidentially been modified
+        // check that range hasn't accidentally been modified
         CHECK(rcopy == range);
 
         // check with empty range


### PR DESCRIPTION
Improves `enumerate` so that it's possible to start at any given index. Similar functionality exists in [boost::adaptors::indexed](https://www.boost.org/doc/libs/1_75_0/libs/range/doc/html/range/reference/adaptors/reference/indexed.html)

This is just a draft, it just adds an additional parameter to `enumerate_fn::operator()`. It works well when used with function call syntax, but:
- doesn't work with pipe syntax without breaking existing user code (big issue)
- increases size of `index_view` (not sure if an issue)
- breaks existing ABI of `enumerate` (probably not an issue)

Another way to implement this would be to transform constructed `zip`, but I'm not sure that's any better (also doesn't fix the first issue).