### PR TITLE
Add support for move-only `view`s

### DIFF
--- a/include/range/v3/range/concepts.hpp
+++ b/include/range/v3/range/concepts.hpp
@@ -251,7 +251,7 @@ namespace ranges
     template<typename T>
     CPP_concept view_ =
         range<T> &&
-        copyable<T> &&
+        movable<T> &&
         enable_view<T>;
 
     /// \concept viewable_range

--- a/test/utility/concepts.cpp
+++ b/test/utility/concepts.cpp
@@ -318,6 +318,14 @@ struct myview : ranges::view_base {
 };
 CPP_assert(ranges::view_<myview>);
 
+struct move_only_view : myview {
+    move_only_view(const move_only_view&) = delete;
+    move_only_view& operator=(const move_only_view &) = delete;
+    move_only_view(move_only_view&&) = default;
+    move_only_view& operator=(move_only_view &&) = default;
+};
+CPP_assert(ranges::view_<move_only_view>);
+
 CPP_template(class T)
     (requires ranges::regular<T>)
 constexpr bool is_regular(T&&)


### PR DESCRIPTION
In C++20, a `std::ranges::view` either has to be copyable in constant time, or a move-only type. In `range-v3`, the `view` concept currently requires the view to be copyable. This PR lifts this restriction, and makes the `::ranges::view` concept idential to `std::ranges::view`.

This allows the implementation of an `owning_view` that can take ownership of a range that is expensive to copy.
While the `owning_view` can be implemented outside of `range-v3`, the proposed (minimal) changes to the `view` concept are necessary as a first step to bring `range-v3` and the C++20 `std::ranges` closer to each other.