### PR TITLE
Remove ABI-incompatible assertion code in any_view.hpp

### DIFF
--- a/include/range/v3/view/any_view.hpp
+++ b/include/range/v3/view/any_view.hpp
@@ -125,15 +125,22 @@ namespace ranges
             template<typename T>
             constexpr any_ref(T & obj) noexcept
               : obj_(detail::addressof(obj))
+#ifndef NDEBUG
+              , info_(&typeid(rtti_tag<T>))
+#endif
             {}
             template<typename T>
             T & get() const noexcept
             {
+                RANGES_ASSERT(obj_ && info_ && *info_ == typeid(rtti_tag<T>));
                 return *const_cast<T *>(static_cast<T const volatile *>(obj_));
             }
 
         private:
             void const volatile * obj_ = nullptr;
+#ifndef NDEBUG
+            std::type_info const * info_ = nullptr;
+#endif
         };
 
         template<typename Base>

--- a/include/range/v3/view/any_view.hpp
+++ b/include/range/v3/view/any_view.hpp
@@ -138,7 +138,7 @@ namespace ranges
 
         private:
             void const volatile * obj_ = nullptr;
-            std::type_info const * info_ = nullptr;
+            [[maybe_unused]] std::type_info const * info_ = nullptr;
         };
 
         template<typename Base>

--- a/include/range/v3/view/any_view.hpp
+++ b/include/range/v3/view/any_view.hpp
@@ -138,9 +138,7 @@ namespace ranges
 
         private:
             void const volatile * obj_ = nullptr;
-#ifndef NDEBUG
             std::type_info const * info_ = nullptr;
-#endif
         };
 
         template<typename Base>

--- a/include/range/v3/view/any_view.hpp
+++ b/include/range/v3/view/any_view.hpp
@@ -128,7 +128,9 @@ namespace ranges
 #ifndef NDEBUG
               , info_(&typeid(rtti_tag<T>))
 #endif
-            {}
+            {
+                (void)info_; // silence unused private member warning
+            }
             template<typename T>
             T & get() const noexcept
             {
@@ -138,7 +140,7 @@ namespace ranges
 
         private:
             void const volatile * obj_ = nullptr;
-            [[maybe_unused]] std::type_info const * info_ = nullptr;
+            std::type_info const * info_ = nullptr;
         };
 
         template<typename Base>

--- a/include/range/v3/view/any_view.hpp
+++ b/include/range/v3/view/any_view.hpp
@@ -125,22 +125,15 @@ namespace ranges
             template<typename T>
             constexpr any_ref(T & obj) noexcept
               : obj_(detail::addressof(obj))
-#ifndef NDEBUG
-              , info_(&typeid(rtti_tag<T>))
-#endif
             {}
             template<typename T>
             T & get() const noexcept
             {
-                RANGES_ASSERT(obj_ && info_ && *info_ == typeid(rtti_tag<T>));
                 return *const_cast<T *>(static_cast<T const volatile *>(obj_));
             }
 
         private:
             void const volatile * obj_ = nullptr;
-#ifndef NDEBUG
-            std::type_info const * info_ = nullptr;
-#endif
         };
 
         template<typename Base>


### PR DESCRIPTION
If a provider of an any_view is built without NDEBUG defined, but a consumer is built with NDEBUG defined (e.g., developing one project but using "release"/installed version of another), the consumer will crash due to ABI-incompatibility in any_ref.

Using "remove the assertion" as a discussion-starter, at least. I'd also understand an argument that some might want the ability to keep this assertion. If that's the case, could do something like [what llvm does](https://llvm.org/docs/ProgrammersManual.html#abi-breaking-checks) to separate ABI-breaking checks from non-ABI-breaking checks. 

Or if we're good with just removing this assertion that works of course (as far as I can tell, it's the only ABI-breaking assertion in range-v3)

Repros on clang with sanitizers, and that's an easily shareable demo:
  https://godbolt.org/z/Go9qxnjrM

Can't get it to repro with a small example in gcc, even with sanitizers

Repros in a small example on windows with msvc using same cpp/hpp files as above link - usually assertion failure in the assertion that this commit removes, sometimes Access Violation, but always crashes one way or another. No sanitizers needed to get a crash with msvc. It's just not easily shareable.