### PR TITLE
Include string class in primitive.hpp

### DIFF
--- a/include/range/v3/range/primitives.hpp
+++ b/include/range/v3/range/primitives.hpp
@@ -25,6 +25,8 @@
 
 #include <range/v3/detail/prologue.hpp>
 
+#include <string>
+
 namespace ranges
 {
     /// \addtogroup group-range

--- a/include/range/v3/range/primitives.hpp
+++ b/include/range/v3/range/primitives.hpp
@@ -25,7 +25,9 @@
 
 #include <range/v3/detail/prologue.hpp>
 
+#if RANGES_CXX_STD <= RANGES_CXX_STD_14
 #include <string>
+#endif
 
 namespace ranges
 {


### PR DESCRIPTION
Some compilers throw an error when compiling - See : https://github.com/citizenfx/fivem/pull/2763

The easy fix is to add the `#include <string>` as some compilers / environnement are not including it, leading to an `error C2039: 'basic_string' is not a member of 'std'`