### PR TITLE
Add missing includes

### DIFF
--- a/include/range/v3/action.hpp
+++ b/include/range/v3/action.hpp
@@ -24,6 +24,7 @@
 #include <range/v3/action/join.hpp>
 #include <range/v3/action/push_back.hpp>
 #include <range/v3/action/push_front.hpp>
+#include <range/v3/action/remove.hpp>
 #include <range/v3/action/remove_if.hpp>
 #include <range/v3/action/reverse.hpp>
 #include <range/v3/action/shuffle.hpp>

--- a/include/range/v3/algorithm.hpp
+++ b/include/range/v3/algorithm.hpp
@@ -20,6 +20,7 @@
 #include <range/v3/algorithm/any_of.hpp>
 #include <range/v3/algorithm/binary_search.hpp>
 #include <range/v3/algorithm/contains.hpp>
+#include <range/v3/algorithm/contains_subrange.hpp>
 #include <range/v3/algorithm/copy.hpp>
 #include <range/v3/algorithm/copy_backward.hpp>
 #include <range/v3/algorithm/copy_if.hpp>

--- a/test/bug-guard.cpp
+++ b/test/bug-guard.cpp
@@ -16,4 +16,5 @@ int main()
 {
     // make sure, that `utility.hpp` is included correctly
     ranges::optional<int> a;
+    (void) a;
 }


### PR DESCRIPTION
I checked file listings and compared them to include files (I also checked indirect includes). These two headers where not included by call `#include <range/v3/all.hpp>`

closes #1811 