### PR TITLE
Add __cpp_impl_coroutine check for LLVM-17 in a test

### DIFF
--- a/cmake/coro_test_code.cpp
+++ b/cmake/coro_test_code.cpp
@@ -1,4 +1,4 @@
-#if defined(__cpp_coroutines) && defined(__has_include)
+#if (defined(__cpp_coroutines) || defined(__cpp_impl_coroutine)) && defined(__has_include)
 #if __has_include(<coroutine>)
 #include <coroutine>
 namespace std_coro = std;


### PR DESCRIPTION
Following #1818, this PR adds `__cpp_impl_coroutine` check for LLVM-17 in `./cmake/coro_test_code.cpp`