### PR TITLE
Add deprecation to deprecated function

### DIFF
--- a/include/range/v3/utility/compressed_pair.hpp
+++ b/include/range/v3/utility/compressed_pair.hpp
@@ -105,6 +105,7 @@ namespace ranges
     {
         // clang-format off
         template<typename... Args>
+        RANGES_DEPRECATED("ranges::compressed_tuple is deprecated.")
         constexpr auto CPP_auto_fun(operator())(Args &&... args) (const)
         (
             return compressed_tuple<bind_element_t<Args>...>{


### PR DESCRIPTION
The `make_compressed_tuple_fn` makes use of deprecated `compressed_tuple`, so it should also be deprecated