### PR TITLE
Bump CMake minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.15)
 get_directory_property(is_subproject PARENT_DIRECTORY)
 
 if(NOT is_subproject)

--- a/cmake/GoogleBenchmark.cmake.in
+++ b/cmake/GoogleBenchmark.cmake.in
@@ -2,7 +2,7 @@
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.15)
 
 project(google-benchmark-download NONE)
 

--- a/cmake/GoogleTest.cmake.in
+++ b/cmake/GoogleTest.cmake.in
@@ -2,7 +2,7 @@
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.15)
 
 project(google-test-download NONE)
 

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -11,7 +11,7 @@
 #
 
 PROJECT(PackageTest)
-cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()


### PR DESCRIPTION
Addresses issues #1839 and #1724.

I bumped the CMake minimum version to 3.15 as suggested in those issues.

I noticed that the version of CMake used in the CI is [`3.16.2`](https://github.com/ericniebler/range-v3/blob/ca1388fb9da8e69314dda222dc7b139ca84e092f/.github/workflows/range-v3-ci.yml#L7), so we can also change the minimum required version to that instead. That would also be more robust.