### PR TITLE
Suppress clang deprecation warning in make_compressed_tuple.

### DIFF
--- a/include/range/v3/utility/compressed_pair.hpp
+++ b/include/range/v3/utility/compressed_pair.hpp
@@ -105,6 +105,7 @@ namespace ranges
     {
         // clang-format off
         template<typename... Args>
+        RANGES_DEPRECATED("ranges::compressed_tuple is deprecated.")
         constexpr auto CPP_auto_fun(operator())(Args &&... args) (const)
         (
             return compressed_tuple<bind_element_t<Args>...>{

--- a/include/range/v3/utility/compressed_pair.hpp
+++ b/include/range/v3/utility/compressed_pair.hpp
@@ -101,6 +101,11 @@ namespace ranges
 
     using compressed_tuple_detail::compressed_tuple;
 
+// Suppress deprecated declaration usage within `make_compressed_tuple`,
+// which is itself deprecated
+RANGES_DIAGNOSTIC_PUSH
+RANGES_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS
+
     struct make_compressed_tuple_fn
     {
         // clang-format off
@@ -117,6 +122,8 @@ namespace ranges
     /// \ingroup group-utility
     /// \sa `make_compressed_tuple_fn`
     RANGES_INLINE_VARIABLE(make_compressed_tuple_fn, make_compressed_tuple)
+
+RANGES_DIAGNOSTIC_POP
 
     template<typename First, typename Second>
     struct RANGES_EMPTY_BASES compressed_pair


### PR DESCRIPTION
Previously, modern clang versions threw warnings due to the use of the deprecated `compressed_tuple` within `make_compressed_tuple`. This caused problems when ranges-v3 or a dependant project included the `ranges/v3/utility/compressed_pair.hpp` header, either directly or indirectly, via `ranges/v3/all.hpp`. This commit suppresses the deprecated-declarations warning within the `make_compressed_tuple` implementation, and adds a deprecation annotation to the former struct, achieving the intended goal of deprecating these structs without disrupting projects that do not use `compressed_tuple` or `make_compressed_tuple`.

The deprecation warning fixed by this commit seems to be unique to newer clang versions, not present in clang 10, but introduced before (or in) clang-19. It does not occur when using gcc (tested 7 and 13).