### PR TITLE
Make range-v3 a Bazel module (Support Bzlmod)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ bld/
 bazel-*
 cmake-build-*/
 
+# Bazel lock file
+MODULE.bazel.lock
+
 # Enable "build/" folder in the NuGet Packages folder since NuGet packages use it for MSBuild targets
 !packages/*/build/
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,3 @@
+module(
+    name = "range-v3",
+)


### PR DESCRIPTION
According to https://bazel.build/external/overview,
WORKSPACE is the legacy way to manage dependencies in Bazel and the new way is now Bzlmod.